### PR TITLE
Add Dependabot to look for vulnerable libraries

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
This PR adds dependabot checks to Liqo. Dependabot will keep track of dependencies, proposing PR if a vulnerable variable is found among the dependencies.