### PR TITLE
Keepalive mechanism

### DIFF
--- a/api/cluster-config/v1/clusterconfig_types.go
+++ b/api/cluster-config/v1/clusterconfig_types.go
@@ -38,6 +38,10 @@ type AdvertisementConfig struct {
 	// +kubebuilder:validation:Minimum=0
 	MaxAcceptableAdvertisement int32 `json:"maxAcceptableAdvertisement,omitempty"`
 	AutoAccept                 bool  `json:"autoAccept"`
+	// +kubebuilder:validation:Minimum=0
+	KeepaliveThreshold int32 `json:"keepaliveThreshold,omitempty"`
+	// +kubebuilder:validation:Minimum=0
+	KeepaliveRetryTime int32 `json:"keepaliveRetryTime,omitempty"`
 }
 
 type DiscoveryConfig struct {

--- a/config/advertisement-operator/crd/bases/protocol.liqo.io_advertisements.yaml
+++ b/config/advertisement-operator/crd/bases/protocol.liqo.io_advertisements.yaml
@@ -287,12 +287,13 @@ spec:
                 It has enough information to retrieve deployment in any namespace
               properties:
                 name:
+                  description: Name is unique within a namespace to reference a deployment
+                    resource.
                   type: string
                 namespace:
+                  description: Namespace defines the space within which the deployment
+                    name must be unique.
                   type: string
-              required:
-              - name
-              - namespace
               type: object
           required:
           - advertisementStatus

--- a/config/cluster-config/crd/bases/policy.liqo.io_clusterconfigs.yaml
+++ b/config/cluster-config/crd/bases/policy.liqo.io_clusterconfigs.yaml
@@ -42,6 +42,14 @@ spec:
                   type: boolean
                 enableBroadcaster:
                   type: boolean
+                keepaliveRetryTime:
+                  format: int32
+                  minimum: 0
+                  type: integer
+                keepaliveThreshold:
+                  format: int32
+                  minimum: 0
+                  type: integer
                 maxAcceptableAdvertisement:
                   format: int32
                   minimum: 0
@@ -52,10 +60,12 @@ spec:
                   minimum: 0
                   type: integer
               required:
-                - autoAccept
+              - autoAccept
               type: object
             discoveryConfig:
               properties:
+                allowUntrustedCA:
+                  type: boolean
                 autojoin:
                   type: boolean
                 autojoinUntrusted:
@@ -74,8 +84,6 @@ spec:
                   maximum: 65355
                   minimum: 1
                   type: integer
-                allowUntrustedCA:
-                  type: boolean
                 service:
                   type: string
                 updateTime:
@@ -85,6 +93,7 @@ spec:
                   minimum: 1
                   type: integer
               required:
+              - allowUntrustedCA
               - autojoin
               - autojoinUntrusted
               - dnsServer
@@ -93,7 +102,6 @@ spec:
               - enableDiscovery
               - name
               - port
-              - allowUntrustedCA
               - service
               - updateTime
               - waitTime
@@ -139,9 +147,9 @@ spec:
       type: object
   version: v1
   versions:
-    - name: v1
-      served: true
-      storage: true
+  - name: v1
+    served: true
+    storage: true
 status:
   acceptedNames:
     kind: ""

--- a/deployments/liqo_chart/crds/policy.liqo.io_clusterconfigs.yaml
+++ b/deployments/liqo_chart/crds/policy.liqo.io_clusterconfigs.yaml
@@ -42,6 +42,14 @@ spec:
                   type: boolean
                 enableBroadcaster:
                   type: boolean
+                keepaliveRetryTime:
+                  format: int32
+                  minimum: 0
+                  type: integer
+                keepaliveThreshold:
+                  format: int32
+                  minimum: 0
+                  type: integer
                 maxAcceptableAdvertisement:
                   format: int32
                   minimum: 0
@@ -52,10 +60,12 @@ spec:
                   minimum: 0
                   type: integer
               required:
-                - autoAccept
+              - autoAccept
               type: object
             discoveryConfig:
               properties:
+                allowUntrustedCA:
+                  type: boolean
                 autojoin:
                   type: boolean
                 autojoinUntrusted:
@@ -74,8 +84,6 @@ spec:
                   maximum: 65355
                   minimum: 1
                   type: integer
-                allowUntrustedCA:
-                  type: boolean
                 service:
                   type: string
                 updateTime:
@@ -85,18 +93,18 @@ spec:
                   minimum: 1
                   type: integer
               required:
-                - autojoin
-                - autojoinUntrusted
-                - dnsServer
-                - domain
-                - enableAdvertisement
-                - enableDiscovery
-                - name
-                - port
-                - allowUntrustedCA
-                - service
-                - updateTime
-                - waitTime
+              - allowUntrustedCA
+              - autojoin
+              - autojoinUntrusted
+              - dnsServer
+              - domain
+              - enableAdvertisement
+              - enableDiscovery
+              - name
+              - port
+              - service
+              - updateTime
+              - waitTime
               type: object
             liqonetConfig:
               properties:
@@ -119,19 +127,19 @@ spec:
                     Vni:
                       type: string
                   required:
-                    - DeviceName
-                    - Network
-                    - Port
-                    - Vni
+                  - DeviceName
+                  - Network
+                  - Port
+                  - Vni
                   type: object
               required:
-                - gatewayPrivateIP
-                - reservedSubnets
+              - gatewayPrivateIP
+              - reservedSubnets
               type: object
           required:
-            - advertisementConfig
-            - discoveryConfig
-            - liqonetConfig
+          - advertisementConfig
+          - discoveryConfig
+          - liqonetConfig
           type: object
         status:
           description: ClusterConfigStatus defines the observed state of ClusterConfig
@@ -139,9 +147,9 @@ spec:
       type: object
   version: v1
   versions:
-    - name: v1
-      served: true
-      storage: true
+  - name: v1
+    served: true
+    storage: true
 status:
   acceptedNames:
     kind: ""

--- a/deployments/liqo_chart/crds/protocol.liqo.io_advertisements.yaml
+++ b/deployments/liqo_chart/crds/protocol.liqo.io_advertisements.yaml
@@ -287,12 +287,13 @@ spec:
                 It has enough information to retrieve deployment in any namespace
               properties:
                 name:
+                  description: Name is unique within a namespace to reference a deployment
+                    resource.
                   type: string
                 namespace:
+                  description: Namespace defines the space within which the deployment
+                    name must be unique.
                   type: string
-              required:
-              - name
-              - namespace
               type: object
           required:
           - advertisementStatus

--- a/deployments/liqo_chart/templates/clusterconfig.yaml
+++ b/deployments/liqo_chart/templates/clusterconfig.yaml
@@ -10,6 +10,8 @@ spec:
     maxAcceptableAdvertisement: 5
     resourceSharingPercentage: 30
     enableBroadcaster: true
+    keepaliveThreshold: 3
+    keepaliveRetryTime: 20
   discoveryConfig:
     autojoin: true
     autojoinUntrusted: true

--- a/pkg/object-references/types.go
+++ b/pkg/object-references/types.go
@@ -3,6 +3,10 @@ package object_references
 // DeploymentReference represents a Deployment Reference. It has enough information to retrieve deployment
 // in any namespace
 type DeploymentReference struct {
-	Name      string `json:"name"`
-	Namespace string `json:"namespace"`
+	// Name is unique within a namespace to reference a deployment resource.
+	// +optional
+	Name string `json:"name,omitempty" protobuf:"bytes,1,opt,name=name"`
+	// Namespace defines the space within which the deployment name must be unique.
+	// +optional
+	Namespace string `json:"namespace,omitempty" protobuf:"bytes,2,opt,name=namespace"`
 }


### PR DESCRIPTION
# Description
In this PR a first implementation of the keepalive mechanism is presented.
There are 3 possibilities:
- **METHOD 1** : create a client to the foreign cluster and try to list the pods every 20 seconds
This approach is the simplest one, but it requires the permissions to list the pods on a given namespace on the foreign cluster.
- **METHOD 2** : create a `CronJob` which executes a `curl -k <url>` every minute
This approach has the limitation given by the Cron format, whose minimum timestamp is 1 minute. Therefore, the convergence time would be 3 times greater.
- **METHOD 3** : perform a `curl -k <url>` every 20 seconds. 
`<url>` is the `healthz` endpoint of the foreign cluster. 
`healthz` endpoint is meant to reply _200 OK_ if the cluster is up and running
Very similar to method 1, the problem with this approach is the `-k` option which is insecure

After 3 failed attempts, the foreign cluster is supposed to be down and its advertisement is deleted.

In the code the first approach is used, the other 2 have been left commented.

## Other changes
- updated `VkReference` field with a description and optional fields

# How Has This Been Tested?

Tested with 2 Kind clusters