### PR TITLE
Modified HomeClusterId for VK

### DIFF
--- a/deployments/liqo_chart/subcharts/adv_chart/templates/adv-deploy.yaml
+++ b/deployments/liqo_chart/subcharts/adv_chart/templates/adv-deploy.yaml
@@ -65,8 +65,8 @@ spec:
           - name: CLUSTER_ID
             valueFrom:
               configMapKeyRef:
-                name: {{ .Values.global.configmapName }}
-                key: clusterID
+                name: cluster-id
+                key: cluster-id
           - name: LOCAL_TUNNEL_PUBLIC_IP
             valueFrom:
               configMapKeyRef:


### PR DESCRIPTION
# Description

The cluster-id taken by the advertisement controller and passed to the VirtualKubelet as `HomeClusterID` is now taken from the configMap created by the discovery module. The name of this configMap is hard-coded in `pkg/clusterID/clusterID.go` and set to `cluster-id`, if we want to parametrize we have to modify that file
