### PR TITLE
Mutating webhook

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,6 +15,8 @@ jobs:
         - schedulingnode-operator
         - discovery
         - tray-agent
+        - init-pod-mutator
+        - pod-mutator
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v1

--- a/build/init-pod-mutator/Dockerfile
+++ b/build/init-pod-mutator/Dockerfile
@@ -1,0 +1,7 @@
+FROM alpine:3.9.5
+RUN apk add --update curl bash openssl
+RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.17.0/bin/linux/amd64/kubectl && chmod +x ./kubectl && cp kubectl /usr/bin/kubectl
+
+COPY config/podMutator/script.sh /usr/bin/local/podMutator-setup.sh
+RUN mkdir /root/.kube
+ENTRYPOINT [ "/usr/bin/local/podMutator-setup.sh" ]

--- a/build/pod-mutator/Dockerfile
+++ b/build/pod-mutator/Dockerfile
@@ -1,0 +1,11 @@
+FROM golang:1.13 as builder
+ENV PATH /go/bin:/usr/local/go/bin:$PATH
+ENV GOPATH /go
+COPY . /go/src/github.com/liqoTech/liqo
+WORKDIR /go/src/github.com/liqoTech/liqo
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build ./cmd/pod-mutator/
+RUN cp pod-mutator /usr/bin/pod-mutator
+
+FROM scratch
+COPY --from=builder /usr/bin/pod-mutator /usr/bin/pod-mutator
+ENTRYPOINT [ "/usr/bin/pod-mutator" ]

--- a/cmd/pod-mutator/main.go
+++ b/cmd/pod-mutator/main.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"flag"
+	"github.com/liqoTech/liqo/pkg/mutate"
+	"k8s.io/klog"
+	"log"
+)
+
+func main() {
+	config := &mutate.MutationConfig{}
+
+	flag.StringVar(&config.SecretNamespace, "secret-namespace", "", "The namespace in which the secret has been created")
+	flag.StringVar(&config.SecretName, "secret-name", "", "The name of the secret to fetch")
+	flag.StringVar(&config.CertFile, "cert-file", "", "The local path in which to copy the certificate")
+	flag.StringVar(&config.KeyFile, "key-file", "", "The local path in which to copy the key")
+	flag.Parse()
+
+	setOptions(config)
+
+	log.Println("Starting server ...")
+
+	s, err := mutate.NewMutationServer(config)
+	if err != nil {
+		klog.Fatal(err)
+	}
+
+	s.Serve()
+}

--- a/cmd/pod-mutator/opts.go
+++ b/cmd/pod-mutator/opts.go
@@ -1,0 +1,28 @@
+package main
+
+import "github.com/liqoTech/liqo/pkg/mutate"
+
+const (
+	defaultNamespace  = "default"
+	defaultSecretName = "pod-mutator-secret"
+	defaultCertFile   = "/etc/ssl/liqo/cert.pem"
+	defaultKeyFile    = "/etc/ssl/liqo/key.pem"
+)
+
+func setOptions(c *mutate.MutationConfig) {
+	if c.SecretNamespace == "" {
+		c.SecretNamespace = defaultNamespace
+	}
+
+	if c.SecretName == "" {
+		c.SecretName = defaultSecretName
+	}
+
+	if c.KeyFile == "" {
+		c.KeyFile = defaultKeyFile
+	}
+
+	if c.CertFile == "" {
+		c.CertFile = defaultCertFile
+	}
+}

