### PR TITLE
Periodic reconciliation of Liqo objects

### DIFF
--- a/cmd/advertisement-operator/main.go
+++ b/cmd/advertisement-operator/main.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog"
 	"os"
+	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -93,6 +94,7 @@ func main() {
 		os.Exit(1)
 	}
 
+
 	// New Client For CSR Auto-approval
 	config := ctrl.GetConfigOrDie()
 	clientset, err := kubernetes.NewForConfig(config)
@@ -131,6 +133,7 @@ func main() {
 		HomeClusterId:    clusterId,
 		AcceptedAdvNum:   acceptedAdv,
 		AdvClient:        advClient,
+		RetryTimeout:     60 * time.Second,
 	}
 
 	if err = r.SetupWithManager(mgr); err != nil {

--- a/cmd/liqonet/main.go
+++ b/cmd/liqonet/main.go
@@ -27,6 +27,7 @@ import (
 	"net"
 	"os"
 	"strconv"
+	"time"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -154,6 +155,7 @@ func main() {
 			NodeName:                           nodeName,
 			GatewayVxlanIP:                     gatewayVxlanIP,
 			ClusterPodCIDR:                     podCIDR,
+			RetryTimeout:                       30*time.Second,
 		}
 		if err = r.SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "Route")
@@ -196,6 +198,7 @@ func main() {
 				SubnetPerCluster: make(map[string]*net.IPNet),
 				Log:              ctrl.Log.WithName("IPAM"),
 			},
+			RetryTimeout:          30*time.Second,
 		}
 		if err := r.IPManager.Init(); err != nil {
 			setupLog.Error(err, "unable to initialize ipam")

--- a/cmd/liqonet/main.go
+++ b/cmd/liqonet/main.go
@@ -155,7 +155,7 @@ func main() {
 			NodeName:                           nodeName,
 			GatewayVxlanIP:                     gatewayVxlanIP,
 			ClusterPodCIDR:                     podCIDR,
-			RetryTimeout:                       30*time.Second,
+			RetryTimeout:                       30 * time.Second,
 		}
 		if err = r.SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "Route")
@@ -198,7 +198,7 @@ func main() {
 				SubnetPerCluster: make(map[string]*net.IPNet),
 				Log:              ctrl.Log.WithName("IPAM"),
 			},
-			RetryTimeout:          30*time.Second,
+			RetryTimeout: 30 * time.Second,
 		}
 		if err := r.IPManager.Init(); err != nil {
 			setupLog.Error(err, "unable to initialize ipam")

--- a/internal/advertisement-operator/broadcaster.go
+++ b/internal/advertisement-operator/broadcaster.go
@@ -33,6 +33,8 @@ type AdvertisementBroadcaster struct {
 	ForeignClusterId string
 	GatewayPrivateIP string
 	ClusterConfig    policyv1.AdvertisementConfig
+	RetryTimeout     time.Duration
+	BroadcastTimeout time.Duration
 }
 
 // start the broadcaster which sends Advertisement messages
@@ -94,7 +96,7 @@ func StartBroadcaster(homeClusterId, localKubeconfigPath, gatewayPrivateIP, peer
 		remoteClient, err = protocolv1.CreateAdvertisementClient("", secretForAdvertisementCreation)
 		if err != nil {
 			klog.Errorln(err, "Unable to create client to remote cluster "+foreignClusterId+". Retry in 1 minute")
-			time.Sleep(1 * time.Minute)
+			time.Sleep(b.RetryTimeout)
 		} else {
 			break
 		}
@@ -188,6 +190,7 @@ func (b *AdvertisementBroadcaster) GenerateAdvertisement() {
 		})
 
 		time.Sleep(10 * time.Minute)
+		time.Sleep(b.BroadcastTimeout)
 	}
 }
 

