### PR TITLE
Advertisement management test

### DIFF
--- a/test/unit/advertisement-operator/creation_test.go
+++ b/test/unit/advertisement-operator/creation_test.go
@@ -1,0 +1,178 @@
+package advertisement_operator
+
+import (
+	"context"
+	v1 "github.com/liqoTech/liqo/api/advertisement-operator/v1"
+	advertisement_operator "github.com/liqoTech/liqo/pkg/advertisement-operator"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/klog"
+	"path/filepath"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"testing"
+	"time"
+)
+
+func createFakeAdv(name, namespace string) *v1.Advertisement {
+	return &v1.Advertisement{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: v1.AdvertisementSpec{
+			ClusterId: "cluster1",
+			KubeConfigRef: corev1.ObjectReference{
+				Kind:      "Secret",
+				Namespace: "fake",
+				Name:      "fake-kubeconfig",
+			},
+			LimitRange: corev1.LimitRangeSpec{Limits: []corev1.LimitRangeItem{}},
+			Network: v1.NetworkInfo{
+				PodCIDR:            "",
+				GatewayIP:          "",
+				GatewayPrivateIP:   "",
+				SupportedProtocols: nil,
+			},
+			Timestamp:  metav1.NewTime(time.Now()),
+			TimeToLive: metav1.NewTime(time.Now().Add(30 * time.Minute)),
+		},
+	}
+}
+
+func createFakePod(name, namespace string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  "container1",
+					Image: "image1",
+				},
+			},
+		},
+	}
+}
+
+func createFakeCRDClient() client.Client {
+	env := &envtest.Environment{
+		CRDDirectoryPaths: []string{filepath.Join("..", "..", "..", "deployments", "liqo_chart", "crds")},
+	}
+
+	cfg, err := env.Start()
+	if err != nil {
+		klog.Error(err)
+		panic(err)
+	}
+
+	if err = v1.AddToScheme(scheme.Scheme); err != nil {
+		klog.Error(err)
+		panic(err)
+	}
+
+	manager, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme:             scheme.Scheme,
+		MetricsBindAddress: "0",
+	})
+	if err != nil {
+		klog.Error(err)
+		panic(err)
+	}
+
+	cacheStarted := make(chan struct{})
+	go func() {
+		if err = manager.Start(cacheStarted); err != nil {
+			klog.Error(err)
+			panic(err)
+		}
+	}()
+	manager.GetCache().WaitForCacheSync(cacheStarted)
+	return manager.GetClient()
+}
+
+func TestCreateVkDeployment(t *testing.T) {
+	name, ns := "advertisement-cluster1", "fakens"
+	adv := createFakeAdv(name, ns)
+	saName := "fake-sa"
+	vkNamespace := "fake"
+	vkImage := "liqo/virtual-kubelet"
+	initVkImage := "liqo/init-vk"
+	homeClusterId := "cluster2"
+
+	deploy := advertisement_operator.CreateVkDeployment(adv, saName, vkNamespace, vkImage, initVkImage, homeClusterId)
+
+	assert.Equal(t, "vkubelet-"+adv.Spec.ClusterId, deploy.Name)
+	assert.Equal(t, vkNamespace, deploy.Namespace)
+	assert.Equal(t, advertisement_operator.GetOwnerReference(adv), deploy.OwnerReferences)
+	assert.Equal(t, adv.Spec.ClusterId, deploy.Spec.Template.Labels["cluster"])
+	assert.Len(t, deploy.Spec.Template.Spec.Volumes, 2)
+	assert.Equal(t, adv.Spec.KubeConfigRef.Name, deploy.Spec.Template.Spec.Volumes[0].VolumeSource.Secret.SecretName)
+	assert.Equal(t, initVkImage, deploy.Spec.Template.Spec.InitContainers[0].Image)
+	assert.Equal(t, vkImage, deploy.Spec.Template.Spec.Containers[0].Image)
+	assert.NotEmpty(t, deploy.Spec.Template.Spec.Containers[0].Args)
+	assert.Contains(t, deploy.Spec.Template.Spec.Containers[0].Args, adv.Spec.ClusterId)
+	assert.Contains(t, deploy.Spec.Template.Spec.Containers[0].Args, "vk-"+adv.Spec.ClusterId)
+	assert.Contains(t, deploy.Spec.Template.Spec.Containers[0].Args, vkNamespace)
+	assert.Contains(t, deploy.Spec.Template.Spec.Containers[0].Args, homeClusterId)
+	assert.NotEmpty(t, deploy.Spec.Template.Spec.Containers[0].Command)
+	assert.NotEmpty(t, deploy.Spec.Template.Spec.Containers[0].VolumeMounts)
+	assert.NotEmpty(t, deploy.Spec.Template.Spec.Containers[0].Env)
+	assert.Equal(t, saName, deploy.Spec.Template.Spec.ServiceAccountName)
+	assert.NotEmpty(t, deploy.Spec.Template.Spec.Affinity)
+}
+
+func TestCreateOrUpdate(t *testing.T) {
+	c := createFakeCRDClient()
+
+	testPod(t, c)
+	testAdvertisement(t, c)
+}
+
+func testPod(t *testing.T, c client.Client) {
+	name, ns := "pod", "fakens"
+	key := types.NamespacedName{
+		Name:      name,
+		Namespace: ns,
+	}
+	pod := createFakePod(name, ns)
+
+	// test pod creation
+	err := advertisement_operator.CreateOrUpdate(c, context.Background(), pod)
+	assert.Nil(t, err)
+
+	// creation requires some time to be effective
+	// wait 1 second to assure the resource is retrieved by Get
+	time.Sleep(1 * time.Second)
+
+	// test pod update
+	pod.Spec.Containers[0].Image = "image2"
+	err = advertisement_operator.CreateOrUpdate(c, context.Background(), pod)
+	assert.Nil(t, err)
+
+	time.Sleep(1 * time.Second)
+
+	var pod2 corev1.Pod
+	err = c.Get(context.Background(), key, &pod2)
+	assert.Nil(t, err)
+	assert.Equal(t, pod.Spec.Containers[0].Image, pod2.Spec.Containers[0].Image)
+}
+
+func testAdvertisement(t *testing.T, c client.Client) {
+	name, ns := "advertisement-cluster1", "fakens"
+	adv := createFakeAdv(name, ns)
+
+	// test adv creation
+	err := advertisement_operator.CreateOrUpdate(c, context.Background(), adv)
+	assert.Nil(t, err)
+
+	//TODO: update test
+	// adv creation is not effective and Get returns an error
+}

