### PR TITLE
Provider failed pod status handling

### DIFF
--- a/cmd/virtual-kubelet/internal/commands/root/root.go
+++ b/cmd/virtual-kubelet/internal/commands/root/root.go
@@ -187,8 +187,8 @@ func runRootCommand(ctx context.Context, s *provider.Store, c Opts) error {
 					_, err = client.CoreV1().Nodes().Create(newNode)
 					log.G(ctx).Debug("created new node")
 				} else {
-					newNode.Spec = oldNode.Spec
-					_, err = client.CoreV1().Nodes().Update(newNode)
+					oldNode.Status = newNode.Status
+					_, err = client.CoreV1().Nodes().UpdateStatus(oldNode)
 					log.G(ctx).Debug("Node updated")
 				}
 

--- a/internal/kubernetes/pod.go
+++ b/internal/kubernetes/pod.go
@@ -51,7 +51,7 @@ func (p *KubernetesProvider) CreatePod(ctx context.Context, pod *v1.Pod) error {
 
 	podServer, err := p.foreignClient.Client().CoreV1().Pods(podTranslated.Namespace).Create(podTranslated)
 	if err != nil {
-		return errors.Wrap(err, "Unable to create pod")
+		return err
 	}
 	log.G(ctx).Info("Pod", podServer.Name, "successfully created on remote cluster")
 	// Here we have to change the view of the remote POD to show it as a local one
@@ -81,7 +81,7 @@ func (p *KubernetesProvider) UpdatePod(ctx context.Context, pod *v1.Pod) error {
 
 	poUpdated, err := p.foreignClient.Client().CoreV1().Pods(nattedNS).Get(podTranslated.Name, metav1.GetOptions{})
 	if err != nil {
-		return errors.Wrap(err, "Unable to create pod")
+		return err
 	}
 	podInverse := F2HTranslate(poUpdated, p.RemappedPodCidr, pod.Namespace)
 	p.notifier(podInverse)


### PR DESCRIPTION
An offloaded pod can be in `providerFailed` status; this status is mainly triggered by the behavior of the pod lifecycle handler that tries to reconcile the local status of a pod with a remote one that doesn't exist anymore. This PR addresses this status transition by deleting the local pod in case the remote one is not found. There is also a minor modification in the virtual node: upon the deletion of the virtual node, the virtual kubelet re-creates it at runtime seamlessly.