### PR TITLE
Virtual kubelet logging and node update structure

### DIFF
--- a/cmd/virtual-kubelet/internal/commands/root/http.go
+++ b/cmd/virtual-kubelet/internal/commands/root/http.go
@@ -19,12 +19,12 @@ import (
 	"crypto/tls"
 	"fmt"
 	"io"
+	"k8s.io/klog"
 	"net"
 	"net/http"
 	"os"
 
 	"github.com/liqoTech/liqo/cmd/virtual-kubelet/internal/provider"
-	"github.com/liqoTech/liqo/internal/log"
 	"github.com/liqoTech/liqo/internal/node/api"
 	"github.com/pkg/errors"
 )
@@ -71,10 +71,7 @@ func setupHTTPServer(ctx context.Context, p provider.Provider, cfg *apiServerCon
 	}()
 
 	if cfg.CertPath == "" || cfg.KeyPath == "" {
-		log.G(ctx).
-			WithField("certPath", cfg.CertPath).
-			WithField("keyPath", cfg.KeyPath).
-			Error("TLS certificates not provided, not setting up pod http server")
+		klog.Error("TLS certificates not provided, not setting up pod http server")
 	} else {
 		tlsCfg, err := loadTLSConfig(cfg.CertPath, cfg.KeyPath)
 		if err != nil {
@@ -103,7 +100,7 @@ func setupHTTPServer(ctx context.Context, p provider.Provider, cfg *apiServerCon
 	}
 
 	if cfg.MetricsAddr == "" {
-		log.G(ctx).Info("Pod metrics server not setup due to empty metrics address")
+		klog.Info("Pod metrics server not setup due to empty metrics address")
 	} else {
 		l, err := net.Listen("tcp", cfg.MetricsAddr)
 		if err != nil {
@@ -135,7 +132,8 @@ func serveHTTP(ctx context.Context, s *http.Server, l net.Listener, name string)
 		select {
 		case <-ctx.Done():
 		default:
-			log.G(ctx).WithError(err).Errorf("Error setting up %s http server", name)
+			klog.Error(err)
+
 		}
 	}
 	l.Close()

--- a/cmd/virtual-kubelet/internal/provider/provider.go
+++ b/cmd/virtual-kubelet/internal/provider/provider.go
@@ -30,6 +30,8 @@ type Provider interface {
 	ConfigureNode(context.Context, *v1.Node)
 
 	ConfigureReflection() error
+
+	StartNodeUpdater(nodeRunner *node.NodeController) (chan struct{}, chan struct{}, error)
 }
 
 // PodMetricsProvider is an optional interface that providers can implement to expose pod stats

--- a/internal/kubernetes/configMap.go
+++ b/internal/kubernetes/configMap.go
@@ -16,7 +16,7 @@ func (p *KubernetesProvider) manageCmEvent(event watch.Event) error {
 	if !ok {
 		return errors.New("cannot cast object to configMap")
 	}
-	klog.V(3).Info("received %v on configmap %v", event.Type, cm.Name)
+	klog.V(3).Infof("received %v on configmap %v", event.Type, cm.Name)
 
 	nattedNS, err := p.NatNamespace(cm.Namespace, false)
 	if err != nil {
@@ -32,7 +32,7 @@ func (p *KubernetesProvider) manageCmEvent(event watch.Event) error {
 			if err = CreateConfigMap(p.foreignClient.Client(), cm, nattedNS); err != nil {
 				klog.Error(err, "unable to create configMap "+cm.Name+" on cluster "+p.foreignClusterId)
 			} else {
-				klog.Info("correctly created configMap " + cm.Name + " on cluster " + p.foreignClusterId)
+				klog.V(3).Infof("correctly created configMap %v on cluster %v", cm.Name, p.foreignClusterId)
 			}
 		}
 
@@ -40,14 +40,14 @@ func (p *KubernetesProvider) manageCmEvent(event watch.Event) error {
 		if err = UpdateConfigMap(p.foreignClient.Client(), cm, nattedNS); err != nil {
 			klog.Error(err, "unable to update configMap "+cm.Name+" on cluster "+p.foreignClusterId)
 		} else {
-			klog.Infof("correctly updated configMap %v on cluster %v", cm.Name, p.foreignClusterId)
+			klog.V(3).Infof("correctly updated configMap %v on cluster %v", cm.Name, p.foreignClusterId)
 		}
 
 	case watch.Deleted:
 		if err = DeleteConfigMap(p.foreignClient.Client(), cm, nattedNS); err != nil {
 			klog.Error(err, "unable to delete configMap "+cm.Name+" on cluster "+p.foreignClusterId)
 		} else {
-			klog.Infof("correctly deleted configMap %v on cluster %v", cm.Name, p.foreignClusterId)
+			klog.V(3).Infof("correctly deleted configMap %v on cluster %v", cm.Name, p.foreignClusterId)
 		}
 	}
 	return nil

--- a/internal/kubernetes/endpoints.go
+++ b/internal/kubernetes/endpoints.go
@@ -5,6 +5,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/klog"
 	"strconv"
 )
 
@@ -13,6 +14,7 @@ func (p *KubernetesProvider) manageRemoteEpEvent(event watch.Event) error {
 	if !ok {
 		return errors.New("cannot cast endpoints")
 	}
+	klog.V(3).Info("received %v on endpoint %v", event.Type, foreignEps.Name)
 
 	denattedNS, err := p.DeNatNamespace(foreignEps.Namespace)
 	if err != nil {
@@ -37,6 +39,7 @@ func (p *KubernetesProvider) manageEpEvent(event timestampedEvent) error {
 	if !ok {
 		return errors.New("cannot cast object to endpoint")
 	}
+	klog.V(3).Info("received %v on endpoint %v", event.event.Type, endpoints.Name)
 
 	nattedNS, err := p.NatNamespace(endpoints.Namespace, false)
 	if err != nil {

--- a/internal/kubernetes/endpoints.go
+++ b/internal/kubernetes/endpoints.go
@@ -14,7 +14,7 @@ func (p *KubernetesProvider) manageRemoteEpEvent(event watch.Event) error {
 	if !ok {
 		return errors.New("cannot cast endpoints")
 	}
-	klog.V(3).Info("received %v on endpoint %v", event.Type, foreignEps.Name)
+	klog.V(3).Infof("received %v on endpoint %v", event.Type, foreignEps.Name)
 
 	denattedNS, err := p.DeNatNamespace(foreignEps.Namespace)
 	if err != nil {
@@ -39,7 +39,7 @@ func (p *KubernetesProvider) manageEpEvent(event timestampedEvent) error {
 	if !ok {
 		return errors.New("cannot cast object to endpoint")
 	}
-	klog.V(3).Info("received %v on endpoint %v", event.event.Type, endpoints.Name)
+	klog.V(3).Infof("received %v on endpoint %v", event.event.Type, endpoints.Name)
 
 	nattedNS, err := p.NatNamespace(endpoints.Namespace, false)
 	if err != nil {

--- a/internal/kubernetes/kubernetes.go
+++ b/internal/kubernetes/kubernetes.go
@@ -1,7 +1,6 @@
 package kubernetes
 
 import (
-	"github.com/go-logr/logr"
 	protocolv1 "github.com/liqoTech/liqo/api/advertisement-operator/v1"
 	nattingv1 "github.com/liqoTech/liqo/api/namespaceNattingTable/v1"
 	"github.com/liqoTech/liqo/internal/node"
@@ -45,8 +44,6 @@ type KubernetesProvider struct { // nolint:golint]
 	RemappedPodCidr    string
 
 	foreignPodWatcherStop chan bool
-
-	log logr.Logger
 }
 
 // NewKubernetesProviderKubernetesConfig creates a new KubernetesV0Provider. Kubernetes legacy provider does not implement the new asynchronous podnotifier interface

--- a/internal/kubernetes/secret.go
+++ b/internal/kubernetes/secret.go
@@ -16,6 +16,7 @@ func (p *KubernetesProvider) manageSecEvent(event watch.Event) error {
 	if !ok {
 		return errors.New("cannot cast object to secret")
 	}
+	klog.V(3).Info("received %v on secret %v", event.Type, sec.Name)
 
 	nattedNS, err := p.NatNamespace(sec.Namespace, false)
 	if err != nil {
@@ -26,12 +27,12 @@ func (p *KubernetesProvider) manageSecEvent(event watch.Event) error {
 	case watch.Added:
 		_, err := p.foreignClient.Client().CoreV1().Secrets(nattedNS).Get(sec.Name, metav1.GetOptions{})
 		if err != nil {
-			klog.Info("remote secret " + sec.Name + " doesn't exist: creating it")
+			klog.V(5).Info("remote secret " + sec.Name + " doesn't exist: creating it")
 
 			if err = CreateSecret(p.foreignClient.Client(), sec, nattedNS); err != nil {
 				klog.Error(err, "unable to create secret "+sec.Name+" on cluster "+p.foreignClusterId)
 			} else {
-				klog.Info("correctly created secret " + sec.Name + " on cluster " + p.foreignClusterId)
+				klog.V(5).Info("correctly created secret " + sec.Name + " on cluster " + p.foreignClusterId)
 			}
 		}
 
@@ -39,14 +40,14 @@ func (p *KubernetesProvider) manageSecEvent(event watch.Event) error {
 		if err = UpdateSecret(p.foreignClient.Client(), sec, nattedNS); err != nil {
 			klog.Error(err, "unable to update secret "+sec.Name+" on cluster "+p.foreignClusterId)
 		} else {
-			klog.Info("correctly updated secret " + sec.Name + " on cluster " + p.foreignClusterId)
+			klog.V(5).Info("correctly updated secret " + sec.Name + " on cluster " + p.foreignClusterId)
 		}
 
 	case watch.Deleted:
 		if err = DeleteSecret(p.foreignClient.Client(), sec, nattedNS); err != nil {
 			klog.Error(err, "unable to delete secret "+sec.Name+" on cluster "+p.foreignClusterId)
 		} else {
-			klog.Info("correctly deleted secret " + sec.Name + " on cluster " + p.foreignClusterId)
+			klog.V(5).Info("correctly deleted secret " + sec.Name + " on cluster " + p.foreignClusterId)
 		}
 	}
 	return nil

--- a/internal/kubernetes/secret.go
+++ b/internal/kubernetes/secret.go
@@ -16,7 +16,7 @@ func (p *KubernetesProvider) manageSecEvent(event watch.Event) error {
 	if !ok {
 		return errors.New("cannot cast object to secret")
 	}
-	klog.V(3).Info("received %v on secret %v", event.Type, sec.Name)
+	klog.V(3).Infof("received %v on secret %v", event.Type, sec.Name)
 
 	nattedNS, err := p.NatNamespace(sec.Namespace, false)
 	if err != nil {

--- a/internal/kubernetes/service.go
+++ b/internal/kubernetes/service.go
@@ -16,7 +16,7 @@ func (p *KubernetesProvider) manageSvcEvent(event watch.Event) error {
 	if !ok {
 		return errors.New("cannot cast object to service")
 	}
-	klog.V(3).Info("received %v on service %v", event.Type, svc.Name)
+	klog.V(3).Infof("received %v on service %v", event.Type, svc.Name)
 
 	nattedNS, err := p.NatNamespace(svc.Namespace, false)
 	if err != nil {

--- a/internal/kubernetes/service.go
+++ b/internal/kubernetes/service.go
@@ -16,6 +16,7 @@ func (p *KubernetesProvider) manageSvcEvent(event watch.Event) error {
 	if !ok {
 		return errors.New("cannot cast object to service")
 	}
+	klog.V(3).Info("received %v on service %v", event.Type, svc.Name)
 
 	nattedNS, err := p.NatNamespace(svc.Namespace, false)
 	if err != nil {

--- a/internal/manager/resource.go
+++ b/internal/manager/resource.go
@@ -18,8 +18,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	corev1listers "k8s.io/client-go/listers/core/v1"
-
-	"github.com/liqoTech/liqo/internal/log"
+	"k8s.io/klog"
 )
 
 // ResourceManager acts as a passthrough to a cache (lister) for pods assigned to the current node.
@@ -48,7 +47,7 @@ func (rm *ResourceManager) GetPods() []*v1.Pod {
 	if err == nil {
 		return l
 	}
-	log.L.Errorf("failed to fetch pods from lister: %v", err)
+	klog.Errorf("failed to fetch pods from lister: %v", err)
 	return make([]*v1.Pod, 0)
 }
 

--- a/internal/node/env.go
+++ b/internal/node/env.go
@@ -17,6 +17,8 @@ package node
 import (
 	"context"
 	"fmt"
+	"github.com/liqoTech/liqo/internal/log"
+	"k8s.io/klog"
 	"sort"
 	"strings"
 
@@ -28,7 +30,6 @@ import (
 	fieldpath "k8s.io/kubernetes/pkg/fieldpath"
 	"k8s.io/kubernetes/third_party/forked/golang/expansion"
 
-	"github.com/liqoTech/liqo/internal/log"
 	"github.com/liqoTech/liqo/internal/manager"
 )
 
@@ -139,7 +140,7 @@ loop:
 					if errors.IsNotFound(err) {
 						recorder.Eventf(pod, corev1.EventTypeWarning, ReasonOptionalConfigMapNotFound, "configmap %q not found", ef.Name)
 					} else {
-						log.G(ctx).Warnf("failed to read configmap %q: %v", ef.Name, err)
+						klog.Warningf("failed to read configmap %q: %v", ef.Name, err)
 						recorder.Eventf(pod, corev1.EventTypeWarning, ReasonFailedToReadOptionalConfigMap, "failed to read configmap %q", ef.Name)
 					}
 					// Continue on to the next reference.

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -330,11 +330,11 @@ func (n *NodeController) updateLease(ctx context.Context) error {
 	return nil
 }
 
-func (n *NodeController) UpdateNodeFromOutside(ctx context.Context, skipErrorCb bool, no *corev1.Node) error {
+func (n *NodeController) UpdateNodeFromOutside(skipErrorCb bool, no *corev1.Node) error {
 
 	n.n = no
 
-	return n.updateStatus(ctx, skipErrorCb)
+	return n.updateStatus(context.Background(), skipErrorCb)
 }
 
 func (n *NodeController) updateStatus(ctx context.Context, skipErrorCb bool) error {

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -18,10 +18,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/liqoTech/liqo/internal/log"
+	"k8s.io/klog"
 	"sync"
 	"time"
 
-	"github.com/liqoTech/liqo/internal/log"
 	"github.com/liqoTech/liqo/internal/trace"
 	pkgerrors "github.com/pkg/errors"
 	coord "k8s.io/api/coordination/v1beta1"
@@ -210,7 +211,7 @@ func (n *NodeController) Run(ctx context.Context) error {
 		if !errors.IsNotFound(err) {
 			return pkgerrors.Wrap(err, "error creating node lease")
 		}
-		log.G(ctx).Info("Node leases not supported, falling back to only node status updates")
+		klog.Info("Node leases not supported, falling back to only node status updates")
 		n.disableLease = true
 	}
 	n.lease = l

--- a/internal/node/pod.go
+++ b/internal/node/pod.go
@@ -34,13 +34,7 @@ const (
 )
 
 func addPodAttributes(ctx context.Context, span trace.Span, pod *corev1.Pod) context.Context {
-	return span.WithFields(ctx, log.Fields{
-		"uid":       string(pod.GetUID()),
-		"namespace": pod.GetNamespace(),
-		"name":      pod.GetName(),
-		"phase":     string(pod.Status.Phase),
-		"reason":    pod.Status.Reason,
-	})
+	return span.WithFields(ctx, nil)
 }
 
 func (pc *PodController) createOrUpdatePod(ctx context.Context, pod *corev1.Pod) error {

--- a/internal/node/queue.go
+++ b/internal/node/queue.go
@@ -39,10 +39,10 @@ func handleQueueItem(ctx context.Context, q workqueue.RateLimitingInterface, han
 		return false
 	}
 
-	klog.Info("Got queue object")
+	klog.V(5).Info("Got queue object")
 
 	err := func(obj interface{}) error {
-		defer klog.Info("Processed queue item")
+		defer klog.V(5).Info("Processed queue item")
 		// We call Done here so the work queue knows we have finished processing this item.
 		// We also must remember to call Forget if we do not want this work item being re-queued.
 		// For example, we do not call Forget if a transient error occurs.

--- a/internal/node/sync.go
+++ b/internal/node/sync.go
@@ -2,11 +2,12 @@ package node
 
 import (
 	"context"
+	"github.com/liqoTech/liqo/internal/log"
+	"k8s.io/klog"
 	"sync"
 	"time"
 
 	"github.com/liqoTech/liqo/internal/errdefs"
-	"github.com/liqoTech/liqo/internal/log"
 	"github.com/liqoTech/liqo/internal/trace"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -48,7 +49,7 @@ func (p *syncProviderWrapper) NotifyPods(ctx context.Context, f func(*corev1.Pod
 }
 
 func (p *syncProviderWrapper) _deletePodKey(ctx context.Context, key string) {
-	log.G(ctx).WithField("key", key).Debug("Cleaning up pod from deletion cache")
+	klog.V(4).Info("Cleaning up pod from deletion cache")
 	p.deletedPods.Delete(key)
 }
 


### PR DESCRIPTION
# Description

This PR addresses two main features:

1. **logging**: The first commit is complementary to #36, where `zapr.logger` was been replaced by klog as the logging interface. In this PR the logging is improved in density and precision. It has been made wide use of `klog.V(x).Info` function, in order to make the logging verbosity customizable at runtime (very useful especially when debugging)

2. **node updater**: The second commit replaces the node updater (previously implemented with kubebuilder) with a new version making use of liqo custom crd client.