### PR TITLE
e2e service reflection test

### DIFF
--- a/internal/kubernetes/endpointsReflection_e2e_test.go
+++ b/internal/kubernetes/endpointsReflection_e2e_test.go
@@ -11,10 +11,6 @@ import (
 	"time"
 )
 
-const (
-	timeout = 10 * time.Second
-)
-
 func TestHandleEpEvents(t *testing.T) {
 	// set the client in fake mode
 	v1alpha1.Fake = true
@@ -48,7 +44,7 @@ func TestHandleEpEvents(t *testing.T) {
 	}
 
 	// create a new namespaceNattingTable and deploy it in the fake cache
-	nt := createNamespaceNattingTable()
+	nt := test.CreateNamespaceNattingTable()
 	if err = p.ntCache.Store.Add(nt); err != nil {
 		t.Fatal(err)
 	}
@@ -61,7 +57,7 @@ func TestHandleEpEvents(t *testing.T) {
 	}
 
 	// ticker useful for make the test failing if some expected events are not triggered
-	ticker := time.NewTicker(timeout)
+	ticker := time.NewTicker(test.Timeout)
 	done := make(chan struct{}, 1)
 	errChan := make(chan error, 1)
 
@@ -171,22 +167,4 @@ func createEpEvents(p KubernetesProvider) error {
 	}
 
 	return nil
-}
-
-func createNamespaceNattingTable() *v1.NamespaceNattingTable {
-	return &v1.NamespaceNattingTable{
-		TypeMeta: metav1.TypeMeta{},
-		ObjectMeta: metav1.ObjectMeta{
-			Name: test.ForeignClusterId,
-		},
-		Spec: v1.NamespaceNattingTableSpec{
-			ClusterId: test.ForeignClusterId,
-			NattingTable: map[string]string{
-				test.Namespace: test.NattedNamespace,
-			},
-			DeNattingTable: map[string]string{
-				test.NattedNamespace: test.Namespace,
-			},
-		},
-	}
 }

