### PR TITLE
Add default ClusterConfig

### DIFF
--- a/deployments/liqo_chart/templates/clusterconfig.yaml
+++ b/deployments/liqo_chart/templates/clusterconfig.yaml
@@ -1,0 +1,8 @@
+apiVersion: policy.liqo.io/v1
+kind: ClusterConfig
+metadata:
+  name: configuration
+spec:
+  autoAccept: true
+  maxAcceptableAdvertisement: 5
+  resourceSharingPercentage: 30


### PR DESCRIPTION
# Description

This PR adds to the chart HELM a default clusterConfig to enable fast one-click cluster addition.