### PR TITLE
Remote-Watcher & Broadcaster refactoring

### DIFF
--- a/api/advertisement-operator/v1/advertisementClient.go
+++ b/api/advertisement-operator/v1/advertisementClient.go
@@ -2,11 +2,16 @@ package v1
 
 import (
 	"github.com/liqoTech/liqo/pkg/crdClient/v1alpha1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 )
 
-func CreateAdvertisementClient(kubeconfig string) (*v1alpha1.CRDClient, error) {
+// create a client for Advertisement CR using a provided kubeconfig
+// - secret != nil                     : the kubeconfig is extracted from the secret
+// - secret == nil && kubeconfig == "" : use an in-cluster configuration
+// - secret == nil && kubeconfig != "" : read the kubeconfig from the provided filepath
+func CreateAdvertisementClient(kubeconfig string, secret *v1.Secret) (*v1alpha1.CRDClient, error) {
 	var config *rest.Config
 	var err error
 
@@ -14,9 +19,16 @@ func CreateAdvertisementClient(kubeconfig string) (*v1alpha1.CRDClient, error) {
 		panic(err)
 	}
 
-	config, err = v1alpha1.NewKubeconfig(kubeconfig, &GroupVersion)
-	if err != nil {
-		panic(err)
+	if secret == nil {
+		config, err = v1alpha1.NewKubeconfig(kubeconfig, &GroupVersion)
+		if err != nil {
+			panic(err)
+		}
+	} else {
+		config, err = v1alpha1.NewKubeconfigFromSecret(secret, &GroupVersion)
+		if err != nil {
+			panic(err)
+		}
 	}
 	clientSet, err := v1alpha1.NewFromConfig(config)
 	if err != nil {

--- a/cmd/advertisement-broadcaster/main.go
+++ b/cmd/advertisement-broadcaster/main.go
@@ -8,13 +8,12 @@ import (
 )
 
 func main() {
-	var localKubeconfig, foreignKubeconfig, clusterId string
+	var localKubeconfig, clusterId string
 	var gatewayIP, gatewayPrivateIP string
 	var peeringRequestName string
 	var saName string
 
 	flag.StringVar(&localKubeconfig, "local-kubeconfig", "", "The path to the kubeconfig of your local cluster.")
-	flag.StringVar(&foreignKubeconfig, "foreign-kubeconfig", "", "The path to the kubeconfig of the foreign cluster.")
 	flag.StringVar(&clusterId, "cluster-id", "", "The cluster ID of your cluster")
 	flag.StringVar(&gatewayIP, "gateway-ip", "", "The IP address of the gateway node")
 	flag.StringVar(&gatewayPrivateIP, "gateway-private-ip", "", "The private IP address of the gateway node")
@@ -27,7 +26,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	err := advertisement_operator.StartBroadcaster(clusterId, localKubeconfig, foreignKubeconfig, gatewayIP, gatewayPrivateIP, peeringRequestName, saName)
+	err := advertisement_operator.StartBroadcaster(clusterId, localKubeconfig, gatewayIP, gatewayPrivateIP, peeringRequestName, saName)
 	if err != nil {
 		klog.Errorln(err, "Unable to start broadcaster: exiting")
 		os.Exit(1)

--- a/cmd/advertisement-operator/main.go
+++ b/cmd/advertisement-operator/main.go
@@ -103,7 +103,7 @@ func main() {
 	go csrApprover.WatchCSR(clientset, "virtual-kubelet=true")
 
 	// get the number of already accepted advertisements
-	advClient, err := protocolv1.CreateAdvertisementClient(localKubeconfig)
+	advClient, err := protocolv1.CreateAdvertisementClient(localKubeconfig, nil)
 	if err != nil {
 		klog.Errorln(err, "unable to create local client for Advertisement")
 		os.Exit(1)

--- a/config/advertisement-operator/crd/bases/protocol.liqo.io_advertisements.yaml
+++ b/config/advertisement-operator/crd/bases/protocol.liqo.io_advertisements.yaml
@@ -14,6 +14,8 @@ spec:
     listKind: AdvertisementList
     plural: advertisements
     singular: advertisement
+    shortNames:
+      - adv
   scope: Cluster
   subresources:
     status: {}

--- a/deployments/liqo_chart/crds/protocol.liqo.io_advertisements.yaml
+++ b/deployments/liqo_chart/crds/protocol.liqo.io_advertisements.yaml
@@ -14,6 +14,8 @@ spec:
     listKind: AdvertisementList
     plural: advertisements
     singular: advertisement
+    shortNames:
+      - adv
   scope: Cluster
   subresources:
     status: {}

--- a/internal/advertisement-operator/config-watcher.go
+++ b/internal/advertisement-operator/config-watcher.go
@@ -1,7 +1,6 @@
 package advertisement_operator
 
 import (
-	"context"
 	protocolv1 "github.com/liqoTech/liqo/api/advertisement-operator/v1"
 	policyv1 "github.com/liqoTech/liqo/api/cluster-config/v1"
 	"github.com/liqoTech/liqo/pkg/clusterConfig"
@@ -56,7 +55,7 @@ func (r *AdvertisementReconciler) ManageConfigUpdate(configuration *policyv1.Clu
 			for i := 0; i < int(r.AcceptedAdvNum-r.ClusterConfig.MaxAcceptableAdvertisement); i++ {
 				adv := advList.Items[i]
 				if adv.Status.AdvertisementStatus == "ACCEPTED" {
-					err := r.Client.Delete(context.Background(), &adv)
+					err := r.AdvClient.Resource("advertisements").Delete(adv.Name, metav1.DeleteOptions{})
 					if err != nil {
 						klog.Errorln(err, "Unable to apply configuration: error deleting Advertisement "+adv.Name)
 						return err, updateFlag

--- a/internal/kubernetes/kubernetes.go
+++ b/internal/kubernetes/kubernetes.go
@@ -54,7 +54,7 @@ func NewKubernetesProvider(nodeName, clusterId, homeClusterId, operatingSystem s
 		return nil, err
 	}
 
-	advClient, err := protocolv1.CreateAdvertisementClient(kubeconfig)
+	advClient, err := protocolv1.CreateAdvertisementClient(kubeconfig, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/crdClient/v1alpha1/api.go
+++ b/pkg/crdClient/v1alpha1/api.go
@@ -17,6 +17,7 @@ type CrdClientInterface interface {
 	Create(obj runtime.Object, opts metav1.CreateOptions) (runtime.Object, error)
 	Watch(opts metav1.ListOptions) (watch.Interface, error)
 	Update(name string, obj runtime.Object, opts metav1.UpdateOptions) (runtime.Object, error)
+	UpdateStatus(name string, obj runtime.Object, opts metav1.UpdateOptions) (runtime.Object, error)
 	Delete(name string, opts metav1.DeleteOptions) error
 }
 
@@ -141,6 +142,27 @@ func (c *Client) Update(name string, obj runtime.Object, opts metav1.UpdateOptio
 		VersionedParams(&opts, scheme.ParameterCodec).
 		NamespaceIfScoped(c.ns, namespaced).
 		Name(name).
+		Body(obj).
+		Do().
+		Into(result.(runtime.Object))
+
+	return result.(runtime.Object), err
+}
+
+func (c *Client) UpdateStatus(name string, obj runtime.Object, opts metav1.UpdateOptions) (runtime.Object, error) {
+	result := reflect.New(c.resource.SingularType).Interface()
+
+	var namespaced bool
+	if c.ns != "" {
+		namespaced = true
+	}
+
+	err := c.Client.Put().
+		Resource(c.api).
+		VersionedParams(&opts, scheme.ParameterCodec).
+		NamespaceIfScoped(c.ns, namespaced).
+		Name(name).
+		SubResource("status").
 		Body(obj).
 		Do().
 		Into(result.(runtime.Object))


### PR DESCRIPTION
# Description

This PR modifies the Advertisement Broadcaster and Remote watcher implementation
- [x] The remote watcher now uses our `crdClient` instead of kubebuilder `Manager` object
- [x] The Broadcaster has been simplified removing redundant clients and useless fields, and using only our `crdClient` 
- [ ] testing (will be integrated in the next PR)

## Minor changes
- added `UpdateStatus()` method to custom `crdClient`
- modified client used in `ClusterConfig` watcher (kubebuilder client was used, now our `crdClient` is)

# How it has been tested
- [x] install liqo on two kind cluster, the broadcaster correctly creates or updates the Avertisement and the remote-watcher correctly updates Advertisement status