--- a/internal/kubernetes/namespace.go
+++ b/internal/kubernetes/namespace.go
@@ -202,13 +202,14 @@ func (p *KubernetesProvider) manageReflections(oldObj interface{}, newObj interf
 
 	for k, v := range p.reflectedNamespaces.ns {
 		if _, ok := nt[k]; !ok {
-
 			close(v)
 			if r := recover(); r != nil {
 				klog.Info("channel already closed by the reflection routine")
 			} else {
 				if err := p.cleanupNamespace(oldNt[k]); err != nil {
-					klog.Error(err, "error in cleaning up namespace")
+					klog.Errorf("error in cleaning up namespace %v - %v", k, err)
+				} else {
+					klog.Infof("namespace %v reflection correctly stopped", k)
 				}
 			}
 			delete(p.reflectedNamespaces.ns, k)

--- a/internal/kubernetes/service.go
+++ b/internal/kubernetes/service.go
@@ -84,10 +84,11 @@ func (p *KubernetesProvider) updateService(svc *corev1.Service, namespace string
 		return err
 	}
 
-	svc.SetNamespace(namespace)
-	svc.SetResourceVersion(serviceOld.ResourceVersion)
-	svc.SetUID(serviceOld.UID)
-	_, err = p.foreignClient.Client().CoreV1().Services(namespace).Update(svc)
+	svc2 := svc.DeepCopy()
+	svc2.SetNamespace(namespace)
+	svc2.SetResourceVersion(serviceOld.ResourceVersion)
+	svc2.SetUID(serviceOld.UID)
+	_, err = p.foreignClient.Client().CoreV1().Services(namespace).Update(svc2)
 
 	return err
 }

--- a/internal/kubernetes/serviceReflection_e2e_test.go
+++ b/internal/kubernetes/serviceReflection_e2e_test.go
@@ -1,0 +1,249 @@
+package kubernetes
+
+import (
+	"errors"
+	"fmt"
+	v1 "github.com/liqoTech/liqo/api/namespaceNattingTable/v1"
+	"github.com/liqoTech/liqo/internal/kubernetes/test"
+	"github.com/liqoTech/liqo/pkg/crdClient/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/klog"
+	"testing"
+	"time"
+)
+
+func TestHandleServiceEvents(t *testing.T) {
+	// set the client in fake mode
+	v1alpha1.Fake = true
+
+	// create fake client for the home cluster
+	homeClient, err := v1.CreateClient("")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// create the fake client for the foreign cluster
+	foreignClient, err := v1.CreateClient("")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// instantiate a fake provider
+	p := &KubernetesProvider{
+		Reflector:        &Reflector{started: false},
+		ntCache:          &namespaceNTCache{nattingTableName: test.ForeignClusterId},
+		foreignClient:    foreignClient,
+		homeClient:       homeClient,
+		startTime:        time.Time{},
+		foreignClusterId: test.ForeignClusterId,
+		homeClusterID:    test.HomeClusterId,
+	}
+
+	// start the fake cache for the namespaceNattingTable
+	if err := p.startNattingCache(homeClient); err != nil {
+		t.Fatal(err)
+	}
+
+	// create a new namespaceNattingTable and deploy it in the fake cache
+	nt := test.CreateNamespaceNattingTable()
+	if err = p.ntCache.Store.Add(nt); err != nil {
+		t.Fatal(err)
+	}
+
+	// wait the namespace to be completely remotely reflected
+	for {
+		if p.isNamespaceReflected(test.Namespace) {
+			break
+		}
+	}
+
+	// ticker useful for make the test failing if some expected events are not triggered
+	ticker := time.NewTicker(test.Timeout)
+	createsdDone := make(chan struct{}, 1)
+	updatesDone := make(chan struct{}, 1)
+	deletesDone := make(chan struct{}, 1)
+	errChan := make(chan error, 1)
+
+	// remote ep watcher is needed to be sure that all the expected home events are replicated in the
+	// foreign cluster
+	w, err := p.foreignClient.Client().CoreV1().Services(test.NattedNamespace).Watch(metav1.ListOptions{
+		Watch: true,
+	})
+	if err != nil {
+		errChan <- err
+		return
+	}
+
+	go serviceEventsMonitoring(errChan, createsdDone, updatesDone, deletesDone, ticker, w)
+	go svcCreation(p, errChan)
+
+loop:
+	for {
+		select {
+		case <-createsdDone:
+			if err := verifySvcConsistency(p, "creation"); err != nil {
+				t.Fatal(err)
+			}
+			go svcUpdate(p, errChan)
+		case <-updatesDone:
+			if err = verifySvcConsistency(p, "update"); err != nil {
+				t.Fatal(err)
+			}
+			go svcDelete(p, errChan)
+		case <-deletesDone:
+			break loop
+		case <-ticker.C:
+			t.Fatal("timeout")
+		case err := <-errChan:
+			t.Fatal(err)
+		}
+	}
+
+	// delete the natting entry in the namespace natting table
+	// this operation implies the reflection stop
+	nt2 := nt.DeepCopy()
+	nt2.Spec.NattingTable = nil
+	nt2.Spec.DeNattingTable = nil
+	if err = p.ntCache.Store.Update(nt2); err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait the namespace reflection to be stopped
+	for {
+		if !p.isNamespaceReflected(test.Namespace) {
+			break
+		}
+	}
+
+	if err := verifySvcConsistency(p, "delete"); err != nil {
+		t.Fatal(err)
+	}
+
+	// last check to be sure that only the expected number of foreign events has been triggered
+	select {
+	case err = <-errChan:
+		t.Fatal(err)
+	default:
+		w.Stop()
+	}
+}
+
+func serviceEventsMonitoring(errChan chan error, createsDone, updatesDone, deletesDone chan struct{}, ticker *time.Ticker, w watch.Interface) {
+	// counters for event type
+	creates := 0
+	updates := 0
+	deletes := 0
+
+	// needed to avoid close of closed channel
+	var cc, uc, dc bool
+
+	for e := range w.ResultChan() {
+		klog.Infof("TEST - New foreign event of type %v", e.Type)
+		switch e.Type {
+		case watch.Added:
+			creates++
+		case watch.Modified:
+			updates++
+		case watch.Deleted:
+			deletes++
+		default:
+			errChan <- fmt.Errorf("unexpected event of type %v", e.Type)
+			return
+		}
+
+		if creates == len(test.ServiceTestCases.InputServices) && !cc {
+			createsDone <- struct{}{}
+			cc = true
+		}
+		if updates == len(test.ServiceTestCases.UpdateServices) && !uc {
+			updatesDone <- struct{}{}
+			uc = true
+		}
+		if deletes == len(test.ServiceTestCases.DeleteServices) && !dc {
+			close(deletesDone)
+			dc = true
+			ticker.Stop()
+		}
+
+		if creates > len(test.ServiceTestCases.InputServices) {
+			errChan <- errors.New("too many create events")
+			return
+		}
+		if updates > len(test.ServiceTestCases.UpdateServices) {
+			errChan <- errors.New("too many update events")
+			return
+		}
+		if deletes > len(test.ServiceTestCases.DeleteServices) {
+			errChan <- errors.New("too many delete events")
+			return
+		}
+	}
+}
+
+func svcCreation(p *KubernetesProvider, chanError chan error) {
+	klog.Info("TEST - starting svc creation")
+	for _, s := range test.ServiceTestCases.InputServices {
+		_, err := p.homeClient.Client().CoreV1().Services(test.Namespace).Create(s)
+		if err != nil {
+			chanError <- err
+			return
+		}
+	}
+}
+
+func svcUpdate(p *KubernetesProvider, chanError chan error) {
+	klog.Info("TEST - starting svc update")
+	for _, s := range test.ServiceTestCases.UpdateServices {
+		_, err := p.homeClient.Client().CoreV1().Services(test.Namespace).Update(s)
+		if err != nil {
+			chanError <- err
+			return
+		}
+	}
+}
+
+func svcDelete(p *KubernetesProvider, chanError chan error) {
+	klog.Info("TEST - starting svc delete")
+	for _, s := range test.ServiceTestCases.DeleteServices {
+		err := p.homeClient.Client().CoreV1().Services(test.Namespace).Delete(s.Name, &metav1.DeleteOptions{})
+		if err != nil {
+			chanError <- err
+			return
+		}
+	}
+}
+
+func verifySvcConsistency(p *KubernetesProvider, event string) error {
+	klog.Infof("TEST - Asserting status coherency after %v", event)
+	homeSvcs, err := p.homeClient.Client().CoreV1().Services(test.Namespace).List(metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+	foreignSvcs, err := p.foreignClient.Client().CoreV1().Services(test.NattedNamespace).List(metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	if len(homeSvcs.Items) != len(foreignSvcs.Items) {
+		return errors.New("home services not correctly reflected remotely")
+	}
+
+	for _, svc1 := range homeSvcs.Items {
+		var found bool
+		for _, svc2 := range foreignSvcs.Items {
+			if svc1.Name == svc2.Name {
+				found = true
+				if !test.AssertServiceEquality(svc1, svc2) {
+					return errors.New("services not matching")
+				}
+				break
+			}
+		}
+		if !found {
+			return errors.New("home services not correctly reflected remotely")
+		}
+	}
+	klog.Infof("TEST - Status coherency after %v asserted", event)
+	return nil
+}

--- a/internal/kubernetes/test/const.go
+++ b/internal/kubernetes/test/const.go
@@ -1,0 +1,13 @@
+package test
+
+import "time"
+
+const (
+	Namespace        = "test"
+	NattedNamespace  = Namespace + "-" + HomeClusterId
+	HostName         = "testHost"
+	EndpointsName    = "testEndpoints"
+	HomeClusterId    = "homeClusterID"
+	ForeignClusterId = "foreignClusterID"
+	Timeout          = 10 * time.Second
+)

--- a/internal/kubernetes/test/endpointsTestCases.go
+++ b/internal/kubernetes/test/endpointsTestCases.go
@@ -6,15 +6,6 @@ import (
 	"strings"
 )
 
-const (
-	Namespace        = "test"
-	NattedNamespace  = Namespace + "-" + HomeClusterId
-	HostName         = "testHost"
-	EndpointsName    = "testEndpoints"
-	HomeClusterId    = "homeClusterID"
-	ForeignClusterId = "foreignClusterID"
-)
-
 var (
 	nodeName1 = "testNode"
 	nodeName2 = "testNode2"

--- a/internal/kubernetes/test/namespaceNattingTable.go
+++ b/internal/kubernetes/test/namespaceNattingTable.go
@@ -1,0 +1,24 @@
+package test
+
+import (
+	v1 "github.com/liqoTech/liqo/api/namespaceNattingTable/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func CreateNamespaceNattingTable() *v1.NamespaceNattingTable {
+	return &v1.NamespaceNattingTable{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: ForeignClusterId,
+		},
+		Spec: v1.NamespaceNattingTableSpec{
+			ClusterId: ForeignClusterId,
+			NattingTable: map[string]string{
+				Namespace: NattedNamespace,
+			},
+			DeNattingTable: map[string]string{
+				NattedNamespace: Namespace,
+			},
+		},
+	}
+}

--- a/internal/kubernetes/test/service.go
+++ b/internal/kubernetes/test/service.go
@@ -1,0 +1,29 @@
+package test
+
+import corev1 "k8s.io/api/core/v1"
+
+func AssertServiceEquality(svc1, svc2 corev1.Service) bool {
+	if svc1.Name != svc2.Name {
+		return false
+	}
+
+	for _, p1 := range svc1.Spec.Ports {
+		var found bool
+		for _, p2 := range svc2.Spec.Ports {
+			if p1.Name == p2.Name {
+				if p1.Protocol == p2.Protocol &&
+					p1.NodePort == p2.NodePort &&
+					p1.Port == p2.Port &&
+					p1.TargetPort == p2.TargetPort {
+					found = true
+					break
+				}
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+
+	return true
+}

--- a/internal/kubernetes/test/serviceTestCases.go
+++ b/internal/kubernetes/test/serviceTestCases.go
@@ -1,0 +1,105 @@
+package test
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+var ServiceTestCases = struct {
+	InputServices  map[string]*corev1.Service
+	UpdateServices map[string]*corev1.Service
+	DeleteServices map[string]*corev1.Service
+}{
+	InputServices: map[string]*corev1.Service{
+		"service1": {
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "service1",
+				Namespace: Namespace,
+			},
+			Spec: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{
+					{
+						Name:       "sp1",
+						Protocol:   corev1.ProtocolTCP,
+						Port:       1000,
+						TargetPort: intstr.IntOrString{},
+						NodePort:   5000,
+					},
+				},
+			},
+		},
+		"service2": {
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "service2",
+				Namespace: Namespace,
+			},
+			Spec: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{
+					{
+						Name:       "sp2",
+						Protocol:   corev1.ProtocolUDP,
+						Port:       1001,
+						TargetPort: intstr.IntOrString{},
+						NodePort:   5001,
+					},
+				},
+			},
+		},
+	},
+	UpdateServices: map[string]*corev1.Service{
+		"service1": {
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "service1",
+				Namespace: Namespace,
+			},
+			Spec: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{
+					{
+						Name:       "sp1",
+						Protocol:   corev1.ProtocolTCP,
+						Port:       10000,
+						TargetPort: intstr.IntOrString{},
+						NodePort:   50000,
+					},
+				},
+			},
+		},
+		"service2": {
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "service2",
+				Namespace: Namespace,
+			},
+			Spec: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{
+					{
+						Name:       "sp2",
+						Protocol:   corev1.ProtocolUDP,
+						Port:       10001,
+						TargetPort: intstr.IntOrString{},
+						NodePort:   50001,
+					},
+				},
+			},
+		},
+	},
+	DeleteServices: map[string]*corev1.Service{
+		"service1": {
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "service1",
+				Namespace: Namespace,
+			},
+			Spec: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{
+					{
+						Name:       "sp1",
+						Protocol:   corev1.ProtocolTCP,
+						Port:       10000,
+						TargetPort: intstr.IntOrString{},
+						NodePort:   50000,
+					},
+				},
+			},
+		},
+	},
+}


### PR DESCRIPTION
This commit implements an e2e test for service reflection. A new namespaceNattingTable is created (hence, a namespace is remotely reflected), then some CRUD operations are performed on the services (create, update, delete). After each CRUD operation set, the coherency of the foreign cache status with the local one is asserted.