--- a/internal/advertisement-operator/broadcaster.go
+++ b/internal/advertisement-operator/broadcaster.go
@@ -96,7 +96,7 @@ func StartBroadcaster(homeClusterId, localKubeconfigPath, gatewayPrivateIP, peer
 		remoteClient, err = protocolv1.CreateAdvertisementClient("", secretForAdvertisementCreation)
 		if err != nil {
 			klog.Errorln(err, "Unable to create client to remote cluster "+foreignClusterId+". Retry in 1 minute")
-			time.Sleep(b.RetryTimeout)
+			time.Sleep(1*time.Minute)
 		} else {
 			break
 		}

--- a/internal/advertisement-operator/broadcaster.go
+++ b/internal/advertisement-operator/broadcaster.go
@@ -33,8 +33,6 @@ type AdvertisementBroadcaster struct {
 	ForeignClusterId string
 	GatewayPrivateIP string
 	ClusterConfig    policyv1.AdvertisementConfig
-	RetryTimeout     time.Duration
-	BroadcastTimeout time.Duration
 }
 
 // start the broadcaster which sends Advertisement messages
@@ -96,7 +94,7 @@ func StartBroadcaster(homeClusterId, localKubeconfigPath, gatewayPrivateIP, peer
 		remoteClient, err = protocolv1.CreateAdvertisementClient("", secretForAdvertisementCreation)
 		if err != nil {
 			klog.Errorln(err, "Unable to create client to remote cluster "+foreignClusterId+". Retry in 1 minute")
-			time.Sleep(1*time.Minute)
+			time.Sleep(1 * time.Minute)
 		} else {
 			break
 		}
@@ -172,6 +170,7 @@ func (b *AdvertisementBroadcaster) GenerateAdvertisement() {
 		physicalNodes, virtualNodes, availability, limits, images, err := b.GetResourcesForAdv()
 		if err != nil {
 			klog.Errorln(err, "Error while computing resources for Advertisement")
+			time.Sleep(1 * time.Minute)
 			continue
 		}
 
@@ -190,7 +189,6 @@ func (b *AdvertisementBroadcaster) GenerateAdvertisement() {
 		})
 
 		time.Sleep(10 * time.Minute)
-		time.Sleep(b.BroadcastTimeout)
 	}
 }
 

