### PR TITLE
Fix Commit reference when triggered in a PR

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -27,8 +27,17 @@ jobs:
     steps:
       - name: setup-docker
         uses: docker-practice/actions-setup-docker@0.0.1
+      - name: Set the commit to build
+        run: |
+         if [ "$GITHUB_EVENT_NAME" == "pull_request" ]; then
+            echo "::set-env name=commit_ref::${{ github.event.pull_request.head.sha }}"
+         else
+            echo "::set-env name=commit_ref::${{ github.sha }}"
+         fi
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
+        with:
+          ref: "${{ env.commit_ref }}"
       - name: Push ${{ matrix.component }} image on repo
         uses: elgohr/Publish-Docker-Github-Action@master
         with:
@@ -36,7 +45,7 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           dockerfile: build/${{ matrix.component }}/Dockerfile
           password: ${{ secrets.DOCKER_PASSWORD }}
-          tags: "latest,${{ github.sha }}"
+          tags: "latest,${{ env.commit_ref }}"
         if: github.ref == 'refs/heads/master'
       - name: Push ${{ matrix.component }} image on repo
         uses: elgohr/Publish-Docker-Github-Action@master
@@ -45,17 +54,26 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           dockerfile: build/${{ matrix.component }}/Dockerfile
           password: ${{ secrets.DOCKER_PASSWORD }}
-          tags: "${{ github.sha }}"
+          tags: "${{ env.commit_ref }}"
         if: github.ref != 'refs/heads/master'
   e2e-test-trigger:
      runs-on: ubuntu-latest
-     needs: [ build ]
+     needs: [build, test]
      steps:
+       - name: Set the commit to build
+         run: |
+           if [ "$GITHUB_EVENT_NAME" == "pull_request" ]; then
+              echo "::set-env name=commit_ref::${{ github.event.pull_request.head.sha }}"
+           else
+              echo "::set-env name=commit_ref::${{ github.sha }}"
+           fi
        - uses: actions/checkout@v2
+         with:
+           ref: "${{ env.commit_ref }}"
        - name: "Make scripts executable"
          run: chmod +x ./scripts/utils/*
        - name: "Set PR number"
-         run: echo "::set-env name=branch_owner::`git log -1 --format='%ae' $GITHUB_SHA^!`"
+         run: echo "::set-env name=branch_owner::`git log -1 --format='%ae' $commit_ref^!`"
        - name: "Install python dependencies"
          run: pip install requests
        - name: "Set branch name"
@@ -65,7 +83,7 @@ jobs:
            curl -X POST https://api.github.com/repos/LiqoTech/liqops/dispatches \
            -H 'Accept: application/vnd.github.everest-preview+json' \
            -u ${{ secrets.CI_TOKEN }} \
-           --data '{"event_type": "dev-event", "client_payload": { "actor": "${{ env.branch_owner }}", "ref": "${{ env.branch_name }}", "commit":"${{ github.sha }}" }}'
+           --data '{"event_type": "dev-event", "client_payload": { "actor": "${{ env.branch_owner }}", "ref": "${{ env.branch_name }}", "commit":"${{ env.commit_ref }}" }}'
   release:
     runs-on: ubuntu-latest
     needs: [build, test]
@@ -82,6 +100,13 @@ jobs:
     name: Test Launch
     runs-on: ubuntu-20.04
     steps:
+    - name: Set the commit to build
+      run: |
+        if [ "$GITHUB_EVENT_NAME" == "pull_request" ]; then
+           echo "::set-env name=commit_ref::${{ github.event.pull_request.head.sha }}"
+        else
+           echo "::set-env name=commit_ref::${{ github.sha }}"
+        fi
     - name: Set up Go 1.13
       uses: actions/setup-go@v2
       with:
@@ -89,6 +114,8 @@ jobs:
       id: go
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
+      with:
+        ref: "${{ env.commit_ref }}"
     - name: Install Kubebuilder
       run: |
         version=2.3.1 # latest stable version


### PR DESCRIPTION
This commit changes the commit reference built when the pipelines are triggered via
the Pull Request event. This allows to build images with the HEAD commit and trigger the E2E testing with the right commit reference.

# How Has This Been Tested?

Run all the pipelines, including the E2E one.
