### PR TITLE
Add version templating for Helm chart

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,5 +1,9 @@
 name: Integration Pipeline
-on: [push]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 jobs:
   build:
     runs-on: ubuntu-20.04
@@ -45,7 +49,7 @@ jobs:
         if: github.ref != 'refs/heads/master'
   e2e-test-trigger:
      runs-on: ubuntu-latest
-#     needs: [ build ]
+     needs: [ build ]
      steps:
        - uses: actions/checkout@v2
        - name: "Make scripts executable"

--- a/deployments/liqo_chart/subcharts/adv_chart/templates/adv-deploy.yaml
+++ b/deployments/liqo_chart/subcharts/adv_chart/templates/adv-deploy.yaml
@@ -6,11 +6,15 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     k8s-app: advertisement-operator
+    app: liqo.io
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: advertisement-operator
+  labels:
+    k8s-app: advertisement-operator
+    app: liqo.io
 subjects:
   - kind: ServiceAccount
     name: advertisement-operator
@@ -26,6 +30,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     run: advertisement-operator
+    app: liqo.io
   name: advertisement-operator
 spec:
   replicas: 1
@@ -48,7 +53,7 @@ spec:
                       - virtual-node
       serviceAccountName: advertisement-operator
       containers:
-      - image: {{ .Values.advController.image.repository }}
+      - image: {{ .Values.advController.image.repository }}{{ .Values.global.suffix | default .Values.suffix }}:{{ .Values.global.version | default .Values.version }}
         imagePullPolicy: {{ .Values.advController.image.pullPolicy }}
         name: advertisement-operator
         command: ["/usr/bin/advertisement-operator"]

--- a/deployments/liqo_chart/subcharts/adv_chart/values.yaml
+++ b/deployments/liqo_chart/subcharts/adv_chart/values.yaml
@@ -6,9 +6,11 @@ advController:
   image:
     repository: "liqo/advertisement-operator"
     pullPolicy: "IfNotPresent"
-  foreignClusterID: "clusterID"
 
 broadcaster:
   image:
     repository: "liqo/advertisement-broadcaster"
     pullPolicy: "IfNotPresent"
+
+suffix: ""
+version: "latest"

--- a/deployments/liqo_chart/subcharts/discovery_chart/templates/discovery-cm.yaml
+++ b/deployments/liqo_chart/subcharts/discovery_chart/templates/discovery-cm.yaml
@@ -3,6 +3,8 @@ kind: ConfigMap
 metadata:
   name: discovery-config
   namespace: {{ .Release.Namespace }}
+  labels:
+    app: liqo.io
 data:
   name: MyLiqo                      # service name
   service: _liqo._tcp               # service type

--- a/deployments/liqo_chart/subcharts/discovery_chart/templates/discovery-deploy.yaml
+++ b/deployments/liqo_chart/subcharts/discovery_chart/templates/discovery-deploy.yaml
@@ -6,12 +6,16 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     k8s-app: discovery
+    app: liqo.io
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: discovery
   namespace: {{ .Release.Namespace }}
+  labels:
+    k8s-app: discovery
+    app: liqo.io
 subjects:
   - kind: ServiceAccount
     name: discovery-sa
@@ -26,6 +30,7 @@ kind: Deployment
 metadata:
   labels:
     run: discovery
+    app: liqo.io
   name: discovery
   namespace: {{ .Release.Namespace }}
 spec:
@@ -40,9 +45,9 @@ spec:
     spec:
       serviceAccountName: discovery-sa
       containers:
-        - image: liqo/discovery
+        - image: {{ .Values.discovery.image.repository }}{{ .Values.global.suffix | default .Values.suffix }}:{{ .Values.global.version | default .Values.version }}
           name: discovery
-          imagePullPolicy: Always
+          imagePullPolicy: {{ .Values.discovery.image.pullPolicy }}
           command: ["/usr/bin/discovery"]
           args:
           - "--namespace"

