### PR TITLE
Anti-throttling mechanism

### DIFF
--- a/cmd/virtual-kubelet/internal/commands/root/root.go
+++ b/cmd/virtual-kubelet/internal/commands/root/root.go
@@ -184,7 +184,9 @@ func runRootCommand(ctx context.Context, s *provider.Store, c Opts) error {
 				} else {
 					oldNode.Status = newNode.Status
 					_, newErr = client.CoreV1().Nodes().UpdateStatus(oldNode)
-					klog.Info("node updated")
+					if newErr != nil {
+						klog.Info("node updated")
+					}
 				}
 
 				if newErr != nil {

--- a/internal/kubernetes/configmapReflection_e2e_test.go
+++ b/internal/kubernetes/configmapReflection_e2e_test.go
@@ -33,6 +33,9 @@ func TestHandleConfigmapEvents(t *testing.T) {
 	p := &KubernetesProvider{
 		Reflector:        &Reflector{started: false},
 		ntCache:          &namespaceNTCache{nattingTableName: test.ForeignClusterId},
+		foreignPodCaches: make(map[string]*podCache),
+		homeEpCaches:     make(map[string]*epCache),
+		foreignEpCaches:  make(map[string]*epCache),
 		foreignClient:    foreignClient,
 		homeClient:       homeClient,
 		startTime:        time.Time{},

--- a/internal/kubernetes/endpoints.go
+++ b/internal/kubernetes/endpoints.go
@@ -1,99 +1,63 @@
 package kubernetes
 
 import (
-	"errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog"
-	"strconv"
+	"strings"
+	"time"
 )
 
-func (p *KubernetesProvider) manageRemoteEpEvent(event watch.Event) error {
-	klog.V(3).Info("FOREIGN EP EVENT - starting remote ep reconciliation")
-	foreignEps, ok := event.Object.(*corev1.Endpoints)
-	if !ok {
-		return errors.New("cannot cast endpoints")
-	}
-	klog.V(3).Infof("FOREIGN EP EVENT - event %v on endpoint %v with version %v", event.Type, foreignEps.Name, foreignEps.ResourceVersion)
+const (
+	// epUpdateRate defines the minimum interval in which to push the endpoints in the ep queue
+	epUpdateRate = 500 * time.Millisecond
+	// epExpirationRate defines whether if the ep in the queue is too old to be handled
+	epExpirationRate = 100 * time.Millisecond
 
-	denattedNS, err := p.DeNatNamespace(foreignEps.Namespace)
-	if err != nil {
-		return err
-	}
-	endpoints, err := p.homeClient.Client().CoreV1().Endpoints(denattedNS).Get(foreignEps.Name, metav1.GetOptions{})
-	if err != nil {
-		return err
-	}
+	// resync periods of the local and foreign caches
+	epHomeCacheResyncPeriod    = 1 * time.Second
+	epForeignCacheResyncPeriod = 2 * time.Second
+)
 
-	if !hasToBeUpdated(endpoints.Subsets, foreignEps.Subsets) {
-		klog.V(3).Infof("FOREIGN EP EVENT - endpoint %v has not to be updated", foreignEps.Name)
-		return nil
-	}
-
-	foreignEps.Subsets = p.updateEndpoints(endpoints.Subsets, foreignEps.Subsets)
-
-	_, err = p.foreignClient.Client().CoreV1().Endpoints(foreignEps.Namespace).Update(foreignEps)
-	if err != nil {
-		return err
-	}
-
-	klog.V(3).Infof("FOREIGN EP EVENT - event %v on endpoint %v with version %v correctly reconciliated", event.Type, foreignEps.Name, foreignEps.ResourceVersion)
-
-	return nil
-}
-
-// manageEpEvent gets an event of type watch.MODIFIED, then cast it to the correct type,
-// gets the natted namespace, and finally calls the updateEndpoints function
-func (p *KubernetesProvider) manageEpEvent(event timestampedEvent) error {
-	klog.V(3).Info("HOME EP EVENT - starting home ep reconciliation")
-	endpoints, ok := event.event.Object.(*corev1.Endpoints)
-	if !ok {
-		return errors.New("cannot cast object to endpoint")
-	}
-	klog.V(3).Infof("HOME EP EVENT - event %v on endpoint %v with version %v", event.event.Type, endpoints.Name, endpoints.ResourceVersion)
+// manageEpEvent gets an event a local endpoints resource,
+// translates the namespace, then gets the reflected endpoints,
+// checks whether the remote instance has to be updated according the the local one,
+// and finally calls the updateEndpoints function
+func (p *KubernetesProvider) manageEpEvent(endpoints *corev1.Endpoints) error {
+	klog.V(3).Infof("received update of endpoint %v", endpoints.Name)
 
 	nattedNS, err := p.NatNamespace(endpoints.Namespace, false)
 	if err != nil {
 		return err
 	}
 
-	foreignEps, err := p.foreignClient.Client().CoreV1().Endpoints(nattedNS).Get(endpoints.Name, metav1.GetOptions{})
+	foreignEps, err := p.foreignEpCaches[nattedNS].get(endpoints.Name, metav1.GetOptions{})
 	if err != nil {
 		return err
 	}
 
 	if !hasToBeUpdated(endpoints.Subsets, foreignEps.Subsets) {
-		klog.V(3).Infof("HOME EP EVENT - endpoint %v has not to be updated", foreignEps.Name)
+		klog.V(5).Infof("ep %v hasn't to be updated", endpoints.Name)
 		return nil
 	}
 
-	var t int64
-	if v, ok := foreignEps.GetLabels()[timestampedLabel]; ok {
-		t, err = strconv.ParseInt(v, 10, 64)
-		if err != nil {
-			return nil
-		}
-
-		// old event
-		if event.ts < t {
-			return nil
-		}
-	}
-
+	klog.V(5).Infof("ep %v has to be updated", endpoints.Name)
 	foreignEps.Subsets = p.updateEndpoints(endpoints.Subsets, foreignEps.Subsets)
 
 	if foreignEps.Labels == nil {
 		foreignEps.Labels = make(map[string]string)
 	}
-	foreignEps.Labels[timestampedLabel] = strconv.FormatInt(event.ts, 10)
 	foreignEps.Namespace = nattedNS
 	_, err = p.foreignClient.Client().CoreV1().Endpoints(nattedNS).Update(foreignEps)
 	if err != nil {
 		return err
 	}
 
-	klog.V(3).Infof("HOME EP EVENT - event %v on endpoint %v with version %v correctly reconciliated", event.event.Type, endpoints.Name, endpoints.ResourceVersion)
+	klog.V(3).Infof("Endpoint %v with version %v correctly reconciliated", endpoints.Name, endpoints.ResourceVersion)
 	return nil
 }
 
@@ -122,7 +86,7 @@ func (p *KubernetesProvider) updateEndpoints(eps, foreignEps []corev1.EndpointSu
 			}
 		}
 
-		if foreignEps == nil {
+		if len(foreignEps) == 0 {
 			continue
 		}
 
@@ -135,23 +99,160 @@ func (p *KubernetesProvider) updateEndpoints(eps, foreignEps []corev1.EndpointSu
 	return subsets
 }
 
+// hasToBeUpdated gets two different endpoints instances (local and remote) and
+// check if the remote instance has to be updated according to the local one
 func hasToBeUpdated(home, foreign []corev1.EndpointSubset) bool {
 	if len(home) != len(foreign) {
-		klog.V(4).Info("the ep has to be updated because home and foreign subsets lengths are different")
+		klog.V(6).Info("the ep has to be updated because home and foreign subsets lengths are different")
 		return true
 	}
 	for i := 0; i < len(home); i++ {
 		if len(home[i].Addresses) != len(foreign[i].Addresses) {
-			klog.V(4).Info("the ep has to be updated because home and foreign addresses lengths are different")
+			klog.V(6).Info("the ep has to be updated because home and foreign addresses lengths are different")
 			return true
 		}
 		for j := 0; j < len(home[i].Addresses); j++ {
 			if home[i].Addresses[j].IP != foreign[i].Addresses[j].IP {
-				klog.V(4).Info("the ep has to be updated because home and foreign IPs are different")
+				klog.V(6).Info("the ep has to be updated because home and foreign IPs are different")
 				return true
 			}
 		}
 	}
 
 	return false
+}
+
+// epCache is a structure that serves as endpoints cache and can be used both locally an remotely
+type epCache struct {
+	client    kubernetes.Interface
+	namespace string
+	store     cache.Store
+	stop      chan struct{}
+}
+
+// epCache.get is a method that allows to fetch a specific endpoints from the cache and, if not found,
+// fetches it remotely by using the client
+func (c *epCache) get(name string, options metav1.GetOptions) (*corev1.Endpoints, error) {
+	n := strings.Join([]string{c.namespace, name}, "/")
+	ep, found, _ := c.store.GetByKey(n)
+	if found {
+		klog.V(6).Infof("endpoint %v fetched from cache", name)
+		return ep.(*corev1.Endpoints), nil
+	}
+
+	ep, err := c.client.CoreV1().Endpoints(c.namespace).Get(name, options)
+	if err != nil {
+		return nil, err
+	}
+
+	klog.V(6).Infof("endpoint %v fetched from remote", name)
+	return ep.(*corev1.Endpoints), nil
+}
+
+// epCache.get is a method that allows to list all the endpoints from the cache and,
+// if not eps are found locally, then they are fetched remotely
+func (c *epCache) list(options metav1.ListOptions) (*corev1.EndpointsList, error) {
+	epList := &corev1.EndpointsList{
+		Items: []corev1.Endpoints{},
+	}
+	if c.store == nil {
+		klog.V(6).Info("endpoints listed from remote")
+		return c.client.CoreV1().Endpoints(c.namespace).List(options)
+	}
+
+	eps := c.store.List()
+	if eps == nil {
+		klog.V(6).Info("endpoints listed from remote")
+		return c.client.CoreV1().Endpoints(c.namespace).List(options)
+	}
+
+	for _, ep := range eps {
+		epList.Items = append(epList.Items, ep.(corev1.Endpoints))
+	}
+
+	klog.V(6).Info("endpoints listed from cache")
+	return epList, nil
+}
+
+// newForeignEpCache creates a new cache that serves the remote endpoints.
+func (p *KubernetesProvider) newForeignEpCache(c kubernetes.Interface, namespace string, stopChan chan struct{}) *epCache {
+	listFunc := func(ls metav1.ListOptions) (result runtime.Object, err error) {
+		return c.CoreV1().Endpoints(namespace).List(ls)
+	}
+	watchFunc := func(ls metav1.ListOptions) (watch.Interface, error) {
+		return c.CoreV1().Endpoints(namespace).Watch(ls)
+	}
+
+	store, controller := cache.NewInformer(
+		&cache.ListWatch{
+			ListFunc:  listFunc,
+			WatchFunc: watchFunc,
+		},
+		&corev1.Endpoints{},
+		epForeignCacheResyncPeriod,
+		cache.ResourceEventHandlerFuncs{},
+	)
+
+	go controller.Run(stopChan)
+
+	return &epCache{
+		client:    c,
+		store:     store,
+		stop:      stopChan,
+		namespace: namespace,
+	}
+}
+
+// newForeignEpCache creates a new cache that serves the remote endpoints.
+// whenever the onUpdate function is triggered, the endpoints resource is pushed to the channel handled by the
+// control loop mechanism
+func (p *KubernetesProvider) newHomeEpCache(c kubernetes.Interface, namespace string, stopChan chan struct{}) *epCache {
+	lastUpdates := make(map[string]time.Time)
+	listFunc := func(ls metav1.ListOptions) (result runtime.Object, err error) {
+		eps, err := c.CoreV1().Endpoints(namespace).List(ls)
+		if err != nil {
+			return eps, err
+		}
+		for _, ep := range eps.Items {
+			p.epEvent <- timestampedEndpoints{
+				ep: &ep,
+				t:  time.Now(),
+			}
+		}
+
+		return eps, err
+	}
+	watchFunc := func(ls metav1.ListOptions) (watch.Interface, error) {
+		return c.CoreV1().Endpoints(namespace).Watch(ls)
+	}
+
+	store, controller := cache.NewInformer(
+		&cache.ListWatch{
+			ListFunc:  listFunc,
+			WatchFunc: watchFunc,
+		},
+		&corev1.Endpoints{},
+		epHomeCacheResyncPeriod,
+		cache.ResourceEventHandlerFuncs{
+			UpdateFunc: func(oldObj, newObj interface{}) {
+				ep := newObj.(*corev1.Endpoints)
+				if t, ok := lastUpdates[ep.Name]; !ok || time.Since(t) >= epUpdateRate {
+					p.epEvent <- timestampedEndpoints{
+						ep: ep,
+						t:  time.Now(),
+					}
+					lastUpdates[ep.Name] = time.Now()
+				}
+			},
+		},
+	)
+
+	go controller.Run(stopChan)
+
+	return &epCache{
+		client:    c,
+		store:     store,
+		stop:      stopChan,
+		namespace: namespace,
+	}
 }

--- a/internal/kubernetes/endpointsReflection_e2e_test.go
+++ b/internal/kubernetes/endpointsReflection_e2e_test.go
@@ -31,6 +31,9 @@ func TestHandleEpEvents(t *testing.T) {
 	p := KubernetesProvider{
 		Reflector:        &Reflector{started: false},
 		ntCache:          &namespaceNTCache{nattingTableName: test.ForeignClusterId},
+		foreignPodCaches: make(map[string]*podCache),
+		homeEpCaches:     make(map[string]*epCache),
+		foreignEpCaches:  make(map[string]*epCache),
 		foreignClient:    foreignClient,
 		homeClient:       homeClient,
 		startTime:        time.Time{},

--- a/internal/kubernetes/kubernetes.go
+++ b/internal/kubernetes/kubernetes.go
@@ -17,11 +17,13 @@ import (
 type KubernetesProvider struct { // nolint:golint]
 	*Reflector
 
-	ntCache          *namespaceNTCache
-	nodeUpdateClient *crdClient.CRDClient
-	foreignClient    *crdClient.CRDClient
-	homeClient       *crdClient.CRDClient
-
+	ntCache            *namespaceNTCache
+	foreignPodCaches   map[string]*podCache
+	homeEpCaches       map[string]*epCache
+	foreignEpCaches    map[string]*epCache
+	nodeUpdateClient   *crdClient.CRDClient
+	foreignClient      *crdClient.CRDClient
+	homeClient         *crdClient.CRDClient
 	nodeName           string
 	operatingSystem    string
 	internalIP         string
@@ -72,6 +74,9 @@ func NewKubernetesProvider(nodeName, clusterId, homeClusterId, operatingSystem s
 	provider := KubernetesProvider{
 		Reflector:             &Reflector{},
 		ntCache:               &namespaceNTCache{nattingTableName: clusterId},
+		foreignPodCaches:      make(map[string]*podCache),
+		homeEpCaches:          make(map[string]*epCache),
+		foreignEpCaches:       make(map[string]*epCache),
 		nodeName:              nodeName,
 		operatingSystem:       operatingSystem,
 		internalIP:            internalIP,

--- a/internal/kubernetes/secretReflection_e2e_test.go
+++ b/internal/kubernetes/secretReflection_e2e_test.go
@@ -33,6 +33,9 @@ func TestHandleSecretEvents(t *testing.T) {
 	p := &KubernetesProvider{
 		Reflector:        &Reflector{started: false},
 		ntCache:          &namespaceNTCache{nattingTableName: test.ForeignClusterId},
+		foreignPodCaches: make(map[string]*podCache),
+		homeEpCaches:     make(map[string]*epCache),
+		foreignEpCaches:  make(map[string]*epCache),
 		foreignClient:    foreignClient,
 		homeClient:       homeClient,
 		startTime:        time.Time{},

--- a/internal/kubernetes/serviceReflection_e2e_test.go
+++ b/internal/kubernetes/serviceReflection_e2e_test.go
@@ -33,6 +33,9 @@ func TestHandleServiceEvents(t *testing.T) {
 	p := &KubernetesProvider{
 		Reflector:        &Reflector{started: false},
 		ntCache:          &namespaceNTCache{nattingTableName: test.ForeignClusterId},
+		foreignPodCaches: make(map[string]*podCache),
+		homeEpCaches:     make(map[string]*epCache),
+		foreignEpCaches:  make(map[string]*epCache),
 		foreignClient:    foreignClient,
 		homeClient:       homeClient,
 		startTime:        time.Time{},

--- a/internal/kubernetes/virtualNodeupdater.go
+++ b/internal/kubernetes/virtualNodeupdater.go
@@ -48,8 +48,7 @@ func (p *KubernetesProvider) ReconcileNodeFromAdv(event watch.Event) {
 
 	adv, ok := event.Object.(*advv1.Advertisement)
 	if !ok {
-		klog.Error("error in casting advertisement")
-		return
+		klog.Fatal("error in casting advertisement")
 	}
 	if event.Type == watch.Deleted {
 		klog.Infof("advertisement %v deleted...the node is going to be deleted", adv.Name)


### PR DESCRIPTION
# Description
This PR implements a mechanism that prevents both the home and foreign clients to be throttled from the API server. Since the clients have to perform many interactions with the API server, the interactions have been limited in number and timing: the expired events aren't reflected remotely and the CRUD operations are handled by a synchronization mechanism that allows performing only a defined number of operations per second.