### PR TITLE
Virtual Kubelet Reflection testing platform

### DIFF
--- a/api/advertisement-operator/v1/advertisementClient.go
+++ b/api/advertisement-operator/v1/advertisementClient.go
@@ -23,7 +23,7 @@ func CreateAdvertisementClient(kubeconfig string) (*v1alpha1.CRDClient, error) {
 		return nil, err
 	}
 
-	v1alpha1.AddToRegistry("advertisements", &Advertisement{}, &AdvertisementList{})
+	v1alpha1.AddToRegistry("advertisements", &Advertisement{}, &AdvertisementList{}, nil, GroupResource)
 
 	return clientSet, nil
 }

--- a/api/advertisement-operator/v1/groupversion_info.go
+++ b/api/advertisement-operator/v1/groupversion_info.go
@@ -27,6 +27,8 @@ var (
 	// GroupVersion is group version used to register these objects
 	GroupVersion = schema.GroupVersion{Group: "protocol.liqo.io", Version: "v1"}
 
+	GroupResource = schema.GroupResource{Group: GroupVersion.Group, Resource: "advertisements"}
+
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
 

--- a/api/cluster-config/v1/clusterConfigClient.go
+++ b/api/cluster-config/v1/clusterConfigClient.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"github.com/liqoTech/liqo/pkg/crdClient/v1alpha1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 )
@@ -23,7 +24,10 @@ func CreateClusterConfigClient(kubeconfig string) (*v1alpha1.CRDClient, error) {
 		return nil, err
 	}
 
-	v1alpha1.AddToRegistry("clusterconfigs", &ClusterConfig{}, &ClusterConfigList{})
+	v1alpha1.AddToRegistry("clusterconfigs", &ClusterConfig{}, &ClusterConfigList{}, nil, schema.GroupResource{
+		Group:    GroupVersion.Group,
+		Resource: "clusterconfigs",
+	})
 
 	return clientSet, nil
 }

