### PR TITLE
Natting table delete fix

### DIFF
--- a/internal/kubernetes/namespace.go
+++ b/internal/kubernetes/namespace.go
@@ -28,6 +28,9 @@ func (p *KubernetesProvider) startNattingCache(clientSet v1alpha1.NamespacedCRDC
 		UpdateFunc: p.manageReflections,
 		DeleteFunc: func(obj interface{}) {
 			p.StopReflector()
+			if err := p.createNattingTable(p.foreignClusterId); err != nil {
+				p.log.Error(err, "cannot create nattingTable")
+			}
 		},
 	}
 	lo := metav1.ListOptions{FieldSelector: strings.Join([]string{"metadata.name", p.ntCache.nattingTableName}, "=")}


### PR DESCRIPTION
This commit fixes a bug triggered by the delete of a `namespacenattingtable`. Before is caused a closing of closed channel panic. Another improvement is the creation of a new natting table upon the deletion of the older one.