### PR TITLE
Introduce CSR Auto-approver for virtual-kubelet

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -21,6 +21,8 @@ jobs:
         - pod-mutator
         - peering-request-webhook-init
     steps:
+      - name: setup-docker
+        uses: docker-practice/actions-setup-docker@0.0.1
       - name: Check out code into the Go module directory
         uses: actions/checkout@v1
       - name: Push ${{ matrix.component }} image on repo

--- a/README.md
+++ b/README.md
@@ -74,7 +74,6 @@ curl https://raw.githubusercontent.com/LiqoTech/liqo/master/install.sh | bash
 ```
 ## Architecture
 
-
 Liqo relies on several components:
 
 * *Liqo Virtual Kubelet*: Based on [Virtual Kubelet](https://github.com/virtual-kubelet/virtual-kubelet) project, the VK

--- a/README.md
+++ b/README.md
@@ -62,14 +62,14 @@ curl https://raw.githubusercontent.com/LiqoTech/liqo/master/install.sh | bash
 K3s is a minimal Kubernetes cluster which is pretty small and easy to set up. However, it does not store its configuration in the
 way that traditional installers (e.g.; Kubedam) do. Therefore, it is required to know the configuration you entered for your cluster.
 
-After having exported your K3s Kubeconfig, you can install LIQO setting the following variables before launching the installer. The following values represent the default configuration for K3s cluster, 
-you may need to adapt them to the actual values of your cluster.
+After having exported your K3s Kubeconfig, you can install LIQO setting the following variables before launching the installer.
+The following values represent the default configuration for K3s cluster, you may need to adapt them to the actual values of your cluster.
 
 ```bash
-POD_CIDR=10.42.0.0/16
-SERVICE_CIDR=10.43.0.0/16
-GATEWAY_IP=10.0.0.31
-GATEWAY_PRIVATE_IP=192.168.100.1
+export POD_CIDR=10.42.0.0/16
+export SERVICE_CIDR=10.43.0.0/16
+export GATEWAY_IP=10.0.0.31
+export GATEWAY_PRIVATE_IP=192.168.100.1
 curl https://raw.githubusercontent.com/LiqoTech/liqo/master/install.sh | bash
 ```
 ## Architecture

--- a/config/virtual-kubelet/script.sh
+++ b/config/virtual-kubelet/script.sh
@@ -35,6 +35,8 @@ apiVersion: certificates.k8s.io/v1beta1
 kind: CertificateSigningRequest
 metadata:
   name: ${POD_NAME}
+  labels:
+     "virtual-kubelet": "true"
 spec:
   request: $(cat server.csr | base64 | tr -d '\n')
   usages:

--- a/pkg/csrApprover/csr.go
+++ b/pkg/csrApprover/csr.go
@@ -1,0 +1,57 @@
+package csrApprover
+
+import (
+	certificatesv1beta1 "k8s.io/api/certificates/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8s "k8s.io/client-go/kubernetes"
+	"k8s.io/klog"
+)
+
+func approveCSR(clientSet k8s.Interface, csr *certificatesv1beta1.CertificateSigningRequest) error {
+	// certificate already added to CSR
+	if csr.Status.Certificate != nil {
+		return nil
+	}
+	// Check if the certificate is already approved but the certificate is still not available
+	for _, b := range csr.Status.Conditions {
+		if b.Type == "Approved" {
+			return nil
+		}
+	}
+	// Approve
+	csr.Status.Conditions = append(csr.Status.Conditions, certificatesv1beta1.CertificateSigningRequestCondition{
+		Type:           certificatesv1beta1.CertificateApproved,
+		Reason:         "VirtualKubeletApproval",
+		Message:        "This CSR was approved by Liqo Advertisement Operator",
+		LastUpdateTime: metav1.Now(),
+	})
+	_, errApproval := clientSet.CertificatesV1beta1().CertificateSigningRequests().UpdateApproval(csr)
+	if errApproval != nil {
+		return errApproval
+	}
+	return nil
+}
+
+func WatchCSR(clientset k8s.Interface, label string) {
+	watch, err := clientset.CertificatesV1beta1().CertificateSigningRequests().Watch(metav1.ListOptions{
+		LabelSelector: label,
+	})
+	if err != nil {
+		klog.Error(err)
+	}
+	go func() {
+		for event := range watch.ResultChan() {
+			csr, ok := event.Object.(*certificatesv1beta1.CertificateSigningRequest)
+			if !ok {
+				klog.Error("Unable to cast object from watch operation")
+			}
+			// Check if the certificare is already approved
+			err := approveCSR(clientset, csr)
+			if err != nil {
+				klog.Error(err)
+			}
+		}
+		watch.Stop()
+	}()
+
+}

--- a/pkg/csrApprover/csr_test.go
+++ b/pkg/csrApprover/csr_test.go
@@ -1,0 +1,43 @@
+package csrApprover
+
+import (
+	"github.com/stretchr/testify/assert"
+	certificatesv1beta1 "k8s.io/api/certificates/v1beta1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	testclient "k8s.io/client-go/kubernetes/fake"
+	"testing"
+)
+
+func TestNewNamespaceWithSuffix(t *testing.T) {
+	//setup
+	certificateToValidate := certificatesv1beta1.CertificateSigningRequest{
+		TypeMeta: v1.TypeMeta{},
+		ObjectMeta: v1.ObjectMeta{
+			Name: "to_validate",
+			Labels: map[string]string{
+				"virtual-kubelet": "true",
+			},
+		},
+		Spec:   certificatesv1beta1.CertificateSigningRequestSpec{},
+		Status: certificatesv1beta1.CertificateSigningRequestStatus{},
+	}
+
+	c := testclient.NewSimpleClientset()
+	_, err := c.CertificatesV1beta1().CertificateSigningRequests().Create(&certificateToValidate)
+	if err != nil {
+		t.Fail()
+	}
+	err = approveCSR(c, &certificateToValidate)
+	if err != nil {
+		t.Fail()
+	}
+	cert, err := c.CertificatesV1beta1().CertificateSigningRequests().Get("to_validate", v1.GetOptions{})
+	if err != nil {
+		t.Fail()
+	}
+	assert.NotEmpty(t, cert.Status.Conditions)
+	conditions := cert.Status.Conditions
+	assert.Equal(t, conditions[0].Type, certificatesv1beta1.CertificateApproved)
+	assert.Equal(t, conditions[0].Reason, "VirtualKubeletApproval")
+	assert.Equal(t, conditions[0].Message, "This CSR was approved by Liqo Advertisement Operator")
+}

--- a/test/kind/adv-deploy.yaml
+++ b/test/kind/adv-deploy.yaml
@@ -58,10 +58,6 @@ spec:
         args:
           - "--cluster-id"
           - "$(CLUSTER_ID)"
-          - "--gateway-ip"
-          - "$(LOCAL_TUNNEL_PUBLIC_IP)"
-          - "--gateway-private-ip"
-          - "$(LOCAL_TUNNEL_PRIVATE_IP)"
           - "--run-in-kind"
         env:
           - name: CLUSTER_ID


### PR DESCRIPTION
# Description

This commit adds a CSR-approve routine in Advertisement Operator
main function in order to auto-approve CSR coming from the virtual-kubelet.

(to-do): So far, the advertisement operator simply checks if a label is put on the
CSR, in future we will add some more accurate checks.

# How Has This Been Tested?

- [x] Test auto-approve of a virtual-kubelet issued CSR
- [x] Test ignore of other CSRs
