### PR TITLE
Discovered clusters merge logic

### DIFF
--- a/docs/design/discovery-component.md
+++ b/docs/design/discovery-component.md
@@ -5,7 +5,7 @@ This component's goal is to find other clusters running Liqo around us, get info
 ### Features
 List of supported features
 * ClusterID creation
-  * if not already present, during component starting, it creates new ClusterID taking the UID of first master of our cluster or generate new UUID if no master is present (NOTE: in this case ID will be different if ConfigMap where it is store is deleted)
+  * if not already present, during component starting, it creates new ClusterID taking the UID of first master of our cluster or generates new UUID if no master is present (NOTE: in this case ID will be different if ConfigMap where it is store is deleted)
 * Make our cluster discoverable by other clusters
   * this feature can be enabled and disabled at runtime setting `enableAdvertisement` flag in `ClusterConfig` CR
   * register Liqo service on local mDNS server and answers when someone is looking for it
@@ -16,6 +16,8 @@ List of supported features
 * Discovery on WAN
   * when a new `SearchDomain` CR is added, an operator retrieves data from DNS server, a new `ForeignCluster` CR will be created for each cluster registered to domain provided
   * if a cluster is no more in domain registered list, related `ForeignCluster` is deleted
+* Detect IP changes
+  * if remote cluster IP changes, it is updated in `ForeignCluster`
 * Automatically join discovered clusters
   * this feature can be enabled and disabled at runtime setting `autojoin` flag in `ClusterConfig` CR
   * when new `ForeignCluster` is added, peering process will automatically begin
@@ -34,7 +36,7 @@ List of known limitations
   * no way to use URL as API server address (only raw IP is supported)
 * Local cluster does not handle remote cluster CA changes
 * It is not possible to trust or not CAs and to authenticate remote cluster
-* If API Server IP changes, `ForeignCluster` will continue to point to th old one and will never change, leading to impossibility to contact remote cluster
+* If API Server IP changes and the two clusters are joined, related advertisement is deleted as all remote resources
 
 ## Architecture and workflow
 

--- a/internal/discovery/foreign.go
+++ b/internal/discovery/foreign.go
@@ -3,12 +3,20 @@ package discovery
 import (
 	"errors"
 	v1 "github.com/liqoTech/liqo/api/discovery/v1"
+	k8serror "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog"
 )
 
