### PR TITLE
Add broadcaster ServiceAccount parameter in peering-request-operator

### DIFF
--- a/cmd/peering-request-operator/main.go
+++ b/cmd/peering-request-operator/main.go
@@ -15,13 +15,14 @@ var (
 func main() {
 	mainLog.Info("Starting")
 
-	var namespace, liqoConfigmap, broadcasterImage string
+	var namespace, liqoConfigmap, broadcasterImage, broadcasterServiceAccount string
 	var certPath string
 
 	flag.StringVar(&namespace, "namespace", "default", "Namespace where your configs are stored.")
 	flag.StringVar(&certPath, "cert-path", "", "Certificate files for webhook, needed only if run outside of cluster")
 	flag.StringVar(&liqoConfigmap, "config-map", "liqo-configmap", "Liqo ConfigMap name")
 	flag.StringVar(&broadcasterImage, "broadcaster-image", "liqo/advertisement-broadcaster", "Broadcaster-operator image name")
+	flag.StringVar(&broadcasterServiceAccount, "broadcaster-sa", "broadcaster", "Broadcaster-operator ServiceAccount name")
 	flag.Parse()
 
 	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
@@ -30,5 +31,5 @@ func main() {
 	_ = peering_request_admission.StartWebhook(certPath, namespace)
 
 	mainLog.Info("Starting peering-request operator")
-	peering_request_operator.StartOperator(namespace, liqoConfigmap, broadcasterImage)
+	peering_request_operator.StartOperator(namespace, liqoConfigmap, broadcasterImage, broadcasterServiceAccount)
 }

--- a/internal/peering-request-operator/peering-request-controller.go
+++ b/internal/peering-request-operator/peering-request-controller.go
@@ -34,12 +34,13 @@ type PeeringRequestReconciler struct {
 	Log    logr.Logger
 	Scheme *runtime.Scheme
 
-	client           *kubernetes.Clientset
-	discoveryClient  *v1.DiscoveryV1Client
-	Namespace        string
-	clusterId        *clusterID.ClusterID
-	configMapName    string
-	broadcasterImage string
+	client                    *kubernetes.Clientset
+	discoveryClient           *v1.DiscoveryV1Client
+	Namespace                 string
+	clusterId                 *clusterID.ClusterID
+	configMapName             string
+	broadcasterImage          string
+	broadcasterServiceAccount string
 }
 
 // +kubebuilder:rbac:groups=discovery.liqo.io,resources=peeringrequests,verbs=get;list;watch;create;update;patch;delete
@@ -71,7 +72,7 @@ func (r *PeeringRequestReconciler) Reconcile(req ctrl.Request) (ctrl.Result, err
 		if err != nil {
 			return ctrl.Result{}, err
 		}
-		deploy := GetBroadcasterDeployment(fr, "broadcaster", r.Namespace, r.broadcasterImage, r.clusterId.GetClusterID(), cm.Data["gatewayIP"], cm.Data["gatewayPrivateIP"])
+		deploy := GetBroadcasterDeployment(fr, r.broadcasterServiceAccount, r.Namespace, r.broadcasterImage, r.clusterId.GetClusterID(), cm.Data["gatewayIP"], cm.Data["gatewayPrivateIP"])
 		_, err = r.client.AppsV1().Deployments(r.Namespace).Create(&deploy)
 		if err != nil {
 			return ctrl.Result{}, err

--- a/internal/peering-request-operator/setup.go
+++ b/internal/peering-request-operator/setup.go
@@ -20,7 +20,7 @@ func init() {
 	// +kubebuilder:scaffold:scheme
 }
 
-func StartOperator(namespace string, configMapName string, broadcasterImage string) {
+func StartOperator(namespace string, configMapName string, broadcasterImage string, broadcasterServiceAccount string) {
 	log := ctrl.Log.WithName("controllers").WithName("PeeringRequest")
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
@@ -55,12 +55,13 @@ func StartOperator(namespace string, configMapName string, broadcasterImage stri
 		Log:    log,
 		Scheme: mgr.GetScheme(),
 
-		client:           client,
-		discoveryClient:  discoveryClient,
-		Namespace:        namespace,
-		clusterId:        clusterId,
-		configMapName:    configMapName,
-		broadcasterImage: broadcasterImage,
+		client:                    client,
+		discoveryClient:           discoveryClient,
+		Namespace:                 namespace,
+		clusterId:                 clusterId,
+		configMapName:             configMapName,
+		broadcasterImage:          broadcasterImage,
+		broadcasterServiceAccount: broadcasterServiceAccount,
 	}).SetupWithManager(mgr); err != nil {
 		log.Error(err, "unable to create controller")
 		os.Exit(1)


### PR DESCRIPTION
# Description

Add ServiceAccount name parameter in peering-request-operator that is used in new broadcaster deployments
