### PR TITLE
Add new linter and CI checks 

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           ref: "${{ env.commit_ref }}"
-      - name: Push ${{ matrix.component }} image on repo
+      - name: Push ${{ matrix.component }} image on repo (Master)
         uses: elgohr/Publish-Docker-Github-Action@master
         with:
           name: liqo/${{ matrix.component }}
@@ -47,7 +47,7 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
           tags: "latest,${{ env.commit_ref }}"
         if: github.ref == 'refs/heads/master' && github.event.pull_request.head.repo.full_name == 'liqotech/liqo'
-      - name: Push ${{ matrix.component }} image on repo
+      - name: Push ${{ matrix.component }} image on repo (Development)
         uses: elgohr/Publish-Docker-Github-Action@master
         with:
           name: liqo/${{ matrix.component }}-ci
@@ -56,7 +56,7 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
           tags: "${{ env.commit_ref }}"
         if: github.ref != 'refs/heads/master' && github.event.pull_request.head.repo.full_name == 'liqotech/liqo'
-      - name: Build Only ${{ matrix.component }} image
+      - name: Build Only ${{ matrix.component }} image (Forked Repositories)
         uses: docker/build-push-action@v1
         with:
           name: liqo/${{ matrix.component }}-ci

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -46,7 +46,7 @@ jobs:
           dockerfile: build/${{ matrix.component }}/Dockerfile
           password: ${{ secrets.DOCKER_PASSWORD }}
           tags: "latest,${{ env.commit_ref }}"
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/master' && github.event.pull_request.head.repo.full_name == 'liqotech/liqo'
       - name: Push ${{ matrix.component }} image on repo
         uses: elgohr/Publish-Docker-Github-Action@master
         with:
@@ -55,7 +55,14 @@ jobs:
           dockerfile: build/${{ matrix.component }}/Dockerfile
           password: ${{ secrets.DOCKER_PASSWORD }}
           tags: "${{ env.commit_ref }}"
-        if: github.ref != 'refs/heads/master'
+        if: github.ref != 'refs/heads/master' && github.event.pull_request.head.repo.full_name == 'liqotech/liqo'
+      - name: Build Only ${{ matrix.component }} image
+        uses: docker/build-push-action@v1
+        with:
+          name: liqo/${{ matrix.component }}-ci
+          dockerfile: build/${{ matrix.component }}/Dockerfile
+          push: false
+        if: github.ref != 'refs/heads/master' && github.event.pull_request.head.repo.full_name != 'liqotech/liqo'
   e2e-test-trigger:
      runs-on: ubuntu-latest
      needs: [build, test]

--- a/.github/workflows/golint.yml
+++ b/.github/workflows/golint.yml
@@ -19,20 +19,4 @@ jobs:
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
           version: v1.26
-          args: --timeout=600s -D unused,structcheck
-  fmt:
-    name: Check Code Format
-    runs-on: ubuntu-latest
-    steps:
-    - name: Set up Go 1.13
-      uses: actions/setup-go@v2
-      with:
-        go-version: 1.13
-      id: go
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
-    - name: Go Fmt Check
-      run: |
-         changed=$(go fmt ./... | wc -l)
-         if [ $changed == 0 ]; then exit 0; else exit 1; fi 
-
+          args: --timeout=600s -D unused,structcheck -E gosec,prealloc,gofmt,govet --skip-files "zz_generated.*.go"

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 Liqo is a framework to enable dynamic sharing across Kubernetes Clusters. You can run your pods on a remote cluster
 seamlessly, without any modification (Kubernetes or your application). 
 
