### PR TITLE
Bump Ubuntu version of the Runner to 20.04

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,7 +2,7 @@ name: Go
 on: [push]
 jobs:
    build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
@@ -55,7 +55,7 @@ jobs:
         if: always() && github.ref == 'refs/heads/master' # Pick up events even if the job fails or is canceled.
    test:
     name: Test Launch
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - name: Set up Go 1.13
       uses: actions/setup-go@v2

--- a/.github/workflows/golint.yml
+++ b/.github/workflows/golint.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   golangci:
     name: lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Install dependencies

--- a/build/tray-agent/Dockerfile
+++ b/build/tray-agent/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04 as builder
+FROM liqo/runner as builder
 #install required dependencies
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get -y install gcc tar wget libgtk-3-dev libappindicator3-dev \


### PR DESCRIPTION
# Description

This PR bumps the version of Github Actions runner to 20.04. This would prevent random failures occured while building in 18.04

# How Has This Been Tested?

The CI pipelines of this PR are used as validation.
