### PR TITLE
Update config watcher

### DIFF
--- a/docs/design/advertisement_protocol.md
+++ b/docs/design/advertisement_protocol.md
@@ -10,8 +10,7 @@ These messages are then used to build a local virtual-node where jobs can be sch
 actually sent to the respective foreign cluster. 
 
 ## Architecture and workflow
-
-![architecture](../images/advertisement-protocol/architecture.png)
+![](../images/advertisement-protocol/architecture.png)
 
 ### Components
 * The [broadcaster](broadcaster.md) is in charge of sending to other clusters the Advertisement message, containing the resources made available for sharing and (optionally) their prices

--- a/docs/design/broadcaster.md
+++ b/docs/design/broadcaster.md
@@ -30,8 +30,7 @@ After having created the Advertisement on the remote cluster, the broadcaster st
 * MetricsAPI to have more precise values of available resources
 
 ## Architecture and workflow
-
-![broadcaster-workflow](../images/advertisement-protocol/broadcaster-workflow.png)
+![](../images/advertisement-protocol/broadcaster-workflow.png)
 
 1. A `PeeringRequest` is created by the foreign cluster: a broadcaster deployment is launched
 2. Get the resources available in the cluster considering all its physical nodes

--- a/docs/design/controller.md
+++ b/docs/design/controller.md
@@ -22,8 +22,7 @@ the jobs it receives on them.
 * Recreation of virtual-kubelet if it is unexpectedly deleted
 
 ## Architecture and workflow
-
-![controller-workflow](../images/advertisement-protocol/controller-workflow.png)
+![](../images/advertisement-protocol/controller-workflow.png)
 
 1. An `Advertisement` is created by the foreign cluster
 2. Apply configuration read from `ClusterConfig` CR to accept/refuse the `Advertisement`


### PR DESCRIPTION
# Description
This PR adds a check in the `ClusterConfig` watcher so that each component reacts only to updates on its piece of configuration
- the watcher in the broadcaster reacts only to updates on `ResourceSharingPercentage` field
- the watcher in the controller reacts only to updates on `AutoAccept` and `MaxAcceptableAdvertisement` fields

## Other changes
- try to fix a problem of images not displayed in documentation

# How Has This Been Tested?
The broadcaster and controller have been launched locally to check they ignore updates on fields they are not interested in
