### PR TITLE
[tray-agent]: LiqoDash integration

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -141,7 +141,7 @@ jobs:
       run: |
         go get -u github.com/ory/go-acc
     - name: install tray-agent dependencies
-      run: sudo apt update && sudo apt-get install gcc libgtk-3-dev libappindicator3-dev libwebkit2gtk-4.0-dev
+      run: sudo apt update && sudo apt-get install gcc libgtk-3-dev libappindicator3-dev libwebkit2gtk-4.0-dev xclip
     - run: go-acc ./... --ignore liqo/test/e2e
     - name: Send coverage
       uses: shogo82148/actions-goveralls@v1

--- a/build/tray-agent/Dockerfile
+++ b/build/tray-agent/Dockerfile
@@ -2,7 +2,7 @@ FROM liqo/runner as builder
 #install required dependencies
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get -y install gcc tar wget libgtk-3-dev libappindicator3-dev \
-libwebkit2gtk-4.0-dev
+libwebkit2gtk-4.0-dev xclip
 
 FROM builder as gobuild
 RUN wget https://dl.google.com/go/go1.14.3.linux-amd64.tar.gz && tar -xzf go1.14.3.linux-amd64.tar.gz

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,9 @@ go 1.13
 require (
 	contrib.go.opencensus.io/exporter/jaeger v0.2.0
 	contrib.go.opencensus.io/exporter/ocagent v0.7.0
+	github.com/agrison/go-commons-lang v0.0.0-20200208220349-58e9fcb95174
 	github.com/apparentlymart/go-cidr v1.1.0
+	github.com/atotto/clipboard v0.1.2
 	github.com/certifi/gocertifi v0.0.0-20200104152315-a6d78f326758 // indirect
 	github.com/cloudflare/cfssl v1.4.1 // indirect
 	github.com/cloudflare/redoctober v0.0.0-20200117180338-34d894fcc2a1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -79,6 +79,8 @@ github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6/go.mod h1:3eOhrU
 github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
 github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia65gfNATL8TAiHDNxPzPdmEL5uirI2Uyuz6c=
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=
+github.com/agrison/go-commons-lang v0.0.0-20200208220349-58e9fcb95174 h1:ExNQbrN2sYVsz5vDpV0wfFAu2gGpcnVewOXY9qpIjA8=
+github.com/agrison/go-commons-lang v0.0.0-20200208220349-58e9fcb95174/go.mod h1:u+Zwm0OKtJAGx+DXcmp2NNwZ0GKtV80ipbF/uhKhQdw=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
 github.com/akavel/rsrc v0.8.0/go.mod h1:uLoCtb9J+EyAqh+26kdrTgmzRBFPGOolLWKpdxkKq+c=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
@@ -107,6 +109,8 @@ github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj
 github.com/aryann/difflib v0.0.0-20170710044230-e206f873d14a/go.mod h1:DAHtR1m6lCRdSC2Tm3DSWRPvIPr6xNKyeHdqDQSQT+A=
 github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
+github.com/atotto/clipboard v0.1.2 h1:YZCtFu5Ie8qX2VmVTBnrqLSiU9XOWwqNRmdT3gIQzbY=
+github.com/atotto/clipboard v0.1.2/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/auth0/go-jwt-middleware v0.0.0-20170425171159-5493cabe49f7/go.mod h1:LWMyo4iOLWXHGdBki7NIht1kHru/0wM179h+d3g8ATM=
 github.com/aws/aws-lambda-go v1.13.3/go.mod h1:4UKl9IzQMoD+QF79YdCuzCwp8VbmG4VAQwij/eHl5CU=
 github.com/aws/aws-sdk-go v1.16.26/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=

--- a/internal/tray-agent/agent/client/agent-client.go
+++ b/internal/tray-agent/agent/client/agent-client.go
@@ -138,21 +138,18 @@ func GetAgentController() *AgentController {
 		var err error
 		if agentCtrl.kubeClient, err = createKubeClient(); err == nil {
 			if !mockedController {
-				if agentCtrl.kubeClient, err = createKubeClient(); err == nil {
-					if agentCtrl.client, err = createClient(); err == nil {
-						agentCtrl.valid = true
-						if test := agentCtrl.ConnectionTest(); test {
-							agentCtrl.StartCaches()
-						}
-					}
-				} else {
+				if agentCtrl.client, err = createClient(); err == nil {
 					agentCtrl.valid = true
-					agentCtrl.connected = true
-					agentCtrl.StartCaches()
+					if test := agentCtrl.ConnectionTest(); test {
+						agentCtrl.StartCaches()
+					}
 				}
+			} else {
+				agentCtrl.valid = true
+				agentCtrl.connected = true
+				agentCtrl.StartCaches()
 			}
 		}
-
 	}
 	return agentCtrl
 }
@@ -225,11 +222,7 @@ func createKubeClient() (kubernetes.Interface, error) {
 	if !ok || kubeconfig == "" {
 		return nil, errors.New("no kubeconfig provided")
 	}
-	var (
-		cfg *rest.Config
-		err error
-	)
-	cfg, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
+	cfg, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/tray-agent/agent/client/dashboard-client.go
+++ b/internal/tray-agent/agent/client/dashboard-client.go
@@ -23,6 +23,8 @@ const (
 	liqoDashboardSAName = "liqodash-admin-sa"
 	//liqoDashboardTkPrefix is the name prefix of the LiqoDash access token.
 	liqoDashboardTkPrefix = "liqodash-admin-sa-token"
+	//masterNodeLabel is the label name associated with master nodes.
+	masterNodeLabel = "node-role.kubernetes.io/master"
 	//EnvLiqoDashHost defines the env var for the HOST part of the LiqoDash address.
 	EnvLiqoDashHost = "LIQODASH_HOST"
 	//EnvLiqoDashPort defines the env var for the PORT part of the LiqoDash address.
@@ -53,8 +55,22 @@ func (ctrl *AgentController) AcquireDashboardConfig() error {
 	if len(dashPodL.Items) < 1 {
 		return errors.New("the LiqoDash is not currently available")
 	}
+	//check if all LiqoDash pods are ready to serve
+	ready := true
+loop:
+	for _, pod := range dashPodL.Items {
+		for _, condition := range pod.Status.Conditions {
+			if condition.Type == corev1.PodReady && condition.Status != corev1.ConditionTrue {
+				ready = false
+				break loop
+			}
+		}
+	}
+	if !ready {
+		return errors.New("the LiqoDash is not currently available")
+	}
 	/*-----------------------------------------------------------------------------------
-	CASE 1: check the presence of an ingress controller for the LiqoDash
+	CASE 1: check the presence of an ingress for the LiqoDash
 	-------------------------------------------------------------------------------------*/
 	var ok bool
 	if ok = ctrl.getDashboardConfigRemote(); !ok {
@@ -110,7 +126,7 @@ func (ctrl *AgentController) getDashboardConfigLocal() bool {
 	found := false
 	/*search for a LiqoDash Service of type NodePort*/
 	service, err := c.CoreV1().Services(liqoDashboardNamespace).Get(context.TODO(), liqoDashboardServiceName, metav1.GetOptions{})
-	if err == nil && service.Spec.Type == "NodePort" {
+	if err == nil && service.Spec.Type == corev1.ServiceTypeNodePort {
 		ports := service.Spec.Ports
 		for i := range ports {
 			port := ports[i]
@@ -126,7 +142,7 @@ func (ctrl *AgentController) getDashboardConfigLocal() bool {
 	if found {
 		found = false
 		nodeL, err := c.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{
-			LabelSelector: "node-role.kubernetes.io/master",
+			LabelSelector: masterNodeLabel,
 		})
 		if err == nil && len(nodeL.Items) > 0 {
 			for _, addr := range nodeL.Items[0].Status.Addresses {
@@ -153,7 +169,7 @@ func (ctrl *AgentController) getDashboardConfigLocal() bool {
 //GetLiqoDashSecret returns the access token for the LiqoDash service.
 func (ctrl *AgentController) GetLiqoDashSecret() (*string, error) {
 	var token = ""
-	if !ctrl.connected {
+	if !ctrl.Connected() {
 		return &token, errors.New("no connection to the cluster")
 	}
 	errNoToken := errors.New("cannot retrieve token")

--- a/internal/tray-agent/agent/client/dashboard-client.go
+++ b/internal/tray-agent/agent/client/dashboard-client.go
@@ -1,0 +1,184 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"os"
+	"strings"
+)
+
+const (
+	//liqoDashboardIngressName is the name of the LiqoDash Ingress for remote access.
+	liqoDashboardIngressName = "liqo-dashboard-content"
+	//liqoDashboardServiceName is the name of the LiqoDash Service.
+	liqoDashboardServiceName = "liqo-dashboard"
+	//liqoDashboardNamespace is the name of the LiqoDash namespace.
+	liqoDashboardNamespace = "liqo"
+	//liqoDashboardSAName is the name of the LiqoDash ServiceAccount containing the reference
+	//to the secret with the access token.
+	liqoDashboardSAName = "liqodash-admin-sa"
+	//liqoDashboardTkPrefix is the name prefix of the LiqoDash access token.
+	liqoDashboardTkPrefix = "liqodash-admin-sa-token"
+	//EnvLiqoDashHost defines the env var for the HOST part of the LiqoDash address.
+	EnvLiqoDashHost = "LIQODASH_HOST"
+	//EnvLiqoDashPort defines the env var for the PORT part of the LiqoDash address.
+	EnvLiqoDashPort = "LIQODASH_PORT"
+)
+
+//AcquireDashboardConfig tries to retrieve required data to access the LiqoDash service.
+//
+//If a valid configuration is found, the EnvLiqoDashHost and EnvLiqoDashPort env vars are set.
+func (ctrl *AgentController) AcquireDashboardConfig() error {
+	//cleanup LiqoDash env vars
+	var err error
+	if err = os.Unsetenv(EnvLiqoDashHost); err != nil {
+		return err
+	}
+	if err = os.Unsetenv(EnvLiqoDashPort); err != nil {
+		return err
+	}
+	//preliminary check to verify the LiqoDash pod is running
+	var dashPodL *corev1.PodList
+	dashPodL, err = ctrl.kubeClient.CoreV1().Pods(liqoDashboardNamespace).List(context.TODO(), metav1.ListOptions{
+		LabelSelector: "app=" + liqoDashboardServiceName,
+		FieldSelector: fields.OneTermEqualSelector("status.phase", "Running").String(),
+	})
+	if err != nil {
+		return errors.New("cluster connection not available")
+	}
+	if len(dashPodL.Items) < 1 {
+		return errors.New("the LiqoDash is not currently available")
+	}
+	/*-----------------------------------------------------------------------------------
+	CASE 1: check the presence of an ingress controller for the LiqoDash
+	-------------------------------------------------------------------------------------*/
+	var ok bool
+	if ok = ctrl.getDashboardConfigRemote(); !ok {
+		/*-----------------------------------------------------------------------------------
+		CASE 2: check the presence of a Service NodePort for the LiqoDash
+		-------------------------------------------------------------------------------------*/
+		if ok = ctrl.getDashboardConfigLocal(); !ok {
+			return errors.New("cannot establish a connection to LiqoDash")
+		}
+	}
+	return nil
+}
+
+//getDashboardConfigRemote searches for a valid configuration required to
+//remotely connect with the LiqoDash.
+//
+//In case of success, it sets the env vars specified by EnvLiqoDashHost
+//and EnvLiqoDashPort with proper values.
+func (ctrl *AgentController) getDashboardConfigRemote() bool {
+	if !ctrl.Connected() {
+		return false
+	}
+	/*search for a LiqoDash Ingress. To increase security, it must contain
+	a 'tls' field with at least one explicitly specified 'host' (https connection)*/
+	ingress, err := ctrl.kubeClient.NetworkingV1beta1().Ingresses(liqoDashboardNamespace).Get(context.TODO(), liqoDashboardIngressName,
+		metav1.GetOptions{})
+	if err == nil && len(ingress.Spec.TLS) > 0 {
+		hosts := ingress.Spec.TLS[0].Hosts
+		if len(hosts) > 0 {
+			dashHost := hosts[0]
+			if err = os.Setenv(EnvLiqoDashHost, fmt.Sprintf(
+				"https://%s", dashHost)); err == nil {
+				if err = os.Setenv(EnvLiqoDashPort, ""); err == nil {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+//getDashboardConfigLocal searches for a valid configuration required to
+//establish a local connection to the LiqoDash.
+//
+//In case of success, it sets the env vars specified by EnvLiqoDashHost
+//and EnvLiqoDashPort with proper values.
+func (ctrl *AgentController) getDashboardConfigLocal() bool {
+	if !ctrl.Connected() {
+		return false
+	}
+	c := ctrl.kubeClient
+	var nodePortNo, masterIP string
+	found := false
+	/*search for a LiqoDash Service of type NodePort*/
+	service, err := c.CoreV1().Services(liqoDashboardNamespace).Get(context.TODO(), liqoDashboardServiceName, metav1.GetOptions{})
+	if err == nil && service.Spec.Type == "NodePort" {
+		ports := service.Spec.Ports
+		for i := range ports {
+			port := ports[i]
+			if port.Name == "http" {
+				nodePortNo = fmt.Sprint(port.NodePort)
+				found = true
+				break
+			}
+		}
+	}
+	/*A valid port has been found.
+	For the local connection, the master node IP address will be used.*/
+	if found {
+		found = false
+		nodeL, err := c.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{
+			LabelSelector: "node-role.kubernetes.io/master",
+		})
+		if err == nil && len(nodeL.Items) > 0 {
+			for _, addr := range nodeL.Items[0].Status.Addresses {
+				if addr.Type == corev1.NodeInternalIP {
+					masterIP = addr.Address
+					found = true
+					break
+				}
+			}
+		}
+	}
+	if found {
+		/*having found both address and port, it is possible to set
+		the two env vars*/
+		if err = os.Setenv(EnvLiqoDashHost, masterIP); err == nil {
+			if err = os.Setenv(EnvLiqoDashPort, nodePortNo); err == nil {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+//GetLiqoDashSecret returns the access token for the LiqoDash service.
+func (ctrl *AgentController) GetLiqoDashSecret() (*string, error) {
+	var token = ""
+	if !ctrl.connected {
+		return &token, errors.New("no connection to the cluster")
+	}
+	errNoToken := errors.New("cannot retrieve token")
+	/*In order to better prune its search, the secret is retrieved by its name, using the
+	service account associated with it.*/
+	c := ctrl.KubeClient()
+	liqoSA, err := c.CoreV1().ServiceAccounts(liqoDashboardNamespace).Get(context.TODO(), liqoDashboardSAName, metav1.GetOptions{})
+	if err != nil {
+		return &token, errNoToken
+	}
+	found := false
+	var secretName string
+	for i := range liqoSA.Secrets {
+		secret := liqoSA.Secrets[i]
+		if strings.HasPrefix(secret.Name, liqoDashboardTkPrefix) {
+			found = true
+			secretName = secret.Name
+			break
+		}
+	}
+	if found {
+		if secret, err := c.CoreV1().Secrets(liqoDashboardNamespace).Get(context.TODO(), secretName, metav1.GetOptions{}); err == nil {
+			token = fmt.Sprintf("%s", secret.Data["token"])
+			return &token, nil
+		}
+	}
+	return &token, errNoToken
+}

--- a/internal/tray-agent/agent/client/dashboard-client_test.go
+++ b/internal/tray-agent/agent/client/dashboard-client_test.go
@@ -1,0 +1,270 @@
+package client
+
+import (
+	"fmt"
+	testutil "github.com/liqoTech/liqo/internal/test/util"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/api/networking/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	ktesting "k8s.io/client-go/testing"
+	"os"
+	"strconv"
+	"testing"
+)
+
+//configLocal params
+var nodePort = 32000
+var masterNodeIP = "10.0.0.1"
+var getLiqoDashServiceReactor ktesting.ReactionFunc = func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
+	getAction := action.(ktesting.GetAction)
+	servName := getAction.GetName()
+	servNamespace := getAction.GetNamespace()
+	if servName != liqoDashboardServiceName || servNamespace != liqoDashboardNamespace {
+		return false, nil, nil
+	}
+	liqoServ := testutil.FakeService(liqoDashboardNamespace, liqoDashboardServiceName,
+		"10.0.0.2", "TCP", 80)
+	liqoServ.Spec.Type = corev1.ServiceTypeNodePort
+	liqoServ.Spec.Ports[0].Name = "http"
+	liqoServ.Spec.Ports[0].NodePort = int32(nodePort)
+	return true, liqoServ, nil
+}
+var listMasterNodeReactor ktesting.ReactionFunc = func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
+	labelsMap := make(map[string]string)
+	labelsMap[masterNodeLabel] = ""
+	var labelSet = labels.Set{}
+	labelSet[masterNodeLabel] = ""
+	listAction := action.(ktesting.ListAction)
+	if !listAction.GetListRestrictions().Labels.Matches(labelSet) {
+		return false, nil, nil
+	}
+	nodeL := corev1.NodeList{
+		ListMeta: metav1.ListMeta{
+			ResourceVersion: strconv.Itoa(1),
+		},
+		Items: []corev1.Node{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "test-master_node",
+					ResourceVersion: strconv.Itoa(1),
+					Labels:          labelsMap,
+				},
+				Status: corev1.NodeStatus{
+					Phase: corev1.NodeRunning,
+					Addresses: []corev1.NodeAddress{
+						{
+							Type:    corev1.NodeInternalIP,
+							Address: masterNodeIP,
+						},
+					},
+				},
+			},
+		},
+	}
+	return true, &nodeL, nil
+}
+
+//configRemote params
+var ingressTestHost = "test.host.net"
+var getLiqoDashIngressReactor ktesting.ReactionFunc = func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
+	getAction := action.(ktesting.GetAction)
+	if getAction.GetName() != liqoDashboardIngressName || getAction.GetNamespace() != liqoDashboardNamespace {
+		return false, nil, nil
+	}
+	ingress := v1beta1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            liqoDashboardIngressName,
+			Namespace:       liqoDashboardNamespace,
+			ResourceVersion: strconv.Itoa(1),
+		},
+		Spec: v1beta1.IngressSpec{
+			TLS: []v1beta1.IngressTLS{
+				{
+					Hosts: []string{
+						ingressTestHost,
+					},
+					SecretName: "",
+				},
+			},
+		},
+	}
+	return true, &ingress, nil
+}
+
+//getLiqoDashSecret params
+var secrTestName = liqoDashboardTkPrefix + "-test"
+var testData = "test-data"
+var getLiqoDashServiceAccountReactor ktesting.ReactionFunc = func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
+	getAction := action.(ktesting.GetAction)
+	if getAction.GetName() != liqoDashboardSAName || getAction.GetNamespace() != liqoDashboardNamespace {
+		return false, nil, nil
+	}
+	servAcc := corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            liqoDashboardSAName,
+			Namespace:       liqoDashboardNamespace,
+			ResourceVersion: strconv.Itoa(1),
+		},
+		Secrets: []corev1.ObjectReference{
+			{
+				Namespace:       liqoDashboardNamespace,
+				Name:            secrTestName,
+				ResourceVersion: strconv.Itoa(1),
+			},
+		},
+	}
+	return true, &servAcc, nil
+}
+var getLiqoDashSecretReactor ktesting.ReactionFunc = func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
+	getAction := action.(ktesting.GetAction)
+	if getAction.GetName() != secrTestName || getAction.GetNamespace() != liqoDashboardNamespace {
+		return false, nil, nil
+	}
+	secret := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            secrTestName,
+			Namespace:       liqoDashboardNamespace,
+			ResourceVersion: strconv.Itoa(1),
+		},
+		Data: make(map[string][]byte),
+	}
+	secret.Data["token"] = []byte(testData)
+	return true, &secret, nil
+}
+
+//acquireDashboardConfig params
+var listLiqoDashPodsReactor ktesting.ReactionFunc = func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
+	var labelSet = labels.Set{}
+	labelSet["app"] = liqoDashboardServiceName
+	listAction := action.(ktesting.ListAction)
+	if !listAction.GetListRestrictions().Labels.Matches(labelSet) || listAction.GetNamespace() != liqoDashboardNamespace {
+		return false, nil, nil
+	}
+	labelsMap := make(map[string]string)
+	labelsMap["app"] = liqoDashboardServiceName
+	podList := corev1.PodList{
+		ListMeta: metav1.ListMeta{
+			ResourceVersion: strconv.Itoa(1),
+		},
+		Items: []corev1.Pod{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: liqoDashboardNamespace,
+					Labels:    labelsMap,
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					Conditions: []corev1.PodCondition{
+						{
+							Type:   corev1.PodReady,
+							Status: corev1.ConditionTrue,
+						},
+					},
+				},
+			},
+		},
+	}
+	return true, &podList, nil
+}
+
+func TestAgentController_AcquireDashboardConfig(t *testing.T) {
+	UseMockedAgentController()
+	DestroyMockedAgentController()
+	ctrl := GetAgentController()
+	//test no LiqoDash pod present and running
+	err := ctrl.AcquireDashboardConfig()
+	assert.Error(t, err, "AcquireDashboardConfig should return error if no \nLiqoDash Pod "+
+		"is 'Running' ")
+	//test function return with Local configuration
+	fakeKubeClient := ctrl.kubeClient.(*fake.Clientset)
+	fakeKubeClient.Fake.PrependReactor("list", "pods", listLiqoDashPodsReactor)
+	fakeKubeClient.Fake.PrependReactor("list", "nodes", listMasterNodeReactor)
+	fakeKubeClient.Fake.PrependReactor("get",
+		"services", getLiqoDashServiceReactor)
+	err = ctrl.AcquireDashboardConfig()
+	assert.NoError(t, err, "AcquireDashboardConfig should return nil when\n"+
+		"a LiqoDash pod is running and at least one config is available")
+	_, isSet := os.LookupEnv(EnvLiqoDashHost)
+	assert.True(t, isSet, "EnvLiqoDashHost should be set")
+	_, isSet = os.LookupEnv(EnvLiqoDashPort)
+	assert.True(t, isSet, "EnvLiqoDashPort should be set")
+}
+
+func TestAgentController_getDashboardConfigLocal(t *testing.T) {
+	UseMockedAgentController()
+	DestroyMockedAgentController()
+	var err error
+	if err = os.Unsetenv(EnvLiqoDashHost); err != nil {
+		t.Fatal("unable to unset ENV liqodash HOST")
+	}
+	if err = os.Unsetenv(EnvLiqoDashPort); err != nil {
+		t.Fatal("unable to unset ENV liqodash PORT")
+	}
+	ctrl := GetAgentController()
+	fakeKubeClient := ctrl.kubeClient.(*fake.Clientset)
+	fakeKubeClient.Fake.PrependReactor("list", "nodes", listMasterNodeReactor)
+	fakeKubeClient.Fake.PrependReactor("get",
+		"services", getLiqoDashServiceReactor)
+	res := ctrl.getDashboardConfigLocal()
+	assert.True(t, res, "DashboardConfigLocal should return true")
+	var dashHost, dashPort string
+	var envSet bool
+	if dashHost, envSet = os.LookupEnv(EnvLiqoDashHost); envSet {
+		assert.Equal(t, masterNodeIP, dashHost)
+	} else {
+		t.Fatal("ENV liqodash HOST not set after configLocal")
+	}
+	if dashPort, envSet = os.LookupEnv(EnvLiqoDashPort); envSet {
+		assert.Equal(t, fmt.Sprint(nodePort), dashPort)
+	} else {
+		t.Fatal("ENV liqodash PORT not set after configLocal")
+	}
+}
+
+func TestAgentController_getDashboardConfigRemote(t *testing.T) {
+	UseMockedAgentController()
+	DestroyMockedAgentController()
+	var err error
+	if err = os.Unsetenv(EnvLiqoDashHost); err != nil {
+		t.Fatal("unable to unset ENV liqodash HOST")
+	}
+	if err = os.Unsetenv(EnvLiqoDashPort); err != nil {
+		t.Fatal("unable to unset ENV liqodash PORT")
+	}
+	ctrl := GetAgentController()
+	fakeKubeClient := ctrl.kubeClient.(*fake.Clientset)
+	fakeKubeClient.Fake.PrependReactor("get", "ingresses", getLiqoDashIngressReactor)
+	res := ctrl.getDashboardConfigRemote()
+	assert.True(t, res, "DashboardConfigRemote should return true")
+	var dashHost, dashPort string
+	var envSet bool
+	if dashHost, envSet = os.LookupEnv(EnvLiqoDashHost); envSet {
+		assert.Equal(t, fmt.Sprintf("https://%s", ingressTestHost), dashHost)
+	} else {
+		t.Fatal("ENV liqodash HOST not set after configRemote")
+	}
+	if dashPort, envSet = os.LookupEnv(EnvLiqoDashPort); envSet {
+		assert.Equal(t, "", dashPort)
+	} else {
+		t.Fatal("ENV liqodash PORT not set after configRemote")
+	}
+}
+
+func TestAgentController_GetLiqoDashSecret(t *testing.T) {
+	UseMockedAgentController()
+	DestroyMockedAgentController()
+	ctrl := GetAgentController()
+	fakeKubeClient := ctrl.kubeClient.(*fake.Clientset)
+	fakeKubeClient.Fake.PrependReactor("get", "secrets", getLiqoDashSecretReactor)
+	fakeKubeClient.Fake.PrependReactor("get", "serviceaccounts", getLiqoDashServiceAccountReactor)
+	token, err := ctrl.GetLiqoDashSecret()
+	if err != nil {
+		t.Fatal("GetLiqoDashSecret should not return an error")
+	}
+	assert.Equal(t, testData, *token, "secret token differs from the test one")
+
+}

--- a/internal/tray-agent/agent/logic/logic_test.go
+++ b/internal/tray-agent/agent/logic/logic_test.go
@@ -19,7 +19,7 @@ func TestOnReady(t *testing.T) {
 	i := app.GetIndicator()
 	//test startup Icon
 	startIcon := i.Icon()
-	assert.Equal(t, app.IconLiqoNoConn, startIcon, "startup Indicator icon is not IconLiqoNoConn")
+	assert.Equal(t, app.IconLiqoMain, startIcon, "startup Indicator icon is not IconLiqoMain")
 	//test ACTIONs and QUICKs registrations
 	var exist bool
 	_, exist = i.Quick(qOnOff)
@@ -58,7 +58,7 @@ func TestAdvertisementNotify(t *testing.T) {
 	client.DestroyMockedAgentController()
 	i := app.GetIndicator()
 	startListenerAdvertisements(i)
-	assert.Equal(t, app.IconLiqoNoConn, i.Icon(), "startup Indicator icon is not IconLiqoNoConn")
+	assert.Equal(t, app.IconLiqoMain, i.Icon(), "startup Indicator icon is not IconLiqoMain")
 	i.AgentCtrl().StartCaches()
 	advChannels := i.AgentCtrl().AdvCache().NotifyChannels
 	testAdvName := "test"

--- a/internal/tray-agent/agent/logic/logic_test.go
+++ b/internal/tray-agent/agent/logic/logic_test.go
@@ -19,7 +19,7 @@ func TestOnReady(t *testing.T) {
 	i := app.GetIndicator()
 	//test startup Icon
 	startIcon := i.Icon()
-	assert.Equal(t, app.IconLiqoMain, startIcon, "startup Indicator icon is not IconLiqoMain")
+	assert.Equal(t, app.IconLiqoNoConn, startIcon, "startup Indicator icon is not IconLiqoNoConn")
 	//test ACTIONs and QUICKs registrations
 	var exist bool
 	_, exist = i.Quick(qOnOff)
@@ -58,7 +58,7 @@ func TestAdvertisementNotify(t *testing.T) {
 	client.DestroyMockedAgentController()
 	i := app.GetIndicator()
 	startListenerAdvertisements(i)
-	assert.Equal(t, app.IconLiqoMain, i.Icon(), "startup Indicator icon is not IconLiqoMain")
+	assert.Equal(t, app.IconLiqoNoConn, i.Icon(), "startup Indicator icon is not IconLiqoNoConn")
 	i.AgentCtrl().StartCaches()
 	advChannels := i.AgentCtrl().AdvCache().NotifyChannels
 	testAdvName := "test"

--- a/internal/tray-agent/agent/logic/managers.go
+++ b/internal/tray-agent/agent/logic/managers.go
@@ -68,8 +68,7 @@ func startQuickLiqoWebsite(i *app.Indicator) {
 //startQuickDashboard is the wrapper function to register QUICK "LAUNCH Liqo Dash".
 func startQuickDashboard(i *app.Indicator) {
 	i.AddQuick("LiqoDash", qDash, func(args ...interface{}) {
-		cmd := exec.Command("xdg-open", "http://liqo.io")
-		_ = cmd.Run()
+		quickConnectDashboard(i)
 	})
 }
 

--- a/internal/tray-agent/app-indicator/notify.go
+++ b/internal/tray-agent/app-indicator/notify.go
@@ -2,6 +2,7 @@ package app_indicator
 
 import (
 	"fmt"
+	"github.com/agrison/go-commons-lang/stringUtils"
 	bip "github.com/gen2brain/beeep"
 	"github.com/gen2brain/dlgs"
 	"github.com/ozgio/strutil"
@@ -79,7 +80,10 @@ func (i *Indicator) Notify(title string, message string, notifyIcon NotifyIcon, 
 			icoName = "liqo-black.png"
 		}
 		if !i.gProvider.Mocked() {
-			_ = bip.Notify(title, message, filepath.Join(i.config.notifyIconPath, icoName))
+			/*The golang guidelines suggests error messages should not start with a capitalized letter.
+			Therefore, since Notify sometimes receives an error as 'message', the Capitalize() function
+			overcomes this problem, correctly displaying the string to the user.*/
+			_ = bip.Notify(title, stringUtils.Capitalize(message), filepath.Join(i.config.notifyIconPath, icoName))
 		}
 	default:
 		return


### PR DESCRIPTION
# Description

This PR adds the Liqo Agent feature "launch LiqoDash" allowing the user to open in the default browser the [Liqodash](https://github.com/LiqoTech/dashboard) application and easily access the required access token directly from the clipboard.