### PR TITLE
Add custom resolution for testing purpose

### DIFF
--- a/docs/pages/User/Configure/discovery.md
+++ b/docs/pages/User/Configure/discovery.md
@@ -77,6 +77,8 @@ myliqo1._liqo._tcp.test.mydomain.com.	TXT	"id=<YourClusterIDHere>"
 						"namespace=<YourNamespaceHere>"
 
 cluster1.test.mydomain.com.		A	<YourIPHere>
+### OR
+cluster1.test.mydomain.com.		CNAME	<YourEndpointHere>
 
 
 
@@ -86,6 +88,8 @@ myliqo2._liqo._tcp.test.mydomain.com.	TXT	"id=<YourClusterIDHere>"
 						"namespace=<YourNamespaceHere>"
 
 cluster2.test.mydomain.com.		A	<YourIPHere>
+### OR
+cluster2.test.mydomain.com.		CNAME	<YourEndpointHere>
 ```
 
 Discovery process consist on 4 DNS queries:

--- a/internal/discovery/search-domain-operator/search-domain-controller.go
+++ b/internal/discovery/search-domain-operator/search-domain-controller.go
@@ -49,7 +49,7 @@ func (r *SearchDomainReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error
 
 	update := false
 
-	txts, err := Wan(r.DiscoveryCtrl.Config.DnsServer, sd.Spec.Domain)
+	txts, err := Wan(r.DiscoveryCtrl.Config.DnsServer, sd.Spec.Domain, false)
 	if err != nil {
 		klog.Error(err, err.Error())
 		return ctrl.Result{

--- a/internal/discovery/txtData.go
+++ b/internal/discovery/txtData.go
@@ -29,7 +29,7 @@ func (txtData *TxtData) GetAllowUntrustedCA() string {
 	}
 }
 
-func Decode(ip string, port string, data []string) (*TxtData, error) {
+func Decode(address string, port string, data []string) (*TxtData, error) {
 	var res = TxtData{}
 	for _, d := range data {
 		if strings.HasPrefix(d, "id=") {
@@ -40,7 +40,7 @@ func Decode(ip string, port string, data []string) (*TxtData, error) {
 			res.AllowUntrustedCA = d[len("untrusted-ca="):] == "true"
 		}
 	}
-	res.ApiUrl = "https://" + ip + ":" + port
+	res.ApiUrl = "https://" + address + ":" + port
 	if res.ID == "" || res.Namespace == "" || res.ApiUrl == "" {
 		return nil, errors.New("TxtData missing required field")
 	}

--- a/test/unit/discovery/dns_test.go
+++ b/test/unit/discovery/dns_test.go
@@ -27,7 +27,7 @@ func testDns(t *testing.T) {
 		getTxtData(serverCluster, "dns-server-cluster"),
 	}
 
-	txts, err := search_domain_operator.Wan("127.0.0.1:8053", registryDomain)
+	txts, err := search_domain_operator.Wan("127.0.0.1:8053", registryDomain, true)
 	assert.NilError(t, err, "Error during WAN DNS discovery")
 
 	assert.Equal(t, len(txts), len(targetTxts))
@@ -57,7 +57,7 @@ func testCname(t *testing.T) {
 		getTxtData(serverCluster, "dns-server-cluster"),
 	}
 
-	txts, err := search_domain_operator.Wan("127.0.0.1:8053", registryDomain)
+	txts, err := search_domain_operator.Wan("127.0.0.1:8053", registryDomain, true)
 	assert.NilError(t, err, "Error during WAN DNS discovery")
 
 	assert.Equal(t, len(txts), len(targetTxts))


### PR DESCRIPTION
# Description

This PR allows DNS discovery process to use CNAME record as the last step

So, it's possible to use both IP or server name to contact remote API Server

This is useful for testing purpose