### PR TITLE
Broadcaster & Remote-watcher testing

### DIFF
--- a/cmd/advertisement-broadcaster/main.go
+++ b/cmd/advertisement-broadcaster/main.go
@@ -9,13 +9,12 @@ import (
 
 func main() {
 	var localKubeconfig, clusterId string
-	var gatewayIP, gatewayPrivateIP string
+	var gatewayPrivateIP string
 	var peeringRequestName string
 	var saName string
 
 	flag.StringVar(&localKubeconfig, "local-kubeconfig", "", "The path to the kubeconfig of your local cluster.")
 	flag.StringVar(&clusterId, "cluster-id", "", "The cluster ID of your cluster")
-	flag.StringVar(&gatewayIP, "gateway-ip", "", "The IP address of the gateway node")
 	flag.StringVar(&gatewayPrivateIP, "gateway-private-ip", "", "The private IP address of the gateway node")
 	flag.StringVar(&peeringRequestName, "peering-request", "", "Name of PeeringRequest CR containing configurations")
 	flag.StringVar(&saName, "service-account", "broadcaster", "The name of the ServiceAccount used to create the kubeconfig that will be sent to the foreign cluster")
@@ -26,7 +25,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	err := advertisement_operator.StartBroadcaster(clusterId, localKubeconfig, gatewayIP, gatewayPrivateIP, peeringRequestName, saName)
+	err := advertisement_operator.StartBroadcaster(clusterId, localKubeconfig, gatewayPrivateIP, peeringRequestName, saName)
 	if err != nil {
 		klog.Errorln(err, "Unable to start broadcaster: exiting")
 		os.Exit(1)

--- a/deployments/liqo_chart/values.yaml
+++ b/deployments/liqo_chart/values.yaml
@@ -2,11 +2,10 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-configmap:
-  clusterID: "cluster-1"
-  podCIDR: "10.244.0.0/16"
-  serviceCIDR: "10.96.0.0/12"
-  gatewayPrivateIP: "10.244.2.47"
+clusterID: "lab9"
+podCIDR: "10.244.0.0/16"
+serviceCIDR: "10.96.0.0/12"
+gatewayPrivateIP: "192.168.1.1"
 
 
 ##### Needed

--- a/deployments/liqo_chart/values.yaml
+++ b/deployments/liqo_chart/values.yaml
@@ -2,11 +2,11 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-clusterID: "lab9"
-podCIDR: "10.244.0.0/16"
-serviceCIDR: "10.96.0.0/12"
-gatewayPrivateIP: "192.168.1.1"
-gatewayIP: "X.Y.Z.Q" # The public IP of your gateway
+configmap:
+  clusterID: "cluster-1"
+  podCIDR: "10.244.0.0/16"
+  serviceCIDR: "10.96.0.0/12"
+  gatewayPrivateIP: "10.244.2.47"
 
 
 ##### Needed

--- a/internal/advertisement-operator/broadcaster.go
+++ b/internal/advertisement-operator/broadcaster.go
@@ -3,8 +3,8 @@ package advertisement_operator
 import (
 	"errors"
 	"github.com/liqoTech/liqo/internal/discovery/kubeconfig"
-	"github.com/liqoTech/liqo/pkg/crdClient"
 	pkg "github.com/liqoTech/liqo/pkg/advertisement-operator"
+	"github.com/liqoTech/liqo/pkg/crdClient"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/klog"
@@ -311,7 +311,7 @@ func (b *AdvertisementBroadcaster) SendAdvertisementToForeignCluster(advToCreate
 			klog.Info("Correctly created advertisement on remote cluster " + b.ForeignClusterId)
 			adv.Kind = "Advertisement"
 			adv.APIVersion = protocolv1.GroupVersion.String()
-			b.KubeconfigSecretForForeign.SetOwnerReferences(pkg.GetOwnerReference(&adv))
+			b.KubeconfigSecretForForeign.SetOwnerReferences(pkg.GetOwnerReference(adv))
 			_, err = b.RemoteClient.Client().CoreV1().Secrets(b.KubeconfigSecretForForeign.Namespace).Update(b.KubeconfigSecretForForeign)
 			if err != nil {
 				klog.Errorln(err, "Unable to update secret "+b.KubeconfigSecretForForeign.Name)
@@ -431,7 +431,6 @@ func ComputeAnnouncedResources(physicalNodes *corev1.NodeList, reqs corev1.Resou
 	mem.Sub(reqs.Memory().DeepCopy())
 	pods := allocatable.Pods().DeepCopy()
 
-	// TODO: policy to decide how many resources to announce
 	cpu.SetScaled(cpu.MilliValue()*sharingPercentage/100, resource.Milli)
 	mem.Set(mem.Value() * sharingPercentage / 100)
 	pods.Set(pods.Value() * sharingPercentage / 100)

--- a/internal/advertisement-operator/controller.go
+++ b/internal/advertisement-operator/controller.go
@@ -92,7 +92,7 @@ func (r *AdvertisementReconciler) Reconcile(req ctrl.Request) (ctrl.Result, erro
 		if err != nil {
 			return ctrl.Result{}, err
 		}
-		klog.V(3).Info("Coorect creation of virtual kubelet deployment for cluster " + adv.Spec.ClusterId)
+		klog.V(3).Info("Correct creation of virtual kubelet deployment for cluster " + adv.Spec.ClusterId)
 		return ctrl.Result{}, nil
 	}
 

--- a/internal/peering-request-operator/broadcaster.go
+++ b/internal/peering-request-operator/broadcaster.go
@@ -23,14 +23,12 @@ func (r *PeeringRequestReconciler) BroadcasterExists(request *discoveryv1.Peerin
 	return true, nil
 }
 
-func GetBroadcasterDeployment(request *discoveryv1.PeeringRequest, nameSA string, namespace string, image string, clusterId string, gatewayIP string, gatewayPrivateIP string) appsv1.Deployment {
+func GetBroadcasterDeployment(request *discoveryv1.PeeringRequest, nameSA string, namespace string, image string, clusterId string, gatewayPrivateIP string) appsv1.Deployment {
 	args := []string{
 		"--peering-request",
 		request.Name,
 		"--cluster-id",
 		clusterId,
-		"--gateway-ip",
-		gatewayIP,
 		"--gateway-private-ip",
 		gatewayPrivateIP,
 		"--service-account",

--- a/internal/peering-request-operator/peering-request-controller.go
+++ b/internal/peering-request-operator/peering-request-controller.go
@@ -75,7 +75,7 @@ func (r *PeeringRequestReconciler) Reconcile(req ctrl.Request) (ctrl.Result, err
 			klog.Error(err, err.Error())
 			return ctrl.Result{}, err
 		}
-		deploy := GetBroadcasterDeployment(pr, r.broadcasterServiceAccount, r.Namespace, r.broadcasterImage, r.clusterId.GetClusterID(), cm.Data["gatewayIP"], cm.Data["gatewayPrivateIP"])
+		deploy := GetBroadcasterDeployment(pr, r.broadcasterServiceAccount, r.Namespace, r.broadcasterImage, r.clusterId.GetClusterID(), cm.Data["gatewayPrivateIP"])
 		_, err = r.crdClient.Client().AppsV1().Deployments(r.Namespace).Create(&deploy)
 		if err != nil {
 			klog.Error(err, err.Error())

--- a/pkg/advertisement-operator/owner-ref.go
+++ b/pkg/advertisement-operator/owner-ref.go
@@ -4,6 +4,7 @@ import (
 	protocolv1 "github.com/liqoTech/liqo/api/advertisement-operator/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog"
 )
 
 func GetOwnerReference(object interface{}) []metav1.OwnerReference {
@@ -29,6 +30,8 @@ func GetOwnerReference(object interface{}) []metav1.OwnerReference {
 				UID:        obj.UID,
 			},
 		}
+	default:
+		klog.Error("Invalid type for owner reference")
 	}
 
 	return ownerRef

--- a/pkg/clusterConfig/watchConfig.go
+++ b/pkg/clusterConfig/watchConfig.go
@@ -34,7 +34,7 @@ func WatchConfiguration(handler func(*policyv1.ClusterConfig), client *crdClient
 	for event := range watcher.ResultChan() {
 		configuration, ok := event.Object.(*policyv1.ClusterConfig)
 		if !ok {
-			klog.Error("Configuration object is not a ClusterConfig")
+			klog.Error("Received object is not a ClusterConfig")
 			continue
 		}
 		switch event.Type {

--- a/pkg/crdClient/fakeApi.go
+++ b/pkg/crdClient/fakeApi.go
@@ -72,5 +72,18 @@ func (c *FakeClient) Update(name string, obj runtime.Object, _ metav1.UpdateOpti
 }
 
 func (c *FakeClient) UpdateStatus(name string, obj runtime.Object, opts metav1.UpdateOptions) (runtime.Object, error) {
-	panic("to implement")
+	err := c.storage.Update(obj)
+	if err != nil {
+		return nil, err
+	}
+
+	result, found, err := c.storage.GetByKey(name)
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return nil, kerrors.NewNotFound(c.storage.groupResource, name)
+	}
+
+	return result.(runtime.Object), nil
 }

--- a/test/unit/advertisement-operator/broadcaster_test.go
+++ b/test/unit/advertisement-operator/broadcaster_test.go
@@ -130,6 +130,9 @@ func TestComputePrices(t *testing.T) {
 func TestCreateAdvertisement(t *testing.T) {
 
 	pNodes, vNodes, images, _, pods := createFakeResources()
+	pNodes.Items[0].Labels = make(map[string]string)
+	pNodes.Items[0].Labels["liqonet.liqo.io/gateway"] = "true"
+	gatewayNode := pNodes.Items[0]
 	reqs, limits := advertisement_operator.GetAllPodsResources(pods)
 	availability, _ := advertisement_operator.ComputeAnnouncedResources(pNodes, reqs, 50)
 	neighbours := make(map[v1.ResourceName]v1.ResourceList)
@@ -150,7 +153,6 @@ func TestCreateAdvertisement(t *testing.T) {
 	broadcaster := advertisement_operator.AdvertisementBroadcaster{
 		KubeconfigSecretForForeign: secret,
 		HomeClusterId:              "fake-cluster",
-		GatewayIP:                  "1.2.3.4",
 		GatewayPrivateIP:           "10.0.0.1",
 	}
 
@@ -169,7 +171,7 @@ func TestCreateAdvertisement(t *testing.T) {
 	assert.Equal(t, limits, adv.Spec.LimitRange.Limits[0].Max)
 	assert.Equal(t, neighbours, adv.Spec.Neighbors)
 	assert.Equal(t, pNodes.Items[0].Spec.PodCIDR, adv.Spec.Network.PodCIDR)
-	assert.Equal(t, "1.2.3.4", adv.Spec.Network.GatewayIP)
+	assert.Equal(t, gatewayNode.Status.Addresses[0].Address, adv.Spec.Network.GatewayIP)
 	assert.Equal(t, "10.0.0.1", adv.Spec.Network.GatewayPrivateIP)
 	assert.Empty(t, adv.Status, "Status should not be set")
 }

--- a/test/unit/advertisement-operator/broadcaster_test.go
+++ b/test/unit/advertisement-operator/broadcaster_test.go
@@ -2,97 +2,161 @@ package advertisement_operator
 
 import (
 	"fmt"
+	protocolv1 "github.com/liqoTech/liqo/api/advertisement-operator/v1"
+	policyv1 "github.com/liqoTech/liqo/api/cluster-config/v1"
 	"github.com/liqoTech/liqo/internal/advertisement-operator"
+	"github.com/liqoTech/liqo/internal/kubernetes/test"
+	pkg "github.com/liqoTech/liqo/pkg/advertisement-operator"
+	"github.com/liqoTech/liqo/pkg/crdClient"
 	"github.com/stretchr/testify/assert"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"strconv"
 	"testing"
+	"time"
 )
 
-func createFakeResources() (physicalNodes *v1.NodeList, virtualNodes *v1.NodeList, images []v1.ContainerImage, sum resource.Quantity, podList *v1.PodList) {
-	pNodes := make([]v1.Node, 5)
-	vNodes := make([]v1.Node, 5)
-	physicalNodes = new(v1.NodeList)
-	virtualNodes = new(v1.NodeList)
-	images = make([]v1.ContainerImage, 5)
+func createBroadcaster(sharingPercentage int32) advertisement_operator.AdvertisementBroadcaster {
+	// set the client in fake mode
+	crdClient.Fake = true
+
+	// create fake client for the home cluster
+	homeClient, err := protocolv1.CreateAdvertisementClient("", nil)
+	if err != nil {
+		panic(err)
+	}
+
+	// create the fake client for the foreign cluster
+	foreignClient, err := protocolv1.CreateAdvertisementClient("", nil)
+	if err != nil {
+		panic(err)
+	}
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "test",
+		},
+		Data:       nil,
+		StringData: nil,
+		Type:       "",
+	}
+
+	return advertisement_operator.AdvertisementBroadcaster{
+		LocalClient:                homeClient,
+		DiscoveryClient:            nil,
+		KubeconfigSecretForForeign: secret,
+		RemoteClient:               foreignClient,
+		HomeClusterId:              test.HomeClusterId,
+		ForeignClusterId:           test.ForeignClusterId,
+		GatewayPrivateIP:           "10.0.0.1",
+		ClusterConfig: policyv1.AdvertisementConfig{
+			ResourceSharingPercentage: sharingPercentage,
+		},
+	}
+}
+
+func createFakeResources() (physicalNodes *corev1.NodeList, virtualNodes *corev1.NodeList, images []corev1.ContainerImage, sum resource.Quantity, podList *corev1.PodList) {
+	pNodes := make([]corev1.Node, 5)
+	vNodes := make([]corev1.Node, 5)
+	physicalNodes = new(corev1.NodeList)
+	virtualNodes = new(corev1.NodeList)
+	images = make([]corev1.ContainerImage, 5)
 	sum = resource.Quantity{}
 
 	p := 0
 	v := 0
 
 	for i := 0; i < 10; i++ {
-		resources := v1.ResourceList{}
+		resources := corev1.ResourceList{}
 		q := *resource.NewQuantity(int64(i), resource.DecimalSI)
-		resources[v1.ResourceCPU] = q
-		resources[v1.ResourceMemory] = q
-		resources[v1.ResourcePods] = q
+		resources[corev1.ResourceCPU] = q
+		resources[corev1.ResourceMemory] = q
+		resources[corev1.ResourcePods] = q
 
 		if i%2 == 0 {
-			im := make([]v1.ContainerImage, 1)
+			// physical node
+			im := make([]corev1.ContainerImage, 1)
 			im[0].Names = append(im[0].Names, fmt.Sprint(p))
 			im[0].SizeBytes = int64(p)
 			images[p] = im[0]
 
-			pNodes[p] = v1.Node{
-				Spec: v1.NodeSpec{
+			pNodes[p] = corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "pnode-" + strconv.Itoa(p),
+					Labels: make(map[string]string),
+				},
+				Spec: corev1.NodeSpec{
 					PodCIDR: fmt.Sprintf("%d.%d.%d.%d/%d", i, i, i, i, 16),
 				},
-				Status: v1.NodeStatus{
+				Status: corev1.NodeStatus{
 					Allocatable: resources,
 					Images:      im,
-					Addresses:   []v1.NodeAddress{{Type: v1.NodeExternalIP, Address: fmt.Sprintf("%d.%d.%d.%d", i, i, i, i)}},
+					Addresses:   []corev1.NodeAddress{{Type: corev1.NodeExternalIP, Address: fmt.Sprintf("%d.%d.%d.%d", i, i, i, i)}},
 				},
 			}
 			sum.Add(q)
 			p++
 		} else {
-			vNodes[v] = v1.Node{
+			// virtual node
+			vNodes[v] = corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
+					Name:   "vk-cluster" + strconv.Itoa(v),
 					Labels: map[string]string{"type": "virtual-node"},
 				},
-				Spec: v1.NodeSpec{
+				Spec: corev1.NodeSpec{
 					PodCIDR: fmt.Sprintf("%d.%d.%d.%d/%d", i, i, i, i, 16),
 				},
-				Status: v1.NodeStatus{
+				Status: corev1.NodeStatus{
 					Allocatable: resources,
-					Addresses:   []v1.NodeAddress{{Type: v1.NodeExternalIP, Address: fmt.Sprintf("%d.%d.%d.%d", i, i, i, i)}},
+					Addresses:   []corev1.NodeAddress{{Type: corev1.NodeExternalIP, Address: fmt.Sprintf("%d.%d.%d.%d", i, i, i, i)}},
 				},
 			}
 			v++
 		}
 	}
 
-	pods := make([]v1.Pod, 10)
+	p, v = 0, 0
+	pods := make([]corev1.Pod, 10)
 	for i := 0; i < 10; i++ {
 		if i%2 == 0 {
-			pods[i] = v1.Pod{
-				TypeMeta:   metav1.TypeMeta{},
-				ObjectMeta: metav1.ObjectMeta{},
-				Spec: v1.PodSpec{
-					NodeName: "vk-cluster" + strconv.Itoa(i),
+			// pods on physical nodes
+			pods[i] = corev1.Pod{
+				TypeMeta: metav1.TypeMeta{},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pod-" + strconv.Itoa(i),
 				},
-				Status: v1.PodStatus{
-					Phase: v1.PodRunning,
+				Spec: corev1.PodSpec{
+					NodeName: pNodes[p].Name,
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
 				},
 			}
+			p++
 		} else {
-			pods[i] = v1.Pod{
-				TypeMeta:   metav1.TypeMeta{},
-				ObjectMeta: metav1.ObjectMeta{},
-				Spec: v1.PodSpec{
-					NodeName: "node" + strconv.Itoa(i),
+			// pods on virtual nodes
+			pods[i] = corev1.Pod{
+				TypeMeta: metav1.TypeMeta{},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pod-" + strconv.Itoa(i),
 				},
-				Status: v1.PodStatus{
-					Phase: v1.PodRunning,
+				Spec: corev1.PodSpec{
+					NodeName: vNodes[v].Name,
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
 				},
 			}
+			v++
 		}
 	}
-	podList = &v1.PodList{Items: pods}
+	pNodes[0].Labels["liqonet.liqo.io/gateway"] = "true"
 	physicalNodes.Items = pNodes
 	virtualNodes.Items = vNodes
+	podList = &corev1.PodList{Items: pods}
+
 	return physicalNodes, virtualNodes, images, sum, podList
 }
 
@@ -130,42 +194,27 @@ func TestComputePrices(t *testing.T) {
 func TestCreateAdvertisement(t *testing.T) {
 
 	pNodes, vNodes, images, _, pods := createFakeResources()
-	pNodes.Items[0].Labels = make(map[string]string)
-	pNodes.Items[0].Labels["liqonet.liqo.io/gateway"] = "true"
 	gatewayNode := pNodes.Items[0]
+	sharingPercentage := int32(50)
 	reqs, limits := advertisement_operator.GetAllPodsResources(pods)
-	availability, _ := advertisement_operator.ComputeAnnouncedResources(pNodes, reqs, 50)
-	neighbours := make(map[v1.ResourceName]v1.ResourceList)
+	availability, _ := advertisement_operator.ComputeAnnouncedResources(pNodes, reqs, int64(sharingPercentage))
+	neighbours := make(map[corev1.ResourceName]corev1.ResourceList)
 	for _, vNode := range vNodes.Items {
-		neighbours[v1.ResourceName(vNode.Name)] = vNode.Status.Allocatable
+		neighbours[corev1.ResourceName(vNode.Name)] = vNode.Status.Allocatable
 	}
 
-	secret := &v1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test",
-			Namespace: "test",
-		},
-		Data:       nil,
-		StringData: nil,
-		Type:       "",
-	}
-
-	broadcaster := advertisement_operator.AdvertisementBroadcaster{
-		KubeconfigSecretForForeign: secret,
-		HomeClusterId:              "fake-cluster",
-		GatewayPrivateIP:           "10.0.0.1",
-	}
+	broadcaster := createBroadcaster(sharingPercentage)
 
 	adv := broadcaster.CreateAdvertisement(pNodes, vNodes, availability, images, limits)
 
 	assert.NotEmpty(t, adv.Name, "Name should be provided")
 	assert.NotEmpty(t, adv.Namespace, "Namespace should be set")
 	assert.Empty(t, adv.ResourceVersion)
-	assert.NotEmpty(t, adv.Spec.ClusterId)
+	assert.Equal(t, broadcaster.HomeClusterId, adv.Spec.ClusterId)
 	assert.NotEmpty(t, adv.Spec.KubeConfigRef)
 	assert.NotEmpty(t, adv.Spec.Timestamp)
 	assert.NotEmpty(t, adv.Spec.TimeToLive)
-	assert.Equal(t, adv.Name, "advertisement-fake-cluster")
+	assert.Equal(t, "advertisement-"+broadcaster.HomeClusterId, adv.Name)
 	assert.Equal(t, images, adv.Spec.Images)
 	assert.Equal(t, availability, adv.Spec.ResourceQuota.Hard)
 	assert.Equal(t, limits, adv.Spec.LimitRange.Limits[0].Max)
@@ -174,4 +223,70 @@ func TestCreateAdvertisement(t *testing.T) {
 	assert.Equal(t, gatewayNode.Status.Addresses[0].Address, adv.Spec.Network.GatewayIP)
 	assert.Equal(t, "10.0.0.1", adv.Spec.Network.GatewayPrivateIP)
 	assert.Empty(t, adv.Status, "Status should not be set")
+}
+
+func TestGetResourceForAdv(t *testing.T) {
+
+	b := createBroadcaster(int32(50))
+	pNodes, vNodes, images, _, pods := createFakeResources()
+
+	// create resources on home cluster
+	for i := 0; i < len(pNodes.Items); i++ {
+		_, err := b.LocalClient.Client().CoreV1().Nodes().Create(&pNodes.Items[i])
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, err = b.LocalClient.Client().CoreV1().Nodes().Create(&vNodes.Items[i])
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	for i := 0; i < len(pods.Items); i++ {
+		_, err := b.LocalClient.Client().CoreV1().Pods("").Create(&pods.Items[i])
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	time.Sleep(5 * time.Second)
+
+	reqs, limits := advertisement_operator.GetAllPodsResources(pods)
+	availability, _ := advertisement_operator.ComputeAnnouncedResources(pNodes, reqs, int64(b.ClusterConfig.ResourceSharingPercentage))
+
+	pNodes2, vNodes2, availability2, limits2, images2, err := b.GetResourcesForAdv()
+	assert.Nil(t, err)
+	assert.Equal(t, pNodes, pNodes2)
+	assert.Equal(t, vNodes, vNodes2)
+	assert.Equal(t, availability, availability2)
+	assert.Equal(t, limits, limits2)
+	assert.Equal(t, images, images2)
+}
+
+func TestSendAdvertisementCreation(t *testing.T) {
+	pNodes, vNodes, images, _, pods := createFakeResources()
+	sharingPercentage := int32(50)
+	reqs, limits := advertisement_operator.GetAllPodsResources(pods)
+	availability, _ := advertisement_operator.ComputeAnnouncedResources(pNodes, reqs, int64(sharingPercentage))
+	neighbours := make(map[corev1.ResourceName]corev1.ResourceList)
+	for _, vNode := range vNodes.Items {
+		neighbours[corev1.ResourceName(vNode.Name)] = vNode.Status.Allocatable
+	}
+
+	b := createBroadcaster(sharingPercentage)
+	adv := b.CreateAdvertisement(pNodes, vNodes, availability, images, limits)
+
+	_, err := b.RemoteClient.Client().CoreV1().Secrets(b.KubeconfigSecretForForeign.Namespace).Create(b.KubeconfigSecretForForeign)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// create adv on foreign cluster
+	adv2, err := b.SendAdvertisementToForeignCluster(adv)
+	assert.Nil(t, err)
+	assert.Equal(t, b.KubeconfigSecretForForeign.OwnerReferences, pkg.GetOwnerReference(adv2))
+
+	// update adv on foreign cluster
+	adv.Spec.ResourceQuota.Hard[corev1.ResourceCPU] = resource.MustParse("10")
+	adv3, err := b.SendAdvertisementToForeignCluster(adv)
+	assert.Nil(t, err)
+	assert.Equal(t, adv.Spec.ResourceQuota.Hard.Cpu().Value(), adv3.Spec.ResourceQuota.Hard.Cpu().Value())
 }

--- a/test/unit/advertisement-operator/remote-watcher_test.go
+++ b/test/unit/advertisement-operator/remote-watcher_test.go
@@ -1,0 +1,61 @@
+package advertisement_operator
+
+import (
+	protocolv1 "github.com/liqoTech/liqo/api/advertisement-operator/v1"
+	advertisement_operator "github.com/liqoTech/liqo/internal/advertisement-operator"
+	"gotest.tools/assert"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
+	"time"
+)
+
+func TestWatchAdvertisement(t *testing.T) {
+	// prepare resources for advertisement
+	pNodes, vNodes, images, _, pods := createFakeResources()
+	sharingPercentage := int32(50)
+	reqs, limits := advertisement_operator.GetAllPodsResources(pods)
+	availability, _ := advertisement_operator.ComputeAnnouncedResources(pNodes, reqs, int64(sharingPercentage))
+	neighbours := make(map[corev1.ResourceName]corev1.ResourceList)
+	for _, vNode := range vNodes.Items {
+		neighbours[corev1.ResourceName(vNode.Name)] = vNode.Status.Allocatable
+	}
+
+	b := createBroadcaster(sharingPercentage)
+
+	// create fake home and foreign cluster advertisements
+	homeAdv := b.CreateAdvertisement(pNodes, vNodes, availability, images, limits)
+	foreignAdv := homeAdv.DeepCopy()
+	foreignAdv.Name = "advertisement-" + b.ForeignClusterId
+	foreignAdv.Spec.ClusterId = b.ForeignClusterId
+
+	_, err := b.LocalClient.Resource("advertisements").Create(foreignAdv, v1.CreateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = b.RemoteClient.Resource("advertisements").Create(&homeAdv, v1.CreateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(1 * time.Second)
+
+	// after having created home adv on foreign cluster, start watching it
+	go advertisement_operator.WatchAdvertisement(b.LocalClient, b.RemoteClient, homeAdv.Name, foreignAdv.Name)
+
+	// set home cluster adv status and update it: this will trigger the watcher
+	newPodCIDR := "1.2.3.4/16"
+	homeAdv.Status.RemoteRemappedPodCIDR = newPodCIDR
+	_, err = b.RemoteClient.Resource("advertisements").Update(homeAdv.Name, &homeAdv, v1.UpdateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	time.Sleep(5 * time.Second)
+
+	tmp, err := b.LocalClient.Resource("advertisements").Get(foreignAdv.Name, v1.GetOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	foreignAdv = tmp.(*protocolv1.Advertisement)
+	assert.Equal(t, newPodCIDR, foreignAdv.Status.LocalRemappedPodCIDR)
+}


### PR DESCRIPTION
# Description
This PR adds some tests to broadcaster and remote-watcher components, with other minor changes listed below.

## Other changes
- update advertisement on remote cluster when the sharing percentage in `ClusterConfig` changes
- refactoring of broadcaster code: moved some logig in specific methods to have cleaner code
- removed GatewayIP argument to broadcaster deployment: it is now taken through `GetGateway()` function that retrieves the gateway node using the label

# How Has This Been Tested?

- [x] Broadcaster unit tests: added tests for Advertisement creation/update on fake clusters
- [x] Remote-watcher unit tests
1. create `homeAdv` on foreign cluster and `foreignAdv` on home cluster
2. launch remote watcher for `homeAdv`
3. simulate an update of `homeAdv` status by modifying `RemoteRemappedPodCIDR`: the update triggers an update of `LocalRemappedPodCIDR` field in `foreignAdv`
4. check the two values are the same