### PR TITLE
Unjoin

### DIFF
--- a/api/discovery/v1/foreigncluster_methods.go
+++ b/api/discovery/v1/foreigncluster_methods.go
@@ -1,12 +1,15 @@
 package v1
 
 import (
+	protocolv1 "github.com/liqoTech/liqo/api/advertisement-operator/v1"
+	"github.com/liqoTech/liqo/pkg/crdClient"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	"k8s.io/klog"
 )
 
 func (fc *ForeignCluster) GetConfig(client kubernetes.Interface) (*rest.Config, error) {
@@ -81,6 +84,35 @@ func (fc *ForeignCluster) LoadForeignCA(localClient kubernetes.Interface, localN
 		Name:       localSecret.Name,
 		UID:        localSecret.UID,
 		APIVersion: "v1",
+	}
+	return nil
+}
+
+func (fc *ForeignCluster) SetAdvertisement(adv *protocolv1.Advertisement, discoveryClient *crdClient.CRDClient) error {
+	if fc.Status.Advertisement == nil {
+		// Advertisement has not been set in ForeignCluster yet
+		fc.Status.Advertisement = &v1.ObjectReference{
+			Kind:       "Advertisement",
+			Name:       adv.Name,
+			UID:        adv.UID,
+			APIVersion: "protocol.liqo.io/v1",
+		}
+		_, err := discoveryClient.Resource("foreignclusters").Update(fc.Name, fc, metav1.UpdateOptions{})
+		if err != nil {
+			klog.Error(err, err.Error())
+			return err
+		}
+	}
+	return nil
+}
+
+func (fc *ForeignCluster) DeleteAdvertisement(advClient *crdClient.CRDClient) error {
+	if fc.Status.Advertisement != nil {
+		err := advClient.Resource("advertisements").Delete(fc.Status.Advertisement.Name, metav1.DeleteOptions{})
+		if err != nil {
+			return err
+		}
+		fc.Status.Advertisement = nil
 	}
 	return nil
 }

--- a/api/discovery/v1/foreigncluster_types.go
+++ b/api/discovery/v1/foreigncluster_types.go
@@ -27,15 +27,24 @@ import (
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
+type DiscoveryType string
+
+const (
+	LanDiscovery    DiscoveryType = "LAN"
+	WanDiscovery    DiscoveryType = "WAN"
+	ManualDiscovery DiscoveryType = "Manual"
+)
+
 // ForeignClusterSpec defines the desired state of ForeignCluster
 type ForeignClusterSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
-	ClusterID string `json:"clusterID"`
-	Namespace string `json:"namespace"`
-	Join      bool   `json:"join"`
-	ApiUrl    string `json:"apiUrl"`
+	ClusterID     string        `json:"clusterID"`
+	Namespace     string        `json:"namespace"`
+	Join          bool          `json:"join"`
+	ApiUrl        string        `json:"apiUrl"`
+	DiscoveryType DiscoveryType `json:"discoveryType"`
 }
 
 // ForeignClusterStatus defines the observed state of ForeignCluster
