### PR TITLE
Simplify LIQO installattion procedure

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,20 +41,6 @@ Liqo can be installed via Helm.
 
 The following process will install Liqo on your Cluster. This will make your cluster ready to share resources with other Liqo resources.
 
-### Pre-requirements
-
-You have to label one node of your cluster as the gateway node. This will be used as the gateway for the inter-cluster traffic.
-
-```bash
-kubectl label no __your__gateway__node liqonet.liqo.io/gateway=true
-```
-
-To get the list of your nodes, you can use: 
-
-```
-kubectl get no
-```
-
 #### Kubernetes
 
 Liqo Installer should be capable to look for the cluster parameters required. 


### PR DESCRIPTION
# Description

This commit add the possibility to add auto-labeling of gateway node. If no node has been already labelled ***liqonet.liqo.io/gateway***, the last node in kubectl get no is selected as gateway node.

# How Has This Been Tested?

This commit has been tested with the E2E pipeline.