### PR TITLE
Liqo Helm Chart bugfix and update

### DIFF
--- a/deployments/liqo_chart/Chart.yaml
+++ b/deployments/liqo_chart/Chart.yaml
@@ -34,3 +34,7 @@ dependencies:
   version: "0.1.0"
   repository: file://subcharts/tunnelEndpointCreator_chart/
   condition: tunnelEndpointCreator_chart.enabled
+- name: schedulingNodeOperator_chart
+  version: "0.1.0"
+  repository: file://subcharts/schedulingNodeOperator_chart/
+  condition: schedulingNodeOperator_chart.enabled

--- a/deployments/liqo_chart/values.yaml
+++ b/deployments/liqo_chart/values.yaml
@@ -20,7 +20,7 @@ adv_chart:
     image:
       repository: "liqo/advertisement-broadcaster"
       pullPolicy: "IfNotPresent"
-  enable: true
+  enabled: true
 
 #configuration values for the networkModule subchart
 networkModule_chart:
@@ -32,21 +32,21 @@ networkModule_chart:
     image:
       repository: "liqo/liqonet"
       pullPolicy: "IfNotPresent"
-  enable: true
+  enabled: true
 
 #configuration values for the tunnelendpointCreator subchart
 tunnelEndpointCreator_chart:
   image:
     repository: "liqo/liqonet"
     pullPolicy: "IfNotPresent"
-  enable: true
+  enabled: true
 
 #configuration values for the schedulingNode subchart
 schedulingNodeOperator_chart:
   image:
     repository: "liqo/schedulingnode-operator"
     pullPolicy: "IfNotPresent"
-  enable: true
+  enabled: true
 
 global:
   configmapName: "liqo-configmap"


### PR DESCRIPTION
Update:
 

-  Added the schedulingnodeOperator subchart to the dependencies.

Fix:
 

-  Fixed a mismatching name of variable "enabled" in files values.yaml and Chart.yaml. Renamed it in values.yaml from "enable" to "enabled".
At install time when we want to exclude by setting the condition variable "enabled" to false it works.