### PR TITLE
VK taint addition

### DIFF
--- a/pkg/advertisement-operator/creation.go
+++ b/pkg/advertisement-operator/creation.go
@@ -88,7 +88,6 @@ func CreateVkDeployment(adv *protocolv1.Advertisement, nameSA, vkNamespace, vkIm
 		adv.Spec.ClusterId,
 		"--provider",
 		"kubernetes",
-		"--disable-taint",
 		"--nodename",
 		"vk-" + adv.Spec.ClusterId,
 		"--kubelet-namespace",
@@ -216,6 +215,18 @@ func CreateVkDeployment(adv *protocolv1.Advertisement, nameSA, vkNamespace, vkIm
 								{
 									Name:      "VKUBELET_POD_IP",
 									ValueFrom: &v1.EnvVarSource{FieldRef: &v1.ObjectFieldSelector{FieldPath: "status.podIP", APIVersion: "v1"}},
+								},
+								{
+									Name:  "VKUBELET_TAINT_KEY",
+									Value: "virtual-node.liqo.io/not-allowed",
+								},
+								{
+									Name:  "VKUBELET_TAINT_VALUE",
+									Value: "true",
+								},
+								{
+									Name:  "VKUBELET_TAINT_EFFECT",
+									Value: "NoExecute",
 								},
 							},
 						},


### PR DESCRIPTION
Taint for pods not belonging to the liqo ecosystem is added to the
virtual node. This approach, joint with the mutating webhook in #25
allows to avoid the scheduling of pods not belonging to the liqo
ecosystem in the virtual nodes.