### PR TITLE
Add checks on negative advertised resources

### DIFF
--- a/internal/advertisement-operator/broadcaster.go
+++ b/internal/advertisement-operator/broadcaster.go
@@ -428,7 +428,13 @@ func ComputeAnnouncedResources(physicalNodes *corev1.NodeList, reqs corev1.Resou
 	// subtract used resources from available ones to have available resources
 	cpu := allocatable.Cpu().DeepCopy()
 	cpu.Sub(reqs.Cpu().DeepCopy())
+	if cpu.Value() < 0 {
+		cpu.Set(0)
+	}
 	mem := allocatable.Memory().DeepCopy()
+	if mem.Value() < 0 {
+		mem.Set(0)
+	}
 	mem.Sub(reqs.Memory().DeepCopy())
 	pods := allocatable.Pods().DeepCopy()
 

--- a/internal/advertisement-operator/controller.go
+++ b/internal/advertisement-operator/controller.go
@@ -114,6 +114,12 @@ func (r *AdvertisementReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 // check if the advertisement is interesting and set its status accordingly
 func (r *AdvertisementReconciler) CheckAdvertisement(adv *protocolv1.Advertisement) {
+	// if announced resources are negative, always refuse the Adv
+	for _, v := range adv.Spec.ResourceQuota.Hard {
+		if v.Value() < 0 {
+			adv.Status.AdvertisementStatus = AdvertisementRefused
+		}
+	}
 
 	if r.ClusterConfig.AutoAccept {
 		if r.AcceptedAdvNum < r.ClusterConfig.MaxAcceptableAdvertisement {

--- a/test/unit/advertisement-operator/broadcaster_test.go
+++ b/test/unit/advertisement-operator/broadcaster_test.go
@@ -252,6 +252,9 @@ func TestGetResourceForAdv(t *testing.T) {
 
 	reqs, limits := advertisement_operator.GetAllPodsResources(pods)
 	availability, _ := advertisement_operator.ComputeAnnouncedResources(pNodes, reqs, int64(b.ClusterConfig.ResourceSharingPercentage))
+	if availability.Cpu().Value() < 0 || availability.Memory().Value() < 0 {
+		t.Fatal("Available resources cannot be negative")
+	}
 
 	pNodes2, vNodes2, availability2, limits2, images2, err := b.GetResourcesForAdv()
 	assert.Nil(t, err)


### PR DESCRIPTION
# Description

This PR adds some checks on the resources announced in the Advertisement
- If the computed resources by the broadcaster are negative, set them to 0
- If the advertisement operator receives an Advertisement with negative resources, refuse it
