### PR TITLE
Enable default LAN discovery

### DIFF
--- a/deployments/liqo_chart/templates/clusterconfig.yaml
+++ b/deployments/liqo_chart/templates/clusterconfig.yaml
@@ -12,8 +12,8 @@ spec:
   discoveryConfig:
     autojoin: true
     domain: local.
-    enableAdvertisement: false
-    enableDiscovery: false
+    enableAdvertisement: true
+    enableDiscovery: true
     name: MyLiqo
     port: 6443
     service: _liqo._tcp


### PR DESCRIPTION
# Description

Set default Liqo configuration to discover clusters on LAN