--- a/api/discovery/v1/foreigncluster_types.go
+++ b/api/discovery/v1/foreigncluster_types.go
@@ -20,6 +20,7 @@ import (
 	"github.com/liqoTech/liqo/pkg/crdClient/v1alpha1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
@@ -70,5 +71,8 @@ type ForeignClusterList struct {
 func init() {
 	SchemeBuilder.Register(&ForeignCluster{}, &ForeignClusterList{})
 
-	v1alpha1.AddToRegistry("foreignclusters", &ForeignCluster{}, &ForeignClusterList{})
+	v1alpha1.AddToRegistry("foreignclusters", &ForeignCluster{}, &ForeignClusterList{}, nil, schema.GroupResource{
+		Group:    GroupVersion.Group,
+		Resource: "foreignclusters",
+	})
 }

--- a/api/discovery/v1/peeringrequest_types.go
+++ b/api/discovery/v1/peeringrequest_types.go
@@ -20,6 +20,7 @@ import (
 	"github.com/liqoTech/liqo/pkg/crdClient/v1alpha1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
@@ -65,5 +66,8 @@ type PeeringRequestList struct {
 func init() {
 	SchemeBuilder.Register(&PeeringRequest{}, &PeeringRequestList{})
 
-	v1alpha1.AddToRegistry("peeringrequests", &PeeringRequest{}, &PeeringRequestList{})
+	v1alpha1.AddToRegistry("peeringrequests", &PeeringRequest{}, &PeeringRequestList{}, nil, schema.GroupResource{
+		Group:    v1.SchemeGroupVersion.Group,
+		Resource: "peeringrequests",
+	})
 }

--- a/api/namespaceNattingTable/v1/groupversion_info.go
+++ b/api/namespaceNattingTable/v1/groupversion_info.go
@@ -28,6 +28,8 @@ var (
 	// GroupVersion is group version used to register these objects
 	GroupVersion = schema.GroupVersion{Group: "virtualkubelet.liqo.io", Version: "v1"}
 
+	GroupResource = schema.GroupResource{Group: GroupVersion.Group, Resource: "namespacenattingtables"}
+
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
 

--- a/api/namespaceNattingTable/v1/namespaceNattingTableClient.go
+++ b/api/namespaceNattingTable/v1/namespaceNattingTableClient.go
@@ -1,7 +1,9 @@
 package v1
 
 import (
+	"errors"
 	"github.com/liqoTech/liqo/pkg/crdClient/v1alpha1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 )
@@ -18,12 +20,26 @@ func CreateClient(kubeconfig string) (*v1alpha1.CRDClient, error) {
 	if err != nil {
 		panic(err)
 	}
+
 	clientSet, err := v1alpha1.NewFromConfig(config)
 	if err != nil {
 		return nil, err
 	}
 
-	v1alpha1.AddToRegistry("namespacenattingtables", &NamespaceNattingTable{}, &NamespaceNattingTableList{})
+	v1alpha1.AddToRegistry("namespacenattingtables",
+		&NamespaceNattingTable{},
+		&NamespaceNattingTableList{},
+		Keyer,
+		GroupResource)
 
 	return clientSet, nil
+}
+
+func Keyer(obj runtime.Object) (string, error) {
+	ns, ok := obj.(*NamespaceNattingTable)
+	if !ok {
+		return "", errors.New("cannot cast received object to NamespaceNattingTable")
+	}
+
+	return ns.Name, nil
 }

--- a/internal/kubernetes/endpoints_test.go
+++ b/internal/kubernetes/endpoints_test.go
@@ -1,0 +1,151 @@
+package kubernetes
+
+import (
+	"github.com/liqoTech/liqo/api/namespaceNattingTable/v1"
+	"github.com/liqoTech/liqo/internal/kubernetes/test"
+	"github.com/liqoTech/liqo/pkg/crdClient/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
+	"time"
+)
+
+func TestManageEpEvent(t *testing.T) {
+	v1alpha1.Fake = true
+
+	homeClient, err := v1.CreateClient("")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	foreignClient, err := v1.CreateClient("")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	p := KubernetesProvider{
+		Reflector:        &Reflector{started: false},
+		ntCache:          &namespaceNTCache{nattingTableName: test.ForeignClusterId},
+		foreignClient:    foreignClient,
+		homeClient:       homeClient,
+		startTime:        time.Time{},
+		foreignClusterId: test.ForeignClusterId,
+		homeClusterID:    test.HomeClusterId,
+	}
+
+	if err := p.startNattingCache(homeClient); err != nil {
+		t.Fatal(err)
+	}
+
+	nt := createNamespaceNattingTable()
+
+	if err = p.ntCache.Store.Add(nt); err != nil {
+		t.Fatal(err)
+	}
+
+	for {
+		if p.isNamespaceReflected(test.Namespace) {
+			break
+		}
+	}
+
+	if err := createEpEvents(p); err != nil {
+		t.Fatal(err)
+	}
+
+	done := make(chan struct{}, 1)
+	errChan := make(chan error, 1)
+	go func(errChan chan error) {
+		w, err := p.foreignClient.Client().CoreV1().Endpoints(test.NattedNamespace).Watch(metav1.ListOptions{
+			Watch: true,
+		})
+		if err != nil {
+			errChan <- err
+			return
+		}
+
+		i := 0
+		for range w.ResultChan() {
+			i++
+			if i == test.EndpointsTestCases.ExpectedNumberOfEvents {
+				break
+			}
+		}
+		w.Stop()
+		close(done)
+	}(errChan)
+
+loop:
+	for {
+		select {
+		case <-done:
+			break loop
+		case err := <-errChan:
+			t.Fatal(err)
+		}
+	}
+
+	ep, err := p.foreignClient.Client().CoreV1().Endpoints(test.NattedNamespace).Get(test.EndpointsName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	nt2 := nt.DeepCopy()
+	nt2.Spec.NattingTable = nil
+	nt2.Spec.DeNattingTable = nil
+	if err = p.ntCache.Store.Update(nt2); err != nil {
+		t.Fatal(err)
+	}
+
+	for {
+		if !p.isNamespaceReflected(test.Namespace) {
+			break
+		}
+	}
+
+	if !test.AssertEndpointsCorrectness(ep.Subsets, test.EndpointsTestCases.ExpectedEndpoints.Subsets) {
+		t.Fatal("the received ep doesn't match with the expected one")
+	}
+}
+
+func createEpEvents(p KubernetesProvider) error {
+	// create a new endpoints object in the foreign cluster
+	ep := test.EndpointsTestCases.InputEndpoints
+	_, err := p.homeClient.Client().CoreV1().Endpoints(test.Namespace).Create(ep)
+	if err != nil {
+		return err
+	}
+
+	// create a new endpoints object in the home cluster
+	_, err = p.foreignClient.Client().CoreV1().Endpoints(test.NattedNamespace).Create(ep)
+	if err != nil {
+		return err
+	}
+
+	for _, s := range test.EndpointsTestCases.InputSubsets {
+		ep.Subsets = s
+		_, err = p.homeClient.Client().CoreV1().Endpoints(test.Namespace).Update(ep)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func createNamespaceNattingTable() *v1.NamespaceNattingTable {
+	return &v1.NamespaceNattingTable{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: test.ForeignClusterId,
+		},
+		Spec: v1.NamespaceNattingTableSpec{
+			ClusterId: test.ForeignClusterId,
+			NattingTable: map[string]string{
+				test.Namespace: test.NattedNamespace,
+			},
+			DeNattingTable: map[string]string{
+				test.NattedNamespace: test.Namespace,
+			},
+		},
+	}
+}

--- a/internal/kubernetes/kubernetes.go
+++ b/internal/kubernetes/kubernetes.go
@@ -91,7 +91,9 @@ func NewKubernetesProvider(nodeName, clusterId, homeClusterId, operatingSystem s
 }
 
 func (p *KubernetesProvider) ConfigureReflection() error {
-	p.startNattingCache(p.homeClient)
+	if err := p.startNattingCache(p.homeClient); err != nil {
+		return err
+	}
 
 	if err := p.createNattingTable(p.foreignClusterId); err != nil {
 		return err

--- a/internal/kubernetes/service.go
+++ b/internal/kubernetes/service.go
@@ -5,7 +5,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog"
 )
 
@@ -29,7 +28,7 @@ func (p *KubernetesProvider) manageSvcEvent(event watch.Event) error {
 		if err != nil {
 			klog.Info("remote svc " + svc.Name + " doesn't exist: creating it")
 
-			if err = CreateService(p.foreignClient.Client(), svc, nattedNS); err != nil {
+			if err = p.createService(svc, nattedNS); err != nil {
 				klog.Error(err, "unable to create service "+svc.Name+" on cluster "+p.foreignClusterId)
 			} else {
 				klog.Info("correctly created service " + svc.Name + " on cluster " + p.foreignClusterId)
@@ -37,14 +36,14 @@ func (p *KubernetesProvider) manageSvcEvent(event watch.Event) error {
 		}
 
 	case watch.Modified:
-		if err = UpdateService(p.foreignClient.Client(), svc, nattedNS); err != nil {
+		if err = p.updateService(svc, nattedNS); err != nil {
 			klog.Error(err, "unable to update service "+svc.Name+" on cluster "+p.foreignClusterId)
 		} else {
 			klog.Info("correctly updated service " + svc.Name + " on cluster " + p.foreignClusterId)
 		}
 
 	case watch.Deleted:
-		if err = DeleteService(p.foreignClient.Client(), svc, nattedNS); err != nil {
+		if err = p.deleteService(svc, nattedNS); err != nil {
 			klog.Error(err, "unable to delete service "+svc.Name+" on cluster "+p.foreignClusterId)
 		} else {
 			klog.Info("correctly deleted service " + svc.Name + " on cluster " + p.foreignClusterId)
@@ -54,7 +53,7 @@ func (p *KubernetesProvider) manageSvcEvent(event watch.Event) error {
 	return nil
 }
 
-func CreateService(c *kubernetes.Clientset, svc *corev1.Service, namespace string) error {
+func (p *KubernetesProvider) createService(svc *corev1.Service, namespace string) error {
 	svcRemote := corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        svc.Name,
@@ -74,13 +73,13 @@ func CreateService(c *kubernetes.Clientset, svc *corev1.Service, namespace strin
 	}
 	svcRemote.Labels["liqo/reflection"] = "reflected"
 
-	_, err := c.CoreV1().Services(namespace).Create(&svcRemote)
+	_, err := p.foreignClient.Client().CoreV1().Services(namespace).Create(&svcRemote)
 
 	return err
 }
 
-func UpdateService(c *kubernetes.Clientset, svc *corev1.Service, namespace string) error {
-	serviceOld, err := c.CoreV1().Services(namespace).Get(svc.Name, metav1.GetOptions{})
+func (p *KubernetesProvider) updateService(svc *corev1.Service, namespace string) error {
+	serviceOld, err := p.foreignClient.Client().CoreV1().Services(namespace).Get(svc.Name, metav1.GetOptions{})
 	if err != nil {
 		return err
 	}
@@ -88,14 +87,14 @@ func UpdateService(c *kubernetes.Clientset, svc *corev1.Service, namespace strin
 	svc.SetNamespace(namespace)
 	svc.SetResourceVersion(serviceOld.ResourceVersion)
 	svc.SetUID(serviceOld.UID)
-	_, err = c.CoreV1().Services(namespace).Update(svc)
+	_, err = p.foreignClient.Client().CoreV1().Services(namespace).Update(svc)
 
 	return err
 }
 
-func DeleteService(c *kubernetes.Clientset, svc *corev1.Service, namespace string) error {
+func (p *KubernetesProvider) deleteService(svc *corev1.Service, namespace string) error {
 	svc.Namespace = namespace
-	err := c.CoreV1().Services(namespace).Delete(svc.Name, &metav1.DeleteOptions{})
+	err := p.foreignClient.Client().CoreV1().Services(namespace).Delete(svc.Name, &metav1.DeleteOptions{})
 
 	return err
 }

--- a/internal/kubernetes/test/endpoints.go
+++ b/internal/kubernetes/test/endpoints.go
@@ -1,0 +1,21 @@
+package test
+
+import corev1 "k8s.io/api/core/v1"
+
+func AssertEndpointsCorrectness(received, expected []corev1.EndpointSubset) bool {
+	if len(received) != len(expected) {
+		return false
+	}
+	for i := 0; i < len(received); i++ {
+		if len(received[i].Addresses) != len(expected[i].Addresses) {
+			return false
+		}
+		for j := 0; j < len(received[i].Addresses); j++ {
+			if received[i].Addresses[j].IP != expected[i].Addresses[j].IP {
+				return false
+			}
+		}
+	}
+
+	return true
+}

--- a/internal/kubernetes/test/endpointsTestCases.go
+++ b/internal/kubernetes/test/endpointsTestCases.go
@@ -1,0 +1,116 @@
+package test
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"strings"
+)
+
+const (
+	Namespace        = "test"
+	NattedNamespace  = Namespace + "-" + HomeClusterId
+	HostName         = "testHost"
+	EndpointsName    = "testEndpoints"
+	HomeClusterId    = "homeClusterID"
+	ForeignClusterId = "foreignClusterID"
+)
+
+var (
+	nodeName1 = "testNode"
+	nodeName2 = "testNode2"
+)
+
+var EndpointsTestCases = struct {
+	InputEndpoints         *corev1.Endpoints
+	InputSubsets           [][]corev1.EndpointSubset
+	ExpectedEndpoints      *corev1.Endpoints
+	ExpectedNumberOfEvents int
+}{
+	ExpectedNumberOfEvents: 2,
+	InputEndpoints: &corev1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: EndpointsName,
+		},
+		Subsets: nil,
+	},
+	InputSubsets: [][]corev1.EndpointSubset{
+		{
+			{
+				Addresses: []corev1.EndpointAddress{
+					{
+						IP:        "10.0.0.1",
+						Hostname:  strings.Join([]string{HostName, "1"}, ""),
+						NodeName:  &nodeName2,
+						TargetRef: nil,
+					},
+				},
+				NotReadyAddresses: nil,
+				Ports: []corev1.EndpointPort{
+					{
+						Name:     "TestPort",
+						Port:     8000,
+						Protocol: corev1.ProtocolTCP,
+					},
+				},
+			},
+		},
+		{
+			{
+				Addresses: []corev1.EndpointAddress{
+					{
+						IP:        "10.0.0.1",
+						Hostname:  strings.Join([]string{HostName, "1"}, ""),
+						NodeName:  &nodeName1,
+						TargetRef: nil,
+					},
+					{
+						IP:        "10.0.0.2",
+						Hostname:  "testHost",
+						NodeName:  &nodeName2,
+						TargetRef: nil,
+					},
+				},
+				NotReadyAddresses: nil,
+				Ports: []corev1.EndpointPort{
+					{
+						Name:     "TestPort",
+						Port:     8000,
+						Protocol: corev1.ProtocolTCP,
+					},
+				},
+			},
+		},
+	},
+	ExpectedEndpoints: &corev1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "serviceTest",
+			Namespace: Namespace,
+		},
+		Subsets: []corev1.EndpointSubset{
+			{
+				Addresses: []corev1.EndpointAddress{
+					{
+						IP:        "10.0.0.1",
+						Hostname:  strings.Join([]string{HostName, "1"}, ""),
+						NodeName:  nil,
+						TargetRef: nil,
+					},
+					{
+						IP:        "10.0.0.2",
+						Hostname:  "testHost",
+						NodeName:  nil,
+						TargetRef: nil,
+					},
+				},
+				NotReadyAddresses: nil,
+				Ports: []corev1.EndpointPort{
+					{
+						Name:     "TestPort",
+						Port:     8000,
+						Protocol: corev1.ProtocolTCP,
+					},
+				},
+			},
+		},
+	},
+}

--- a/pkg/crdClient/fakeInformer.go
+++ b/pkg/crdClient/fakeInformer.go
@@ -1,0 +1,36 @@
+package crdClient
+
+import (
+	"github.com/liqoTech/liqo/pkg/crdClient/v1alpha1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/tools/cache"
+)
+
+// NewFakeCustomInformer creates a new FakeCustomInformer, registers the callbacks
+// and start the watching routine that implements the caching functionality
+// and the callbak notifications
+func NewFakeCustomInformer(handlers cache.ResourceEventHandlerFuncs,
+	keyer v1alpha1.KeyerFunc,
+	groupResource schema.GroupResource) (cache.Store, chan struct{}) {
+	i := &fakeInformer{
+		FakeCustomStore: cache.FakeCustomStore{},
+		funcs:           handlers,
+		keyer:           keyer,
+		data:            make(map[string]runtime.Object),
+		groupResource:   groupResource,
+	}
+
+	i.AddFunc = i.AddFake
+	i.UpdateFunc = i.UpdateFake
+	i.DeleteFunc = i.DeleteFake
+	i.ListFunc = i.ListFake
+	i.ListKeysFunc = i.ListKeysFake
+	i.GetFunc = i.GetFake
+	i.GetByKeyFunc = i.GetByKeyFake
+	i.ReplaceFunc = i.ReplaceFake
+	i.ResyncFunc = i.ResyncFake
+
+	i.Watch()
+	return i, make(chan struct{}, 1)
+}

--- a/pkg/crdClient/fakeInformerMethods.go
+++ b/pkg/crdClient/fakeInformerMethods.go
@@ -1,0 +1,157 @@
+package crdClient
+
+import (
+	"errors"
+	v1 "github.com/liqoTech/liqo/api/namespaceNattingTable/v1"
+	"github.com/liqoTech/liqo/pkg/crdClient/v1alpha1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog"
+	"sync"
+)
+
+// FakeInformer is an implementation of the cache.FakeCustomStore that
+// allows to trigger some callbacks when CRUD events occur.
+type fakeInformer struct {
+	cache.FakeCustomStore
+	funcs cache.ResourceEventHandlerFuncs
+
+	// Keyer is a function that allows to create a key given a generic runtime.Object
+	// The API should implement the keyer interface
+	keyer v1alpha1.KeyerFunc
+
+	data          map[string]runtime.Object
+	lock          sync.Mutex
+	watcher       *watch.RaceFreeFakeWatcher
+	groupResource schema.GroupResource
+}
+
+func (i *fakeInformer) AddFake(obj interface{}) error {
+	if i.keyer == nil {
+		return errors.New("keyer function not set")
+	}
+	k, err := i.keyer(obj.(runtime.Object))
+	if err != nil {
+		return err
+	}
+
+	i.lock.Lock()
+	i.data[k] = obj.(runtime.Object)
+	i.lock.Unlock()
+
+	i.watcher.Add(obj.(runtime.Object))
+
+	return nil
+}
+
+func (i *fakeInformer) UpdateFake(obj interface{}) error {
+	if i.keyer == nil {
+		return errors.New("keyer function not set")
+	}
+	k, err := i.keyer(obj.(runtime.Object))
+	if err != nil {
+		return err
+	}
+
+	i.lock.Lock()
+	defer i.lock.Unlock()
+	old, ok := i.data[k]
+	if !ok {
+		return kerrors.NewNotFound(v1.GroupResource, k)
+	}
+	i.data[k] = obj.(runtime.Object)
+
+	i.watcher.Modify(old)
+
+	return nil
+}
+
+func (i *fakeInformer) DeleteFake(obj interface{}) error {
+	if i.keyer == nil {
+		return errors.New("keyer function not set")
+	}
+	k, err := i.keyer(obj.(runtime.Object))
+	if err != nil {
+		return err
+	}
+
+	i.lock.Lock()
+	delete(i.data, k)
+	i.lock.Unlock()
+
+	i.watcher.Delete(obj.(runtime.Object))
+
+	return nil
+}
+
+func (i *fakeInformer) ListFake() []interface{} {
+	panic("to implement")
+}
+
+func (i *fakeInformer) ListKeysFake() []string {
+	panic("to implement")
+}
+
+func (i *fakeInformer) GetFake(obj interface{}) (item interface{}, exists bool, err error) {
+	panic("to implement")
+}
+
+func (i *fakeInformer) GetByKeyFake(key string) (item interface{}, exists bool, err error) {
+	i.lock.Lock()
+	v, ok := i.data[key]
+	i.lock.Unlock()
+
+	if !ok {
+		return nil, false, kerrors.NewNotFound(i.groupResource, key)
+	}
+
+	return v, true, nil
+}
+
+func (i *fakeInformer) ReplaceFake(list []interface{}, resourceVersion string) error {
+	panic("to implement")
+}
+
+func (i *fakeInformer) ResyncFake() error {
+	panic("to implement")
+}
+
+func (i *fakeInformer) Watch() {
+	w := watch.NewRaceFreeFake()
+	i.watcher = w
+	go func() {
+		for e := range w.ResultChan() {
+			switch e.Type {
+			case watch.Added:
+				if i.funcs.AddFunc != nil {
+					i.funcs.AddFunc(e.Object)
+				}
+			case watch.Deleted:
+				if i.funcs.DeleteFunc != nil {
+					i.funcs.DeleteFunc(e.Object)
+				}
+			case watch.Modified:
+				if i.keyer == nil {
+					klog.Error("keyer function not set")
+					break
+				}
+				k, err := i.keyer(e.Object)
+				if err != nil {
+					klog.Fatal(err)
+				}
+				i.lock.Lock()
+				newObj, ok := i.data[k]
+				if !ok {
+					klog.Fatal(err)
+				}
+				i.lock.Unlock()
+				if i.funcs.UpdateFunc != nil {
+					i.funcs.UpdateFunc(e.Object, newObj)
+				}
+			}
+		}
+	}()
+}

--- a/pkg/crdClient/informer.go
+++ b/pkg/crdClient/informer.go
@@ -1,6 +1,7 @@
 package crdClient
 
 import (
+	"fmt"
 	clientv1alpha1 "github.com/liqoTech/liqo/pkg/crdClient/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -10,11 +11,27 @@ import (
 	"time"
 )
 
+// WatchResources is a wrapper cache function that allows to create either a real cache
+// or a fake one, depending on the global variable Fake
 func WatchResources(clientSet clientv1alpha1.NamespacedCRDClientInterface,
 	resource, namespace string,
 	resyncPeriod time.Duration,
 	handlers cache.ResourceEventHandlerFuncs,
-	lo metav1.ListOptions) (cache.Store, chan struct{}) {
+	lo metav1.ListOptions) (cache.Store, chan struct{}, error) {
+
+	if clientv1alpha1.Fake {
+		return WatchfakeResources(resource, handlers)
+	} else {
+		return WatchRealResources(clientSet, resource, namespace, resyncPeriod, handlers, lo)
+	}
+}
+
+// Watch RealResources creates
+func WatchRealResources(clientSet clientv1alpha1.NamespacedCRDClientInterface,
+	resource, namespace string,
+	resyncPeriod time.Duration,
+	handlers cache.ResourceEventHandlerFuncs,
+	lo metav1.ListOptions) (cache.Store, chan struct{}, error) {
 
 	listFunc := func(ls metav1.ListOptions) (result runtime.Object, err error) {
 		ls = lo
@@ -25,13 +42,18 @@ func WatchResources(clientSet clientv1alpha1.NamespacedCRDClientInterface,
 		ls = lo
 		return clientSet.Resource(resource).Namespace(namespace).Watch(ls)
 	}
+	res, ok := clientv1alpha1.Registry[resource]
+	if !ok {
+		return nil, nil, fmt.Errorf("reflection for api %v not set", resource)
+	}
+	t := reflect.New(res.SingularType).Interface().(runtime.Object)
 
 	store, controller := cache.NewInformer(
 		&cache.ListWatch{
 			ListFunc:  listFunc,
 			WatchFunc: watchFunc,
 		},
-		reflect.New(clientv1alpha1.Registry[resource].SingularType).Interface().(runtime.Object),
+		t,
 		resyncPeriod,
 		handlers,
 	)
@@ -40,5 +62,17 @@ func WatchResources(clientSet clientv1alpha1.NamespacedCRDClientInterface,
 
 	go controller.Run(stopChan)
 
-	return store, stopChan
+	return store, stopChan, nil
+}
+
+// WatchfakeResources creates a Fake custom informer, useful for testing purposes
+// TODO: to implement all the caching functionality, such as resync, filtering, etc.
+func WatchfakeResources(resource string, handlers cache.ResourceEventHandlerFuncs) (cache.Store, chan struct{}, error) {
+	res, ok := clientv1alpha1.Registry[resource]
+	if !ok {
+		return nil, nil, fmt.Errorf("reflection for api %v not set", resource)
+	}
+
+	store, stop := NewFakeCustomInformer(handlers, res.Keyer, res.Resource)
+	return store, stop, nil
 }

--- a/pkg/crdClient/v1alpha1/registry.go
+++ b/pkg/crdClient/v1alpha1/registry.go
@@ -2,19 +2,27 @@ package v1alpha1
 
 import (
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"reflect"
 )
+
+type KeyerFunc func(obj runtime.Object) (string, error)
 
 type RegistryType struct {
 	SingularType reflect.Type
 	PluralType   reflect.Type
+
+	Keyer    KeyerFunc
+	Resource schema.GroupResource
 }
 
 var Registry = make(map[string]RegistryType)
 
-func AddToRegistry(api string, singular, plural runtime.Object) {
+func AddToRegistry(api string, singular, plural runtime.Object, keyer KeyerFunc, resource schema.GroupResource) {
 	Registry[api] = RegistryType{
 		SingularType: reflect.TypeOf(singular).Elem(),
 		PluralType:   reflect.TypeOf(plural).Elem(),
+		Keyer:        keyer,
+		Resource:     resource,
 	}
 }


### PR DESCRIPTION
# Description
This PR introduces a mechanism that allows virtual kubelet reflection testing. It has been implemented a fake cache that stores the home crd resources (needed by the `namespaceNattingtable`) and a mechanism for reflecting fake home resources in a fake foreign cluster.

### CRDClient 
The client has been improved by adding a testing functionality: by setting the global variable `Fake` to true, all the client objects are instantiated in a "fake" mode, by using fake `rest.client`, fake `kubernetes.Clientset` and fake `caches`.
The fake client objects allow the LIQO modules to use their client as they are real and masquerade the fake data storage.

### API
The client interface has been slightly changed, therefore all the Resources making use of the CRD client have been updated in their client instantiation. 

### Virtual kubelet
The whole mechanism has been mainly implemented for the reflection mechanism of the virtual kubelet. All the reflection calls are implemented by asynchronous callbacks registered to some Kubernetes events, and this approach allows us to test all the reflection functionalities.

### Test
A first test regarding the endpoints creation has been implemented. In the next PRs, all the reflection functionalities will be tested.
