### PR TITLE
Introduction of new Liqo Agent version

### DIFF
--- a/cmd/tray-agent/README.md
+++ b/cmd/tray-agent/README.md
@@ -13,6 +13,6 @@ In order to build it, install these dependencies via
 ### RUN
 Liqo Agent requires a valid kubeconfig file in order to connect to the Kubernetes cluster. You can select a file explicitly with the **kubeconfig** argument:
 
-```./liqo-agent --kubeconfig='path/to/kubeconfig/file'```.
+```./liqo-agent -kubeconf='path/to/kubeconfig/file'```.
 
 If **kubeconfig** option is missing, the program searches for a kubeconfig file in ```$HOME/.kube/config```.

--- a/internal/tray-agent/agent/client/advertisement-cache.go
+++ b/internal/tray-agent/agent/client/advertisement-cache.go
@@ -2,7 +2,7 @@ package client
 
 import (
 	advtypes "github.com/liqoTech/liqo/api/advertisement-operator/v1"
-	advertisement_operator "github.com/liqoTech/liqo/internal/advertisement-operator"
+	advop "github.com/liqoTech/liqo/internal/advertisement-operator"
 	"github.com/liqoTech/liqo/pkg/crdClient"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
@@ -92,7 +92,7 @@ func (c *AdvertisementCache) StopCache() {
 // callback function for the Advertisement watch.
 func checkNewAdv(obj interface{}) {
 	newAdv := obj.(*advtypes.Advertisement)
-	if newAdv.Status.AdvertisementStatus == advertisement_operator.AdvertisementAccepted {
+	if newAdv.Status.AdvertisementStatus == advop.AdvertisementAccepted {
 		agentCtrl.advCache.NotifyChannels[ChanAdvAccepted] <- newAdv.Name
 	} else {
 		agentCtrl.advCache.NotifyChannels[ChanAdvNew] <- newAdv.Name
@@ -103,9 +103,9 @@ func checkNewAdv(obj interface{}) {
 func updateAcceptedAdv(oldObj interface{}, newObj interface{}) {
 	oldAdv := oldObj.(*advtypes.Advertisement)
 	newAdv := newObj.(*advtypes.Advertisement)
-	if oldAdv.Status.AdvertisementStatus != advertisement_operator.AdvertisementAccepted && newAdv.Status.AdvertisementStatus == advertisement_operator.AdvertisementAccepted {
+	if oldAdv.Status.AdvertisementStatus != advop.AdvertisementAccepted && newAdv.Status.AdvertisementStatus == advop.AdvertisementAccepted {
 		agentCtrl.advCache.NotifyChannels[ChanAdvAccepted] <- newAdv.Name
-	} else if oldAdv.Status.AdvertisementStatus == advertisement_operator.AdvertisementAccepted && newAdv.Status.AdvertisementStatus != advertisement_operator.AdvertisementAccepted {
+	} else if oldAdv.Status.AdvertisementStatus == advop.AdvertisementAccepted && newAdv.Status.AdvertisementStatus != advop.AdvertisementAccepted {
 		agentCtrl.advCache.NotifyChannels[ChanAdvRevoked] <- newAdv.Name
 	}
 }

--- a/internal/tray-agent/agent/client/agent-client.go
+++ b/internal/tray-agent/agent/client/agent-client.go
@@ -119,12 +119,10 @@ func GetAgentController() *AgentController {
 		crdClient.AddToRegistry("advertisements", &v1.Advertisement{}, &v1.AdvertisementList{}, advertisementKeyer, v1.GroupResource)
 		if !mockedController {
 			var err error
-			if c := AcquireKubeconfig(); c {
-				if agentCtrl.client, err = createClient(); err == nil {
-					agentCtrl.valid = true
-					if test := agentCtrl.ConnectionTest(); test {
-						agentCtrl.StartCaches()
-					}
+			if agentCtrl.client, err = createClient(); err == nil {
+				agentCtrl.valid = true
+				if test := agentCtrl.ConnectionTest(); test {
+					agentCtrl.StartCaches()
 				}
 			}
 		} else {
@@ -162,13 +160,13 @@ func (ctrl *AgentController) ConnectionTest() bool {
 // LIQO_KCONFIG represents the location of a kubeconfig file in order to let
 // the client connect to the local cluster.
 //
-// The file path - if not expressed with the 'kubeconfig' program argument -
+// The file path - if not expressed with the 'kubeconf' program argument -
 // is set to $HOME/.kube/config .
 //
 // It returns whether a valid file path for a possible kubeconfig has been set.
 func AcquireKubeconfig() bool {
 	kubePath := filepath.Join(os.Getenv("HOME"), ".kube")
-	kubeconfig := flag.String("kubeconfig", filepath.Join(kubePath, "config"),
+	kubeconfig := flag.String("kubeconf", filepath.Join(kubePath, "config"),
 		"[OPT] absolute path to the kubeconfig file."+
 			" Default = $HOME/.kube/config")
 	flag.Parse()

--- a/internal/tray-agent/agent/logic/actions.go
+++ b/internal/tray-agent/agent/logic/actions.go
@@ -36,14 +36,3 @@ func actionShowAdv() {
 	}
 
 }
-
-/*** SETTINGS ***/
-
-// callback function for the ACTION "settings" that displays the settings submenu.
-/*func actionSettings() {
-	i := app.GetIndicator()
-	if _, pres := i.Action(aSettings); !pres {
-		return
-	}
-	i.SelectAction(aSettings)
-}*/

--- a/internal/tray-agent/agent/logic/actions.go
+++ b/internal/tray-agent/agent/logic/actions.go
@@ -1,8 +1,6 @@
 package logic
 
 import (
-	"fmt"
-	"github.com/gen2brain/dlgs"
 	advtypes "github.com/liqoTech/liqo/api/advertisement-operator/v1"
 	"github.com/liqoTech/liqo/internal/tray-agent/agent/client"
 	app "github.com/liqoTech/liqo/internal/tray-agent/app-indicator"
@@ -16,11 +14,11 @@ func actionShowAdv() {
 		advCache := ctrl.AdvCache()
 		if ctrl.Connected() && advCache.Running {
 			// start indicator ACTION
-			act, pres := i.Action(aShowAdv)
+			act, pres := i.Action(aShowPeers)
 			if !pres {
 				return
 			}
-			i.SelectAction(aShowAdv)
+			i.SelectAction(aShowPeers)
 			i.SetIcon(app.IconLiqoMain)
 			// exec ACTION
 			if !ctrl.Mocked() {
@@ -42,24 +40,10 @@ func actionShowAdv() {
 /*** SETTINGS ***/
 
 // callback function for the ACTION "settings" that displays the settings submenu.
-func actionSettings() {
+/*func actionSettings() {
 	i := app.GetIndicator()
 	if _, pres := i.Action(aSettings); !pres {
 		return
 	}
 	i.SelectAction(aSettings)
-}
-
-// callback function for the OPTION "notifications" of "settings" action.
-func optionChangeNotifyLevel() {
-	i := app.GetIndicator()
-	if !app.GetGuiProvider().Mocked() {
-		notifyDescription := i.Config().NotifyDescriptions()
-		level, ok, _ := dlgs.List("NOTIFICATION SETTINGS", fmt.Sprintf("Choose how you would like to receive "+
-			"notifications from Liqo.\n"+
-			"CURRENT: %s", i.Config().NotifyTranslate(i.Config().NotifyLevel())), notifyDescription)
-		if ok {
-			i.NotificationSetLevel(i.Config().NotifyTranslateReverse(level))
-		}
-	}
-}
+}*/

--- a/internal/tray-agent/agent/logic/logic_test.go
+++ b/internal/tray-agent/agent/logic/logic_test.go
@@ -14,24 +14,30 @@ func TestOnReady(t *testing.T) {
 	client.UseMockedAgentController()
 	app.DestroyMockedIndicator()
 	client.DestroyMockedAgentController()
-	OldReady()
+	app.DestroyStatus()
+	OnReady()
 	i := app.GetIndicator()
 	//test startup Icon
 	startIcon := i.Icon()
 	assert.Equal(t, app.IconLiqoMain, startIcon, "startup Indicator icon is not IconLiqoMain")
 	//test ACTIONs and QUICKs registrations
 	var exist bool
-	_, exist = i.Quick(qHome)
-	assert.Truef(t, exist, "QUICK %s not registered", qHome)
+	_, exist = i.Quick(qOnOff)
+	assert.Truef(t, exist, "QUICK %s not registered", qOnOff)
+	_, exist = i.Quick(qMode)
+	assert.Truef(t, exist, "QUICK %s not registered", qMode)
+	_, exist = i.Quick(qWeb)
+	assert.Truef(t, exist, "QUICK %s not registered", qWeb)
 	_, exist = i.Quick(qQuit)
 	assert.Truef(t, exist, "QUICK %s not registered", qQuit)
 	_, exist = i.Quick(qDash)
 	assert.Truef(t, exist, "QUICK %s not registered", qDash)
+	_, exist = i.Quick(qNotify)
+	assert.Truef(t, exist, "QUICK %s not registered", qNotify)
 	//
 	_, exist = i.Action(aShowPeers)
 	assert.Truef(t, exist, "ACTION %s not registered", aShowPeers)
-	_, exist = i.Action(aSettings)
-	assert.Truef(t, exist, "ACTION %s not registered", aSettings)
+
 	// test Listeners registrations
 	_, exist = i.Listener(client.ChanAdvNew)
 	assert.True(t, exist, "Listener for NotifyChanType ChanAdvNew not registered")

--- a/internal/tray-agent/agent/logic/logic_test.go
+++ b/internal/tray-agent/agent/logic/logic_test.go
@@ -14,7 +14,7 @@ func TestOnReady(t *testing.T) {
 	client.UseMockedAgentController()
 	app.DestroyMockedIndicator()
 	client.DestroyMockedAgentController()
-	OnReady()
+	OldReady()
 	i := app.GetIndicator()
 	//test startup Icon
 	startIcon := i.Icon()
@@ -28,8 +28,8 @@ func TestOnReady(t *testing.T) {
 	_, exist = i.Quick(qDash)
 	assert.Truef(t, exist, "QUICK %s not registered", qDash)
 	//
-	_, exist = i.Action(aShowAdv)
-	assert.Truef(t, exist, "ACTION %s not registered", aShowAdv)
+	_, exist = i.Action(aShowPeers)
+	assert.Truef(t, exist, "ACTION %s not registered", aShowPeers)
 	_, exist = i.Action(aSettings)
 	assert.Truef(t, exist, "ACTION %s not registered", aSettings)
 	// test Listeners registrations

--- a/internal/tray-agent/agent/logic/managers.go
+++ b/internal/tray-agent/agent/logic/managers.go
@@ -6,19 +6,14 @@ import (
 	"os/exec"
 )
 
-// set of action tags
+//set of action tags
 const (
 	aShowPeers = "A_SHOW_PEERS"
 )
 
-// set of options
+//set of options
 const (
 	oAddPeer = "O_ADD_PEER"
-)
-
-//set of timer tags
-const (
-	timerStatus = "T_STATUS"
 )
 
 //OnReady is the routine orchestrating Liqo Agent execution.
@@ -34,30 +29,9 @@ func OnReady() {
 	startQuickSetNotifications(i)
 	startQuickLiqoWebsite(i)
 	startQuickQuit(i)
-	//todo auto selection of startActionPeers
 	startActionPeers(i)
-	//
-	//start liqo
+	//try to start Liqo and main ACTION
 	quickTurnOnOff(i)
-}
-
-//OnReady is the routine orchestrating Liqo Tray Agent execution.
-func OldReady() {
-	// Indicator configuration
-	i := app.GetIndicator()
-	i.SetMenuTitle("Liqo Agent")
-	// LISTENERS insertion
-	startListenerAdvertisements(i)
-	// QUICKS insertion
-
-	startQuickDashboard(i)
-	startQuickQuit(i)
-	//
-	i.AddSeparator()
-	//
-	// ACTIONS insertion
-	startActionPeers(i)
-	//todo add optional start liqo
 }
 
 //OnExit is the routine containing clean-up operations to be performed at Liqo Agent exit.
@@ -76,9 +50,9 @@ func startQuickOnOff(i *app.Indicator) {
 
 //startQuickChangeMode is the wrapper function to register the QUICK "CHANGE LIQO MODE"
 func startQuickChangeMode(i *app.Indicator) {
-	i.AddQuick("",qMode, func(args ...interface{}) {
+	i.AddQuick("", qMode, func(args ...interface{}) {
 		quickChangeMode(i)
-	},i)
+	}, i)
 	//the Quick MenuNode title is refreshed
 	updateQuickChangeMode(i)
 }
@@ -116,9 +90,14 @@ func startQuickQuit(i *app.Indicator) {
 
 //startActionPeers is the wrapper function to register ACTION "Show available peers".
 func startActionPeers(i *app.Indicator) {
-	i.AddAction("Show Advertisements", aShowPeers, func(args ...interface{}) {
+	a := i.AddAction("Available Peers", aShowPeers, func(args ...interface{}) {
 		actionShowAdv()
 	})
+	if a != nil {
+		a.SetIsVisible(false)
+		a.AddOption("Add remote peer", oAddPeer, nil)
+	}
+
 }
 
 //LISTENERS
@@ -174,5 +153,6 @@ func startListenerAdvertisements(i *app.Indicator) {
 	})
 	i.Listen(client.ChanAdvDeleted, i.AgentCtrl().AdvCache().NotifyChannels[client.ChanAdvDeleted], func(objName string, args ...interface{}) {
 		i.NotifyDeletedAdv(objName)
+		i.Status().DecConsumePeerings()
 	})
 }

--- a/internal/tray-agent/agent/logic/managers.go
+++ b/internal/tray-agent/agent/logic/managers.go
@@ -24,6 +24,11 @@ const (
 	oChangeNotify = "O_CHANGE_NOTIFY"
 )
 
+//set of timer tags
+const (
+	timerTitle = "T_TITLE"
+)
+
 //OnReady is the routine orchestrating Liqo Tray Agent execution.
 func OnReady() {
 	// Indicator configuration

--- a/internal/tray-agent/agent/logic/quicks.go
+++ b/internal/tray-agent/agent/logic/quicks.go
@@ -1,0 +1,117 @@
+package logic
+
+import (
+	"fmt"
+	"github.com/gen2brain/dlgs"
+	app "github.com/liqoTech/liqo/internal/tray-agent/app-indicator"
+	"strings"
+)
+
+// set of quick tags
+const (
+	qOnOff  = "Q_ON_OFF"
+	qMode   = "Q_MODE"
+	qDash   = "Q_LAUNCH_DASH"
+	qWeb    = "Q_WEBSITE"
+	qNotify = "Q_NOTIFY"
+	qQuit   = "Q_QUIT"
+)
+
+//quickTurnOnOff is the callback for the QUICK "START/STOP LIQO".
+func quickTurnOnOff(i *app.Indicator) {
+	runSt := i.Status().Running()
+	switch runSt {
+	case app.StatRunOff:
+		if i.AgentCtrl().Connected() {
+			i.Status().SetRunning(app.StatRunOn)
+			updateQuickTurnOnOff(i)
+			//user can access the ACTION
+			i.SelectAction(aShowPeers)
+		}
+	case app.StatRunOn:
+		//todo insert "shutdown peerings" logic
+		i.Status().SetRunning(app.StatRunOff)
+		updateQuickTurnOnOff(i)
+		//the active ACTION is turned off
+		i.DeselectAction()
+	}
+}
+
+//updateQuickTurnOnOff is the callback that refreshes the QUICK MenuNode
+//"START/STOP LIQO" accordingly to internal status information.
+func updateQuickTurnOnOff(i *app.Indicator) {
+	if q, present := i.Quick(qOnOff); present {
+		title := strings.Builder{}
+		switch i.Status().Running() {
+		case app.StatRunOff:
+			title.WriteString("START")
+		case app.StatRunOn:
+			title.WriteString("STOP")
+		}
+		title.WriteString(" LIQO")
+		q.SetTitle(title.String())
+	}
+}
+
+//quickChangeMode is the callback that manages the QUICK "Change Liqo Mode".
+func quickChangeMode(i *app.Indicator) {
+	stat := i.Status()
+	mode := stat.Mode()
+	switch mode {
+	case app.StatModeAutonomous:
+		//transition to TETHERED mode
+		if err := stat.SetMode(app.StatModeTethered); err == nil {
+			//todo transition logic
+			updateQuickChangeMode(i)
+			i.RefreshStatus()
+		} else {
+			i.ShowWarning("LIQO AGENT","Mode change not allowed.")
+		}
+	case app.StatModeTethered:
+		//transition to AUTONOMOUS mode
+		if err := stat.SetMode(app.StatModeAutonomous); err == nil {
+			//todo transition logic
+			updateQuickChangeMode(i)
+			i.RefreshStatus()
+		} else {
+			i.ShowWarningForbiddenTethered()
+		}
+
+	}
+}
+
+//updateQuickChangeMode refreshes the QUICK MenuNode "Change Liqo Mode"
+//accordingly to internal status information.
+func updateQuickChangeMode(i *app.Indicator) {
+	if q, present := i.Quick(qMode); present {
+		title := strings.Builder{}
+		title.WriteString("SET ")
+		mode := i.Status().Mode()
+		switch mode {
+		case app.StatModeAutonomous:
+			title.WriteString(app.StatModeTetheredHeaderDescription)
+			//check if TETHERED mode is eligible
+			q.SetIsEnabled(i.Status().IsTetheredCompliant())
+		case app.StatModeTethered:
+			title.WriteString(app.StatModeAutonomousHeaderDescription)
+			//In the current implementation, it is always possible ti switch into AUTONOMOUS mode.
+			q.SetIsEnabled(true)
+		}
+		title.WriteString(" MODE")
+		q.SetTitle(title.String())
+	}
+}
+
+//quickChangeNotifyLevel is the callback function for the OPTION "notifications" of "settings" action.
+func quickChangeNotifyLevel() {
+	i := app.GetIndicator()
+	if !app.GetGuiProvider().Mocked() {
+		notifyDescription := i.Config().NotifyDescriptions()
+		level, ok, _ := dlgs.List("NOTIFICATION SETTINGS", fmt.Sprintf("Choose how you would like to receive "+
+			"notifications from Liqo.\n"+
+			"CURRENT: %s", i.Config().NotifyTranslate(i.Config().NotifyLevel())), notifyDescription)
+		if ok {
+			i.NotificationSetLevel(i.Config().NotifyTranslateReverse(level))
+		}
+	}
+}

--- a/internal/tray-agent/agent/logic/quicks.go
+++ b/internal/tray-agent/agent/logic/quicks.go
@@ -22,18 +22,29 @@ func quickTurnOnOff(i *app.Indicator) {
 	runSt := i.Status().Running()
 	switch runSt {
 	case app.StatRunOff:
+		//turning ON Liqo if possible
 		if i.AgentCtrl().Connected() {
 			i.Status().SetRunning(app.StatRunOn)
 			updateQuickTurnOnOff(i)
+			i.RefreshStatus()
 			//user can access the ACTION
+			if action, present := i.Action(aShowPeers); present {
+				action.SetIsVisible(true)
+			}
 			i.SelectAction(aShowPeers)
 		}
 	case app.StatRunOn:
+		//turning OFF Liqo
 		//todo insert "shutdown peerings" logic
 		i.Status().SetRunning(app.StatRunOff)
 		updateQuickTurnOnOff(i)
+		i.RefreshStatus()
+		i.SetIcon(app.IconLiqoMain)
 		//the active ACTION is turned off
 		i.DeselectAction()
+		if action, present := i.Action(aShowPeers); present {
+			action.SetIsVisible(false)
+		}
 	}
 }
 
@@ -65,7 +76,7 @@ func quickChangeMode(i *app.Indicator) {
 			updateQuickChangeMode(i)
 			i.RefreshStatus()
 		} else {
-			i.ShowWarning("LIQO AGENT","Mode change not allowed.")
+			i.ShowWarningForbiddenTethered()
 		}
 	case app.StatModeTethered:
 		//transition to AUTONOMOUS mode
@@ -74,7 +85,7 @@ func quickChangeMode(i *app.Indicator) {
 			updateQuickChangeMode(i)
 			i.RefreshStatus()
 		} else {
-			i.ShowWarningForbiddenTethered()
+			i.ShowWarning("LIQO AGENT", "Mode change not allowed.")
 		}
 
 	}

--- a/internal/tray-agent/agent/logic/timers.go
+++ b/internal/tray-agent/agent/logic/timers.go
@@ -1,1 +1,0 @@
-package logic

--- a/internal/tray-agent/agent/logic/timers.go
+++ b/internal/tray-agent/agent/logic/timers.go
@@ -1,0 +1,1 @@
+package logic

--- a/internal/tray-agent/app-indicator/config.go
+++ b/internal/tray-agent/app-indicator/config.go
@@ -35,6 +35,11 @@ func newConfig() *config {
 	return conf
 }
 
+//Config returns the Indicator config.
+func (i *Indicator) Config() *config {
+	return i.config
+}
+
 //NotifyTranslate translates a NotifyLevel into its correspondent user-friendly textual description.
 //If such level does not exist, it returns NotifyLevelUnknown
 func (c *config) NotifyTranslate(level NotifyLevel) string {

--- a/internal/tray-agent/app-indicator/indicator.go
+++ b/internal/tray-agent/app-indicator/indicator.go
@@ -154,6 +154,7 @@ func (i *Indicator) SelectAction(tag string) *MenuNode {
 				}(action, &wgOther)
 			} else {
 				//recursively show selected ACTION with its sub-components
+				action.SetIsVisible(true)
 				action.SetIsEnabled(false)
 				//OPTIONS are shown by default
 				for _, option := range action.optionMap {
@@ -186,6 +187,9 @@ func (i *Indicator) DeselectAction() {
 				for _, listNode := range action.nodesList {
 					listNode.DisuseListChild()
 				}
+				//temporary workaround for current implementation of "Liqo Peers;
+				//the action is automatically managed.
+				action.SetIsEnabled(false)
 			}
 		}
 		i.activeNode = i.menu

--- a/internal/tray-agent/app-indicator/listener.go
+++ b/internal/tray-agent/app-indicator/listener.go
@@ -1,0 +1,50 @@
+package app_indicator
+
+import "github.com/liqoTech/liqo/internal/tray-agent/agent/client"
+
+//Listener is an event listener that can react calling a specific callback.
+type Listener struct {
+	//Tag specifies the type of notification channel on which it listens to
+	Tag client.NotifyChannelType
+	//StopChan lets control the Listener event loop
+	StopChan chan struct{}
+	//NotifyChan is the notification channel on which it listens to
+	NotifyChan chan string
+}
+
+//newListener returns a new Listener.
+func newListener(tag client.NotifyChannelType, rcv chan string) *Listener {
+	l := Listener{StopChan: make(chan struct{}, 1), Tag: tag, NotifyChan: rcv}
+	return &l
+}
+
+//Listener returns the registered Listener for the specified NotifyChannelType. If such Listener does not exist,
+//present == false.
+func (i *Indicator) Listener(tag client.NotifyChannelType) (listener *Listener, present bool) {
+	listener, present = i.listeners[tag]
+	return
+}
+
+//Listen starts a Listener for a specific channel, executing callback when a notification arrives.
+func (i *Indicator) Listen(tag client.NotifyChannelType, notifyChan chan string, callback func(objName string, args ...interface{}), args ...interface{}) {
+	l := newListener(tag, notifyChan)
+	i.listeners[tag] = l
+	go func() {
+		for {
+			select {
+			//exec handler
+			case name, open := <-l.NotifyChan:
+				if open {
+					callback(name, args...)
+				}
+				//closing application
+			case <-i.quitChan:
+				return
+				//closing single listener. Channel controlled by Indicator
+			case <-l.StopChan:
+				delete(i.listeners, tag)
+				return
+			}
+		}
+	}()
+}

--- a/internal/tray-agent/app-indicator/menu-node.go
+++ b/internal/tray-agent/app-indicator/menu-node.go
@@ -10,35 +10,43 @@ import (
 
 NodeType distinguishes different kinds of MenuNodes:
 
-		ROOT: root of the Menu Tree
+		ROOT: root of the Menu Tree.
 
 		QUICK: simple shortcut to perform quick actions, e.g. navigation commands. It is always visible.
 
-		ACTION: launch an application command. It can open command submenu (if present)
+		ACTION: launch an application command. It can open command submenu (if present).
 
-		OPTION: submenu choice
+		OPTION: submenu choice.
 
-		LIST: placeholder item used to dynamically display application output
+		LIST: placeholder item used to dynamically display application output.
 
-		TITLE: node with special text formatting used to display menu header
+		TITLE: node with special text formatting used to display menu header.
+
+		STATUS: non clickable node that displays status information.
 */
 type NodeType int
 
 //set of defined NodeType kinds
 const (
-	//Nodetype of a ROOT MenuNode: root of the Menu Tree
+	//NodeTypeRoot represents a Nodetype of a ROOT MenuNode: root of the Menu Tree.
 	NodeTypeRoot NodeType = iota
-	//Nodetype of a QUICK MenuNode: simple shortcut to perform quick actions,
+	//NodeTypeQuick represents a Nodetype of a QUICK MenuNode: simple shortcut to perform quick actions,
 	//e.g. navigation commands. It is always visible.
 	NodeTypeQuick
-	//NodeType of an ACTION MenuNode: launches an application command. It can open command submenu (if present)
+	//NodeTypeAction represents a NodeType of an ACTION MenuNode: launches an application command.
+	//It can open command submenu (if present).
 	NodeTypeAction
-	//NodeType of an OPTION MenuNode: submenu choice (hidden by default)
+	//NodeTypeOption represents a NodeType of an OPTION MenuNode: submenu choice (hidden by default).
 	NodeTypeOption
-	//NodeType of a LIST MenuNode: placeholder MenuNode used to dynamically display application output
+	//NodeTypeList represents a NodeType of a LIST MenuNode: placeholder MenuNode used to dynamically
+	//display application output.
 	NodeTypeList
-	//NodeType of a TITLE MenuNode: node with special text formatting used to display the menu header
+	//NodeTypeTitle represents a NodeType of a TITLE MenuNode: node with special text formatting
+	//used to display the menu header.
 	NodeTypeTitle
+	//NodeTypeStatus represents a NodeType of a STATUS MenuNode: non clickable node that displays status information
+	//about Liqo.
+	NodeTypeStatus
 )
 
 //NodeIcon represents a string prefix helping to graphically distinguish different kinds of Menu entries (NodeType)
@@ -46,9 +54,9 @@ type NodeIcon string
 
 //literal prefix that can be prepended to a MenuNode title, identifying its NodeType or some feature
 const (
-	nodeIconQuick   = "❱"
-	nodeIconAction  = "⬢"
-	nodeIconOption  = "\t-"
+	nodeIconQuick   = "❱ "
+	nodeIconAction  = "⬢ "
+	nodeIconOption  = "\t- "
 	nodeIconDefault = ""
 	nodeIconChecked = "✔ "
 )
@@ -124,6 +132,10 @@ func newMenuNode(nodeType NodeType) *MenuNode {
 		n.icon = nodeIconDefault
 	case NodeTypeList:
 		n.icon = nodeIconDefault
+	case NodeTypeStatus:
+		n.parent = &n
+		n.icon = nodeIconDefault
+		n.SetIsEnabled(false)
 	default:
 		n.icon = nodeIconDefault
 	}
@@ -255,7 +267,7 @@ func (n *MenuNode) SetTitle(title string) {
 		n.item.SetTitle(strutil.CenterText(title, menuWidth))
 
 	} else {
-		n.item.SetTitle(fmt.Sprintln(n.icon, " ", title))
+		n.item.SetTitle(fmt.Sprintln(n.icon, title))
 	}
 	n.title = title
 }

--- a/internal/tray-agent/app-indicator/notify.go
+++ b/internal/tray-agent/app-indicator/notify.go
@@ -144,7 +144,7 @@ func (i *Indicator) NotifyDeletedAdv(name string) {
 //ShowWarning displays a Warning window box.
 func (i *Indicator) ShowWarning(title, message string) {
 	if !GetGuiProvider().Mocked() {
-		dlgs.Warning(title, fmt.Sprintln(strutil.CenterText("", menuWidth*2), message))
+		_, _ = dlgs.Warning(title, fmt.Sprintln(strutil.CenterText("", menuWidth*2), message))
 	}
 }
 

--- a/internal/tray-agent/app-indicator/notify.go
+++ b/internal/tray-agent/app-indicator/notify.go
@@ -3,6 +3,8 @@ package app_indicator
 import (
 	"fmt"
 	bip "github.com/gen2brain/beeep"
+	"github.com/gen2brain/dlgs"
+	"github.com/ozgio/strutil"
 	"path/filepath"
 )
 
@@ -137,4 +139,18 @@ func (i *Indicator) NotifyRevokedAdv(name string) {
 func (i *Indicator) NotifyDeletedAdv(name string) {
 	i.Notify("Liqo Agent: DELETED ADVERTISEMENT", fmt.Sprintf("advertisement %s deleted", name),
 		NotifyIconOrange, IconLiqoAdvNew)
+}
+
+//ShowWarning displays a Warning window box.
+func (i *Indicator) ShowWarning(title, message string) {
+	if !GetGuiProvider().Mocked() {
+		dlgs.Warning(title, fmt.Sprintln(strutil.CenterText("", menuWidth*2), message))
+	}
+}
+
+//ShowWarningForbiddenTethered is an already configured ShowWarning() call to warn users
+//when they attempt to set the TETHERED mode without the required conditions.
+func (i *Indicator) ShowWarningForbiddenTethered() {
+	i.ShowWarning("LIQO AGENT: mode change not allowed", "TETHERED mode is only available"+
+		"with 1 active peering, offering resources.\n\nPlease disconnect from other peerings and retry.")
 }

--- a/internal/tray-agent/app-indicator/status.go
+++ b/internal/tray-agent/app-indicator/status.go
@@ -1,0 +1,350 @@
+package app_indicator
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+)
+
+/*----- StatRun -----*/
+
+//StatRun defines the running status of Liqo.
+type StatRun bool
+
+const (
+	//StatRunOff defines the 'OFF' running status of Liqo.
+	StatRunOff StatRun = false
+	//StatRunOn defines the 'ON' running status of Liqo.
+	StatRunOn StatRun = true
+)
+
+const (
+	//textual description for the StatRunOff StatRun value.
+	statRunOffDescription = "OFF"
+	//textual description for the StatRunOn StatRun value.
+	statRunOnDescription = "ON"
+)
+
+//String converts in human-readable format the StatRun information.
+func (rs StatRun) String() string {
+	str := ""
+	switch rs {
+	case StatRunOff:
+		str = statRunOffDescription
+	case StatRunOn:
+		str = statRunOnDescription
+	}
+	return str
+}
+
+/*----- StatMode -----*/
+
+//StatMode defines the Working Modes for Liqo, i.e. abstraction models designed to cover some common use cases.
+//Each Mode represents a set of allowed operations and statuses.
+type StatMode int
+
+const (
+	/*StatModeAutonomous defines the AUTONOMOUS working mode.
+
+	The device uses its own on-board intelligence, i.e. it connects
+	to its local K8s API server and lets the local orchestrator control the scheduling.
+
+	- It can work as a stand-alone cluster, consuming only its own resources
+
+	- It can connect to multiple peers, both consuming (under its control) foreign resources
+	and sharing its proprietary resources to other peers.
+	The system acts as a set of cooperating nodes, exploiting each foreign cluster's VirtualKubelet
+	seen by the local scheduler. Each sharing operation is independent of the others.
+	*/
+	StatModeAutonomous StatMode = iota
+	/* StatModeTethered defines the TETHERED working mode.
+	The device can choose to connect to a single foreign Liqo peer
+	(e.g. the corporate network), allowing the remote orchestrator to control the usage of its resources.
+
+	When the tethered peering is established, the remote peer, working in Autonomous mode,
+	uses its own API Server and takes control of the shared resources.
+	Every resource request made by the device is forwarded to the remote peer which will perform a proper scheduling.
+	*/
+	StatModeTethered
+)
+
+const (
+	//StatModeAutonomousHeaderDescription is the short description for the AUTONOMOUS mode.
+	StatModeAutonomousHeaderDescription = "AUTONOMOUS"
+	//StatModeAutonomousBodyDescription is the extended description for the AUTONOMOUS mode.
+	StatModeAutonomousBodyDescription = "Be in control of your Liqo: exchange resources with multiple peers"
+	//StatModeTetheredHeaderDescription is the short description for the TETHERED mode.
+	StatModeTetheredHeaderDescription = "TETHERED"
+	//StatModeTetheredBodyDescription is the extended description for the TETHERED mode.
+	StatModeTetheredBodyDescription = "Let a remote peer control your Liqo"
+	//StatModeUnknownDescription is a fallback description for undefined mode received from the graphic input.
+	StatModeUnknownDescription = "unknown"
+)
+
+//String converts in human-readable format the StatMode information.
+func (sm StatMode) String() string {
+	str := ""
+	switch sm {
+	case StatModeAutonomous:
+		str = StatModeAutonomousHeaderDescription
+	case StatModeTethered:
+		str = StatModeTetheredHeaderDescription
+	default:
+		str = StatModeUnknownDescription
+	}
+	return str
+}
+
+//GoString implements the fmt.GoStringer interface. This method is used to display
+//an extended text format for a StatMode.
+func (sm StatMode) GoString() string {
+	var str string
+	switch sm {
+	case StatModeAutonomous:
+		str = fmt.Sprintf("%s\n\n%s", StatModeAutonomousHeaderDescription, StatModeAutonomousBodyDescription)
+	case StatModeTethered:
+		str = fmt.Sprintf("%s\n\n%s", StatModeTetheredHeaderDescription, StatModeTetheredBodyDescription)
+	default:
+		str = StatModeUnknownDescription
+	}
+	return str
+}
+
+/* ----- STATUS -----*/
+
+//Status singleton instance for the Indicator
+var statusBlock *Status
+
+//StatusInterface wraps the methods to manage the Indicator status.
+type StatusInterface interface {
+	//User returns the Liqo Name of the home cluster connected to the Agent.
+	User() string
+	//SetUser sets the Liqo Name of the home cluster connected to the Agent.
+	SetUser(user string)
+	//Running returns the running status of Liqo.
+	Running() StatRun
+	//SetRunning changes the running status of Liqo. Transition to StatRunOff
+	//implies the end of all active peerings.
+	SetRunning(running StatRun)
+	//Mode returns the current working mode of Liqo.
+	Mode() StatMode
+	//SetMode sets the working mode for Liqo.
+	//If the operation is not allowed for current configuration, it returns an error.
+	SetMode(mode StatMode) error
+	/*IsTetheredCompliant checks if the TETHERED mode is eligible
+	accordingly to current status. The result can be used to display information.
+
+	This method is not to be intended as a preliminary test
+	for an actual mode change. In this case you must use SetMode() which exploits a
+	"Compare&Change" protection.
+	*/
+	IsTetheredCompliant() bool
+	//ConsumePeerings returns the number of active peerings where the Home cluster
+	//is consuming foreign resources.
+	ConsumePeerings() int
+	//IncConsumePeerings adds a consuming peering to the Indicator status.
+	//The operation is allowed only when Liqo is in AUTONOMOUS mode.
+	IncConsumePeerings()
+	//DecConsumePeerings removes a consuming peering from the Indicator status.
+	DecConsumePeerings()
+	//OfferPeerings returns the number of active peerings where the Home cluster is
+	//sharing its own resources.
+	OfferPeerings() int
+	//IncOfferPeerings adds an offering peering to the Indicator status.
+	//When Liqo is not in AUTONOMOUS mode, there can be at most 1 offering peering.
+	IncOfferPeerings()
+	//DecOfferPeerings removes an offering peering from the Indicator status.
+	DecOfferPeerings()
+	//ActivePeerings returns the amount of active peerings.
+	ActivePeerings() int
+	//GoString produces a textual digest on the main status data managed by
+	//a Status instance.
+	GoString() string
+}
+
+//GetStatus initializes and returns the Status singleton. This function should not be called before Run().
+func GetStatus() StatusInterface {
+	if statusBlock == nil {
+		/*statusBlock boots up with default settings:
+			- OFF Liqo status
+			- Autonomous mode
+		Further changes are up to other Indicator components.*/
+		statusBlock = &Status{}
+	}
+	return statusBlock
+}
+
+//Status defines a data structure containing information about the current status of the Liqo instance,
+//e.g. if it is running, the selected working mode and a summary of the active peerings.
+type Status struct {
+	//the LiqoName of the current user.
+	user string
+	//the running status of the Liqo instance.
+	running StatRun
+	//the current Liqo working mode.
+	mode StatMode
+	//current number of the active peerings used by the user for consuming foreign resources.
+	consumePeerings int
+	///current number of the active peerings where the user is sharing its own resources.
+	offerPeerings int
+	//mutex for the Status.
+	lock sync.RWMutex
+}
+
+//IsTetheredCompliant checks if the TETHERED mode is eligible
+//accordingly to current status. The result can be used to display information.
+func (st *Status) IsTetheredCompliant() bool {
+	st.lock.RLock()
+	defer st.lock.RUnlock()
+	return st.offerPeerings <= 1 && st.consumePeerings <= 0
+}
+
+//User returns the Liqo Name of the home cluster connected to the Agent.
+func (st *Status) User() string {
+	st.lock.RLock()
+	defer st.lock.RUnlock()
+	return st.user
+}
+
+//SetUser sets the Liqo Name of the home cluster connected to the Agent.
+func (st *Status) SetUser(user string) {
+	st.lock.Lock()
+	defer st.lock.Unlock()
+	st.user = user
+}
+
+//Running returns the running status of Liqo.
+func (st *Status) Running() StatRun {
+	st.lock.RLock()
+	defer st.lock.RUnlock()
+	return st.running
+}
+
+//SetRunning changes the running status of Liqo. Transition to StatRunOff
+//implies the end of all active peerings.
+func (st *Status) SetRunning(running StatRun) {
+	st.lock.Lock()
+	defer st.lock.Unlock()
+	if running != st.running {
+		if running == StatRunOff {
+			st.consumePeerings = 0
+			st.offerPeerings = 0
+		}
+		st.running = running
+	}
+}
+
+//Mode returns the current working mode of Liqo.
+func (st *Status) Mode() StatMode {
+	st.lock.RLock()
+	defer st.lock.RUnlock()
+	return st.mode
+}
+
+//SetMode sets the working mode for Liqo.
+//If the operation is not allowed for current configuration, it returns an error.
+func (st *Status) SetMode(mode StatMode) error {
+	st.lock.Lock()
+	defer st.lock.Unlock()
+	var err error
+	if mode != st.mode {
+		//it is always possible to revert back to autonomous mode
+		if mode == StatModeAutonomous {
+			st.mode = mode
+		} else if st.mode == StatModeAutonomous && mode == StatModeTethered {
+			if st.consumePeerings == 0 && st.offerPeerings <= 1 {
+				st.mode = mode
+			} else {
+				err = errors.New("tethered not allowed: there are active but not allowed peerings")
+			}
+		}
+	}
+	return err
+}
+
+//ConsumePeerings returns the number of active peerings where the Home cluster
+//is consuming foreign resources.
+func (st *Status) ConsumePeerings() int {
+	st.lock.RLock()
+	defer st.lock.RUnlock()
+	return st.consumePeerings
+}
+
+//IncConsumePeerings adds a consuming peering to the Indicator status.
+//The operation is allowed only when Liqo is in AUTONOMOUS mode.
+func (st *Status) IncConsumePeerings() {
+	st.lock.Lock()
+	defer st.lock.Unlock()
+	if st.mode == StatModeAutonomous {
+		st.consumePeerings += 1
+	}
+}
+
+//DecConsumePeerings removes a consuming peering from the Indicator status.
+func (st *Status) DecConsumePeerings() {
+	st.lock.Lock()
+	defer st.lock.Unlock()
+	if st.consumePeerings > 0 {
+		st.consumePeerings -= 1
+	}
+}
+
+//OfferPeerings returns the number of active peerings where the Home cluster is
+//sharing its own resources.
+func (st *Status) OfferPeerings() int {
+	st.lock.RLock()
+	defer st.lock.RUnlock()
+	return st.offerPeerings
+}
+
+//IncOfferPeerings adds an offering peering to the Indicator status.
+//When Liqo is not in AUTONOMOUS mode, there can be at most 1 offering peering.
+func (st *Status) IncOfferPeerings() {
+	st.lock.Lock()
+	defer st.lock.Unlock()
+	if st.mode == StatModeAutonomous || st.offerPeerings < 1 {
+		st.offerPeerings += 1
+	}
+}
+
+//DecOfferPeerings removes an offering peering from the Indicator status.
+func (st *Status) DecOfferPeerings() {
+	st.lock.Lock()
+	defer st.lock.Unlock()
+	if st.offerPeerings > 0 {
+		st.offerPeerings -= 1
+	}
+}
+
+//GoString produces a textual digest on the main status data managed by
+//a Status instance.
+func (st *Status) GoString() string {
+	st.lock.RLock()
+	defer st.lock.RUnlock()
+	str := strings.Builder{}
+	str.WriteString(fmt.Sprintln(st.user))
+	str.WriteString(fmt.Sprintf("Liqo is %v\n", st.running))
+	str.WriteString(fmt.Sprintf("%v mode\n", st.mode))
+	str.WriteString(fmt.Sprintf("%v consuming peerings\n", st.consumePeerings))
+	str.WriteString(fmt.Sprintf("%v offering peerings", st.offerPeerings))
+	return str.String()
+}
+
+//ActivePeerings returns the amount of active peerings.
+func (st *Status) ActivePeerings() int {
+	st.lock.RLock()
+	defer st.lock.RUnlock()
+	return st.offerPeerings + st.consumePeerings
+}
+
+//Status return the Indicator status.
+func (i *Indicator) Status() StatusInterface {
+	return i.status
+}
+
+//RefreshStatus updates the contents of the STATUS MenuNode and the Indicator Label.
+func (i *Indicator) RefreshStatus() {
+	i.menuStatusNode.SetTitle(i.status.GoString())
+	i.RefreshLabel()
+}

--- a/internal/tray-agent/app-indicator/status.go
+++ b/internal/tray-agent/app-indicator/status.go
@@ -348,3 +348,10 @@ func (i *Indicator) RefreshStatus() {
 	i.menuStatusNode.SetTitle(i.status.GoString())
 	i.RefreshLabel()
 }
+
+//DestroyStatus is a testing function used to refresh the Status component.
+func DestroyStatus() {
+	if GetGuiProvider().Mocked() {
+		statusBlock = nil
+	}
+}

--- a/internal/tray-agent/app-indicator/status_test.go
+++ b/internal/tray-agent/app-indicator/status_test.go
@@ -1,0 +1,49 @@
+package app_indicator
+
+import (
+	"github.com/liqoTech/liqo/internal/tray-agent/agent/client"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestStatus(t *testing.T) {
+	UseMockedGuiProvider()
+	client.UseMockedAgentController()
+	DestroyMockedIndicator()
+	client.DestroyMockedAgentController()
+	stat := GetStatus()
+	//test default configuration
+	assert.Equal(t, StatRunOff, stat.Running(),
+		"default running state should be OFF")
+	assert.Equal(t, StatModeAutonomous, stat.Mode(),
+		"default working mode should be AUTONOMOUS")
+	assert.Equal(t, 0, stat.ConsumePeerings())
+	assert.Equal(t, 0, stat.OfferPeerings())
+	//test status operations
+	stat.SetRunning(StatRunOn)
+	assert.Equal(t, StatRunOn, stat.Running(), "running status should be ON")
+	assert.Equal(t, 0, stat.ConsumePeerings())
+	assert.Equal(t, 0, stat.OfferPeerings())
+	//addition of consuming and offering peerings are allowed while
+	//in AUTONOMOUS mode.
+	stat.IncConsumePeerings()
+	stat.IncOfferPeerings()
+	assert.Equal(t, 1, stat.ConsumePeerings(), "addition of consuming peer in"+
+		"AUTONOMOUS mode is not allowed")
+	assert.Equal(t, 1, stat.OfferPeerings(), "addition of offering peer in"+
+		"AUTONOMOUS mode is not allowed")
+	//test transition to TETHERED mode
+	assert.Errorf(t, stat.SetMode(StatModeTethered), "TETHERED mode should not be allowed with active consuming peerings.")
+	stat.DecConsumePeerings()
+	//without active consuming peerings, TETHERED mode is allowed
+	_ = stat.SetMode(StatModeTethered)
+	assert.Equal(t, StatModeTethered, stat.Mode(), "transition to TETHERED should be"+
+		"allowed with matching requirements")
+	assert.True(t, stat.IsTetheredCompliant(), "TETHERED mode requirements not matching")
+	//turning the system off should shut down all active peerings
+	stat.SetRunning(StatRunOff)
+	assert.Equal(t, 0, stat.ConsumePeerings(), "there should be no active consuming peerings"+
+		"after turning off the system")
+	assert.Equal(t, 0, stat.OfferPeerings(), "there should be no active offering peerings"+
+		"after turning off the system")
+}

--- a/internal/tray-agent/app-indicator/timer.go
+++ b/internal/tray-agent/app-indicator/timer.go
@@ -1,0 +1,24 @@
+package app_indicator
+
+//Timer is a data structure that allows to control a time triggered loop execution of a callback.
+type Timer struct {
+	//tag is the Timer id
+	tag string
+	//controller is the channel that lets control the callback execution, allowing or preventing it whether the channel
+	//receive a true or false value.
+	controller chan bool
+	//active defines if the time triggered callback is executed (active = true)
+	active bool
+	//quitCh is the stop chan used to permanently stop the time loop
+	quitCh chan struct{}
+}
+
+//SetActive controls the Timer behavior, allowing or not future calls of the associated callback.
+func (t *Timer) SetActive(active bool) {
+	t.controller <- active
+}
+
+//Active returns if the Timer is currently active, i.e. timed calls of the associated callback are allowed.
+func (t *Timer) Active() bool {
+	return t.active
+}

--- a/internal/tray-agent/app-indicator/timer.go
+++ b/internal/tray-agent/app-indicator/timer.go
@@ -1,5 +1,10 @@
 package app_indicator
 
+import (
+	"errors"
+	"time"
+)
+
 //Timer is a data structure that allows to control a time triggered loop execution of a callback.
 type Timer struct {
 	//tag is the Timer id
@@ -21,4 +26,46 @@ func (t *Timer) SetActive(active bool) {
 //Active returns if the Timer is currently active, i.e. timed calls of the associated callback are allowed.
 func (t *Timer) Active() bool {
 	return t.active
+}
+
+//StartTimer registers a new Timer in charge of controlling the loop execution of callback. The Timer starts
+//automatically and can be controlled using (*Timer).SetActive() .
+//
+//	- tag : Timer id.
+//
+//	- interval : specifies the time interval after which the callback execution is triggered.
+func (i *Indicator) StartTimer(tag string, interval time.Duration, callback func(args ...interface{}), args ...interface{}) error {
+	if _, present := i.timers[tag]; present {
+		return errors.New("A Timer with the same tag already exists")
+	}
+	t := &Timer{
+		tag:        tag,
+		controller: make(chan bool, 2),
+		quitCh:     i.quitChan,
+		active:     true,
+	}
+	i.timers[tag] = t
+	go func(timer *Timer) {
+		for {
+			select {
+			case <-time.After(interval):
+				if timer.active {
+					callback(args...)
+				}
+			case stat, open := <-timer.controller:
+				if open {
+					timer.active = stat
+				}
+			case <-timer.quitCh:
+				return
+			}
+		}
+	}(t)
+	return nil
+}
+
+//Timer returns the registered Timer for the specified tag. If such Timer does not exist, present == false.
+func (i *Indicator) Timer(tag string) (timer *Timer, present bool) {
+	timer, present = i.timers[tag]
+	return
 }


### PR DESCRIPTION
# Description
 
This PR introduces the new version of Liqo Agent, presenting the features ready to be interconnected with other Liqo components.

* START/STOP Liqo: turn on/off Liqo according to connection and working mode requirements.

* CHANGE LIQO MODE: set AUTONOMOUS or TETHERED mode according to peerings requirements (number and 
type)

* ABOUT LIQO: link to Liqo website

* NOTIFICATIONS SETTINGS: this option has been promoted to a menu item to simplify the graphic interface

* AVAILABLE PEERS: refactoring of the "show advertisements" action, with automatic start/stop 
according to Liqo status and new option for manual addition of a remote peer

* introduction of the Status component that shows some useful information about the status of both
the Agent and the framework.

# How Has This Been Tested?

- unit tests