--- a/config/podMutator/script.sh
+++ b/config/podMutator/script.sh
@@ -1,0 +1,162 @@
+#!/bin/bash
+
+set -e
+
+usage() {
+    cat <<EOF
+Generate certificate suitable for use with an sidecar-injector webhook service.
+This script uses k8s' CertificateSigningRequest API to a generate a
+certificate signed by k8s CA suitable for use with sidecar-injector webhook
+services. This requires permissions to create and approve CSR. See
+https://kubernetes.io/docs/tasks/tls/managing-tls-in-a-cluster for
+detailed explantion and additional instructions.
+The server key/cert k8s CA cert are stored in a k8s secret.
+usage: ${0} [OPTIONS]
+The following flags are required.
+       --service          Service name of webhook.
+       --namespace        Namespace where webhook service and secret reside.
+       --secret           Secret name for CA certificate and server certificate/key pair.
+EOF
+    exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+    case ${1} in
+        --service)
+            service="$2"
+            shift
+            ;;
+        --secret)
+            secret="$2"
+            shift
+            ;;
+        --namespace)
+            namespace="$2"
+            shift
+            ;;
+        *)
+            usage
+            ;;
+    esac
+    shift
+done
+
+[ -z ${service} ] && service=mutatepodtoleration
+[ -z ${secret} ] && secret=pod-mutator-secret
+[ -z ${namespace} ] && namespace=default
+
+if [ ! -x "$(command -v openssl)" ]; then
+    echo "openssl not found"
+    exit 1
+fi
+
+CSR_NAME=${service}.${namespace}
+
+tmpdir="/etc/liqo/ssl"
+mkdir -p $tmpdir
+
+echo "creating certs in tmpdir ${tmpdir} "
+
+cat <<EOF >> ${tmpdir}/csr.conf
+[req]
+req_extensions = v3_req
+distinguished_name = req_distinguished_name
+[req_distinguished_name]
+[ v3_req ]
+basicConstraints = CA:FALSE
+keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+extendedKeyUsage = serverAuth
+subjectAltName = @alt_names
+[alt_names]
+DNS.1 = ${service}
+DNS.2 = ${service}.${namespace}
+DNS.3 = ${service}.${namespace}.svc
+EOF
+
+openssl genrsa -out ${tmpdir}/server-key.pem 2048
+openssl req -new -key ${tmpdir}/server-key.pem -subj "/CN=${service}.${namespace}.svc" -out ${tmpdir}/server.csr -config ${tmpdir}/csr.conf
+
+# clean-up any previously created CSR for our service. Ignore errors if not present.
+kubectl delete csr ${CSR_NAME} 2>/dev/null || true
+
+# create  server cert/key CSR and  send to k8s API
+cat << EOF | kubectl create -f -
+apiVersion: certificates.k8s.io/v1beta1
+kind: CertificateSigningRequest
+metadata:
+  name: ${CSR_NAME}
+spec:
+  groups:
+  - system:authenticated
+  request: $(cat ${tmpdir}/server.csr | base64 | tr -d '\n')
+  usages:
+  - digital signature
+  - key encipherment
+  - server auth
+EOF
+
+# verify CSR has been created
+while true; do
+    kubectl get csr ${CSR_NAME}
+    if [ "$?" -eq 0 ]; then
+        break
+    fi
+done
+
+echo "Wait for CSR to be signed"
+while true;
+  do
+     check=$(kubectl get certificatesigningrequests.certificates.k8s.io "${CSR_NAME}" -o jsonpath='{.status.conditions[:1].type}')
+     if [[ $check == "Approved" ]]; then
+       echo "Approved!"
+       kubectl get csr "${CSR_NAME}" -o jsonpath='{.status.certificate}' | base64 -d > server.crt
+       break
+     fi
+     echo "Waiting for approval of CSR: ${CSR_NAME}"
+     sleep 3
+done
+
+serverCert=$(kubectl get csr ${CSR_NAME} -o jsonpath='{.status.certificate}')
+echo ${serverCert} | openssl base64 -d -A -out ${tmpdir}/server-cert.pem
+
+# create the secret with CA cert and server cert/key
+kubectl create secret generic ${secret} \
+        --from-file=key.pem=${tmpdir}/server-key.pem \
+        --from-file=cert.pem=${tmpdir}/server-cert.pem \
+        --dry-run -o yaml |
+    kubectl -n ${namespace} apply -f -
+
+CACRT=`cat /var/run/secrets/kubernetes.io/serviceaccount/ca.crt | base64 | sed ':a;N;$!ba;s/\n//g'`
+
+cat <<EOF | kubectl apply -f -
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: mutatepodtoleration
+  namespace: $namespace
+  labels:
+    app: mutatepodtoleration
+webhooks:
+  - name: mutatepodtoleration.$namespace.$service
+    clientConfig:
+      caBundle: $CACRT
+      service:
+        name: $service
+        namespace: $namespace
+        path: "/mutate"
+        port: 443
+    rules:
+      - operations: ["CREATE"]
+        apiGroups: [""]
+        apiVersions: ["v1"]
+        resources: ["pods"]
+    sideEffects: None
+    timeoutSeconds: 5
+    reinvocationPolicy: Never
+    failurePolicy: Ignore
+    namespaceSelector:
+      matchLabels:
+        liqo.io/enabled: "true"
+EOF
+
+exit 0

