### PR TITLE
e2e configmap reflection test

### DIFF
--- a/internal/kubernetes/configMap.go
+++ b/internal/kubernetes/configMap.go
@@ -80,10 +80,11 @@ func (p *KubernetesProvider) updateConfigMap(cm *corev1.ConfigMap, namespace str
 		return err
 	}
 
-	cm.SetNamespace(namespace)
-	cm.SetResourceVersion(cmOld.ResourceVersion)
-	cm.SetUID(cmOld.UID)
-	_, err = p.foreignClient.Client().CoreV1().ConfigMaps(namespace).Update(cm)
+	cm2 := cm.DeepCopy()
+	cm2.SetNamespace(namespace)
+	cm2.SetResourceVersion(cmOld.ResourceVersion)
+	cm2.SetUID(cmOld.UID)
+	_, err = p.foreignClient.Client().CoreV1().ConfigMaps(namespace).Update(cm2)
 
 	return err
 }

--- a/internal/kubernetes/endpointsReflection_e2e_test.go
+++ b/internal/kubernetes/endpointsReflection_e2e_test.go
@@ -130,7 +130,7 @@ loop:
 	}
 
 	// assert that the home endpoints have been correctly updated in the remote cluster
-	if !test.AssertEndpointsCorrectness(ep.Subsets, test.EndpointsTestCases.ExpectedEndpoints.Subsets) {
+	if !test.AssertEndpointsCoherency(ep.Subsets, test.EndpointsTestCases.ExpectedEndpoints.Subsets) {
 		t.Fatal("the received ep doesn't match with the expected one")
 	}
 

--- a/internal/kubernetes/test/configmap.go
+++ b/internal/kubernetes/test/configmap.go
@@ -1,0 +1,27 @@
+package test
+
+import corev1 "k8s.io/api/core/v1"
+
+func AssertConfigmapCoherency(cm1, cm2 corev1.ConfigMap) bool {
+	if cm1.Name != cm2.Name {
+		return false
+	}
+
+	for k1, v1 := range cm1.Data {
+		v2, ok := cm2.Data[k1]
+
+		if !ok || v1 != v2 {
+			return false
+		}
+	}
+
+	for k1, v2 := range cm2.Data {
+		v1, ok := cm1.Data[k1]
+
+		if !ok || v1 != v2 {
+			return false
+		}
+	}
+
+	return true
+}

--- a/internal/kubernetes/test/configmapTestCases.go
+++ b/internal/kubernetes/test/configmapTestCases.go
@@ -1,0 +1,66 @@
+package test
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var ConfigmapTestCases = struct {
+	InputConfigmaps  map[string]*corev1.ConfigMap
+	UpdateConfigmaps map[string]*corev1.ConfigMap
+	DeleteConfigmaps map[string]*corev1.ConfigMap
+}{
+	InputConfigmaps: map[string]*corev1.ConfigMap{
+		"configmap1": {
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "configmap1",
+				Namespace: Namespace,
+			},
+			Data: map[string]string{
+				"k1": "v1",
+				"k2": "v2",
+				"k3": "v3",
+			},
+		},
+		"configmap2": {
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "configmap2",
+				Namespace: Namespace,
+			},
+			Data: map[string]string{
+				"k11": "v11",
+				"k22": "v22",
+			},
+		},
+	},
+	UpdateConfigmaps: map[string]*corev1.ConfigMap{
+		"configmap1": {
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "configmap1",
+				Namespace: Namespace,
+			},
+			Data: map[string]string{
+				"ku1": "vu1",
+				"k2":  "v2",
+			},
+		},
+		"configmap2": {
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "configmap2",
+				Namespace: Namespace,
+			},
+			Data: map[string]string{
+				"ku11": "vu11",
+				"k22":  "v22",
+			},
+		},
+	},
+	DeleteConfigmaps: map[string]*corev1.ConfigMap{
+		"configmap2": {
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "configmap2",
+				Namespace: Namespace,
+			},
+		},
+	},
+}

--- a/internal/kubernetes/test/endpoints.go
+++ b/internal/kubernetes/test/endpoints.go
@@ -2,7 +2,7 @@ package test
 
 import corev1 "k8s.io/api/core/v1"
 
-func AssertEndpointsCorrectness(received, expected []corev1.EndpointSubset) bool {
+func AssertEndpointsCoherency(received, expected []corev1.EndpointSubset) bool {
 	if len(received) != len(expected) {
 		return false
 	}

--- a/internal/kubernetes/test/service.go
+++ b/internal/kubernetes/test/service.go
@@ -2,7 +2,7 @@ package test
 
 import corev1 "k8s.io/api/core/v1"
 
-func AssertServiceEquality(svc1, svc2 corev1.Service) bool {
+func AssertServiceCoherency(svc1, svc2 corev1.Service) bool {
 	if svc1.Name != svc2.Name {
 		return false
 	}


### PR DESCRIPTION
# Configmap reflection e2e test
This PR implements an e2e test for configmaps reflection. A new namespaceNattingTable is created (hence, a namespace is remotely reflected), then some CRUD operations are performed on the configmaps (create, update, delete).
After each CRUD operation set, the coherency of the foreign cache status with the local one is asserted.