--- a/deployments/liqo_chart/subcharts/discovery_chart/templates/unauth-role.yaml
+++ b/deployments/liqo_chart/subcharts/discovery_chart/templates/unauth-role.yaml
@@ -2,6 +2,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: anonymous-role-peering
+  labels:
+    k8s-app: discovery
+    app: liqo.io
 rules:
   - apiGroups: ["discovery.liqo.io"]
     resources: ["peeringrequests"]
@@ -12,6 +15,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: anonymous-role-secret
+  labels:
+    k8s-app: discovery
+    app: liqo.io
 rules:
   - apiGroups: [""]
     resources: ["secrets"]
@@ -22,6 +28,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: anonymous-role-secret-ca
+  labels:
+    k8s-app: discovery
+    app: liqo.io
 rules:
   - apiGroups: [""]
     resources: ["secrets"]
@@ -48,6 +57,9 @@ kind: RoleBinding
 metadata:
   name: anonymous-binding-secret
   namespace: {{ .Release.Namespace }}
+  labels:
+    k8s-app: discovery
+    app: liqo.io
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -63,6 +75,9 @@ kind: RoleBinding
 metadata:
   name: anonymous-binding-secret-ca
   namespace: {{ .Release.Namespace }}
+  labels:
+    k8s-app: discovery
+    app: liqo.io
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/deployments/liqo_chart/subcharts/discovery_chart/values.yaml
+++ b/deployments/liqo_chart/subcharts/discovery_chart/values.yaml
@@ -3,8 +3,11 @@
 # Declare variables to be passed into your templates.
 
 
-advController:
+discovery:
   image:
-    repository: "liqo/advertisement-operator"
+    repository: "liqo/discovery"
     pullPolicy: "IfNotPresent"
   foreignClusterID: "clusterID"
+
+suffix: ""
+version: "latest"

--- a/deployments/liqo_chart/subcharts/mutatingWebhook_chart/templates/mutating-webhook.yaml
+++ b/deployments/liqo_chart/subcharts/mutatingWebhook_chart/templates/mutating-webhook.yaml
@@ -2,13 +2,17 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: podmutatoraccount
-
+  labels:
+    k8s-app: discovery
+    app: liqo.io
 ---
-
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: podmutatoraccount
+  labels:
+    k8s-app: discovery
+    app: liqo.io
 subjects:
   - kind: ServiceAccount
     name: podmutatoraccount
@@ -25,7 +29,8 @@ kind: Service
 metadata:
   name: mutatepodtoleration
   labels:
-    app: mutatepodtoleration
+    k8s-app: discovery
+    app: liqo.io
 spec:
   selector:
     app: mutatepodtoleration
@@ -53,7 +58,7 @@ spec:
       serviceAccountName: podmutatoraccount
       initContainers:
       - name: secret-creation
-        image: liqo/secret-creation
+        image: {{ .Values.secretCreation.image.repository }}{{ .Values.global.suffix | default .Values.suffix }}:{{ .Values.global.version | default .Values.version }}
         imagePullPolicy: Always
         args:
           - "--namespace"
@@ -73,7 +78,7 @@ spec:
           - mountPath: /etc/environment/liqo
             name: env-volume
       - name: pod-mutator-deployment
-        image: liqo/init-pod-mutator
+        image: {{ .Values.initMutatingWebhook.image.repository }}{{ .Values.global.suffix | default .Values.suffix }}:{{ .Values.global.version | default .Values.version }}
         imagePullPolicy: Always
         args:
           - "--input-env-file"
@@ -83,7 +88,7 @@ spec:
             name: env-volume
       containers:
       - name: podmutator
-        image: liqo/pod-mutator
+        image: {{ .Values.mutatingWebhook.image.repository }}{{ .Values.global.suffix | default .Values.suffix }}:{{ .Values.global.version | default .Values.version }}
         imagePullPolicy: Always
         args:
           - "--input-env-file"

--- a/deployments/liqo_chart/subcharts/mutatingWebhook_chart/values.yaml
+++ b/deployments/liqo_chart/subcharts/mutatingWebhook_chart/values.yaml
@@ -2,11 +2,11 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-secret-creation:
+secretCreation:
   image:
     repository: "liqo/secret-creation"
     pullPolicy: "IfNotPresent"
