### PR TITLE
docs/design/discovery.md: fix typo

### DIFF
--- a/docs/design/discovery.md
+++ b/docs/design/discovery.md
@@ -1,4 +1,4 @@
-#Discovery 
+# Discovery 
 
 ## Scenarios
 


### PR DESCRIPTION
# Description

Due to missing space title was not rendered

Fixes #(issue)

# How Has This Been Tested?

Thanks to preview in PR
