### PR TITLE
Secret reflection e2e test

### DIFF
--- a/internal/kubernetes/secret.go
+++ b/internal/kubernetes/secret.go
@@ -81,10 +81,11 @@ func (p *KubernetesProvider) updateSecret(sec *corev1.Secret, namespace string) 
 		return err
 	}
 
-	sec.SetNamespace(namespace)
-	sec.SetResourceVersion(secOld.ResourceVersion)
-	sec.SetUID(secOld.UID)
-	_, err = p.foreignClient.Client().CoreV1().Secrets(namespace).Update(sec)
+	sec2 := sec.DeepCopy()
+	sec2.SetNamespace(namespace)
+	sec2.SetResourceVersion(secOld.ResourceVersion)
+	sec2.SetUID(secOld.UID)
+	_, err = p.foreignClient.Client().CoreV1().Secrets(namespace).Update(sec2)
 
 	return err
 }

--- a/internal/kubernetes/test/secret.go
+++ b/internal/kubernetes/test/secret.go
@@ -1,0 +1,27 @@
+package test
+
+import corev1 "k8s.io/api/core/v1"
+
+func AssertSecretCoherency(s1, s2 corev1.Secret) bool {
+	if s1.Name != s2.Name {
+		return false
+	}
+
+	for k1, v1 := range s1.StringData {
+		v2, ok := s2.StringData[k1]
+
+		if !ok || v1 != v2 {
+			return false
+		}
+	}
+
+	for k1, v2 := range s2.StringData {
+		v1, ok := s1.StringData[k1]
+
+		if !ok || v1 != v2 {
+			return false
+		}
+	}
+
+	return true
+}

--- a/internal/kubernetes/test/secretTestCases.go
+++ b/internal/kubernetes/test/secretTestCases.go
@@ -1,0 +1,66 @@
+package test
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var SecretTestCases = struct {
+	InputSecrets  map[string]*corev1.Secret
+	UpdateSecrets map[string]*corev1.Secret
+	DeleteSecrets map[string]*corev1.Secret
+}{
+	InputSecrets: map[string]*corev1.Secret{
+		"secret1": {
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "secret1",
+				Namespace: Namespace,
+			},
+			StringData: map[string]string{
+				"k1": "v1",
+				"k2": "v2",
+				"k3": "v3",
+			},
+		},
+		"secret2": {
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "secret2",
+				Namespace: Namespace,
+			},
+			StringData: map[string]string{
+				"k11": "v11",
+				"k22": "v22",
+			},
+		},
+	},
+	UpdateSecrets: map[string]*corev1.Secret{
+		"secret1": {
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "secret1",
+				Namespace: Namespace,
+			},
+			StringData: map[string]string{
+				"ku1": "vu1",
+				"k2":  "v2",
+			},
+		},
+		"secret2": {
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "secret2",
+				Namespace: Namespace,
+			},
+			StringData: map[string]string{
+				"ku11": "vu11",
+				"k22":  "v22",
+			},
+		},
+	},
+	DeleteSecrets: map[string]*corev1.Secret{
+		"secret2": {
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "secret2",
+				Namespace: Namespace,
+			},
+		},
+	},
+}

--- a/pkg/crdClient/v1alpha1/client.go
+++ b/pkg/crdClient/v1alpha1/client.go
@@ -9,7 +9,6 @@ import (
 	"k8s.io/client-go/rest"
 	restFake "k8s.io/client-go/rest/fake"
 	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/klog"
 	"os"
 )
 
@@ -51,9 +50,6 @@ func NewKubeconfig(configPath string, gv *schema.GroupVersion) (*rest.Config, er
 	config.ContentConfig.GroupVersion = gv
 	config.APIPath = "/apis"
 	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
-	if config.NegotiatedSerializer == nil {
-		klog.Info("aaa")
-	}
 	config.UserAgent = rest.DefaultKubernetesUserAgent()
 
 	return config, nil


### PR DESCRIPTION
This PR implements an e2e test for secrets reflection. A new `namespaceNattingTable` is created (hence, a namespace is remotely reflected), then some CRUD operations are performed on the secrets (create, update, delete). After each CRUD operation set, the coherency of the foreign cache status with the local one is asserted.