+// 1. checks if cluster ID is already known
+// 2. if not exists, create it
+// 3. else
+//   3a. if IP is different set new IP and delete CA data
+//   3b. else it is ok
+// 4. TTL logic
+
 func (discovery *DiscoveryCtrl) UpdateForeign(data []*TxtData, sd *v1.SearchDomain) []*v1.ForeignCluster {
-	createdForeign := []*v1.ForeignCluster{}
+	createdUpdatedForeign := []*v1.ForeignCluster{}
 	var discoveryType v1.DiscoveryType
 	if sd == nil {
 		discoveryType = v1.LanDiscovery
@@ -20,23 +28,39 @@ func (discovery *DiscoveryCtrl) UpdateForeign(data []*TxtData, sd *v1.SearchDoma
 			// is local cluster
 			continue
 		}
-		_, err := discovery.crdClient.Resource("foreignclusters").Get(txtData.ID, metav1.GetOptions{})
-		if err == nil {
-			// already exists
-			continue
-		}
-		fc, err := discovery.createForeign(txtData, sd, discoveryType)
-		if err != nil {
+		tmp, err := discovery.crdClient.Resource("foreignclusters").Get(txtData.ID, metav1.GetOptions{})
+		if k8serror.IsNotFound(err) {
+			fc, err := discovery.createForeign(txtData, sd, discoveryType)
+			if err != nil {
+				klog.Error(err, err.Error())
+				continue
+			}
+			klog.Info("ForeignCluster " + txtData.ID + " created")
+			createdUpdatedForeign = append(createdUpdatedForeign, fc)
+		} else if err == nil {
+			fc, ok := tmp.(*v1.ForeignCluster)
+			if !ok {
+				err = errors.New("retrieved object is not a ForeignCluster")
+				klog.Error(err, err.Error())
+				continue
+			}
+			fc, err = discovery.CheckUpdate(txtData, fc, discoveryType)
+			if err != nil {
+				klog.Error(err, err.Error())
+				continue
+			}
+			klog.Info("ForeignCluster " + txtData.ID + " updated")
+			createdUpdatedForeign = append(createdUpdatedForeign, fc)
+		} else {
+			// unhandled errors
 			klog.Error(err, err.Error())
 			continue
 		}
-		klog.Info("ForeignCluster " + txtData.ID + " created")
-		createdForeign = append(createdForeign, fc)
 	}
 	if discoveryType == v1.LanDiscovery {
 		_ = discovery.UpdateTtl(data)
 	}
-	return createdForeign
+	return createdUpdatedForeign
 }
 
 func (discovery *DiscoveryCtrl) UpdateTtl(txts []*TxtData) error {
@@ -125,6 +149,7 @@ func (discovery *DiscoveryCtrl) createForeign(txtData *TxtData, sd *v1.SearchDom
 	}
 	tmp, err := discovery.crdClient.Resource("foreignclusters").Create(fc, metav1.CreateOptions{})
 	if err != nil {
+		klog.Error(err, err.Error())
 		return nil, err
 	}
 	fc, ok := tmp.(*v1.ForeignCluster)
@@ -132,4 +157,56 @@ func (discovery *DiscoveryCtrl) createForeign(txtData *TxtData, sd *v1.SearchDom
 		return nil, errors.New("created object is not a ForeignCluster")
 	}
 	return fc, err
+}
+
+func (discovery *DiscoveryCtrl) CheckUpdate(txtData *TxtData, fc *v1.ForeignCluster, discoveryType v1.DiscoveryType) (*v1.ForeignCluster, error) {
+	if fc.Spec.ApiUrl != txtData.ApiUrl || fc.Spec.Namespace != txtData.Namespace {
+		fc.Spec.ApiUrl = txtData.ApiUrl
+		fc.Spec.Namespace = txtData.Namespace
+		fc.Spec.DiscoveryType = discoveryType
+		if fc.Status.CaDataRef != nil {
+			err := discovery.crdClient.Client().CoreV1().Secrets(fc.Status.CaDataRef.Namespace).Delete(fc.Status.CaDataRef.Name, &metav1.DeleteOptions{})
+			if err != nil {
+				klog.Error(err, err.Error())
+				return nil, err
+			}
+		}
+		fc.Status.CaDataRef = nil
+		tmp, err := discovery.crdClient.Resource("foreignclusters").Update(fc.Name, fc, metav1.UpdateOptions{})
+		if err != nil {
+			klog.Error(err, err.Error())
+			return nil, err
+		}
+		fc, ok := tmp.(*v1.ForeignCluster)
+		if !ok {
+			err = errors.New("retrieved object is not a ForeignCluster")
+			klog.Error(err, err.Error())
+			return nil, err
+		}
+		if fc.Status.Advertisement != nil {
+			// changed ip in peered cluster, delete advertisement and wait for its recreation
+			// TODO: find more sophisticated logic to not remove all resources on remote cluster
+			advName := fc.Status.Advertisement.Name
+			fc.Status.Advertisement = nil
+			// updating it before adv delete will avoid us to set to false join flag
+			tmp, err = discovery.crdClient.Resource("foreignclusters").Update(fc.Name, fc, metav1.UpdateOptions{})
+			if err != nil {
+				klog.Error(err, err.Error())
+				return nil, err
+			}
+			fc, ok = tmp.(*v1.ForeignCluster)
+			if !ok {
+				err = errors.New("retrieved object is not a ForeignCluster")
+				klog.Error(err, err.Error())
+				return nil, err
+			}
+			err = discovery.advClient.Resource("advertisements").Delete(advName, metav1.DeleteOptions{})
+			if err != nil {
+				klog.Error(err, err.Error())
+				return nil, err
+			}
+		}
+		return fc, nil
+	}
+	return fc, nil
 }

--- a/internal/discovery/resolve.go
+++ b/internal/discovery/resolve.go
@@ -65,6 +65,7 @@ func (discovery *DiscoveryCtrl) getTxts(results <-chan *zeroconf.ServiceEntry, o
 				continue
 			}
 			if txtData, err := Decode(ip, strconv.Itoa(entry.Port), entry.Text); err == nil {
+				klog.Info("Received packet from " + ip)
 				res = append(res, txtData)
 			} else {
 				klog.Error(err, err.Error())
@@ -102,7 +103,6 @@ func (discovery *DiscoveryCtrl) isForeign(foreignIps []net.IP) bool {
 		if myIps[fIp.String()] {
 			return false
 		}
-		klog.Info("Received packet from " + fIp.String())
 	}
 	return true
 }

--- a/test/unit/discovery/env_test.go
+++ b/test/unit/discovery/env_test.go
@@ -61,6 +61,7 @@ func getClientCluster() *Cluster {
 	cluster.discoveryCtrl = discovery.GetDiscoveryCtrl(
 		"default",
 		cluster.client,
+		cluster.advClient,
 		cluster.clusterId,
 	)
 
@@ -107,6 +108,7 @@ func getServerCluster() *Cluster {
 	cluster.discoveryCtrl = discovery.GetDiscoveryCtrl(
 		"default",
 		cluster.client,
+		cluster.advClient,
 		cluster.clusterId,
 	)
 


### PR DESCRIPTION
# Description

It changes the logic how discovered clusters are merged. The new logic is:
* check cluster ID
  * if it not exists create it
  * it it exists
    * check if same ip and namespace, if not update it

In this way we are able to contact clusters even if their ip changes

### Limitation

If the cluster is peered, advertisement is deleted, loosing remotely scheduled resources