### PR TITLE
Automatic natting

### DIFF
--- a/internal/kubernetes/configMap.go
+++ b/internal/kubernetes/configMap.go
@@ -16,7 +16,7 @@ func (p *KubernetesProvider) manageCmEvent(event watch.Event) error {
 		return errors.New("cannot cast object to configMap")
 	}
 
-	nattedNS, err := p.NatNamespace(cm.Namespace)
+	nattedNS, err := p.NatNamespace(cm.Namespace, false)
 	if err != nil {
 		return err
 	}

--- a/internal/kubernetes/endpoints.go
+++ b/internal/kubernetes/endpoints.go
@@ -38,7 +38,7 @@ func (p *KubernetesProvider) manageEpEvent(event timestampedEvent) error {
 		return errors.New("cannot cast object to endpoint")
 	}
 
-	nattedNS, err := p.NatNamespace(endpoints.Namespace)
+	nattedNS, err := p.NatNamespace(endpoints.Namespace, false)
 	if err != nil {
 		return err
 	}

--- a/internal/kubernetes/pod.go
+++ b/internal/kubernetes/pod.go
@@ -42,7 +42,7 @@ func (p *KubernetesProvider) CreatePod(ctx context.Context, pod *v1.Pod) error {
 		return nil
 	}
 
-	nattedNS, err := p.NatNamespace(pod.Namespace)
+	nattedNS, err := p.NatNamespace(pod.Namespace, true)
 	if err != nil {
 		return err
 	}
@@ -72,7 +72,7 @@ func (p *KubernetesProvider) UpdatePod(ctx context.Context, pod *v1.Pod) error {
 	if pod == nil {
 		return errors.New("pod cannot be nil")
 	}
-	nattedNS, err := p.NatNamespace(pod.Namespace)
+	nattedNS, err := p.NatNamespace(pod.Namespace, false)
 	if err != nil {
 		return err
 	}
@@ -100,7 +100,7 @@ func (p *KubernetesProvider) DeletePod(ctx context.Context, pod *v1.Pod) (err er
 	log.G(ctx).Infof("receive DeletePod %q", pod.Name)
 	opts := &metav1.DeleteOptions{}
 
-	nattedNS, err := p.NatNamespace(pod.Namespace)
+	nattedNS, err := p.NatNamespace(pod.Namespace, false)
 	if err != nil {
 		return err
 	}
@@ -149,7 +149,7 @@ func (p *KubernetesProvider) GetPod(ctx context.Context, namespace, name string)
 	log.G(ctx).Infof("receive GetPod %q", name)
 	opts := metav1.GetOptions{}
 
-	nattedNS, err := p.NatNamespace(namespace)
+	nattedNS, err := p.NatNamespace(namespace, false)
 	if err != nil {
 		return nil, err
 	}
@@ -175,7 +175,7 @@ func (p *KubernetesProvider) GetPodStatus(ctx context.Context, namespace, name s
 	// Add namespace and name as attributes to the current span.
 	ctx = addAttributes(ctx, span, namespaceKey, namespace, nameKey, name)
 
-	nattedNS, err := p.NatNamespace(namespace)
+	nattedNS, err := p.NatNamespace(namespace, false)
 
 	if err != nil {
 		return nil, nil
@@ -194,7 +194,7 @@ func (p *KubernetesProvider) GetPodStatus(ctx context.Context, namespace, name s
 // between in/out/err and the container's stdin/stdout/stderr.
 func (p *KubernetesProvider) RunInContainer(ctx context.Context, namespace string, podName string, containerName string, cmd []string, attach api.AttachIO) error {
 
-	nattedNS, err := p.NatNamespace(namespace)
+	nattedNS, err := p.NatNamespace(namespace, false)
 	if err != nil {
 		return err
 	}
@@ -234,7 +234,7 @@ func (p *KubernetesProvider) RunInContainer(ctx context.Context, namespace strin
 
 // GetContainerLogs retrieves the logs of a container by name from the provider.
 func (p *KubernetesProvider) GetContainerLogs(ctx context.Context, namespace string, podName string, containerName string, opts api.ContainerLogOpts) (io.ReadCloser, error) {
-	nattedNS, err := p.NatNamespace(namespace)
+	nattedNS, err := p.NatNamespace(namespace, false)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/kubernetes/reflectionController.go
+++ b/internal/kubernetes/reflectionController.go
@@ -21,7 +21,7 @@ type timestampedEvent struct {
 }
 
 type Reflector struct {
-	stop     chan bool
+	stop     chan struct{}
 	svcEvent chan watch.Event
 	repEvent chan watch.Event
 	epEvent  chan timestampedEvent
@@ -49,7 +49,7 @@ func (p *KubernetesProvider) StartReflector() {
 	p.log.Info("starting reflector for cluster " + p.foreignClusterId)
 
 	p.reflectedNamespaces.ns = make(map[string]chan struct{})
-	p.stop = make(chan bool, 1000)
+	p.stop = make(chan struct{}, 1)
 	p.svcEvent = make(chan watch.Event, 1000)
 	p.epEvent = make(chan timestampedEvent, 1000)
 	p.repEvent = make(chan watch.Event, 1000)
@@ -311,7 +311,7 @@ func (p *KubernetesProvider) reflectNamespace(namespace string) error {
 	var nattedNS string
 	var err error
 
-	nattedNS, err = p.NatNamespace(namespace)
+	nattedNS, err = p.NatNamespace(namespace, false)
 	if err != nil {
 		return err
 	}

--- a/internal/kubernetes/secret.go
+++ b/internal/kubernetes/secret.go
@@ -16,7 +16,7 @@ func (p *KubernetesProvider) manageSecEvent(event watch.Event) error {
 		return errors.New("cannot cast object to secret")
 	}
 
-	nattedNS, err := p.NatNamespace(sec.Namespace)
+	nattedNS, err := p.NatNamespace(sec.Namespace, false)
 	if err != nil {
 		return err
 	}

--- a/internal/kubernetes/service.go
+++ b/internal/kubernetes/service.go
@@ -16,7 +16,7 @@ func (p *KubernetesProvider) manageSvcEvent(event watch.Event) error {
 		return errors.New("cannot cast object to service")
 	}
 
-	nattedNS, err := p.NatNamespace(svc.Namespace)
+	nattedNS, err := p.NatNamespace(svc.Namespace, false)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Every time a pod is scheduled to the vk if the source namespace isn't
natted yet, a new entry in the natting table is created, by using the
following naming convention: `<localClusterId>-<localNamespace>`.