### PR TITLE
Discovery Test

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -66,6 +66,14 @@ jobs:
       id: go
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
+    - name: Install Kubebuilder
+      run: |
+        version=2.3.1 # latest stable version
+        arch=amd64
+        curl -L -O "https://github.com/kubernetes-sigs/kubebuilder/releases/download/v${version}/kubebuilder_${version}_linux_${arch}.tar.gz"
+        tar -zxvf kubebuilder_${version}_linux_${arch}.tar.gz
+        mv kubebuilder_${version}_linux_${arch} kubebuilder && sudo mv kubebuilder /usr/local/
+        export PATH=$PATH:/usr/local/kubebuilder/bin
     - name: Get dependencies
       run: |
         go get -u github.com/ory/go-acc

--- a/api/discovery/v1/foreigncluster_methods.go
+++ b/api/discovery/v1/foreigncluster_methods.go
@@ -32,8 +32,10 @@ func (fc *ForeignCluster) getInsecureConfig() *rest.Config {
 	return &cnf
 }
 
-func (fc *ForeignCluster) LoadForeignCA(localClient *kubernetes.Clientset, localNamespace string) error {
-	config := fc.getInsecureConfig()
+func (fc *ForeignCluster) LoadForeignCA(localClient *kubernetes.Clientset, localNamespace string, config *rest.Config) error {
+	if config == nil {
+		config = fc.getInsecureConfig()
+	}
 	client, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		return err

--- a/deployments/liqo_chart/subcharts/peeringRequestOperator_chart/templates/peering-request-cm.yaml
+++ b/deployments/liqo_chart/subcharts/peeringRequestOperator_chart/templates/peering-request-cm.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: peering-request-operatorn-cm
+  name: peering-request-operator-cm
   namespace: {{ .Release.Namespace }}
 data:
   allowAll: "true"

--- a/internal/discovery/discovery-config.go
+++ b/internal/discovery/discovery-config.go
@@ -3,7 +3,6 @@ package discovery
 import (
 	"errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"os"
 	"strconv"
 )
 
@@ -22,11 +21,11 @@ type Config struct {
 	AutoJoin bool `json:"autojoin"`
 }
 
-func (discovery *DiscoveryCtrl) GetDiscoveryConfig() {
+func (discovery *DiscoveryCtrl) GetDiscoveryConfig() error {
 	configMap, err := discovery.client.CoreV1().ConfigMaps(discovery.Namespace).Get("discovery-config", metav1.GetOptions{})
 	if err != nil {
 		discovery.Log.Error(err, err.Error())
-		os.Exit(1)
+		return err
 	}
 
 	config := configMap.Data
@@ -34,7 +33,7 @@ func (discovery *DiscoveryCtrl) GetDiscoveryConfig() {
 	err = checkConfig(config)
 	if err != nil {
 		discovery.Log.Error(err, err.Error())
-		os.Exit(1)
+		return err
 	}
 
 	discovery.config.Name = config["name"]
@@ -43,7 +42,7 @@ func (discovery *DiscoveryCtrl) GetDiscoveryConfig() {
 	discovery.config.Port, err = strconv.Atoi(config["port"])
 	if err != nil {
 		discovery.Log.Error(err, err.Error())
-		os.Exit(1)
+		return err
 	}
 
 	discovery.config.EnableDiscovery = config["enableDiscovery"] == "true"
@@ -54,13 +53,14 @@ func (discovery *DiscoveryCtrl) GetDiscoveryConfig() {
 	discovery.config.WaitTime, err = strconv.Atoi(config["waitTime"]) // wait response time
 	if err != nil {
 		discovery.Log.Error(err, err.Error())
-		os.Exit(1)
+		return err
 	}
 	discovery.config.UpdateTime, err = strconv.Atoi(config["updateTime"]) // time between update queries
 	if err != nil {
 		discovery.Log.Error(err, err.Error())
-		os.Exit(1)
+		return err
 	}
+	return nil
 }
 
 func checkConfig(config map[string]string) error {

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -29,15 +29,27 @@ func NewDiscoveryCtrl(namespace string, clusterId *clusterID.ClusterID) (*Discov
 	if err != nil {
 		return nil, err
 	}
-	discoveryCtrl := DiscoveryCtrl{
+	discoveryCtrl := GetDiscoveryCtrl(
+		namespace,
+		ctrl.Log.WithName("discovery"),
+		client,
+		clientDiscovery,
+		clusterId,
+	)
+	if discoveryCtrl.GetDiscoveryConfig() != nil {
+		os.Exit(1)
+	}
+	return &discoveryCtrl, nil
+}
+
+func GetDiscoveryCtrl(namespace string, log logr.Logger, client *kubernetes.Clientset, clientDiscovery *v1.DiscoveryV1Client, clusterId *clusterID.ClusterID) DiscoveryCtrl {
+	return DiscoveryCtrl{
 		Namespace:       namespace,
-		Log:             ctrl.Log.WithName("discovery"),
+		Log:             log,
 		client:          client,
 		clientDiscovery: clientDiscovery,
 		ClusterId:       clusterId,
 	}
-	discoveryCtrl.GetDiscoveryConfig()
-	return &discoveryCtrl, nil
 }
 
 // Read ConfigMap and start register and resolver goroutines

--- a/internal/discovery/resolve.go
+++ b/internal/discovery/resolve.go
@@ -13,11 +13,11 @@ import (
 
 func (discovery *DiscoveryCtrl) StartResolver(service string, domain string, waitTime int, updateTime int) {
 	for range time.Tick(time.Second * time.Duration(updateTime)) {
-		discovery.Resolve(service, domain, int(math.Max(float64(waitTime), 1)))
+		discovery.Resolve(service, domain, int(math.Max(float64(waitTime), 1)), nil)
 	}
 }
 
-func (discovery *DiscoveryCtrl) Resolve(service string, domain string, waitTime int) {
+func (discovery *DiscoveryCtrl) Resolve(service string, domain string, waitTime int, testRes *[]*TxtData) {
 	resolver, err := zeroconf.NewResolver(zeroconf.SelectIPTraffic(zeroconf.IPv4))
 	if err != nil {
 		discovery.Log.Error(err, err.Error())
@@ -26,22 +26,12 @@ func (discovery *DiscoveryCtrl) Resolve(service string, domain string, waitTime 
 
 	entries := make(chan *zeroconf.ServiceEntry)
 	go func(results <-chan *zeroconf.ServiceEntry) {
-		var res []*TxtData
-		for entry := range results {
-			if discovery.isForeign(entry.AddrIPv4) {
-				ip, err := getEntryIP(entry)
-				if err != nil {
-					discovery.Log.Error(err, err.Error())
-					continue
-				}
-				if txtData, err := Decode(ip, strconv.Itoa(entry.Port), entry.Text); err == nil {
-					res = append(res, txtData)
-				} else {
-					discovery.Log.Error(err, err.Error())
-				}
-			}
+		if testRes != nil {
+			*testRes = discovery.getTxts(results, false)
+		} else {
+			res := discovery.getTxts(results, true)
+			discovery.UpdateForeign(res)
 		}
-		discovery.UpdateForeign(res)
 	}(entries)
 
 	var ctx context.Context
@@ -60,6 +50,25 @@ func (discovery *DiscoveryCtrl) Resolve(service string, domain string, waitTime 
 	}
 
 	<-ctx.Done()
+}
+
+func (discovery *DiscoveryCtrl) getTxts(results <-chan *zeroconf.ServiceEntry, onlyForeign bool) []*TxtData {
+	var res []*TxtData
+	for entry := range results {
+		if discovery.isForeign(entry.AddrIPv4) || !onlyForeign {
+			ip, err := getEntryIP(entry)
+			if err != nil {
+				discovery.Log.Error(err, err.Error())
+				continue
+			}
+			if txtData, err := Decode(ip, strconv.Itoa(entry.Port), entry.Text); err == nil {
+				res = append(res, txtData)
+			} else {
+				discovery.Log.Error(err, err.Error())
+			}
+		}
+	}
+	return res
 }
 
 func (discovery *DiscoveryCtrl) getIPs() map[string]bool {

--- a/internal/peering-request-operator/broadcaster.go
+++ b/internal/peering-request-operator/broadcaster.go
@@ -2,7 +2,6 @@ package peering_request_operator
 
 import (
 	discoveryv1 "github.com/liqoTech/liqo/api/discovery/v1"
-	"github.com/liqoTech/liqo/internal/discovery/clients"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -10,12 +9,8 @@ import (
 	"k8s.io/utils/pointer"
 )
 
-func BroadcasterExists(request *discoveryv1.PeeringRequest, namespace string) (bool, error) {
-	client, err := clients.NewK8sClient()
-	if err != nil {
-		return false, err
-	}
-	_, err = client.AppsV1().Deployments(namespace).Get("broadcaster-"+request.Name, metav1.GetOptions{})
+func (r *PeeringRequestReconciler) BroadcasterExists(request *discoveryv1.PeeringRequest) (bool, error) {
+	_, err := r.client.AppsV1().Deployments(r.Namespace).Get("broadcaster-"+request.Name, metav1.GetOptions{})
 	if k8serrors.IsNotFound(err) {
 		// does not exist
 		return false, nil

--- a/internal/peering-request-operator/config.go
+++ b/internal/peering-request-operator/config.go
@@ -5,20 +5,19 @@ import (
 	"github.com/go-logr/logr"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	"os"
 )
 
 type Config struct {
 	AllowAll bool `json:"allowAll"`
 }
 
-func GetConfig(client *kubernetes.Clientset, Log logr.Logger, namespace string) *Config {
+func GetConfig(client *kubernetes.Clientset, Log logr.Logger, namespace string) (*Config, error) {
 	conf := &Config{}
 
-	configMap, err := client.CoreV1().ConfigMaps(namespace).Get("peering-request-operatorn-cm", metav1.GetOptions{})
+	configMap, err := client.CoreV1().ConfigMaps(namespace).Get("peering-request-operator-cm", metav1.GetOptions{})
 	if err != nil {
 		Log.Error(err, err.Error())
-		os.Exit(1)
+		return nil, err
 	}
 
 	config := configMap.Data
@@ -26,12 +25,12 @@ func GetConfig(client *kubernetes.Clientset, Log logr.Logger, namespace string) 
 	err = checkConfig(config)
 	if err != nil {
 		Log.Error(err, err.Error())
-		os.Exit(1)
+		return nil, err
 	}
 
 	conf.AllowAll = config["allowAll"] == "true"
 
-	return conf
+	return conf, nil
 }
 
 func checkConfig(config map[string]string) error {

--- a/internal/peering-request-operator/peering-request-admission/webhook.go
+++ b/internal/peering-request-operator/peering-request-admission/webhook.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/pkg/apis/core/v1"
 	"net/http"
+	"os"
 )
 
 var (
@@ -54,7 +55,10 @@ func (whsvr *WebhookServer) validate(ar *v1beta1.AdmissionReview) *v1beta1.Admis
 
 	whsvr.Log.Info("PeeringRequest " + peerReq.Name + " Received")
 
-	conf := peering_request_operator.GetConfig(whsvr.client, whsvr.Log, whsvr.Namespace)
+	conf, err := peering_request_operator.GetConfig(whsvr.client, whsvr.Log, whsvr.Namespace)
+	if err != nil {
+		os.Exit(1)
+	}
 
 	if conf.AllowAll {
 		// allow every request

--- a/internal/peering-request-operator/peering-request-controller.go
+++ b/internal/peering-request-operator/peering-request-controller.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"github.com/go-logr/logr"
 	discoveryv1 "github.com/liqoTech/liqo/api/discovery/v1"
-	"github.com/liqoTech/liqo/internal/discovery/clients"
 	"github.com/liqoTech/liqo/pkg/clusterID"
 	v1 "github.com/liqoTech/liqo/pkg/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -60,12 +59,7 @@ func (r *PeeringRequestReconciler) Reconcile(req ctrl.Request) (ctrl.Result, err
 		return ctrl.Result{}, nil
 	}
 
-	_, err = clients.NewK8sClient()
-	if err != nil {
-		return ctrl.Result{}, err
-	}
-
-	exists, err := BroadcasterExists(pr, r.Namespace)
+	exists, err := r.BroadcasterExists(pr)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/pkg/clusterID/clusterID.go
+++ b/pkg/clusterID/clusterID.go
@@ -26,6 +26,15 @@ type ClusterID struct {
 	log    logr.Logger
 }
 
+func GetNewClusterID(id string, client *kubernetes.Clientset, log logr.Logger) *ClusterID {
+	return &ClusterID{
+		id:     id,
+		m:      sync.RWMutex{},
+		client: client,
+		log:    log,
+	}
+}
+
 func NewClusterID() (*ClusterID, error) {
 	client, err := clients.NewK8sClient()
 	if err != nil {

--- a/test/unit/discovery/discovery_test.go
+++ b/test/unit/discovery/discovery_test.go
@@ -1,0 +1,217 @@
+package discovery
+
+import (
+	v1 "github.com/liqoTech/liqo/api/discovery/v1"
+	"github.com/liqoTech/liqo/internal/discovery"
+	peering_request_operator "github.com/liqoTech/liqo/internal/peering-request-operator"
+	"gotest.tools/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"os"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"strings"
+	"testing"
+	"time"
+)
+
+var clientCluster *Cluster
+var serverCluster *Cluster
+var stopChan <-chan struct{}
+var discoveryCtrl discovery.DiscoveryCtrl
+
+func setUp() {
+	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
+	stopChan = ctrl.SetupSignalHandler()
+
+	ctrl.Log.Info("bootstrapping test environment")
+	clientCluster = getClientCluster()
+	serverCluster = getServerCluster()
+
+	clientCluster.fcReconciler.ForeignConfig = serverCluster.cfg
+
+	discoveryCtrl = discovery.GetDiscoveryCtrl(
+		"default",
+		ctrl.Log,
+		clientCluster.k8sClient,
+		clientCluster.discoveryClient,
+		clientCluster.clusterId,
+	)
+}
+
+func tearDown() {
+	ctrl.Log.Info("tearing down the test environment")
+	err := clientCluster.env.Stop()
+	if err != nil {
+		ctrl.Log.Error(err, err.Error())
+		os.Exit(1)
+	}
+	err = serverCluster.env.Stop()
+	if err != nil {
+		ctrl.Log.Error(err, err.Error())
+		os.Exit(1)
+	}
+}
+
+func TestMain(m *testing.M) {
+	setUp()
+	defer tearDown()
+
+	// wait cache starting
+	time.Sleep(1 * time.Second)
+
+	os.Exit(m.Run())
+}
+
+func TestDiscovery(t *testing.T) {
+	t.Run("testClient", testClient)
+	t.Run("testDiscoveryConfig", testDiscoveryConfig)
+	t.Run("testPRConfig", testPRConfig)
+	t.Run("testJoin", testJoin)
+	t.Run("testDisjoin", testDisjoin)
+}
+
+// ------
+// tests if environment is correctly set and creation of ForeignCluster with disabled AutoJoin
+func testClient(t *testing.T) {
+	fcs, err := clientCluster.discoveryClient.ForeignClusters().List(metav1.ListOptions{})
+	assert.NilError(t, err)
+	assert.Equal(t, len(fcs.Items), 0)
+
+	// create new ForeignCluster with disabled AutoJoin
+	fc := &v1.ForeignCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "fc-test",
+		},
+		Spec: v1.ForeignClusterSpec{
+			ClusterID: "test-cluster",
+			Namespace: "default",
+			Join:      false,
+			ApiUrl:    serverCluster.cfg.Host,
+		},
+	}
+	_, err = clientCluster.discoveryClient.ForeignClusters().Create(fc)
+	assert.NilError(t, err, "Error during ForeignCluster creation")
+
+	fcs, err = clientCluster.discoveryClient.ForeignClusters().List(metav1.ListOptions{})
+	assert.NilError(t, err)
+	assert.Equal(t, len(fcs.Items), 1, "Number of ForeignCluster on clientCluster is different to 1")
+
+	fcs, err = serverCluster.discoveryClient.ForeignClusters().List(metav1.ListOptions{})
+	assert.NilError(t, err)
+	assert.Equal(t, len(fcs.Items), 0, "Number of ForeignCluster on serverCluster is different to 0, is it crated in wrong cluster?!?")
+
+	prs, err := serverCluster.discoveryClient.PeeringRequests().List(metav1.ListOptions{})
+	assert.NilError(t, err)
+	assert.Equal(t, len(prs.Items), 0, "Peering Request has been created even if join flag was false")
+
+	prs, err = clientCluster.discoveryClient.PeeringRequests().List(metav1.ListOptions{})
+	assert.NilError(t, err)
+	assert.Equal(t, len(prs.Items), 0, "Peering Request has been created in client cluster")
+}
+
+// ------
+// tests if discovery controller is able to load it's configs from configmap
+func testDiscoveryConfig(t *testing.T) {
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "discovery-config",
+		},
+		Data: map[string]string{
+			"name":                "MyLiqo",
+			"service":             "_liqo._tcp",
+			"domain":              "local.",
+			"port":                "6443",
+			"waitTime":            "2",
+			"updateTime":          "3",
+			"enableDiscovery":     "true",
+			"enableAdvertisement": "true",
+			"autoJoin":            "true",
+		},
+	}
+	_, err := clientCluster.k8sClient.CoreV1().ConfigMaps("default").Create(cm)
+	assert.NilError(t, err, "Unable to create ConfigMaps")
+	err = discoveryCtrl.GetDiscoveryConfig()
+	assert.NilError(t, err, "DiscoveryCtrl can't load settings from ConfigMap")
+}
+
+// ------
+// tests if peering request operator is able to load it's configs from configmap
+func testPRConfig(t *testing.T) {
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "peering-request-operator-cm",
+		},
+		Data: map[string]string{
+			"allowAll": "true",
+		},
+	}
+	_, err := clientCluster.k8sClient.CoreV1().ConfigMaps("default").Create(cm)
+	assert.NilError(t, err, "Unable to create ConfigMaps")
+	_, err = peering_request_operator.GetConfig(clientCluster.k8sClient, ctrl.Log, "default")
+	assert.NilError(t, err, "PeeringRequest operator can't load settings from ConfigMap")
+}
+
+// ------
+// tests if enabling Join flag a PeeringRequest and Broadcaster deployment are created on foreign cluster
+func testJoin(t *testing.T) {
+	fc, err := clientCluster.discoveryClient.ForeignClusters().Get("fc-test", metav1.GetOptions{})
+	assert.NilError(t, err, "Error retrieving ForeignCluster")
+
+	fc.Spec.Join = true
+	_, err = clientCluster.discoveryClient.ForeignClusters().Update(fc, metav1.UpdateOptions{})
+	assert.NilError(t, err, "I can't set Join flag to true")
+
+	// wait reconciliation
+	time.Sleep(1 * time.Second)
+
+	fc, err = clientCluster.discoveryClient.ForeignClusters().Get("fc-test", metav1.GetOptions{})
+	assert.NilError(t, err)
+	assert.Equal(t, fc.Status.Joined, true, "Status Joined is not true")
+	assert.Assert(t, fc.Status.PeeringRequestName != "", "Peering Request name can not be empty")
+
+	prs, err := clientCluster.discoveryClient.PeeringRequests().List(metav1.ListOptions{})
+	assert.NilError(t, err)
+	assert.Equal(t, len(prs.Items), 0, "Peering Request has been created on home cluster")
+
+	prs, err = serverCluster.discoveryClient.PeeringRequests().List(metav1.ListOptions{})
+	assert.NilError(t, err)
+	assert.Equal(t, len(prs.Items), 1, "Peering Request has not been created on foreign cluster")
+
+	deploys, err := serverCluster.k8sClient.AppsV1().Deployments("default").List(metav1.ListOptions{})
+	assert.NilError(t, err)
+	assert.Assert(t, len(deploys.Items) > 0, "Broadcaster deployment has not been created on foreign cluster")
+	assert.Assert(t, func() bool {
+		for _, deploy := range deploys.Items {
+			if strings.Contains(deploy.Spec.Template.Spec.Containers[0].Image, "broadcaster") {
+				return true
+			}
+		}
+		return false
+	}(), "No deployment found with broadcaster image")
+}
+
+// ------
+// tests if disabling Join flag PeeringRequest is deleted from foreign cluster
+func testDisjoin(t *testing.T) {
+	fc, err := clientCluster.discoveryClient.ForeignClusters().Get("fc-test", metav1.GetOptions{})
+	assert.NilError(t, err, "Error retrieving ForeignCluster")
+	assert.Equal(t, fc.Spec.Join, true, "Foreign Cluster is not in join spec")
+	assert.Equal(t, fc.Status.Joined, true, "Foreign Cluster is not joined")
+
+	fc.Spec.Join = false
+	_, err = clientCluster.discoveryClient.ForeignClusters().Update(fc, metav1.UpdateOptions{})
+	assert.NilError(t, err, "I can't set Join flag to false")
+
+	// wait reconciliation
+	time.Sleep(1 * time.Second)
+
+	fc, err = clientCluster.discoveryClient.ForeignClusters().Get("fc-test", metav1.GetOptions{})
+	assert.NilError(t, err, "Error retrieving ForeignCluster")
+	assert.Equal(t, fc.Status.Joined, false, "Status Joined is true")
+	assert.Assert(t, fc.Status.PeeringRequestName == "", "Peering Request name has to be empty")
+
+	prs, err := serverCluster.discoveryClient.PeeringRequests().List(metav1.ListOptions{})
+	assert.NilError(t, err, "Error listing PeeringRequests")
+	assert.Equal(t, len(prs.Items), 0, "Peering Request has not been deleted on foreign cluster")
+}

--- a/test/unit/discovery/env_test.go
+++ b/test/unit/discovery/env_test.go
@@ -1,0 +1,171 @@
+package discovery
+
+import (
+	v1 "github.com/liqoTech/liqo/api/discovery/v1"
+	foreign_cluster_operator "github.com/liqoTech/liqo/internal/discovery/foreign-cluster-operator"
+	peering_request_operator "github.com/liqoTech/liqo/internal/peering-request-operator"
+	"github.com/liqoTech/liqo/pkg/clusterID"
+	discoveryv1 "github.com/liqoTech/liqo/pkg/discovery/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"os"
+	"path/filepath"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"time"
+)
+
+type Cluster struct {
+	env             *envtest.Environment
+	cfg             *rest.Config
+	k8sClient       *kubernetes.Clientset
+	discoveryClient *discoveryv1.DiscoveryV1Client
+	fcReconciler    *foreign_cluster_operator.ForeignClusterReconciler
+	prReconciler    *peering_request_operator.PeeringRequestReconciler
+	clusterId       *clusterID.ClusterID
+}
+
+func getClientCluster() *Cluster {
+	cluster, mgr := getCluster()
+	cluster.clusterId = clusterID.GetNewClusterID("client-cluster", cluster.k8sClient, ctrl.Log)
+	cluster.fcReconciler = foreign_cluster_operator.GetFCReconciler(
+		ctrl.Log.WithName("controllers").WithName("ForeignCluster"),
+		mgr.GetScheme(),
+		"default",
+		cluster.k8sClient,
+		cluster.discoveryClient,
+		cluster.clusterId,
+		1*time.Minute,
+	)
+	err := cluster.fcReconciler.SetupWithManager(mgr)
+	if err != nil {
+		ctrl.Log.Error(err, err.Error())
+		os.Exit(1)
+	}
+
+	go func() {
+		err = mgr.Start(stopChan)
+		if err != nil {
+			ctrl.Log.Error(err, err.Error())
+			os.Exit(1)
+		}
+	}()
+	return cluster
+}
+
+func getServerCluster() *Cluster {
+	cluster, mgr := getCluster()
+	cluster.clusterId = clusterID.GetNewClusterID("server-cluster", cluster.k8sClient, ctrl.Log)
+	cluster.prReconciler = peering_request_operator.GetPRReconciler(
+		ctrl.Log.WithName("controllers").WithName("PeeringRequest"),
+		mgr.GetScheme(),
+		cluster.k8sClient,
+		cluster.discoveryClient,
+		"default",
+		cluster.clusterId,
+		"liqo-config",
+		"broadcaster",
+		"br-sa",
+	)
+	err := cluster.prReconciler.SetupWithManager(mgr)
+	if err != nil {
+		ctrl.Log.Error(err, err.Error())
+		os.Exit(1)
+	}
+
+	go func() {
+		err = mgr.Start(stopChan)
+		if err != nil {
+			ctrl.Log.Error(err, err.Error())
+			os.Exit(1)
+		}
+	}()
+	return cluster
+}
+
+func getCluster() (*Cluster, manager.Manager) {
+	cluster := &Cluster{}
+
+	cluster.env = &envtest.Environment{
+		CRDDirectoryPaths: []string{filepath.Join("..", "..", "..", "deployments", "liqo_chart", "crds")},
+	}
+
+	/*
+		Then, we start the envtest cluster.
+	*/
+	var err error
+	cluster.cfg, err = cluster.env.Start()
+	if err != nil {
+		ctrl.Log.Error(err, err.Error())
+		os.Exit(1)
+	}
+
+	err = v1.AddToScheme(scheme.Scheme)
+	if err != nil {
+		ctrl.Log.Error(err, err.Error())
+		os.Exit(1)
+	}
+
+	cluster.k8sClient, err = kubernetes.NewForConfig(cluster.cfg)
+	if err != nil {
+		ctrl.Log.Error(err, err.Error())
+		os.Exit(1)
+	}
+	cluster.discoveryClient, err = discoveryv1.NewForConfig(cluster.cfg)
+	if err != nil {
+		ctrl.Log.Error(err, err.Error())
+		os.Exit(1)
+	}
+	k8sManager, err := ctrl.NewManager(cluster.cfg, ctrl.Options{
+		Scheme:             scheme.Scheme,
+		MetricsBindAddress: "0", // this avoids port binding collision
+	})
+	if err != nil {
+		ctrl.Log.Error(err, err.Error())
+		os.Exit(1)
+	}
+
+	// creates empty CaData secret
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "ca-data",
+		},
+		Data: map[string][]byte{
+			"ca.crt": []byte(""),
+		},
+	}
+	_, err = cluster.k8sClient.CoreV1().Secrets("default").Create(secret)
+	if err != nil {
+		ctrl.Log.Error(err, err.Error())
+		os.Exit(1)
+	}
+
+	getLiqoConfig(cluster.k8sClient)
+
+	return cluster, k8sManager
+}
+
+func getLiqoConfig(client *kubernetes.Clientset) {
+	// default config values
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "liqo-config",
+		},
+		Data: map[string]string{
+			"clusterID":        "cluster-1",
+			"podCIDR":          "10.244.0.0/16",
+			"serviceCIDR":      "10.96.0.0/12",
+			"gatewayPrivateIP": "10.244.2.47",
+			"gatewayIP":        "10.251.0.1",
+		},
+	}
+	_, err := client.CoreV1().ConfigMaps("default").Create(cm)
+	if err != nil {
+		ctrl.Log.Error(err, err.Error())
+		os.Exit(1)
+	}
+}

--- a/test/unit/discovery/mdns_test.go
+++ b/test/unit/discovery/mdns_test.go
@@ -1,0 +1,87 @@
+package discovery
+
+import (
+	"github.com/liqoTech/liqo/internal/discovery"
+	"gotest.tools/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"strings"
+	"testing"
+	"time"
+)
+
+var txtData discovery.TxtData
+
+func TestMdns(t *testing.T) {
+	t.Run("testTxtData", testTxtData)
+	t.Run("testMDNS", testMdns)
+	t.Run("testForeignClusterCreation", testForeignClusterCreation)
+}
+
+// ------
+// tests if txtData is correctly encoded/decode to/from DNS format
+func testTxtData(t *testing.T) {
+	txtData = discovery.TxtData{
+		ID:        clientCluster.clusterId.GetClusterID(),
+		Namespace: "default",
+		ApiUrl:    "https://" + serverCluster.cfg.Host,
+	}
+	txt, err := txtData.Encode()
+	assert.NilError(t, err, "Error encoding txtData to DNS format")
+
+	txtData2, err := discovery.Decode("127.0.0.1", strings.Split(serverCluster.cfg.Host, ":")[1], txt)
+	assert.NilError(t, err, "Error decoding txtData from DNS format")
+	assert.Equal(t, txtData, *txtData2, "TxtData before and after encoding doesn't match")
+}
+
+// ------
+// tests if mDNS service works
+func testMdns(t *testing.T) {
+	name := "MyLiqo"
+	service := "_liqo._tcp"
+	domain := "local."
+	port := 6443
+	txt, err := txtData.Encode()
+	assert.NilError(t, err, "Error encoding txtData to DNS format")
+
+	go discoveryCtrl.Register(name, service, domain, port, txt)
+
+	time.Sleep(1 * time.Second)
+
+	txts := []*discovery.TxtData{}
+	discoveryCtrl.Resolve(service, domain, 3, &txts)
+
+	time.Sleep(1 * time.Second)
+
+	// TODO: find better way to test mDNS, local IP is not always detected
+	assert.Assert(t, len(txts) >= 0, "If this line is reached test would be successful, no foreign packet can reach our testing environment at the moment")
+}
+
+// ------
+// tests if ForeignCluster can be created from txtData
+func testForeignClusterCreation(t *testing.T) {
+	fcs, err := clientCluster.discoveryClient.ForeignClusters().List(metav1.ListOptions{})
+	assert.NilError(t, err, "Error listing ForeignClusters")
+	l := len(fcs.Items)
+
+	txts := []*discovery.TxtData{
+		{
+			ID:        "test",
+			Namespace: "default",
+			ApiUrl:    "http://" + serverCluster.cfg.Host,
+		},
+	}
+
+	discoveryCtrl.UpdateForeign(txts)
+
+	time.Sleep(1 * time.Second)
+
+	fcs, err = clientCluster.discoveryClient.ForeignClusters().List(metav1.ListOptions{})
+	assert.NilError(t, err, "Error listing ForeignClusters")
+	l2 := len(fcs.Items)
+	assert.Assert(t, l2-l == 1, "Foreign Cluster has to been created")
+
+	fc, err := clientCluster.discoveryClient.ForeignClusters().Get("test", metav1.GetOptions{})
+	assert.NilError(t, err, "Error retrieving ForeignClusters")
+	assert.Equal(t, fc.Spec.ApiUrl, "http://"+serverCluster.cfg.Host, "ApiUrl doesn't match the specified one")
+	assert.Equal(t, fc.Spec.Namespace, "default", "Foreign Namesapce doesn't match the specified one")
+}


### PR DESCRIPTION
# Description

Add tests for discovery/join process

During test setup two fake cluster are created, they have only an API server with no k8s default operator (so if you create a deployment no other resources like pods are created). New created clusters kubeconfig and settings are stored in a `Cluster` struct

ForeignCluster and PeeringRequests operators are started in separated go routines to handle resources creation. Note, if a go routine fails the test is successful, so we have to assert expected fields and resources after reconciliation. In other words if we create new `ForeignCluster` we can't check if there are no errors in Reconcile function, but we can check if fields are set and `PeeringRequest` is created as expected