### PR TITLE
Fix ClusterConfig race condition

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The following process will install Liqo on your Cluster. This will make your clu
 
 ### Pre-requirements
 
-You have to label one node of your cluster as the gateay node. This will be used as the gateway for the inter-cluster traffic.
+You have to label one node of your cluster as the gateway node. This will be used as the gateway for the inter-cluster traffic.
 
 ```bash
 kubectl label no __your__gateway__node liqonet.liqo.io/gateway=true
@@ -60,7 +60,7 @@ curl https://raw.githubusercontent.com/LiqoTech/liqo/master/install.sh | bash
 #### [K3s](k3s.io)
 
 K3s is a minimal Kubernetes cluster which is pretty small and easy to set up. However, it does not store its configuration in the
-way that traditional installers (e.g.; Kubedam) do. Therefore, it is required to know the configuration you entered for your cluster.
+way that traditional installers (e.g.; Kubeadm) do. Therefore, it is required to know the configuration you entered for your cluster.
 
 After having exported your K3s Kubeconfig, you can install LIQO setting the following variables before launching the installer.
 The following values represent the default configuration for K3s cluster, you may need to adapt them to the actual values of your cluster.

--- a/cmd/advertisement-operator/main.go
+++ b/cmd/advertisement-operator/main.go
@@ -137,6 +137,7 @@ func main() {
 		InitVKImage:      initKubeletImage,
 		HomeClusterId:    clusterId,
 		AcceptedAdvNum:   acceptedAdv,
+		AdvClient:        advClient,
 	}
 
 	if err = r.SetupWithManager(mgr); err != nil {

--- a/docs/design/advertisement_management.md
+++ b/docs/design/advertisement_management.md
@@ -30,26 +30,8 @@ Doing so, the remote clusters (emulated by the virtual nodes) are taken into acc
 To modify the Advertisement you need to
 1. open the file _api/v1/advertisement_types.go_. Here you have all the `struct` types related to the Advertisement CRD
 2. add/modify/delete the fields of `AdvertisementSpec` and/or `AdvertisementStatus`
-3. run `make -f scripts/advertisement-operator/Makefile`; this will regenerate the code for the new version of Advertisement
+3. run `make -f scripts/advertisement-operator/Makefile`; this will generate the code for the new version of Advertisement
+4. run `make -f scripts/advertisement-operator/Makefile manifests`; this will generate the Advertisement CRD
 
-### Test execution with KinD
-You can simply test the system using KinD (https://github.com/kubernetes-sigs/kind/). We suggest to copy _test/kind_ folder in your local machine.
-Move to this folder and modify the file `kind.sh` with the number of clusters you want to create.
-Run the script `./kind.sh <ip_address>`, where `<ip_address>` is the local ip address of your machine (NOT the localhost): it will create, configure and start n clusters with everything you need.
-
-### Run instructions
-1. create a configMap for every foreign cluster you want to communicate with. 
-Each configMap must have name **foreign-kubeconfig-<foreign_cluster_id>** and contain the kubeconfig of the foreign cluster.
-(in _deployments/advertisement-operator_ folder there is a file _foreignKubeconfig_cm.yaml_ already set up, you only need to insert the foreign kubeconfig and cluster_id)
-Apply it to the cluster `kubectl apply -f deployments/advertisement-operator/foreignKubeconfig_cm.yaml`
-2. create a configMap with your configuration information.
-In _deployments/advertisement-operator_ folder there is a file _adv-operator_cm.yaml_ already set up, you only need to insert your cluster ID and some optional network information
-Apply it to the cluster `kubectl apply -f deployments/advertisement-operator/adv-operator_cm.yaml`
-3. run `make install -f scripts/advertisement-operator/Makefile` on both your home cluster and foreign one. This will install the CRD Advertisement
-4. run the advertisement broadcaster, which is in charge of creating an Advertisement CR on each foreign cluster
-    - outside a cluster: `go build cmd/advertisement-broadcaster/main.go --cluster-id <cluster_id>`, where <cluster-id> is the cluster ID of your home cluster
-    - inside a cluster: run `kubectl apply -f deployments/advertisement-broadcaster/broadcaster_deploy.yaml`
-5. run the advertisement controller, which is in charge of reconciling the status of the Advertisement CR and spawning the virtual-kubelet
-    - outside a cluster: `go build cmd/advertisement-operator/main.go --cluster-id <cluster_id>`, where <cluster-id> is the cluster ID of your home cluster
-    - inside a cluster: run `kubectl apply -f deployments/advertisement-operator/adv_deploy.yaml`
-6. repeat all the steps on your foreign cluster so that it starts sending its Advertisements to home cluster
+### Manual execution
+Here we'll explain how to manually run only the Advertisement management components, if needed for testing purposes

--- a/internal/advertisement-operator/controller.go
+++ b/internal/advertisement-operator/controller.go
@@ -21,6 +21,7 @@ import (
 	protocolv1 "github.com/liqoTech/liqo/api/advertisement-operator/v1"
 	policyv1 "github.com/liqoTech/liqo/api/cluster-config/v1"
 	pkg "github.com/liqoTech/liqo/pkg/advertisement-operator"
+	"github.com/liqoTech/liqo/pkg/crdClient/v1alpha1"
 	v1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -44,6 +45,7 @@ type AdvertisementReconciler struct {
 	HomeClusterId    string
 	AcceptedAdvNum   int32
 	ClusterConfig    policyv1.ClusterConfigSpec
+	AdvClient        *v1alpha1.CRDClient
 }
 
 // +kubebuilder:rbac:groups=protocol.liqo.io,resources=advertisements,verbs=get;list;watch;create;update;patch;delete
@@ -84,7 +86,7 @@ func (r *AdvertisementReconciler) Reconcile(req ctrl.Request) (ctrl.Result, erro
 	}
 
 	if !r.KindEnvironment && adv.Status.RemoteRemappedPodCIDR == "" {
-		r.Log.Info("advertisement not complete, remoteRemappedPodCIRD not set yet")
+		r.Log.Info("advertisement not complete, remoteRemappedPodCIDR not set yet")
 		return ctrl.Result{}, nil
 	}
 


### PR DESCRIPTION
# Description

This PR modifies the `ClusterConfig` watcher to use our custom client instead of the kubebuilder one. This is done to avoid the "cache not started" error which sometimes occurred when launching the watcher.

## Minor changes
- removed old instructions in advertisement documentation