--- a/deployments/podMutator/deploy.yaml
+++ b/deployments/podMutator/deploy.yaml
@@ -1,0 +1,79 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: podmutatoraccount
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: podmutatoraccount
+subjects:
+  - kind: ServiceAccount
+    name: podmutatoraccount
+    namespace: liqo
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: mutatepodtoleration
+  labels:
+    app: mutatepodtoleration
+spec:
+  selector:
+    app: mutatepodtoleration
+  ports:
+    - port: 443
+      targetPort: 8443
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: podmutator
+  labels:
+    app: mutatepodtoleration
+spec:
+  selector:
+    matchLabels:
+      app: mutatepodtoleration
+  template:
+    metadata:
+      labels:
+        app: mutatepodtoleration
+    spec:
+      serviceAccountName: podmutatoraccount
+      initContainers:
+      - name: pod-mutator-init
+        image: liqo/init-pod-mutator
+        imagePullPolicy: Always
+        args:
+          - "--namespace"
+          - "liqo"
+          - "--service"
+          - "mutatepodtoleration"
+          - "--secret"
+          - "pod-mutator-secret"
+      containers:
+      - name: podmutator
+        image: liqo/pod-mutator
+        imagePullPolicy: Always
+        args:
+          - "--secret-namespace"
+          - "liqo"
+          - "--secret-name"
+          - "pod-mutator-secret"
+        volumeMounts:
+        - mountPath: /etc/ssl/liqo
+          name: certs-volume
+      volumes:
+        - name: certs-volume
+          emptyDir: {}

