### PR TITLE
Control loop safety function removed

### DIFF
--- a/internal/tray-agent/agent/client/advertisement-op.go
+++ b/internal/tray-agent/agent/client/advertisement-op.go
@@ -12,7 +12,7 @@ func DescribeAdvertisement(adv *advtypes.Advertisement) string {
 	prices := adv.Spec.Prices
 	str.WriteString(fmt.Sprintf("• ClusterID: %v\n", adv.Spec.ClusterId))
 	str.WriteString(fmt.Sprintf("\t• STATUS: %v\n", adv.Status.AdvertisementStatus))
-	str.WriteString(fmt.Sprintf("\t• Available Resources:\n"))
+	str.WriteString("\t• Available Resources:\n")
 	str.WriteString(fmt.Sprintf("\t\t- shared cpu = %v ", adv.Spec.ResourceQuota.Hard.Cpu()))
 	if CpuPrice, cFound := prices["cpu"]; cFound {
 		str.WriteString(fmt.Sprintf("[price %v]", CpuPrice.String()))


### PR DESCRIPTION
# Description

This commit removes part of the endpoints control loop not needed since
logic in #100 has been merged in master. This logic was in charge of
re-pushing the update event in the event queue if the update triggered
an error. With the anti-throttling mechanism, if this occurs, the event
will be automatically ignored, due to its expiration.