+#What is Liqo?
+
 Differently from the [Kubernetes Federation](https://github.com/kubernetes-sigs/kubefed) and the
 [Admiralty](https://admiralty.io/) project, Liqo is designed to handle dynamic, temporary
 resource sharing across multi-owner clusters and targets every type of computing resources (e.g. Raspberry PI, 
@@ -57,7 +59,7 @@ Liqo Installer should be capable to look for the cluster parameters required.
 curl https://raw.githubusercontent.com/LiqoTech/liqo/master/install.sh | bash
 ```
 
-#### [K3s](k3s.io)
+#### [K3s](https://k3s.io)
 
 K3s is a minimal Kubernetes cluster which is pretty small and easy to set up. However, it does not store its configuration in the
 way that traditional installers (e.g.; Kubeadm) do. Therefore, it is required to know the configuration you entered for your cluster.

--- a/README.md
+++ b/README.md
@@ -1,17 +1,21 @@
+<p align="center">
+<img alt="Liqo Logo" src="https://doc.liqo.io/images/logo-liqo-blue.svg" />
+</p>
+
+# Liqo
+
 ![Go](https://github.com/liqoTech/liqo/workflows/Go/badge.svg) 
 [![Coverage Status](https://coveralls.io/repos/github/LiqoTech/liqo/badge.svg?branch=master)](https://coveralls.io/github/LiqoTech/liqo?branch=master)
 [![Go Report Card](https://goreportcard.com/badge/github.com/LiqoTech/liqo)](https://goreportcard.com/report/github.com/LiqoTech/liqo)
-# Liqo
 
 Liqo is a framework to enable dynamic sharing across Kubernetes Clusters. You can run your pods on a remote cluster
 seamlessly, without any modification (Kubernetes or your application). 
 
-#What is Liqo?
+Liqo is an open source project started at Politecnico of Turin that allows Kubernetes to seamlessly and securely share resources and services, so you can run your tasks on any other cluster available nearby.
 
-Differently from the [Kubernetes Federation](https://github.com/kubernetes-sigs/kubefed) and the
-[Admiralty](https://admiralty.io/) project, Liqo is designed to handle dynamic, temporary
-resource sharing across multi-owner clusters and targets every type of computing resources (e.g. Raspberry PI, 
-Desktop PCs, Servers).
+Thanks to the support for K3s, also single machines can participate,creating dynamic, opportunistic data centers that include commodity desktop computers and laptops as well.
+
+Liqo leverages the same highly successful “peering” model of the Internet, without any central point of control. New peering relationships can be established dynamically, whenever needed, even automatically. Cluster auto-discovery can further simplify this process.
 
 ## Features
 

--- a/cmd/virtual-kubelet/internal/commands/root/opts.go
+++ b/cmd/virtual-kubelet/internal/commands/root/opts.go
@@ -123,7 +123,7 @@ func SetDefaultOpts(c *Opts) error {
 
 	if c.ListenPort == 0 {
 		if kp := os.Getenv("KUBELET_PORT"); kp != "" {
-			p, err := strconv.Atoi(kp)
+			p, err := strconv.ParseInt(kp, 10, 32)
 			if err != nil {
 				return errors.Wrap(err, "error parsing KUBELET_PORT environment variable")
 			}

--- a/cmd/virtual-kubelet/internal/provider/mock/mock.go
+++ b/cmd/virtual-kubelet/internal/provider/mock/mock.go
@@ -320,8 +320,7 @@ func (p *MockProvider) GetPods(ctx context.Context) ([]*v1.Pod, error) {
 	defer span.End()
 
 	log.G(ctx).Info("receive GetPods")
-
-	var pods []*v1.Pod
+	pods := make([]*v1.Pod, 0, len(p.pods))
 
 	for _, pod := range p.pods {
 		pods = append(pods, pod)

--- a/internal/advertisement-operator/broadcaster.go
+++ b/internal/advertisement-operator/broadcaster.go
@@ -381,7 +381,8 @@ func GetAllPodsResources(nodeNonTerminatedPodsList *corev1.PodList) (requests co
 
 func getPodsTotalRequestsAndLimits(podList *corev1.PodList) (reqs map[corev1.ResourceName]resource.Quantity, limits map[corev1.ResourceName]resource.Quantity) {
 	reqs, limits = map[corev1.ResourceName]resource.Quantity{}, map[corev1.ResourceName]resource.Quantity{}
-	for _, pod := range podList.Items {
+	for i := range podList.Items {
+		pod := podList.Items[i]
 		podReqs, podLimits := resourcehelper.PodRequestsAndLimits(&pod)
 		for podReqName, podReqValue := range podReqs {
 			if value, ok := reqs[podReqName]; !ok {

--- a/internal/advertisement-operator/config-watcher.go
+++ b/internal/advertisement-operator/config-watcher.go
@@ -70,7 +70,8 @@ func (r *AdvertisementReconciler) WatchConfiguration(kubeconfigPath string) {
 				return
 			}
 			if updateFlag {
-				for _, adv := range advList.Items {
+				for i := range advList.Items {
+					adv := advList.Items[i]
 					r.UpdateAdvertisement(&adv)
 				}
 			}

--- a/internal/advertisement-operator/controller.go
+++ b/internal/advertisement-operator/controller.go
@@ -276,7 +276,8 @@ func (r *AdvertisementReconciler) cleanOldAdvertisements() {
 			klog.Error(err)
 			continue
 		}
-		for _, adv := range advList.Items {
+		for i := range advList.Items {
+			adv := advList.Items[i]
 			now := metav1.NewTime(time.Now())
 			if adv.Spec.TimeToLive.Before(now.DeepCopy()) {
 				if err := r.Client.Delete(context.Background(), &adv, &client.DeleteOptions{}); err != nil {

--- a/internal/discovery/foreign.go
+++ b/internal/discovery/foreign.go
@@ -79,7 +79,8 @@ func (discovery *DiscoveryCtrl) UpdateTtl(txts []*TxtData) error {
 		klog.Error(err, err.Error())
 		return err
 	}
-	for _, fc := range fcs.Items {
+	for i := range fcs.Items {
+		fc := fcs.Items[i]
 		// find the ones that are not in the last retrieved list on LAN
 		found := false
 		for _, txt := range txts {

--- a/internal/discovery/register.go
+++ b/internal/discovery/register.go
@@ -71,7 +71,7 @@ func (discovery *DiscoveryCtrl) getPodNets() ([]*net.IPNet, error) {
 	if err != nil {
 		return nil, err
 	}
-	var res []*net.IPNet
+	res := make([]*net.IPNet, 0, len(nodes.Items))
 	for _, n := range nodes.Items {
 		_, ipnet, err := net.ParseCIDR(n.Spec.PodCIDR)
 		if err != nil {

--- a/internal/kubernetes/endpoints.go
+++ b/internal/kubernetes/endpoints.go
@@ -214,7 +214,8 @@ func (p *KubernetesProvider) newHomeEpCache(c kubernetes.Interface, namespace st
 		if err != nil {
 			return eps, err
 		}
-		for _, ep := range eps.Items {
+		for k := range eps.Items {
+			ep := eps.Items[k]
 			p.epEvent <- timestampedEndpoints{
 				ep: &ep,
 				t:  time.Now(),

--- a/internal/kubernetes/mutation.go
+++ b/internal/kubernetes/mutation.go
@@ -68,9 +68,9 @@ func H2FTranslate(pod *v1.Pod, nattedNS string) *v1.Pod {
 		NodeAffinity: &v1.NodeAffinity{
 			RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
 				NodeSelectorTerms: []v1.NodeSelectorTerm{
-					v1.NodeSelectorTerm{
+					{
 						MatchExpressions: []v1.NodeSelectorRequirement{
-							v1.NodeSelectorRequirement{
+							{
 								Key:      "type",
 								Operator: v1.NodeSelectorOpNotIn,
 								Values:   []string{"virtual-node"},

--- a/internal/kubernetes/pod.go
+++ b/internal/kubernetes/pod.go
@@ -269,7 +269,8 @@ func (p *KubernetesProvider) GetPods(ctx context.Context) ([]*v1.Pod, error) {
 			return nil, errors.Wrap(err, "Unable to get pods")
 		}
 
-		for _, pod := range podsForeignIn.Items {
+		for i := range podsForeignIn.Items {
+			pod := podsForeignIn.Items[i]
 			podsHomeOut = append(podsHomeOut, H2FTranslate(&pod, k))
 		}
 	}

--- a/pkg/crdClient/fakeInformerMethods.go
+++ b/pkg/crdClient/fakeInformerMethods.go
@@ -88,7 +88,7 @@ func (i *fakeInformer) DeleteFake(obj interface{}) error {
 
 func (i *fakeInformer) ListFake() []interface{} {
 	i.lock.Lock()
-	var items []interface{}
+	items := make([]interface{}, 0, len(i.data))
 	for _, v := range i.data {
 		items = append(items, v)
 	}

--- a/pkg/liqonet/overlay_network.go
+++ b/pkg/liqonet/overlay_network.go
@@ -103,7 +103,7 @@ func Enable_rp_filter() error {
 	for index := range ifaces_list {
 		if ifaces_list[index].Type() == "vxlan" {
 			// Enable loose mode reverse path filtering on the vxlan interface.
-			err = ioutil.WriteFile("/proc/sys/net/ipv4/conf/"+ifaces_list[index].Attrs().Name+"/rp_filter", []byte("2"), 0644)
+			err = ioutil.WriteFile("/proc/sys/net/ipv4/conf/"+ifaces_list[index].Attrs().Name+"/rp_filter", []byte("2"), 0600)
 			if err != nil {
 				return fmt.Errorf("unable to update vxlan rp_filter proc entry for interface %s, err: %s", ifaces_list[index].Attrs().Name, err)
 			}


### PR DESCRIPTION
# Description

This PRs hardens the amount of linting checks performed on Liqo Code and add a CI check runnable for forked PRs.

It adds:
* [gosec](https://github.com/securego/gosec)
* [goimports](https://pkg.go.dev/golang.org/x/tools/cmd/goimports?tab=doc)
* [prealloc](https://github.com/alexkohler/prealloc)
* [godot](https://github.com/tetafro/godot)