### PR TITLE
Unit tests for the route-operator

### DIFF
--- a/internal/liqonet/route-operator_test.go
+++ b/internal/liqonet/route-operator_test.go
@@ -1,0 +1,220 @@
+package controllers
+
+import (
+	v1 "github.com/liqoTech/liqo/api/tunnel-endpoint/v1"
+	"github.com/liqoTech/liqo/pkg/liqonet"
+	"github.com/stretchr/testify/assert"
+	"github.com/vishvananda/netlink"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"testing"
+)
+
+func getTunnelEndpointCR() *v1.TunnelEndpoint {
+	return &v1.TunnelEndpoint{
+		TypeMeta:   metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{},
+		Spec: v1.TunnelEndpointSpec{
+			ClusterID:       "cluster-test",
+			PodCIDR:         "10.0.0.0/12",
+			TunnelPublicIP:  "192.168.5.1",
+			TunnelPrivateIP: "192.168.4.1",
+		},
+		Status: v1.TunnelEndpointStatus{
+			Phase:                 "",
+			LocalRemappedPodCIDR:  "None",
+			RemoteRemappedPodCIDR: "None",
+			NATEnabled:            false,
+			RemoteTunnelPublicIP:  "192.168.10.1",
+			RemoteTunnelPrivateIP: "192.168.9.1",
+			LocalTunnelPublicIP:   "192.168.5.1",
+			LocalTunnelPrivateIP:  "192.168.4.1",
+			TunnelIFaceIndex:      0,
+			TunnelIFaceName:       "",
+		},
+	}
+}
+
+func getRouteController() *RouteController {
+	return &RouteController{
+		Client:                             nil,
+		Log:                                ctrl.Log.WithName("route-operator"),
+		Scheme:                             nil,
+		clientset:                          kubernetes.Clientset{},
+		RouteOperator:                      false,
+		NodeName:                           "test",
+		ClientSet:                          nil,
+		RemoteVTEPs:                        nil,
+		IsGateway:                          false,
+		VxlanNetwork:                       "",
+		GatewayVxlanIP:                     "172.12.1.1",
+		VxlanIfaceName:                     "vxlanTest",
+		VxlanPort:                          0,
+		ClusterPodCIDR:                     "",
+		IPTablesRuleSpecsReferencingChains: make(map[string]liqonet.IPtableRule),
+		IPTablesChains:                     make(map[string]liqonet.IPTableChain),
+		IPtablesRuleSpecsPerRemoteCluster:  make(map[string][]liqonet.IPtableRule),
+		RoutesPerRemoteCluster:             make(map[string][]netlink.Route),
+		RetryTimeout:                       0,
+		IPtables: &liqonet.MockIPTables{
+			Rules:  []liqonet.IPtableRule{},
+			Chains: []liqonet.IPTableChain{},
+		},
+		NetLink: &liqonet.MockRouteManager{
+			RouteList: []netlink.Route{},
+		},
+	}
+}
+
+func routePerDestination(routeList []netlink.Route, dest string) bool {
+	for _, route := range routeList {
+		if route.Dst.String() == dest {
+			return true
+		}
+	}
+	return false
+}
+
+func TestCreateAndInsertIPTablesChains(t *testing.T) {
+	//testing that all the tables and chains are inserted correctly
+	//the function should be idempotent
+	r := getRouteController()
+	//the function is run 3 times and we expect that the number of tables is 3 and of rules 4
+	for i := 3; i >= 0; i-- {
+		err := r.createAndInsertIPTablesChains()
+		assert.Nil(t, err, "error should be nil")
+		assert.Equal(t, 3, len(r.IPTablesChains), "there should be three new chains")
+		assert.Equal(t, 4, len(r.IPTablesRuleSpecsReferencingChains), "there should be 4 new rules")
+	}
+}
+
+func TestAddIPTablesRulespecForRemoteCluster(t *testing.T) {
+	r := getRouteController()
+	tep := getTunnelEndpointCR()
+	//test:1 NAT not enabled and node is not the gateway
+	//in this case we expect only 3 rules to be inserted
+	err := r.addIPTablesRulespecForRemoteCluster(tep)
+	assert.Nil(t, err, "error should be nil")
+	assert.Equal(t, 3, len(r.IPtablesRuleSpecsPerRemoteCluster[tep.Spec.ClusterID]), "there should be 3 rules")
+
+	//test:2 NAT enabled and node is not the gateway
+	//in this case we expect 3 rules to be inserted
+	r = getRouteController()
+	tep.Status.RemoteRemappedPodCIDR = "10.96.0.0/16"
+	tep.Status.LocalRemappedPodCIDR = "10.100.0.0/16"
+	err = r.addIPTablesRulespecForRemoteCluster(tep)
+	assert.Nil(t, err, "error should be nil")
+	assert.Equal(t, 3, len(r.IPtablesRuleSpecsPerRemoteCluster[tep.Spec.ClusterID]), "there should be 3 rules")
+
+	//test:3 NAT not enabled and node is the gateway
+	//in this case we expect 4 rules to be inserted
+	r = getRouteController()
+	r.IsGateway = true
+	tep.Status.LocalRemappedPodCIDR = "None"
+	err = r.addIPTablesRulespecForRemoteCluster(tep)
+	assert.Nil(t, err, "error should be nil")
+	assert.Equal(t, 4, len(r.IPtablesRuleSpecsPerRemoteCluster[tep.Spec.ClusterID]), "there should be 4 rules")
+
+	//test:4 NAT enabled and node is the gateway
+	//in this case we expect 6 rules to be inserted
+	r = getRouteController()
+	r.IsGateway = true
+	tep.Status.LocalRemappedPodCIDR = "10.100.0.0/16"
+	err = r.addIPTablesRulespecForRemoteCluster(tep)
+	assert.Nil(t, err, "error should be nil")
+	assert.Equal(t, 6, len(r.IPtablesRuleSpecsPerRemoteCluster[tep.Spec.ClusterID]), "there should be 6 rules")
+}
+
+func TestDeleteIPTablesRulespecForRemoteCluster(t *testing.T) {
+	//Testing that giving a tunnelEnpoint.liqonet.liqo.io we can remove
+	//all the rules inserted for the cluster described by the custom resource
+	//firt we add the rules and then we remove it
+	//expecting that the rulse are 0.
+	r := getRouteController()
+	tep := getTunnelEndpointCR()
+	r.IsGateway = true
+	tep.Status.LocalRemappedPodCIDR = "10.100.0.0/16"
+	err := r.addIPTablesRulespecForRemoteCluster(tep)
+	assert.Nil(t, err, "error should be nil")
+	assert.Equal(t, 6, len(r.IPtablesRuleSpecsPerRemoteCluster[tep.Spec.ClusterID]), "there should be 6 rules")
+	err = r.deleteIPTablesRulespecForRemoteCluster(tep)
+	assert.Nil(t, err, "error should be nil")
+	assert.Equal(t, 0, len(r.IPtablesRuleSpecsPerRemoteCluster[tep.Spec.ClusterID]), "there should be 6 rules")
+}
+
+func TestDeleteAllIPTablesChains(t *testing.T) {
+	//testing that all the iptables chains are deleted
+	//first we add the rules for a new cluster described by a tunnelendpoint.liqone.liqo.io
+	//which have NatEnabled and the node is the gateway node.
+	//after that 6 rules should be present, after the delete function is called
+	//0 rules should be present
+	r := getRouteController()
+	tep := getTunnelEndpointCR()
+	r.IsGateway = true
+	tep.Status.LocalRemappedPodCIDR = "10.100.0.0/16"
+	err := r.addIPTablesRulespecForRemoteCluster(tep)
+	assert.Nil(t, err, "error should be nil")
+	assert.Equal(t, 6, len(r.IPtablesRuleSpecsPerRemoteCluster[tep.Spec.ClusterID]), "there should be 6 rules")
+	r.DeleteAllIPTablesChains()
+	assert.Equal(t, 0, len(r.IPtablesRuleSpecsPerRemoteCluster[tep.Spec.ClusterID]), "there should be 0 rules")
+	assert.Equal(t, 0, len(r.IPTablesChains), "number of chains should be 0")
+	assert.Equal(t, 0, len(r.IPTablesRuleSpecsReferencingChains), "number of rules referencing the chains should be 0")
+
+}
+
+func TestInsertRoutesPerCluster(t *testing.T) {
+	//test1: given a tunnelendpoint.liqonet.liqo.io we add the routes
+	//in a node that is not the gateway node
+	//the expected number of routes is two
+	r := getRouteController()
+	tep := getTunnelEndpointCR()
+	err := r.InsertRoutesPerCluster(tep)
+	assert.Nil(t, err, "error should be nil")
+	assert.Equal(t, 2, len(r.RoutesPerRemoteCluster[tep.Spec.ClusterID]), "number of routes should be 2")
+	assert.True(t, routePerDestination(r.RoutesPerRemoteCluster[tep.Spec.ClusterID], tep.Spec.PodCIDR), "the route for the remote pod cidr should be present")
+	assert.True(t, routePerDestination(r.RoutesPerRemoteCluster[tep.Spec.ClusterID], tep.Status.RemoteTunnelPrivateIP+"/32"), "the route for the remote gateway should be present")
+
+	//test2: same as above but the node is gateway node and the remote pod CIDR has been remapped
+	//the expected number of routes is 2
+	r = getRouteController()
+	r.IsGateway = true
+	tep = getTunnelEndpointCR()
+	tep.Status.RemoteRemappedPodCIDR = "10.100.0.0/16"
+	err = r.InsertRoutesPerCluster(tep)
+	assert.Nil(t, err, "error should be nil")
+	assert.Equal(t, 2, len(r.RoutesPerRemoteCluster[tep.Spec.ClusterID]), "number of routes should be 2")
+	assert.True(t, routePerDestination(r.RoutesPerRemoteCluster[tep.Spec.ClusterID], "10.100.0.0/16"), "the route for the remote remapped pod cidr should be present")
+	assert.True(t, routePerDestination(r.RoutesPerRemoteCluster[tep.Spec.ClusterID], tep.Status.RemoteTunnelPrivateIP+"/32"), "the route for the remote gateway should be present")
+}
+
+func TestDeleteRoutesPerCluster(t *testing.T) {
+	//first we add routes for cluster and then we delete them and check if
+	//the results are as expected
+	//When we delete the routes for a given cluster we expect that all the routes are removed
+	r := getRouteController()
+	tep := getTunnelEndpointCR()
+	err := r.InsertRoutesPerCluster(tep)
+	assert.Nil(t, err, "error should be nil")
+	assert.Equal(t, 2, len(r.RoutesPerRemoteCluster[tep.Spec.ClusterID]), "number of routes should be 2")
+	assert.True(t, routePerDestination(r.RoutesPerRemoteCluster[tep.Spec.ClusterID], tep.Spec.PodCIDR), "the route for the remote pod cidr should be present")
+	assert.True(t, routePerDestination(r.RoutesPerRemoteCluster[tep.Spec.ClusterID], tep.Status.RemoteTunnelPrivateIP+"/32"), "the route for the remote gateway should be present")
+	//here we delete all the routes for the cluster
+	err = r.deleteRoutesPerCluster(tep)
+	assert.Nil(t, err, "error should be nil")
+	assert.Zero(t, len(r.RoutesPerRemoteCluster[tep.Spec.ClusterID]), "routes for the cluster should be zero")
+}
+
+func TestDeleteAllRoutes(t *testing.T) {
+	//testing that all the routes are removed for all the clusters
+	r := getRouteController()
+	tep := getTunnelEndpointCR()
+	err := r.InsertRoutesPerCluster(tep)
+	assert.Nil(t, err, "error should be nil")
+	assert.Equal(t, 2, len(r.RoutesPerRemoteCluster[tep.Spec.ClusterID]), "number of routes should be 2")
+	assert.True(t, routePerDestination(r.RoutesPerRemoteCluster[tep.Spec.ClusterID], tep.Spec.PodCIDR), "the route for the remote pod cidr should be present")
+	assert.True(t, routePerDestination(r.RoutesPerRemoteCluster[tep.Spec.ClusterID], tep.Status.RemoteTunnelPrivateIP+"/32"), "the route for the remote gateway should be present")
+	//here we delete all the routes for the clusters
+	r.deleteAllRoutes()
+	assert.Zero(t, len(r.RoutesPerRemoteCluster), "routes for the cluster should be zero")
+}