@@ -46,9 +55,12 @@ type ForeignClusterStatus struct {
 	Joined             bool                `json:"joined"`
 	PeeringRequestName string              `json:"peering-request-name"`
 	CaDataRef          *v1.ObjectReference `json:"caDataRef,omitempty"`
+	Advertisement      *v1.ObjectReference `json:"advertisement,omitempty"`
+	Ttl                int                 `json:"ttl,omitempty"`
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Cluster
 
 // ForeignCluster is the Schema for the foreignclusters API

--- a/cmd/advertisement-operator/main.go
+++ b/cmd/advertisement-operator/main.go
@@ -17,6 +17,8 @@ package main
 
 import (
 	"flag"
+	discoveryv1 "github.com/liqoTech/liqo/api/discovery/v1"
+	"github.com/liqoTech/liqo/pkg/crdClient"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
@@ -119,6 +121,17 @@ func main() {
 		}
 	}
 
+	discoveryConfig, err := crdClient.NewKubeconfig(localKubeconfig, &discoveryv1.GroupVersion)
+	if err != nil {
+		klog.Error(err, "unable to get kube config")
+		os.Exit(1)
+	}
+	discoveryClient, err := crdClient.NewFromConfig(discoveryConfig)
+	if err != nil {
+		klog.Errorln(err, "unable to create local client for Discovery")
+		os.Exit(1)
+	}
+
 	r := &advertisement_operator.AdvertisementReconciler{
 		Client:           mgr.GetClient(),
 		Scheme:           mgr.GetScheme(),
@@ -130,6 +143,7 @@ func main() {
 		HomeClusterId:    clusterId,
 		AcceptedAdvNum:   acceptedAdv,
 		AdvClient:        advClient,
+		DiscoveryClient:  discoveryClient,
 		RetryTimeout:     1 * time.Minute,
 	}
 

--- a/cmd/discovery/main.go
+++ b/cmd/discovery/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	protocolv1 "github.com/liqoTech/liqo/api/advertisement-operator/v1"
 	discoveryv1 "github.com/liqoTech/liqo/api/discovery/v1"
 	"github.com/liqoTech/liqo/internal/discovery"
 	foreign_cluster_operator "github.com/liqoTech/liqo/internal/discovery/foreign-cluster-operator"
@@ -11,6 +12,7 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/klog"
 	"os"
+	"path/filepath"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"time"
 )
@@ -22,6 +24,7 @@ var (
 func init() {
 	_ = clientgoscheme.AddToScheme(scheme)
 	_ = discoveryv1.AddToScheme(scheme)
+	_ = protocolv1.AddToScheme(scheme)
 	// +kubebuilder:scaffold:scheme
 }
 
@@ -30,12 +33,14 @@ func main() {
 
 	var namespace string
 	var requeueAfter int64 // seconds
+	var kubeconfigPath string
 
 	flag.StringVar(&namespace, "namespace", "default", "Namespace where your configs are stored.")
 	flag.Int64Var(&requeueAfter, "requeueAfter", 30, "Period after that PeeringRequests status is rechecked (seconds)")
+	flag.StringVar(&kubeconfigPath, "kubeconfigPath", filepath.Join(os.Getenv("HOME"), ".kube", "config"), "For debug purpose, set path to local kubeconfig")
 	flag.Parse()
 
-	clusterId, err := clusterID.NewClusterID()
+	clusterId, err := clusterID.NewClusterID(kubeconfigPath)
 	if err != nil {
 		klog.Error(err, err.Error())
 		os.Exit(1)
@@ -46,7 +51,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	discoveryCtl, err := discovery.NewDiscoveryCtrl(namespace, clusterId)
+	discoveryCtl, err := discovery.NewDiscoveryCtrl(namespace, clusterId, kubeconfigPath)
 	if err != nil {
 		klog.Error(err, err.Error())
 		os.Exit(1)
@@ -67,10 +72,10 @@ func main() {
 	}
 
 	klog.Info("Starting SearchDomain operator")
-	search_domain_operator.StartOperator(&mgr, time.Duration(requeueAfter)*time.Second, discoveryCtl)
+	search_domain_operator.StartOperator(&mgr, time.Duration(requeueAfter)*time.Second, discoveryCtl, kubeconfigPath)
 
 	klog.Info("Starting ForeignCluster operator")
-	foreign_cluster_operator.StartOperator(&mgr, namespace, time.Duration(requeueAfter)*time.Second, discoveryCtl)
+	foreign_cluster_operator.StartOperator(&mgr, namespace, time.Duration(requeueAfter)*time.Second, discoveryCtl, kubeconfigPath)
 
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
 		klog.Error(err, "problem running manager")

--- a/cmd/peering-request-operator/main.go
+++ b/cmd/peering-request-operator/main.go
@@ -7,6 +7,7 @@ import (
 	peering_request_admission "github.com/liqoTech/liqo/internal/peering-request-operator/peering-request-admission"
 	"k8s.io/klog"
 	"os"
+	"path/filepath"
 )
 
 func main() {
@@ -14,11 +15,13 @@ func main() {
 
 	var liqoConfigmap, broadcasterImage, broadcasterServiceAccount string
 	var inputEnvFile string
+	var kubeconfigPath string
 
 	flag.StringVar(&inputEnvFile, "input-env-file", "/etc/environment/liqo/env", "The environment variable file to source at startup")
 	flag.StringVar(&liqoConfigmap, "config-map", "liqo-configmap", "Liqo ConfigMap name")
 	flag.StringVar(&broadcasterImage, "broadcaster-image", "liqo/advertisement-broadcaster", "Broadcaster-operator image name")
 	flag.StringVar(&broadcasterServiceAccount, "broadcaster-sa", "broadcaster", "Broadcaster-operator ServiceAccount name")
+	flag.StringVar(&kubeconfigPath, "kubeconfigPath", filepath.Join(os.Getenv("HOME"), ".kube", "config"), "For debug purpose, set path to local kubeconfig")
 	flag.Parse()
 
 	if err := godotenv.Load(inputEnvFile); err != nil {
@@ -40,8 +43,8 @@ func main() {
 	}
 
 	klog.Info("Starting admission webhook")
-	_ = peering_request_admission.StartWebhook(certPath, keyPath, namespace)
+	_ = peering_request_admission.StartWebhook(certPath, keyPath, namespace, kubeconfigPath)
 
 	klog.Info("Starting peering-request operator")
-	peering_request_operator.StartOperator(namespace, liqoConfigmap, broadcasterImage, broadcasterServiceAccount)
+	peering_request_operator.StartOperator(namespace, liqoConfigmap, broadcasterImage, broadcasterServiceAccount, kubeconfigPath)
 }

--- a/deployments/liqo_chart/crds/foreign-cluster-crd.yaml
+++ b/deployments/liqo_chart/crds/foreign-cluster-crd.yaml
@@ -46,8 +46,16 @@ spec:
             apiUrl:
               type: string
               description: URL where to contact foreign API server
+            discoveryType:
+              type: string
+              enum:
+                - LAN
+                - WAN
+                - Manual
           required:
             - join
+            - discoveryType
+          type: object
         status:
           properties:
             joined:
@@ -56,3 +64,13 @@ spec:
             peering-request-name:
               type: string
               description: Name of created PR
+            caDataRef:
+              type: object
+              description: Object Reference to retrieved CaData Secret
+            advertisement:
+              type: object
+              description: Object Reference to created Advertisement CR
+            ttl:
+              type: integer
+              description: If discoveryType is LAN and this counter reach 0 value, this FC will be removed
+          type: object

--- a/go.mod
+++ b/go.mod
@@ -76,11 +76,11 @@ require (
 	k8s.io/klog v1.0.0
 	k8s.io/kubectl v0.17.0
 	k8s.io/kubernetes v1.17.0
-	k8s.io/metrics v0.18.5
+	k8s.io/metrics v0.18.5 // indirect
 	k8s.io/utils v0.0.0-20191114184206-e782cd3c129f
 	mvdan.cc/unparam v0.0.0-20191111180625-960b1ec0f2c2 // indirect
 	sigs.k8s.io/controller-runtime v0.4.0
-	sigs.k8s.io/yaml v1.2.0
+	sigs.k8s.io/yaml v1.2.0 // indirect
 	sourcegraph.com/sqs/pbtypes v1.0.0 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,7 @@ cloud.google.com/go v0.46.3/go.mod h1:a6bKKbmY7er1mI7TEI4lsAkts/mkhTSZK8w33B4RAg
 cloud.google.com/go v0.50.0/go.mod h1:r9sluTvynVuxRIOHXQEHMFffphuXHOMZMycpNR5e6To=
 cloud.google.com/go v0.52.0/go.mod h1:pXajvRH/6o3+F9jDHZWQ5PbGhn+o8w9qiu/CffaVdO4=
 cloud.google.com/go v0.53.0/go.mod h1:fp/UouUEsRkN6ryDKNW/Upv/JBKnv6WDthjR6+vze6M=
+cloud.google.com/go v0.56.0 h1:WRz29PgAsVEyPSDHyk+0fpEkwEFyfhHn+JbksT6gIL4=
 cloud.google.com/go v0.56.0/go.mod h1:jr7tqZxxKOVYizybht9+26Z/gUq7tiRzu+ACVAMbKVk=
 cloud.google.com/go/bigquery v1.0.1/go.mod h1:i/xbL2UlR5RvWAURpBYZTtm/cXjCha9lbfbpx4poX+o=
 cloud.google.com/go/bigquery v1.3.0/go.mod h1:PjpwJnslEMmckchkHFfq+HTD2DmtT67aNFKH1/VBDHE=
@@ -1037,6 +1038,7 @@ golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHl
 golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f h1:J5lckAjkw6qYlOZNj90mLYNTEKDvWeuc1yieZ8qUzUE=
 golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f/go.mod h1:5qLYkcX4OjUUV8bRuDixDT3tpyyb+LUpUlRWLxfhWrs=
 golang.org/x/lint v0.0.0-20200130185559-910be7a94367/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
+golang.org/x/lint v0.0.0-20200302205851-738671d3881b h1:Wh+f8QHJXR411sJR8/vRBTZ7YapZaRvUcLFFJhusH0k=
 golang.org/x/lint v0.0.0-20200302205851-738671d3881b/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/mobile v0.0.0-20190312151609-d3739f865fa6/go.mod h1:z+o9i4GpDbdi3rU15maQ/Ox0txvL9dWGYEHz965HBQE=
 golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028/go.mod h1:E/iHnbuqvinMTCcRqshq8CkpyQDoeVncDDYHnLhea+o=
@@ -1044,6 +1046,7 @@ golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKG
 golang.org/x/mod v0.1.0/go.mod h1:0QHyrYULN0/3qlju5TqG8bIK38QM8yzMo5ekMj3DlcY=
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.1.1-0.20191107180719-034126e5016b/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
+golang.org/x/mod v0.2.0 h1:KU7oHjnv3XNWfa5COkzUifxZmxp1TyI7ImMXqFxLwvQ=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20170114055629-f2499483f923/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20170915142106-8351a756f30f/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -1093,6 +1096,7 @@ golang.org/x/oauth2 v0.0.0-20190402181905-9f3314589c9a/go.mod h1:gOpvHmFTYa4Iltr
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45 h1:SVwTIAaPC2U/AvvLNZ2a7OVsmBpC8L5BlwK1whH3hm0=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
+golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d h1:TzXSXBo42m9gQenoE3b9BGiEpg5IG2JkU5FkPIawgtw=
 golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/perf v0.0.0-20180704124530-6e6d33e29852/go.mod h1:JLpeXjPJfIyPr5TlbXLkXWLhP8nz10XfvxElABhCtcw=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -1238,6 +1242,7 @@ golang.org/x/tools v0.0.0-20200204074204-1cc6d1ef6c74/go.mod h1:TB2adYChydJhpapK
 golang.org/x/tools v0.0.0-20200207183749-b753a1ba74fa/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200212150539-ea181f53ac56/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200224181240-023911ca70b2/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
+golang.org/x/tools v0.0.0-20200331025713-a30bf2db82d4 h1:kDtqNkeBrZb8B+atrj50B5XLHpzXXqcCdZPP/ApQ5NY=
 golang.org/x/tools v0.0.0-20200331025713-a30bf2db82d4/go.mod h1:Sl4aGygMT6LrqrWclx+PTx3U+LnKx/seiNR+3G19Ar8=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898 h1:/atklqdjdhuosWIl6AIbOeHJjicWYPqR9bpxqxYG2pA=
@@ -1274,6 +1279,7 @@ google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7
 google.golang.org/appengine v1.5.0 h1:KxkO13IPW4Lslp2bz+KHP2E3gtFlrIGNThxkZQ3g+4c=
 google.golang.org/appengine v1.5.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.6.1/go.mod h1:i06prIuMbXzDqacNJfV5OdTW448YApPu5ww/cMBSeb0=
+google.golang.org/appengine v1.6.5 h1:tycE03LOZYQNhDpS27tcQdAzLCVMaj7QT2SXxebnpCM=
 google.golang.org/appengine v1.6.5/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/genproto v0.0.0-20170731182057-09f6ed296fc6/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
@@ -1386,6 +1392,7 @@ honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.1-2019.2.2/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2019.2.3 h1:3JgtbtFHMiCmsznwGVTUWbgGov+pVqnlf1dEJTNAXeM=
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
+honnef.co/go/tools v0.0.1-2020.1.3 h1:sXmLre5bzIR6ypkjXCDI3jHPssRhc8KD/Ome589sc3U=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 k8s.io/api v0.0.0-20190805141119-fdd30b57c827 h1:Yf7m8lslHFWm22YDRTAHrGPh729A6Lmxcm1weHHBTuw=
 k8s.io/api v0.0.0-20190805141119-fdd30b57c827/go.mod h1:TBhBqb1AWbBQbW3XRusr7n7E4v2+5ZY8r8sAMnyFC5A=

--- a/internal/discovery/discovery-config.go
+++ b/internal/discovery/discovery-config.go
@@ -5,11 +5,9 @@ import (
 	"github.com/liqoTech/liqo/pkg/clusterConfig"
 	"github.com/liqoTech/liqo/pkg/crdClient"
 	"k8s.io/klog"
-	"os"
-	"path/filepath"
 )
 
-func (discovery *DiscoveryCtrl) GetDiscoveryConfig(crdClient *crdClient.CRDClient) error {
+func (discovery *DiscoveryCtrl) GetDiscoveryConfig(crdClient *crdClient.CRDClient, kubeconfigPath string) error {
 	waitFirst := make(chan bool)
 	isFirst := true
 	go clusterConfig.WatchConfiguration(func(configuration *policyv1.ClusterConfig) {
@@ -19,7 +17,7 @@ func (discovery *DiscoveryCtrl) GetDiscoveryConfig(crdClient *crdClient.CRDClien
 			waitFirst <- true
 			isFirst = false
 		}
-	}, crdClient, filepath.Join(os.Getenv("HOME"), ".kube", "config"))
+	}, crdClient, kubeconfigPath)
 	<-waitFirst
 	close(waitFirst)
 

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -6,7 +6,6 @@ import (
 	"github.com/liqoTech/liqo/pkg/clusterID"
 	"github.com/liqoTech/liqo/pkg/crdClient"
 	"os"
-	"path/filepath"
 )
 
 type DiscoveryCtrl struct {
@@ -18,8 +17,8 @@ type DiscoveryCtrl struct {
 	ClusterId *clusterID.ClusterID
 }
 
-func NewDiscoveryCtrl(namespace string, clusterId *clusterID.ClusterID) (*DiscoveryCtrl, error) {
-	config, err := crdClient.NewKubeconfig(filepath.Join(os.Getenv("HOME"), ".kube", "config"), &discoveryv1.GroupVersion)
+func NewDiscoveryCtrl(namespace string, clusterId *clusterID.ClusterID, kubeconfigPath string) (*DiscoveryCtrl, error) {
+	config, err := crdClient.NewKubeconfig(kubeconfigPath, &discoveryv1.GroupVersion)
 	if err != nil {
 		return nil, err
 	}
@@ -32,7 +31,7 @@ func NewDiscoveryCtrl(namespace string, clusterId *clusterID.ClusterID) (*Discov
 		crdClient,
 		clusterId,
 	)
-	if discoveryCtrl.GetDiscoveryConfig(nil) != nil {
+	if discoveryCtrl.GetDiscoveryConfig(nil, kubeconfigPath) != nil {
 		os.Exit(1)
 	}
 	return &discoveryCtrl, nil

--- a/internal/discovery/foreign.go
+++ b/internal/discovery/foreign.go
@@ -9,6 +9,12 @@ import (
 
 func (discovery *DiscoveryCtrl) UpdateForeign(data []*TxtData, sd *v1.SearchDomain) []*v1.ForeignCluster {
 	createdForeign := []*v1.ForeignCluster{}
+	var discoveryType v1.DiscoveryType
+	if sd == nil {
+		discoveryType = v1.LanDiscovery
+	} else {
+		discoveryType = v1.WanDiscovery
+	}
 	for _, txtData := range data {
 		if txtData.ID == discovery.ClusterId.GetClusterID() {
 			// is local cluster
@@ -19,7 +25,7 @@ func (discovery *DiscoveryCtrl) UpdateForeign(data []*TxtData, sd *v1.SearchDoma
 			// already exists
 			continue
 		}
-		fc, err := discovery.createForeign(txtData, sd)
+		fc, err := discovery.createForeign(txtData, sd, discoveryType)
 		if err != nil {
 			klog.Error(err, err.Error())
 			continue
@@ -27,19 +33,79 @@ func (discovery *DiscoveryCtrl) UpdateForeign(data []*TxtData, sd *v1.SearchDoma
 		klog.Info("ForeignCluster " + txtData.ID + " created")
 		createdForeign = append(createdForeign, fc)
 	}
+	if discoveryType == v1.LanDiscovery {
+		_ = discovery.UpdateTtl(data)
+	}
 	return createdForeign
 }
 
-func (discovery *DiscoveryCtrl) createForeign(txtData *TxtData, sd *v1.SearchDomain) (*v1.ForeignCluster, error) {
+func (discovery *DiscoveryCtrl) UpdateTtl(txts []*TxtData) error {
+	// find all ForeignCluster with discovery type LAN
+	tmp, err := discovery.crdClient.Resource("foreignclusters").List(metav1.ListOptions{
+		LabelSelector: "discovery-type=LAN",
+	})
+	if err != nil {
+		klog.Error(err, err.Error())
+		return err
+	}
+	fcs, ok := tmp.(*v1.ForeignClusterList)
+	if !ok {
+		err = errors.New("retrieved object is not a ForeignClusterList")
+		klog.Error(err, err.Error())
+		return err
+	}
+	for _, fc := range fcs.Items {
+		// find the ones that are not in the last retrieved list on LAN
+		found := false
+		for _, txt := range txts {
+			if txt.ID == fc.Spec.ClusterID {
+				found = true
+				// if cluster TTL was decreased, reset it to default value
+				if fc.Status.Ttl != 3 {
+					fc.Status.Ttl = 3
+					_, err = discovery.crdClient.Resource("foreignclusters").Update(fc.Name, &fc, metav1.UpdateOptions{})
+					if err != nil {
+						klog.Error(err, err.Error())
+						continue
+					}
+				}
+				break
+			}
+		}
+		if !found {
+			// if ForeignCluster is not in Txt list, reduce its TTL
+			fc.Status.Ttl -= 1
+			if fc.Status.Ttl <= 0 {
+				// delete ForeignCluster
+				err = discovery.crdClient.Resource("foreignclusters").Delete(fc.Name, metav1.DeleteOptions{})
+				if err != nil {
+					klog.Error(err, err.Error())
+					continue
+				}
+			} else {
+				// update ForeignCluster
+				_, err = discovery.crdClient.Resource("foreignclusters").Update(fc.Name, &fc, metav1.UpdateOptions{})
+				if err != nil {
+					klog.Error(err, err.Error())
+					continue
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (discovery *DiscoveryCtrl) createForeign(txtData *TxtData, sd *v1.SearchDomain, discoveryType v1.DiscoveryType) (*v1.ForeignCluster, error) {
 	fc := &v1.ForeignCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: txtData.ID,
 		},
 		Spec: v1.ForeignClusterSpec{
-			ClusterID: txtData.ID,
-			Namespace: txtData.Namespace,
-			Join:      discovery.Config.AutoJoin,
-			ApiUrl:    txtData.ApiUrl,
+			ClusterID:     txtData.ID,
+			Namespace:     txtData.Namespace,
+			Join:          discovery.Config.AutoJoin,
+			ApiUrl:        txtData.ApiUrl,
+			DiscoveryType: discoveryType,
 		},
 	}
 	if sd != nil {
@@ -52,6 +118,10 @@ func (discovery *DiscoveryCtrl) createForeign(txtData *TxtData, sd *v1.SearchDom
 				UID:        sd.UID,
 			},
 		}
+	}
+	if discoveryType == v1.LanDiscovery {
+		// set TTL to default value
+		fc.Status.Ttl = 3
 	}
 	tmp, err := discovery.crdClient.Resource("foreignclusters").Create(fc, metav1.CreateOptions{})
 	if err != nil {

--- a/internal/discovery/search-domain-operator/setup.go
+++ b/internal/discovery/search-domain-operator/setup.go
@@ -9,7 +9,6 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"k8s.io/klog"
 	"os"
-	"path/filepath"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"time"
 )
@@ -24,8 +23,8 @@ func init() {
 	// +kubebuilder:scaffold:scheme
 }
 
-func StartOperator(mgr *manager.Manager, requeueAfter time.Duration, discoveryCtrl *discovery.DiscoveryCtrl) {
-	config, err := crdClient.NewKubeconfig(filepath.Join(os.Getenv("HOME"), ".kube", "config"), &discoveryv1.GroupVersion)
+func StartOperator(mgr *manager.Manager, requeueAfter time.Duration, discoveryCtrl *discovery.DiscoveryCtrl, kubeconfigPath string) {
+	config, err := crdClient.NewKubeconfig(kubeconfigPath, &discoveryv1.GroupVersion)
 	if err != nil {
 		klog.Error(err, "unable to get kube config")
 		os.Exit(1)

--- a/internal/peering-request-operator/peering-request-admission/setup.go
+++ b/internal/peering-request-operator/peering-request-admission/setup.go
@@ -8,22 +8,21 @@ import (
 	"k8s.io/klog"
 	"net/http"
 	"os"
-	"path/filepath"
 )
 
-func StartWebhook(certPath string, keyPath string, namespace string) *WebhookServer {
+func StartWebhook(certPath string, keyPath string, namespace string, kubeconfigPath string) *WebhookServer {
 	port := 8443
-	return startTls(certPath, keyPath, port, namespace)
+	return startTls(certPath, keyPath, port, namespace, kubeconfigPath)
 }
 
-func startTls(certPath string, keyPath string, port int, namespace string) *WebhookServer {
+func startTls(certPath string, keyPath string, port int, namespace string, kubeconfigPath string) *WebhookServer {
 	pair, err := tls.LoadX509KeyPair(certPath, keyPath)
 	if err != nil {
 		klog.Error(err, err.Error())
 		os.Exit(1)
 	}
 
-	config, err := crdClient.NewKubeconfig(filepath.Join(os.Getenv("HOME"), ".kube", "config"), &discoveryv1.GroupVersion)
+	config, err := crdClient.NewKubeconfig(kubeconfigPath, &discoveryv1.GroupVersion)
 	if err != nil {
 		klog.Error(err, "unable to get kube config")
 		os.Exit(1)

--- a/internal/peering-request-operator/setup.go
+++ b/internal/peering-request-operator/setup.go
@@ -8,7 +8,6 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/klog"
 	"os"
-	"path/filepath"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"time"
 )
@@ -23,7 +22,7 @@ func init() {
 	// +kubebuilder:scaffold:scheme
 }
 
-func StartOperator(namespace string, configMapName string, broadcasterImage string, broadcasterServiceAccount string) {
+func StartOperator(namespace string, configMapName string, broadcasterImage string, broadcasterServiceAccount string, kubeconfigPath string) {
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:           scheme,
 		Port:             9443,
@@ -35,7 +34,7 @@ func StartOperator(namespace string, configMapName string, broadcasterImage stri
 		os.Exit(1)
 	}
 
-	config, err := crdClient.NewKubeconfig(filepath.Join(os.Getenv("HOME"), ".kube", "config"), &discoveryv1.GroupVersion)
+	config, err := crdClient.NewKubeconfig(kubeconfigPath, &discoveryv1.GroupVersion)
 	if err != nil {
 		klog.Error(err, "unable to get kube config")
 		os.Exit(1)
@@ -46,7 +45,7 @@ func StartOperator(namespace string, configMapName string, broadcasterImage stri
 		os.Exit(1)
 	}
 
-	clusterId, err := clusterID.NewClusterID()
+	clusterId, err := clusterID.NewClusterID(kubeconfigPath)
 	if err != nil {
 		klog.Error(err, "unable to get clusterID")
 		os.Exit(1)

--- a/pkg/clusterID/clusterID.go
+++ b/pkg/clusterID/clusterID.go
@@ -13,7 +13,6 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog"
 	"os"
-	"path/filepath"
 	"sort"
 	"strings"
 	"sync"
@@ -34,8 +33,8 @@ func GetNewClusterID(id string, client kubernetes.Interface) *ClusterID {
 	}
 }
 
-func NewClusterID() (*ClusterID, error) {
-	config, err := crdClient.NewKubeconfig(filepath.Join(os.Getenv("HOME"), ".kube", "config"), &discoveryv1.GroupVersion)
+func NewClusterID(kubeconfigPath string) (*ClusterID, error) {
+	config, err := crdClient.NewKubeconfig(kubeconfigPath, &discoveryv1.GroupVersion)
 	if err != nil {
 		klog.Error(err, "unable to get kube config")
 		os.Exit(1)

--- a/scripts/discovery/foreign-cluster.yaml
+++ b/scripts/discovery/foreign-cluster.yaml
@@ -7,3 +7,4 @@ spec:
   join: true
   namespace: default
   apiUrl: https://192.168.2.100:6443
+  discoveryType: Manual


### PR DESCRIPTION
# Description

This PR adds first step of unjoin process. When you finish to use remote resources you can set `join` flag on that cluster to delete the `PeeringRequest` (-> broadcaster) and the `Advertisement` (-> vk, node, ...)

For other side we can delete received `PeeringRequest` and created `Advertisement` when we want to stop resource sharing. Adv related FC will be triggered by OwnerReference and updates its status

Another new feature is `DiscoveryType` in `ForeignCluster` that let us to know how the specific resource has been discovered. Possible values are `LAN`, `WAN` and `Manual`. For LAN discovered FC is set a TTL, if this cluster is no more visible on mDNS discovery this counter is decreased. When TTL reach 0 value, FC is deleted

# How Has This Been Tested?

- [x] new tests on TTL feature written
- [x] new tests on disable `join` flag and `Advertisement` delete written
- [x] due to test environment garbage collector tests on triggering event on Adv delete can't be tested, I've done some manual tests on my k3s installation