### PR TITLE
Requeue ForeignCluster reconciliations

### DIFF
--- a/cmd/discovery/main.go
+++ b/cmd/discovery/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"time"
 )
 
 var (
@@ -18,8 +19,10 @@ func main() {
 	mainLog.Info("Starting")
 
 	var namespace string
+	var requeueAfter int64 // seconds
 
 	flag.StringVar(&namespace, "namespace", "default", "Namespace where your configs are stored.")
+	flag.Int64Var(&requeueAfter, "requeueAfter", 30, "Period after that PeeringRequests status is rechecked (seconds)")
 	flag.Parse()
 
 	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
@@ -45,5 +48,5 @@ func main() {
 	discoveryCtl.StartDiscovery()
 
 	mainLog.Info("Starting ForeignCluster operator")
-	foreign_cluster_operator.StartOperator(namespace)
+	foreign_cluster_operator.StartOperator(namespace, time.Duration(requeueAfter)*time.Second)
 }

--- a/deployments/liqo_chart/subcharts/discovery_chart/templates/discovery-deploy.yaml
+++ b/deployments/liqo_chart/subcharts/discovery_chart/templates/discovery-deploy.yaml
@@ -47,6 +47,8 @@ spec:
           args:
           - "--namespace"
           - "$(POD_NAMESPACE)"
+          - "--requeueAfter"
+          - "30"
           env:
             - name: POD_NAMESPACE
               valueFrom:

--- a/internal/discovery/foreign-cluster-operator/setup.go
+++ b/internal/discovery/foreign-cluster-operator/setup.go
@@ -9,6 +9,7 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"os"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"time"
 )
 
 var (
@@ -22,7 +23,7 @@ func init() {
 	// +kubebuilder:scaffold:scheme
 }
 
-func StartOperator(namespace string) {
+func StartOperator(namespace string, requeueAfter time.Duration) {
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:           scheme,
 		Port:             9443,
@@ -57,6 +58,7 @@ func StartOperator(namespace string) {
 		client:          client,
 		discoveryClient: discoveryClient,
 		clusterID:       clusterId,
+		RequeueAfter:    requeueAfter,
 	}).SetupWithManager(mgr); err != nil {
 		log.Error(err, "unable to create controller", "controller", "ForeignCluster")
 		os.Exit(1)


### PR DESCRIPTION
# Description

Discovery now periodically checks if foreign PeeringRequest really exists. This will fix issue related to false reconciled ForeignCluster resources