--- a/pkg/liqonet/iptables.go
+++ b/pkg/liqonet/iptables.go
@@ -2,7 +2,6 @@ package liqonet
 
 import (
 	"fmt"
-	"github.com/coreos/go-iptables/iptables"
 	"strings"
 )
 
@@ -17,10 +16,23 @@ type IPTableChain struct {
 	Name  string
 }
 
+type IPTables interface {
+	/*AppendUnique(table string, chain string, rulespec ...string) error*/
+	Insert(table string, chain string, pos int, rulespec ...string) error
+	Delete(table string, chain string, rulespec ...string) error
+	Exists(table string, chain string, rulespec ...string) (bool, error)
+	ListChains(table string) ([]string, error)
+	NewChain(table string, chain string) error
+	List(table, chain string) ([]string, error)
+	AppendUnique(table string, chain string, rulespec ...string) error
+	ClearChain(table, chain string) error
+	DeleteChain(table, chain string) error
+}
+
 //We create the chains in two different tables.
 //LIQONET-POSTROUTING is created in the nat table
 //LIQONET-FORWARD is created in the filter table
-func CreateIptablesChainsIfNotExist(ipt *iptables.IPTables, table string, newChain string) error {
+func CreateIptablesChainsIfNotExist(ipt IPTables, table string, newChain string) error {
 	//get existing chains
 	chains_list, err := ipt.ListChains(table)
 	if err != nil {
@@ -43,7 +55,7 @@ func CreateIptablesChainsIfNotExist(ipt *iptables.IPTables, table string, newCha
 //this function is used to insert the rules that forward the traffic to the specific chains.
 //it takes care that the rule is present only once and at the same time it inserts it at the first position
 //TODO: a go routine which periodically checks if the rules inserted with this function in position one in the chain where belong
-func InsertIptablesRulespecIfNotExists(ipt *iptables.IPTables, table string, chain string, ruleSpec []string) error {
+func InsertIptablesRulespecIfNotExists(ipt IPTables, table string, chain string, ruleSpec []string) error {
 	//get the list of rulespecs for the specified chain
 	rulesList, err := ipt.List(table, chain)
 	if err != nil {
@@ -63,8 +75,20 @@ func InsertIptablesRulespecIfNotExists(ipt *iptables.IPTables, table string, cha
 				return fmt.Errorf("unable to delete iptable rule \"%s\": %v", strings.Join(ruleSpec, " "), err)
 			}
 		}
+		if err = ipt.Insert(table, chain, 1, ruleSpec...); err != nil {
+			return fmt.Errorf("unable to inserte iptable rule \"%s\": %v", strings.Join(ruleSpec, " "), err)
+		}
 	} else if numOccurrences == 1 {
-		//if the occurrence if one then do nothing
+		//if the occurrence is one then check the position and if not at the first one we delete and reinsert it
+		if strings.Contains(rulesList[0], strings.Join(ruleSpec, " ")) {
+			return nil
+		}
+		if err = ipt.Delete(table, chain, ruleSpec...); err != nil {
+			return fmt.Errorf("unable to delete iptable rule \"%s\": %v", strings.Join(ruleSpec, " "), err)
+		}
+		if err = ipt.Insert(table, chain, 1, ruleSpec...); err != nil {
+			return fmt.Errorf("unable to inserte iptable rule \"%s\": %v", strings.Join(ruleSpec, " "), err)
+		}
 		return nil
 	} else if numOccurrences == 0 {
 		//if the occurrence is zero then insert the rule in first position

--- a/pkg/liqonet/iptables_mock.go
+++ b/pkg/liqonet/iptables_mock.go
@@ -1,0 +1,144 @@
+package liqonet
+
+import (
+	"reflect"
+	"strings"
+)
+
+type MockIPTables struct {
+	Rules  []IPtableRule
+	Chains []IPTableChain
+}
+
+func (m *MockIPTables) Exists(table string, chain string, rulespec ...string) (bool, error) {
+	for _, rule := range m.Rules {
+		if rule.Table == table && rule.Chain == chain && strings.Join(rule.RuleSpec, " ") == strings.Join(rulespec, "") {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (m *MockIPTables) AppendUnique(table string, chain string, rulespec ...string) error {
+	r := IPtableRule{
+		Table:    table,
+		Chain:    chain,
+		RuleSpec: rulespec,
+	}
+	if m.containsRule(r) {
+		return nil
+	} else {
+		m.Rules = append(m.Rules, r)
+		return nil
+	}
+}
+
+func (m *MockIPTables) ListChains(table string) ([]string, error) {
+	var chains []string
+	for _, chain := range m.Chains {
+		if chain.Table == table {
+			chains = append(chains, chain.Name)
+		}
+	}
+	return chains, nil
+}
+
+func (m *MockIPTables) NewChain(table string, chain string) error {
+	m.Chains = append(m.Chains, IPTableChain{
+		Table: table,
+		Name:  chain,
+	})
+	return nil
+}
+
+func (m *MockIPTables) containsChain(chain IPTableChain) bool {
+	for _, ch := range m.Chains {
+		if ch.Table == chain.Table && ch.Name == chain.Name {
+			return true
+		}
+	}
+	return false
+}
+
+func (m *MockIPTables) ruleIndex(table string, chain string, rulespec []string) int {
+	for i, rule := range m.Rules {
+		if rule.Table == table && rule.Chain == chain && reflect.DeepEqual(rule.RuleSpec, rulespec) {
+			return i
+		}
+	}
+	return -1
+}
+
+func (m *MockIPTables) chainIndex(table string, name string) int {
+	for i, chain := range m.Chains {
+		if chain.Table == table && chain.Name == name {
+			return i
+		}
+	}
+	return -1
+}
+
+func (m *MockIPTables) containsRule(rule IPtableRule) bool {
+	for _, r := range m.Rules {
+		if r.Table == rule.Table && r.Chain == rule.Chain && strings.Join(r.RuleSpec, " ") == strings.Join(rule.RuleSpec, " ") {
+			return true
+		}
+	}
+	return false
+}
+
+func (m *MockIPTables) Delete(table string, chain string, rulespec ...string) error {
+	var ruleIndex = m.ruleIndex(table, chain, rulespec)
+	if ruleIndex != -1 {
+		m.Rules = append(m.Rules[:ruleIndex], m.Rules[ruleIndex+1:]...)
+	}
+	return nil
+}
+
+func (m *MockIPTables) prependRule(x []IPtableRule, y IPtableRule) []IPtableRule {
+	x = append(x, IPtableRule{})
+	copy(x[1:], x)
+	x[0] = y
+	return x
+}
+
+//this mock function prepends even if the index is different than 1
+func (m *MockIPTables) Insert(table string, chain string, pos int, rulespec ...string) error {
+	m.Rules = m.prependRule(m.Rules, IPtableRule{
+		Table:    table,
+		Chain:    chain,
+		RuleSpec: rulespec,
+	})
+	return nil
+}
+
+func (m *MockIPTables) List(table, chain string) ([]string, error) {
+	var rules []string
+	for _, rule := range m.Rules {
+		if rule.Table == table {
+			rules = append(rules, strings.Join(rule.RuleSpec, " "))
+		}
+	}
+	return rules, nil
+}
+
+func (m *MockIPTables) ClearChain(table, chain string) error {
+	for _, rule := range m.Rules {
+		if rule.Table == table && rule.Chain == chain {
+			err := m.Delete(rule.Table, rule.Chain, rule.RuleSpec...)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (m *MockIPTables) DeleteChain(table, chain string) error {
+	for i, ch := range m.Chains {
+		if ch.Table == table && ch.Name == chain {
+			m.Chains = append(m.Chains[:i], m.Chains[i+1:]...)
+		}
+	}
+	return nil
+}

--- a/pkg/liqonet/iptables_test.go
+++ b/pkg/liqonet/iptables_test.go
@@ -1,0 +1,100 @@
+package liqonet
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestCreateIptablesChainsIfNotExist(t *testing.T) {
+	chain := IPTableChain{
+		Table: "nat",
+		Name:  "testchain",
+	}
+	m := &MockIPTables{
+		Rules:  []IPtableRule{},
+		Chains: []IPTableChain{},
+	}
+	err := CreateIptablesChainsIfNotExist(m, chain.Table, chain.Name)
+	assert.Nil(t, err, "should be nil")
+	assert.Equal(t, true, m.containsChain(chain), "the chain should have been added")
+	//we try to add again the same chain, nothing should happen and length of the chain slices should be 1
+	err = CreateIptablesChainsIfNotExist(m, chain.Table, chain.Name)
+	assert.Nil(t, err, "should be nil")
+	assert.Equal(t, true, m.containsChain(chain), "the chain should have been added")
+	assert.Equal(t, 1, len(m.Chains), "number of chains should be one")
+}
+
+func TestInsertIptablesRulespecIfNotExists(t *testing.T) {
+	//test 1, the rule does not exist
+	//expect for the rule to be inserted
+	m := &MockIPTables{
+		Rules:  []IPtableRule{},
+		Chains: []IPTableChain{},
+	}
+	r := IPtableRule{
+		Table:    "test",
+		Chain:    "testChain",
+		RuleSpec: []string{"test1", "test2"},
+	}
+	err := InsertIptablesRulespecIfNotExists(m, r.Table, r.Chain, r.RuleSpec)
+	assert.Nil(t, err, "should be nil")
+	assert.Equal(t, true, m.containsRule(r), "the rule should exist")
+	//test 2, the rule exist and there are also other rules
+	//expect that the rule is at the first position
+	m = &MockIPTables{
+		Rules: []IPtableRule{
+			{
+				Table:    "test",
+				Chain:    "testChain",
+				RuleSpec: []string{"test1", "test1"}},
+			{
+				Table:    "test",
+				Chain:    "testChain",
+				RuleSpec: []string{"test1", "test2"},
+			}},
+		Chains: []IPTableChain{},
+	}
+	r = IPtableRule{
+		Table:    "test",
+		Chain:    "testChain",
+		RuleSpec: []string{"test1", "test2"},
+	}
+	err = InsertIptablesRulespecIfNotExists(m, r.Table, r.Chain, r.RuleSpec)
+	assert.Nil(t, err, "should be nil")
+	assert.Equal(t, true, m.containsRule(r), "the rule should exist")
+	assert.Equal(t, r, m.Rules[0], "the new added rule should be the first one in the chain")
+	assert.Equal(t, 2, len(m.Rules), "only two rules should be present in the chain")
+
+	//test 3 multiple instances of the same rule are present
+	//we expect that all the instances are removed and only one is left
+	//at the first position
+	m = &MockIPTables{
+		Rules: []IPtableRule{
+			{
+				Table:    "test",
+				Chain:    "testChain",
+				RuleSpec: []string{"test1", "test1"}},
+			{
+				Table:    "test",
+				Chain:    "testChain",
+				RuleSpec: []string{"test1", "test2"},
+			},
+			{
+				Table:    "test",
+				Chain:    "testChain",
+				RuleSpec: []string{"test1", "test2"},
+			},
+		},
+		Chains: []IPTableChain{},
+	}
+	r = IPtableRule{
+		Table:    "test",
+		Chain:    "testChain",
+		RuleSpec: []string{"test1", "test2"},
+	}
+	err = InsertIptablesRulespecIfNotExists(m, r.Table, r.Chain, r.RuleSpec)
+	assert.Nil(t, err, "should be nil")
+	assert.Equal(t, true, m.containsRule(r), "the rule should exist")
+	assert.Equal(t, r, m.Rules[0], "the new added rule should be the first one in the chain")
+	assert.Equal(t, 2, len(m.Rules), "only two rules should be present in the chain")
+}

--- a/pkg/liqonet/route.go
+++ b/pkg/liqonet/route.go
@@ -8,7 +8,15 @@ import (
 	"strings"
 )
 
-func AddRoute(dst string, gw string, deviceName string, onLink bool) (netlink.Route, error) {
+type NetLink interface {
+	AddRoute(dst string, gw string, deviceName string, onLink bool) (netlink.Route, error)
+	DelRoute(route netlink.Route) error
+}
+
+type RouteManager struct {
+}
+
+func (rm *RouteManager) AddRoute(dst string, gw string, deviceName string, onLink bool) (netlink.Route, error) {
 	var route netlink.Route
 	//convert destination in *net.IPNet
 	destinationIP, destinationNet, err := net.ParseCIDR(dst)
@@ -39,7 +47,7 @@ func AddRoute(dst string, gw string, deviceName string, onLink bool) (netlink.Ro
 		}
 		if occurrences > 1 {
 			for _, val := range routes {
-				err = DelRoute(val)
+				err = rm.DelRoute(val)
 				if err != nil {
 					return route, fmt.Errorf("unable to delete route %v:%v", val, err)
 				}
@@ -96,7 +104,7 @@ func GetGateway() (int, net.IP, error) {
 	return iface.Index, gw, nil
 }
 
-func DelRoute(route netlink.Route) error {
+func (rm *RouteManager) DelRoute(route netlink.Route) error {
 
 	//try to remove all the routes for that ip
 	err := netlink.RouteDel(&route)

--- a/pkg/liqonet/route_mock.go
+++ b/pkg/liqonet/route_mock.go
@@ -1,0 +1,80 @@
+package liqonet
+
+import (
+	"fmt"
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
+	"net"
+	"reflect"
+)
+
+type MockRouteManager struct {
+	RouteList []netlink.Route
+}
+
+func (m *MockRouteManager) AddRoute(dst string, gw string, deviceName string, onLink bool) (netlink.Route, error) {
+	var route netlink.Route
+	//convert destination in *net.IPNet
+	_, destinationNet, err := net.ParseCIDR(dst)
+	if err != nil {
+		return route, fmt.Errorf("unable to convert destination \"%s\" from string to net.IPNet: %v", dst, err)
+	}
+	gateway := net.ParseIP(gw)
+	//here we keep the iface index at a fixed value
+	ifaceIndex := 12
+
+	route = netlink.Route{LinkIndex: ifaceIndex, Dst: destinationNet, Gw: gateway}
+	//check if already exist a route for the destination network on our device
+	//we don't care about other routes in devices not managed by liqonet. The user should check the
+	//possible ip conflicts
+	routes := m.RouteList
+	if len(routes) > 0 {
+		//count how many routes exist for the the current destination
+		//if more then one: something went wrong so we remove them all
+		occurrences := 0
+		for _, val := range routes {
+			if val.Dst.String() == route.Dst.String() {
+				occurrences++
+			}
+		}
+		if occurrences > 1 {
+			for _, val := range routes {
+				err = m.DelRoute(val)
+				if err != nil {
+					return route, fmt.Errorf("unable to delete route %v:%v", val, err)
+				}
+			}
+		} else if occurrences == 1 {
+			index := 0
+			for i, val := range routes {
+				if val.Dst.String() == route.Dst.String() {
+					index = i
+				}
+			}
+			if IsRouteConfigTheSame(&routes[index], route) {
+				return routes[index], nil
+			}
+		}
+	}
+	if onLink {
+		route = netlink.Route{LinkIndex: ifaceIndex, Dst: destinationNet, Gw: gateway, Flags: unix.RTNH_F_ONLINK}
+
+		//here we add the route
+		m.RouteList = append(m.RouteList, route)
+	} else {
+		route = netlink.Route{LinkIndex: ifaceIndex, Dst: destinationNet, Gw: gateway}
+		//here we add the route
+		m.RouteList = append(m.RouteList, route)
+	}
+	return route, nil
+}
+
+func (m *MockRouteManager) DelRoute(route netlink.Route) error {
+	//try to remove all the routes for that ip
+	for i, r := range m.RouteList {
+		if reflect.DeepEqual(r, route) {
+			m.RouteList = append(m.RouteList[:i], m.RouteList[i+1:]...)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
The functions used by the operator have external dependencies on the following modules: 
- iptables 
- netlink.

To overcome this limitation mock interfaces have been implemented and injected in functions in order to test the logic.