--- a/pkg/mutate/mutate.go
+++ b/pkg/mutate/mutate.go
@@ -1,0 +1,88 @@
+package mutate
+
+import (
+	"encoding/json"
+	"fmt"
+	v1beta1 "k8s.io/api/admission/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"log"
+)
+
+// Mutate mutates the object received via admReview and creates a response
+// that embeds a patch to the received pod
+func (s *MutationServer) Mutate(body []byte, verbose bool) ([]byte, error) {
+	var err error
+	if verbose {
+		log.Printf("recv: %s\n", string(body)) // untested section
+	}
+
+	// unmarshal request into AdmissionReview struct
+	admReview := v1beta1.AdmissionReview{}
+	if err := json.Unmarshal(body, &admReview); err != nil {
+		return nil, fmt.Errorf("unmarshaling request failed with %s", err)
+	}
+
+	var pod *corev1.Pod
+
+	responseBody := []byte{}
+	ar := admReview.Request
+	resp := v1beta1.AdmissionResponse{}
+
+	if ar != nil {
+
+		// get the Pod object and unmarshal it into its struct, if we cannot, we might as well stop here
+		if err := json.Unmarshal(ar.Object.Raw, &pod); err != nil {
+			return nil, fmt.Errorf("unable unmarshal pod json object %v", err)
+		}
+
+		// set response options
+		resp.Allowed = true
+		resp.UID = ar.UID
+		pT := v1beta1.PatchTypeJSONPatch
+		resp.PatchType = &pT // it's annoying that this needs to be a pointer as you cannot give a pointer to a constant?
+
+		resp.AuditAnnotations = map[string]string{
+			"liqo": "this pod is allowed to run in liqo",
+		}
+
+		type patchType struct {
+			Op    string              `json:"op"`
+			Path  string              `json:"path"`
+			Value []corev1.Toleration `json:"value"`
+		}
+
+		patch := []patchType{
+			{
+				Op:   "add",
+				Path: "/spec/tolerations",
+				Value: []corev1.Toleration{
+					{
+						Key:      "virtual-node.liqo.io/not-allowed",
+						Operator: "Exists",
+						Effect:   "NoExecute",
+					},
+				},
+			},
+		}
+		if resp.Patch, err = json.Marshal(patch); err != nil {
+			return nil, err
+		}
+
+		resp.Result = &metav1.Status{
+			Status: "Success",
+		}
+
+		admReview.Response = &resp
+		responseBody, err = json.Marshal(admReview)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if verbose {
+		log.Printf("resp: %s\n", string(responseBody))
+	}
+
+	return responseBody, nil
+}

--- a/pkg/mutate/server.go
+++ b/pkg/mutate/server.go
@@ -1,0 +1,144 @@
+package mutate
+
+import (
+	"fmt"
+	"html"
+	"io/ioutil"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/klog"
+	"log"
+	"net/http"
+	"os"
+	"time"
+)
+
+type MutationConfig struct {
+	SecretNamespace string
+	SecretName      string
+	CertFile        string
+	KeyFile         string
+}
+
+type MutationServer struct {
+	client *kubernetes.Clientset
+	mux    *http.ServeMux
+	server *http.Server
+
+	config *MutationConfig
+}
+
+func NewMutationServer(c *MutationConfig) (*MutationServer, error) {
+	var err error
+
+	s := &MutationServer{}
+	s.config = c
+
+	s.mux = http.NewServeMux()
+	s.mux.HandleFunc("/", handleRoot)
+	s.mux.HandleFunc("/mutate", s.handleMutate)
+
+	configPath := os.Getenv("KUBECONFIG")
+	var config *rest.Config
+	if _, err := os.Stat(configPath); !os.IsNotExist(err) {
+		config, err = clientcmd.BuildConfigFromFlags("", configPath)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		config, err = rest.InClusterConfig()
+		if err != nil {
+			return nil, err
+		}
+	}
+	if s.client, err = kubernetes.NewForConfig(config); err != nil {
+		return nil, err
+	}
+
+	s.server = &http.Server{
+		Addr:           ":8443",
+		Handler:        s.mux,
+		ReadTimeout:    10 * time.Second,
+		WriteTimeout:   10 * time.Second,
+		MaxHeaderBytes: 1 << 20, // 1048576
+	}
+
+	return s, nil
+}
+
+func handleRoot(w http.ResponseWriter, r *http.Request) {
+	_, _ = fmt.Fprintf(w, "hello %q", html.EscapeString(r.URL.Path))
+}
+
+func (s *MutationServer) handleMutate(w http.ResponseWriter, r *http.Request) {
+	// read the body / request
+	body, err := ioutil.ReadAll(r.Body)
+	defer r.Body.Close()
+
+	if err != nil {
+		s.sendError(err, w)
+		return
+	}
+
+	// mutate the request
+	mutated, err := s.Mutate(body, true)
+	if err != nil {
+		s.sendError(err, w)
+		return
+	}
+
+	// and write it back
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(mutated)
+}
+
+func (s *MutationServer) sendError(err error, w http.ResponseWriter) {
+	log.Println(err)
+	w.WriteHeader(http.StatusInternalServerError)
+	_, _ = fmt.Fprintf(w, "%s", err)
+}
+
+func (s *MutationServer) Serve() {
+	secret, err := s.client.CoreV1().Secrets(s.config.SecretNamespace).Get(s.config.SecretName, metav1.GetOptions{})
+	if err != nil {
+		klog.Error("cannot get the pod mutator secret in namespace ", s.config.SecretNamespace)
+		os.Exit(1)
+	}
+
+	writeSecret(secret, s.config.CertFile, s.config.KeyFile)
+
+	log.Fatal(s.server.ListenAndServeTLS(s.config.CertFile, s.config.KeyFile))
+}
+
+func writeSecret(secret *corev1.Secret, certFile, keyFile string) {
+	f, err := os.Create(certFile)
+	if err != nil {
+		klog.Error("cannot create the cert.pem file")
+		os.Exit(1)
+	}
+	if n, err := f.Write(secret.Data["cert.pem"]); n != len(secret.Data["cert.pem"]) || err != nil {
+		klog.Error("error in writing cert.pem")
+		os.Exit(1)
+	}
+	if err := f.Close(); err != nil {
+		klog.Error("error in closing cert.pem file")
+		os.Exit(1)
+	}
+
+	f, err = os.Create(keyFile)
+	if err != nil {
+		klog.Error("cannot create the key.pem file")
+		os.Exit(1)
+	}
+	if n, err := f.Write(secret.Data["key.pem"]); n != len(secret.Data["key.pem"]) || err != nil {
+		klog.Error("error in writing key.pem")
+		os.Exit(1)
+	}
+	if err := f.Close(); err != nil {
+		klog.Error("error in closing key.pem file")
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
This commit introduces a mutating webhook, that, given a namespace
label, adds a tolerations to the taints posed by the virtual nodes. This
introduces the possibility to schedule on virtual nodes only the pods
belonging to a namespace compliant to the virtual kubelet policy
admission.