### PR TITLE
Fixing the liqonetConfig.vxlanNetConfig

### DIFF
--- a/config/cluster-config/crd/bases/policy.liqo.io_clusterconfigs.yaml
+++ b/config/cluster-config/crd/bases/policy.liqo.io_clusterconfigs.yaml
@@ -121,7 +121,6 @@ spec:
               required:
               - gatewayPrivateIP
               - reservedSubnets
-              - vxlanNetConfig
               type: object
           required:
           - advertisementConfig

--- a/deployments/liqo_chart/crds/policy.liqo.io_clusterconfigs.yaml
+++ b/deployments/liqo_chart/crds/policy.liqo.io_clusterconfigs.yaml
@@ -52,7 +52,7 @@ spec:
                   minimum: 0
                   type: integer
               required:
-              - autoAccept
+                - autoAccept
               type: object
             discoveryConfig:
               properties:
@@ -81,16 +81,16 @@ spec:
                   minimum: 1
                   type: integer
               required:
-              - autojoin
-              - dnsServer
-              - domain
-              - enableAdvertisement
-              - enableDiscovery
-              - name
-              - port
-              - service
-              - updateTime
-              - waitTime
+                - autojoin
+                - dnsServer
+                - domain
+                - enableAdvertisement
+                - enableDiscovery
+                - name
+                - port
+                - service
+                - updateTime
+                - waitTime
               type: object
             liqonetConfig:
               properties:
@@ -113,20 +113,19 @@ spec:
                     Vni:
                       type: string
                   required:
-                  - DeviceName
-                  - Network
-                  - Port
-                  - Vni
+                    - DeviceName
+                    - Network
+                    - Port
+                    - Vni
                   type: object
               required:
-              - gatewayPrivateIP
-              - reservedSubnets
-              - vxlanNetConfig
+                - gatewayPrivateIP
+                - reservedSubnets
               type: object
           required:
-          - advertisementConfig
-          - discoveryConfig
-          - liqonetConfig
+            - advertisementConfig
+            - discoveryConfig
+            - liqonetConfig
           type: object
         status:
           description: ClusterConfigStatus defines the observed state of ClusterConfig
@@ -134,9 +133,9 @@ spec:
       type: object
   version: v1
   versions:
-  - name: v1
-    served: true
-    storage: true
+    - name: v1
+      served: true
+      storage: true
 status:
   acceptedNames:
     kind: ""

--- a/install.sh
+++ b/install.sh
@@ -102,7 +102,7 @@ mkdir -p $TMPDIR/bin/
 echo "[PRE-INSTALL] [HELM] Checking HELM installation..."
 echo "[PRE-INSTALL] [HELM]: Downloading Helm $HELM_VERSION"
 curl --fail -L ${HELM_URL} | tar zxf - --directory="$TMPDIR/bin/" --wildcards '*/helm' --strip 1
-if [ "$LIQO_SUFFIX" == "-ci" ] && [ -z "${LIQO_VERSION}" ]  ; then
+if [ "$LIQO_SUFFIX" == "-ci" ] && [ ! -z "${LIQO_VERSION}" ]  ; then
   git clone "$URL" $TMPDIR/liqo
   cd  $TMPDIR/liqo
   git checkout "$LIQO_VERSION" > /dev/null 2> /dev/null


### PR DESCRIPTION
# Description
Here we fix:
* the `clusterconfigs.policy.liqo.io` CRD which presents the vxlanNetConfig inside the liqonetConfig structure as required, but it should be optional.
* the install script uses the helm chart from the same branch that is installing