-init-mutatingWebhook:
+initMutatingWebhook:
   image:
     repository: "liqo/init-pod-mutator"
     pullPolicy: "IfNotPresent"
@@ -14,3 +14,6 @@ mutatingWebhook:
   image:
     repository: "liqo/pod-mutator"
     pullPolicy: "IfNotPresent"
+
+suffix: ""
+version: "latest"

--- a/deployments/liqo_chart/subcharts/networkModule_chart/templates/route-operator.yaml
+++ b/deployments/liqo_chart/subcharts/networkModule_chart/templates/route-operator.yaml
@@ -54,7 +54,6 @@ subjects:
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  creationTimestamp: null
   labels:
     run: route-operator
   name: route-operator
@@ -64,7 +63,6 @@ spec:
       run: route-operator
   template:
     metadata:
-      creationTimestamp: null
       labels:
         run: route-operator
     spec:
@@ -92,7 +90,7 @@ spec:
                       - virtual-node
       serviceAccountName: route-operator-service-account
       containers:
-        - image: {{ .Values.routeOperator.image.repository }}
+        - image: {{ .Values.routeOperator.image.repository }}:{{ .Values.global.suffix | default .Values.suffix }}:{{ .Values.global.version | default .Values.version }}
           imagePullPolicy: {{ .Values.routeOperator.image.pullPolicy }}
           name: route-operator
           command: ["/usr/bin/liqonet"]

--- a/deployments/liqo_chart/subcharts/networkModule_chart/templates/tunnelEndpoint-operator.yaml
+++ b/deployments/liqo_chart/subcharts/networkModule_chart/templates/tunnelEndpoint-operator.yaml
@@ -7,7 +7,6 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  creationTimestamp: null
   name: tunnel-operator-manager-role
 rules:
   - apiGroups:
@@ -47,7 +46,6 @@ subjects:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  creationTimestamp: null
   labels:
     run: tunnel-operator
   name: tunnel-operator
@@ -59,7 +57,6 @@ spec:
   strategy: {}
   template:
     metadata:
-      creationTimestamp: null
       labels:
         run: tunnel-operator
     spec:
@@ -67,7 +64,7 @@ spec:
         liqonet.liqo.io/gateway: "true"
       serviceAccountName: tunnel-operator-service-account
       containers:
-        - image: {{ .Values.tunnelEndpointOperator.image.repository }}
+        - image: {{ .Values.tunnelEndpointOperator.image.repository }}{{ .Values.global.suffix | default .Values.suffix }}:{{ .Values.global.version | default .Values.version }}
           imagePullPolicy: {{ .Values.tunnelEndpointOperator.image.pullPolicy }}
           name: tunnel-operator
           command: ["/usr/bin/liqonet"]
@@ -94,4 +91,3 @@ spec:
                   key: gatewayPrivateIP
       hostNetwork: true
       restartPolicy: Always
-status: {}

--- a/deployments/liqo_chart/subcharts/networkModule_chart/values.yaml
+++ b/deployments/liqo_chart/subcharts/networkModule_chart/values.yaml
@@ -10,3 +10,6 @@ tunnelEndpointOperator:
   image:
     repository: "liqo/liqonet"
     pullPolicy: "IfNotPresent"
+
+suffix: ""
+version: "latest"

--- a/deployments/liqo_chart/subcharts/peeringRequestOperator_chart/templates/peering-request-deploy.yaml
+++ b/deployments/liqo_chart/subcharts/peeringRequestOperator_chart/templates/peering-request-deploy.yaml
@@ -43,8 +43,8 @@ spec:
       serviceAccountName: peering-request-operator
       initContainers:
         - name: secret-creation
-          image: liqo/secret-creation
-          imagePullPolicy: Always
+          image: {{ .Values.peeringRequest.secretCreation.image.repository }}
+          imagePullPolicy: {{ .Values.peeringRequest.secretCreation.image.pullPolicy }}
           args:
             - "--namespace"
             - {{ .Release.Namespace }}
@@ -63,8 +63,8 @@ spec:
             - mountPath: /etc/environment/liqo
               name: env-volume
         - name: peering-request-deployment