--- a/test/unit/advertisement-operator/owner-ref_test.go
+++ b/test/unit/advertisement-operator/owner-ref_test.go
@@ -1,0 +1,48 @@
+package advertisement_operator
+
+import (
+	advv1 "github.com/liqoTech/liqo/api/advertisement-operator/v1"
+	advertisement_operator "github.com/liqoTech/liqo/pkg/advertisement-operator"
+	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
+)
+
+func TestGetDeployOwnerRef(t *testing.T) {
+	deploy := &appsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Deployment",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "deploy1",
+			UID:  "id1",
+		},
+	}
+	ownerRef := advertisement_operator.GetOwnerReference(deploy)
+	assert.Len(t, ownerRef, 1)
+	assert.Equal(t, deploy.Kind, ownerRef[0].Kind)
+	assert.Equal(t, deploy.APIVersion, ownerRef[0].APIVersion)
+	assert.Equal(t, deploy.Name, ownerRef[0].Name)
+	assert.Equal(t, deploy.UID, ownerRef[0].UID)
+}
+
+func TestGetAdvertisementOwnerRef(t *testing.T) {
+	adv := &advv1.Advertisement{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Advertisement",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "adv1",
+			UID:  "id2",
+		},
+	}
+	ownerRef := advertisement_operator.GetOwnerReference(adv)
+	assert.Len(t, ownerRef, 1)
+	assert.Equal(t, adv.Kind, ownerRef[0].Kind)
+	assert.Equal(t, adv.APIVersion, ownerRef[0].APIVersion)
+	assert.Equal(t, adv.Name, ownerRef[0].Name)
+	assert.Equal(t, adv.UID, ownerRef[0].UID)
+}


### PR DESCRIPTION
# Description

This PR adds some tests for functions related to Advertisement management

- [x] `pkg/advertisement-operator` folder
At the moment we test ownerReference creation functions, Virtual-Kubelet deployment creation and Pod CreateOrUpdate(). The other resources (Deployment, Secret etc...) are not tested because it would require a lot of boilerplate code which maybe can be avoided.

In the next PR some tests for `internal/advertisement-operator` folder will be added, they have not been implemented yet because I would like to modify remote-watcher logic before.