--- a/internal/advertisement-operator/config-watcher.go
+++ b/internal/advertisement-operator/config-watcher.go
@@ -53,7 +53,7 @@ func (r *AdvertisementReconciler) ManageConfigUpdate(configuration *policyv1.Clu
 		r.ClusterConfig = configuration.Spec.AdvertisementConfig
 		for i := 0; i < len(advList.Items); i++ {
 			adv := &advList.Items[i]
-			if adv.Status.AdvertisementStatus == "REFUSED" {
+			if adv.Status.AdvertisementStatus == AdvertisementRefused {
 				r.CheckAdvertisement(adv)
 				updateFlag = true
 			}
@@ -64,7 +64,7 @@ func (r *AdvertisementReconciler) ManageConfigUpdate(configuration *policyv1.Clu
 		if r.ClusterConfig.MaxAcceptableAdvertisement < r.AcceptedAdvNum {
 			for i := 0; i < int(r.AcceptedAdvNum-r.ClusterConfig.MaxAcceptableAdvertisement); i++ {
 				adv := advList.Items[i]
-				if adv.Status.AdvertisementStatus == "ACCEPTED" {
+				if adv.Status.AdvertisementStatus == AdvertisementAccepted {
 					err := r.AdvClient.Resource("advertisements").Delete(adv.Name, metav1.DeleteOptions{})
 					if err != nil {
 						klog.Errorln(err, "Unable to apply configuration: error deleting Advertisement "+adv.Name)

--- a/internal/liqonet/route-operator.go
+++ b/internal/liqonet/route-operator.go
@@ -74,7 +74,7 @@ type RouteController struct {
 	IPtablesRuleSpecsPerRemoteCluster map[string][]liqonetOperator.IPtableRule
 	//here we save routes associated to each remote cluster
 	RoutesPerRemoteCluster map[string][]netlink.Route
-	RetryTimeout  time.Duration
+	RetryTimeout           time.Duration
 }
 
 // +kubebuilder:rbac:groups=liqonet.liqo.io,resources=tunnelendpoints,verbs=get;list;watch;create;update;patch;delete

--- a/internal/liqonet/tunnelEndpointCreator-operator.go
+++ b/internal/liqonet/tunnelEndpointCreator-operator.go
@@ -50,7 +50,7 @@ type TunnelEndpointCreator struct {
 	FreeSubnets       map[string]*net.IPNet
 	IPManager         liqonetOperator.Ipam
 	TunnelEndpointMap map[string]types.NamespacedName
-	RetryTimeout	  time.Duration
+	RetryTimeout      time.Duration
 }
 
 // +kubebuilder:rbac:groups=protocol.liqo.io,resources=advertisements,verbs=get;list;watch;create;update;patch;delete

--- a/internal/peering-request-operator/peering-request-controller.go
+++ b/internal/peering-request-operator/peering-request-controller.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/klog"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"time"
 )
 
 // PeeringRequestReconciler reconciles a PeeringRequest object
@@ -38,6 +39,7 @@ type PeeringRequestReconciler struct {
 	configMapName             string
 	broadcasterImage          string
 	broadcasterServiceAccount string
+	retryTimeout              time.Duration
 }
 
 // +kubebuilder:rbac:groups=discovery.liqo.io,resources=peeringrequests,verbs=get;list;watch;create;update;patch;delete
@@ -52,12 +54,12 @@ func (r *PeeringRequestReconciler) Reconcile(req ctrl.Request) (ctrl.Result, err
 	if err != nil {
 		// TODO: has been removed
 		klog.Info(err, "Destroy peering")
-		return ctrl.Result{}, nil
+		return ctrl.Result{RequeueAfter: r.retryTimeout}, nil
 	}
 	pr, ok := tmp.(*discoveryv1.PeeringRequest)
 	if !ok {
 		klog.Error("loaded object is not a PeeringRequest")
-		return ctrl.Result{}, errors.New("loaded object is not a PeeringRequest")
+		return ctrl.Result{RequeueAfter: r.retryTimeout}, errors.New("loaded object is not a PeeringRequest")
 	}
 	if pr.Spec.KubeConfigRef == nil {
 		return ctrl.Result{}, nil
@@ -66,20 +68,20 @@ func (r *PeeringRequestReconciler) Reconcile(req ctrl.Request) (ctrl.Result, err
 	exists, err := r.BroadcasterExists(pr)
 	if err != nil {
 		klog.Error(err, err.Error())
-		return ctrl.Result{}, err
+		return ctrl.Result{RequeueAfter: r.retryTimeout}, err
 	}
 	if !exists {
 		klog.Info("Deploy Broadcaster")
 		cm, err := r.crdClient.Client().CoreV1().ConfigMaps(r.Namespace).Get(r.configMapName, metav1.GetOptions{})
 		if err != nil {
 			klog.Error(err, err.Error())
-			return ctrl.Result{}, err
+			return ctrl.Result{RequeueAfter: r.retryTimeout}, err
 		}
 		deploy := GetBroadcasterDeployment(pr, r.broadcasterServiceAccount, r.Namespace, r.broadcasterImage, r.clusterId.GetClusterID(), cm.Data["gatewayPrivateIP"])
 		_, err = r.crdClient.Client().AppsV1().Deployments(r.Namespace).Create(&deploy)
 		if err != nil {
 			klog.Error(err, err.Error())
-			return ctrl.Result{}, err
+			return ctrl.Result{RequeueAfter: r.retryTimeout}, err
 		}
 	}
 

--- a/internal/peering-request-operator/setup.go
+++ b/internal/peering-request-operator/setup.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"time"
 )
 
 var (
@@ -80,5 +81,6 @@ func GetPRReconciler(scheme *runtime.Scheme, crdClient *crdClient.CRDClient, nam
 		configMapName:             configMapName,
 		broadcasterImage:          broadcasterImage,
 		broadcasterServiceAccount: broadcasterServiceAccount,
+		retryTimeout:              1 * time.Minute,
 	}
 }

--- a/internal/tray-agent/agent/client/advertisement-cache.go
+++ b/internal/tray-agent/agent/client/advertisement-cache.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	advtypes "github.com/liqoTech/liqo/api/advertisement-operator/v1"
+	advertisement_operator "github.com/liqoTech/liqo/internal/advertisement-operator"
 	"github.com/liqoTech/liqo/pkg/crdClient"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
@@ -91,7 +92,7 @@ func (c *AdvertisementCache) StopCache() {
 // callback function for the Advertisement watch.
 func checkNewAdv(obj interface{}) {
 	newAdv := obj.(*advtypes.Advertisement)
-	if newAdv.Status.AdvertisementStatus == "ACCEPTED" {
+	if newAdv.Status.AdvertisementStatus == advertisement_operator.AdvertisementAccepted {
 		agentCtrl.advCache.NotifyChannels[ChanAdvAccepted] <- newAdv.Name
 	} else {
 		agentCtrl.advCache.NotifyChannels[ChanAdvNew] <- newAdv.Name
@@ -102,9 +103,9 @@ func checkNewAdv(obj interface{}) {
 func updateAcceptedAdv(oldObj interface{}, newObj interface{}) {
 	oldAdv := oldObj.(*advtypes.Advertisement)
 	newAdv := newObj.(*advtypes.Advertisement)
-	if oldAdv.Status.AdvertisementStatus != "ACCEPTED" && newAdv.Status.AdvertisementStatus == "ACCEPTED" {
+	if oldAdv.Status.AdvertisementStatus != advertisement_operator.AdvertisementAccepted && newAdv.Status.AdvertisementStatus == advertisement_operator.AdvertisementAccepted {
 		agentCtrl.advCache.NotifyChannels[ChanAdvAccepted] <- newAdv.Name
-	} else if oldAdv.Status.AdvertisementStatus == "ACCEPTED" && newAdv.Status.AdvertisementStatus != "ACCEPTED" {
+	} else if oldAdv.Status.AdvertisementStatus == advertisement_operator.AdvertisementAccepted && newAdv.Status.AdvertisementStatus != advertisement_operator.AdvertisementAccepted {
 		agentCtrl.advCache.NotifyChannels[ChanAdvRevoked] <- newAdv.Name
 	}
 }

--- a/test/unit/advertisement-operator/controller_test.go
+++ b/test/unit/advertisement-operator/controller_test.go
@@ -43,7 +43,7 @@ func TestAcceptAdvertisementWithAutoAccept(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		adv := createAdvertisement()
 		r.CheckAdvertisement(&adv)
-		assert.Equal(t, "ACCEPTED", adv.Status.AdvertisementStatus)
+		assert.Equal(t, advcontroller.AdvertisementAccepted, adv.Status.AdvertisementStatus)
 	}
 	// check that the Adv counter has been incremented
 	assert.Equal(t, int32(10), r.AcceptedAdvNum)
@@ -62,7 +62,7 @@ func TestRefuseAdvertisementWithAutoAccept(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		adv := createAdvertisement()
 		r.CheckAdvertisement(&adv)
-		assert.Equal(t, "REFUSED", adv.Status.AdvertisementStatus)
+		assert.Equal(t, advcontroller.AdvertisementRefused, adv.Status.AdvertisementStatus)
 	}
 	// check that the Adv counter has not been modified
 	assert.Equal(t, int32(10), r.AcceptedAdvNum)
@@ -75,7 +75,7 @@ func TestCheckAdvertisementWithoutAutoAccept(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		adv := createAdvertisement()
 		r.CheckAdvertisement(&adv)
-		assert.Equal(t, "REFUSED", adv.Status.AdvertisementStatus)
+		assert.Equal(t, advcontroller.AdvertisementRefused, adv.Status.AdvertisementStatus)
 	}
 	// check that the Adv counter has not been incremented
 	assert.Equal(t, int32(0), r.AcceptedAdvNum)
@@ -116,7 +116,7 @@ func TestManageConfigUpdate(t *testing.T) {
 	assert.Equal(t, config.Spec.AdvertisementConfig, r.ClusterConfig)
 	assert.Equal(t, int32(advCount), r.AcceptedAdvNum)
 	for _, adv := range advList.Items {
-		assert.Equal(t, "ACCEPTED", adv.Status.AdvertisementStatus)
+		assert.Equal(t, advcontroller.AdvertisementAccepted, adv.Status.AdvertisementStatus)
 	}
 
 	// FALSE TEST


### PR DESCRIPTION
# Description

So far, Liqo controllers are triggered only when a resource is modified.
In this commit, we add a periodic reconciliation to ensure the desired state of Liqo objects.

## Minor changes
- added const variables for Advertisement status