-          image: liqo/peering-request-webhook-init
-          imagePullPolicy: Always
+          image: {{ .Values.peeringRequest.deployment.image.repository }}{{ .Values.suffix }}:{{ .Values.version }}
+          imagePullPolicy: {{ .Values.peeringRequest.operator.pullPolicy }}
           args:
             - "--input-env-file"
             - "/etc/environment/liqo/env"

--- a/deployments/liqo_chart/subcharts/peeringRequestOperator_chart/values.yaml
+++ b/deployments/liqo_chart/subcharts/peeringRequestOperator_chart/values.yaml
@@ -3,3 +3,19 @@
 # Declare variables to be passed into your templates.
 
 
+peeringRequest:
+  operator:
+    repository: "liqo/peering-request-operator"
+    pullPolicy: "IfNotPresent"
+  secretCreation:
+    image:
+      repository: "liqo/secret-creation"
+      pullPolicy: "IfNotPresent"
+  deployment:
+    image:
+      repository: "liqo/peering-request-webhook-init"
+      pullPolicy: "IfNotPresent"
+
+
+suffix: ""
+version: "latest"

--- a/deployments/liqo_chart/subcharts/schedulingNodeOperator_chart/templates/sn-deploy.yaml
+++ b/deployments/liqo_chart/subcharts/schedulingNodeOperator_chart/templates/sn-deploy.yaml
@@ -24,7 +24,6 @@ roleRef:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  creationTimestamp: null
   labels:
     run: schedulingnode-operator
   name: schedulingnode-operator
@@ -36,15 +35,13 @@ spec:
   strategy: {}
   template:
     metadata:
-      creationTimestamp: null
       labels:
         run: schedulingnode-operator
     spec:
       serviceAccountName: sn-operator
       containers:
-      - image: {{ .Values.image.repository }}
+      - image: {{ .Values.image.repository }}{{ .Values.global.suffix | default .Values.suffix }}:{{ .Values.global.version | default .Values.version }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         name: schedulingnode-operator
         command: ["/usr/bin/schedulingNode-operator"]
-status: {}
 

--- a/deployments/liqo_chart/subcharts/schedulingNodeOperator_chart/values.yaml
+++ b/deployments/liqo_chart/subcharts/schedulingNodeOperator_chart/values.yaml
@@ -7,3 +7,5 @@ image:
   repository: "liqo/schedulingnode-operator"
   pullPolicy: "IfNotPresent"
 
+suffix: ""
+version: "latest"

--- a/deployments/liqo_chart/subcharts/tunnelEndpointCreator_chart/templates/tunnelEndpointCreator.yaml
+++ b/deployments/liqo_chart/subcharts/tunnelEndpointCreator_chart/templates/tunnelEndpointCreator.yaml
@@ -93,7 +93,7 @@ spec:
                     values:
                       - virtual-node
       containers:
-        - image: {{ .Values.image.repository }}
+        - image: {{ .Values.image.repository }}{{ .Values.global.suffix | default .Values.suffix }}:{{ .Values.global.version | default .Values.version }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           name: tunnelendpointcreator-operator
           command: ["/usr/bin/liqonet"]

--- a/deployments/liqo_chart/subcharts/tunnelEndpointCreator_chart/values.yaml
+++ b/deployments/liqo_chart/subcharts/tunnelEndpointCreator_chart/values.yaml
@@ -5,3 +5,6 @@
 image:
   repository: "liqo/liqonet"
   pullPolicy: "IfNotPresent"
+
+suffix: ""
+version: "latest"

--- a/deployments/liqo_chart/templates/clusterconfig.yaml
+++ b/deployments/liqo_chart/templates/clusterconfig.yaml
@@ -2,6 +2,8 @@ apiVersion: policy.liqo.io/v1
 kind: ClusterConfig
 metadata:
   name: configuration
+  labels:
+    app: liqo.io
 spec:
   advertisementConfig:
     autoAccept: true

--- a/deployments/liqo_chart/templates/configmap.yaml
+++ b/deployments/liqo_chart/templates/configmap.yaml
@@ -2,9 +2,11 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ .Values.global.configmapName }}
+  labels:
+    app: liqo.io
 data:
-  clusterID: {{ .Values.configmap.clusterID}}
-  podCIDR: {{ .Values.configmap.podCIDR}}
-  serviceCIDR: {{ .Values.configmap.serviceCIDR}}
-  gatewayPrivateIP: {{ .Values.configmap.gatewayPrivateIP}}
-  gatewayIP: {{ .Values.configmap.gatewayIP}}
+  clusterID: {{ .Values.clusterID}}
+  podCIDR: {{ .Values.podCIDR}}
+  serviceCIDR: {{ .Values.serviceCIDR}}
+  gatewayPrivateIP: {{ .Values.gatewayPrivateIP}}
+  gatewayIP: {{ .Values.gatewayIP}}

--- a/deployments/liqo_chart/values.yaml
+++ b/deployments/liqo_chart/values.yaml
@@ -2,24 +2,27 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-configmap:
-  clusterID: "cluster-1"
-  podCIDR: "10.244.0.0/16"
-  serviceCIDR: "10.96.0.0/12"
-  gatewayPrivateIP: "10.244.2.47"
-  gatewayIP: "10.251.0.1"
+clusterID: "lab9"
+podCIDR: "10.244.0.0/16"
+serviceCIDR: "10.96.0.0/12"
+gatewayPrivateIP: "192.168.1.1"
+gatewayIP: "X.Y.Z.Q" # The public IP of your gateway
+
+
+##### Needed
+suffix: ""
+version: "latest"
 
 #configuration values for the adv subchart
 adv_chart:
   advController:
     image:
       repository: "liqo/advertisement-operator"
-      pullPolicy: "IfNotPresent"
-    foreignClusterID: "cluster-2"
+      pullPolicy: "Always"
   broadcaster:
     image:
       repository: "liqo/advertisement-broadcaster"
-      pullPolicy: "IfNotPresent"
+      pullPolicy: "Always"
   enabled: true
 
 #configuration values for the networkModule subchart
@@ -27,42 +30,51 @@ networkModule_chart:
   routeOperator:
     image:
       repository: "liqo/liqonet"
-      pullPolicy: "IfNotPresent"
+      pullPolicy: "Always"
   tunnelEndpointOperator:
     image:
       repository: "liqo/liqonet"
-      pullPolicy: "IfNotPresent"
+      pullPolicy: "Always"
   enabled: true
 
 #configuration values for the tunnelendpointCreator subchart
 tunnelEndpointCreator_chart:
   image:
     repository: "liqo/liqonet"
-    pullPolicy: "IfNotPresent"
+    pullPolicy: "Always"
   enabled: true
 
 #configuration values for the schedulingNode subchart
 schedulingNodeOperator_chart:
   image:
     repository: "liqo/schedulingnode-operator"
-    pullPolicy: "IfNotPresent"
+    pullPolicy: "Always"
   enabled: true
 
 #configuration values for the mutatingWebhook subchart
 mutatingWebhook_chart:
-  secret-creation:
-    image:
-      repository: "liqo/secret-creation"
-      pullPolicy: "IfNotPresent"
   init-mutatingWebhook:
     image:
       repository: "liqo/init-pod-mutator"
-      pullPolicy: "IfNotPresent"
+      pullPolicy: "Always"
   mutatingWebhook:
     image:
       repository: "liqo/pod-mutator"
-      pullPolicy: "IfNotPresent"
+      pullPolicy: "Always"
   enabled: true
+
+discovery:
+  image:
+    repository: "liqo/discovery"
+    pullPolicy: "Always"
+  foreignClusterID: "clusterID"
+
+peeringRequest:
+  image:
+    repository: "liqo/peering-request-operator"
+    pullPolicy: "Always"
 
 global:
   configmapName: "liqo-configmap"
+  suffix: ""
+  version: ""


### PR DESCRIPTION
# Description

This PR refactors the Helm chart in order to be easily used in continous integration deployments. It also changes the trigger to launch all the checks when a new PR is opened in a fork repository.

# How Has This Been Tested?
