### PR TITLE
Removing the GatewayPrivateIP parameter from the network module

### DIFF
--- a/api/cluster-config/v1/clusterconfig_types.go
+++ b/api/cluster-config/v1/clusterconfig_types.go
@@ -77,9 +77,9 @@ type DiscoveryConfig struct {
 
 type LiqonetConfig struct {
 	//contains a list of reserved subnets in CIDR notation used by the k8s cluster like the podCIDR and ClusterCIDR
-	ReservedSubnets  []string               `json:"reservedSubnets"`
-	GatewayPrivateIP string                 `json:"gatewayPrivateIP"`
-	VxlanNetConfig   liqonet.VxlanNetConfig `json:"vxlanNetConfig,omitempty"`
+	ReservedSubnets []string               `json:"reservedSubnets"`
+	PodCIDR         string                 `json:"podCIDR"`
+	VxlanNetConfig  liqonet.VxlanNetConfig `json:"vxlanNetConfig,omitempty"`
 }
 
 //contains a list of resources identified by their GVR

--- a/config/cluster-config/crd/bases/policy.liqo.io_clusterconfigs.yaml
+++ b/config/cluster-config/crd/bases/policy.liqo.io_clusterconfigs.yaml
@@ -128,7 +128,7 @@ spec:
               type: object
             liqonetConfig:
               properties:
-                gatewayPrivateIP:
+                podCIDR:
                   type: string
                 reservedSubnets:
                   description: contains a list of reserved subnets in CIDR notation
@@ -153,7 +153,7 @@ spec:
                   - Vni
                   type: object
               required:
-              - gatewayPrivateIP
+              - podCIDR
               - reservedSubnets
               type: object
           required:

--- a/deployments/liqo_chart/crds/policy.liqo.io_clusterconfigs.yaml
+++ b/deployments/liqo_chart/crds/policy.liqo.io_clusterconfigs.yaml
@@ -128,7 +128,7 @@ spec:
               type: object
             liqonetConfig:
               properties:
-                gatewayPrivateIP:
+                podCIDR:
                   type: string
                 reservedSubnets:
                   description: contains a list of reserved subnets in CIDR notation
@@ -153,7 +153,7 @@ spec:
                   - Vni
                   type: object
               required:
-              - gatewayPrivateIP
+              - podCIDR
               - reservedSubnets
               type: object
           required:
@@ -167,9 +167,9 @@ spec:
       type: object
   version: v1
   versions:
-  - name: v1
-    served: true
-    storage: true
+    - name: v1
+      served: true
+      storage: true
 status:
   acceptedNames:
     kind: ""

--- a/deployments/liqo_chart/subcharts/adv_chart/templates/adv-deploy.yaml
+++ b/deployments/liqo_chart/subcharts/adv_chart/templates/adv-deploy.yaml
@@ -68,16 +68,6 @@ spec:
               configMapKeyRef:
                 name: cluster-id
                 key: cluster-id
-          - name: LOCAL_TUNNEL_PUBLIC_IP
-            valueFrom:
-              configMapKeyRef:
-                name: {{ .Values.global.configmapName }}
-                key: gatewayIP
-          - name: LOCAL_TUNNEL_PRIVATE_IP
-            valueFrom:
-              configMapKeyRef:
-                name: {{ .Values.global.configmapName }}
-                key: gatewayPrivateIP
           - name: POD_NAMESPACE
             valueFrom:
              fieldRef:

--- a/deployments/liqo_chart/subcharts/networkModule_chart/templates/route-operator.yaml
+++ b/deployments/liqo_chart/subcharts/networkModule_chart/templates/route-operator.yaml
@@ -37,6 +37,18 @@ rules:
       - get
       - patch
       - update
+  - apiGroups:
+      - policy.liqo.io
+    resources:
+     - clusterconfigs
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -115,10 +127,5 @@ spec:
               valueFrom:
                fieldRef:
                  fieldPath: spec.nodeName
-            - name: POD_CIDR
-              valueFrom:
-                configMapKeyRef:
-                  name: {{ .Values.global.configmapName }}
-                  key: podCIDR
       hostNetwork: true
       restartPolicy: Always

--- a/deployments/liqo_chart/subcharts/networkModule_chart/templates/tunnelEndpoint-operator.yaml
+++ b/deployments/liqo_chart/subcharts/networkModule_chart/templates/tunnelEndpoint-operator.yaml
@@ -84,10 +84,5 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
-            - name: LOCAL_TUNNEL_PRIVATE_IP
-              valueFrom:
-                configMapKeyRef:
-                  name: {{ .Values.global.configmapName }}
-                  key: gatewayPrivateIP
       hostNetwork: true
       restartPolicy: Always

--- a/deployments/liqo_chart/subcharts/tunnelEndpointCreator_chart/templates/tunnelEndpointCreator.yaml
+++ b/deployments/liqo_chart/subcharts/tunnelEndpointCreator_chart/templates/tunnelEndpointCreator.yaml
@@ -111,16 +111,5 @@ spec:
           command: ["/usr/bin/liqonet"]
           args:
             - "-run-as=tunnelEndpointCreator-operator"
-          env:
-            - name: POD_CIDR
-              valueFrom:
-                configMapKeyRef:
-                  name: {{ .Values.global.configmapName }}
-                  key: podCIDR
-            - name: CLUSTER_CIDR
-              valueFrom:
-                configMapKeyRef:
-                  name: {{ .Values.global.configmapName }}
-                  key: serviceCIDR
       restartPolicy: Always
 status: {}

--- a/deployments/liqo_chart/templates/clusterconfig.yaml
+++ b/deployments/liqo_chart/templates/clusterconfig.yaml
@@ -26,7 +26,7 @@ spec:
     waitTime: 2
     dnsServer: '8.8.8.8:53'
   liqonetConfig:
-    gatewayPrivateIP: {{ .Values.gatewayPrivateIP }}
+    podCIDR: {{ .Values.podCIDR }}
     reservedSubnets:
     - {{ .Values.podCIDR }}
     - {{ .Values.serviceCIDR }}

--- a/deployments/liqo_chart/templates/configmap.yaml
+++ b/deployments/liqo_chart/templates/configmap.yaml
@@ -5,8 +5,8 @@ metadata:
   labels:
     app: liqo.io
 data:
-  clusterID: {{ .Values.clusterID}}
-  podCIDR: {{ .Values.podCIDR}}
-  serviceCIDR: {{ .Values.serviceCIDR}}
-  gatewayPrivateIP: {{ .Values.gatewayPrivateIP}}
-  gatewayIP: {{ .Values.gatewayIP}}
+  clusterID: "placeHolder"
+  podCIDR: {{ .Values.podCIDR }}
+  serviceCIDR: {{ .Values.serviceCIDR }}
+  gatewayPrivateIP: "192.168.1.1" #placeholder, needed by broadcaster. soon will be removed
+  gatewayIP: "placeholder"

--- a/deployments/liqo_chart/values.yaml
+++ b/deployments/liqo_chart/values.yaml
@@ -5,7 +5,6 @@
 clusterID: "lab9"
 podCIDR: "10.244.0.0/16"
 serviceCIDR: "10.96.0.0/12"
-gatewayPrivateIP: "192.168.1.1"
 
 ##### Needed
 suffix: ""
@@ -88,7 +87,7 @@ liqodash_chart:
   image:
     repository: "liqo/dashboard"
     pullpolicy: "Always"
-  enabled: true  
+  enabled: true
 
 global:
   configmapName: "liqo-configmap"

--- a/install.sh
+++ b/install.sh
@@ -32,7 +32,6 @@ function print_help()
    echo "This script is designed to install LIQO on your cluster. This script is configurable via environment variables:"
    echo "   POD_CIDR: the POD CIDR of your cluster (e.g.; 10.0.0.0/16). The script will try to detect it, but you can override this by having this variable already set"
    echo "   SERVICE_CIDR: the POD CIDR of your cluster (e.g.; 10.96.0.0/12) . The script will try to detect it, but you can override thisthis by having this variable already set"
-   echo "   GATEWAY_PRIVATE_IP: the IP used by the cluster inside the cluster-to-cluster interconnection (e.g.; 192.168.1.1)"
    echo "   GATEWAY_IP: the public IP that will be used by LIQO to establish the interconnection with other clusters"
 }
 
@@ -84,7 +83,6 @@ URL=https://github.com/LiqoTech/liqo.git
 HELM_VERSION=v3.2.3
 HELM_ARCHIVE=helm-${HELM_VERSION}-linux-amd64.tar.gz
 HELM_URL=https://get.helm.sh/$HELM_ARCHIVE
-DEFAULT_GATEWAY_PRIVATE_IP=192.168.1.1
 NAMESPACE_DEFAULT="liqo"
 # The following variable are used a default value to select the images when installing LIQO.
 # When installing a non released version:
@@ -140,8 +138,6 @@ POD_CIDR_COMMAND='kubectl cluster-info dump | grep -m 1 -Po "(?<=--cluster-cidr=
 set_variable_from_command POD_CIDR POD_CIDR_COMMAND "[ERROR]: Unable to find POD_CIDR"
 SERVICE_CIDR_COMMAND='kubectl cluster-info dump | grep -m 1 -Po "(?<=--service-cluster-ip-range=)[0-9.\/]+"'
 set_variable_from_command SERVICE_CIDR SERVICE_CIDR_COMMAND "[ERROR]: Unable to find Service CIDR"
-GATEWAY_PRIVATE_IP_COMMAND="echo $DEFAULT_GATEWAY_PRIVATE_IP"
-set_variable_from_command GATEWAY_PRIVATE_IP GATEWAY_PRIVATE_IP_COMMAND "[ERROR]: Unable to set Gateway Private IP"
 NAMESPACE_COMMAND="echo $NAMESPACE_DEFAULT"
 set_variable_from_command NAMESPACE NAMESPACE_COMMAND "[ERROR]: Error while creating the namespace... "
 LIQO_SUFFIX_COMMAND="echo $LIQO_SUFFIX_DEFAULT"
@@ -155,7 +151,7 @@ set_variable_from_command DASHBOARD_APISERVER DASHBOARD_APISERVER_COMMAND "[ERRO
 kubectl create ns $NAMESPACE
 $TMPDIR/bin/helm dependency update $TMPDIR/liqo/deployments/liqo_chart
 $TMPDIR/bin/helm install liqo -n liqo $TMPDIR/liqo/deployments/liqo_chart --set podCIDR=$POD_CIDR --set serviceCIDR=$SERVICE_CIDR \
---set gatewayPrivateIP=$GATEWAY_PRIVATE_IP --set gatewayIP=$GATEWAY_IP --set global.suffix="$LIQO_SUFFIX" --set global.version="$LIQO_VERSION" \
+--set gatewayIP=$GATEWAY_IP --set global.suffix="$LIQO_SUFFIX" --set global.version="$LIQO_VERSION" \
 --set global.apiServerURL=$DASHBOARD_APISERVER
 echo "[INSTALL]: Installing LIQO on your cluster..."
 sleep 30

--- a/internal/liqonet/route-operator-config.go
+++ b/internal/liqonet/route-operator-config.go
@@ -1,0 +1,35 @@
+package controllers
+
+import (
+	policyv1 "github.com/liqoTech/liqo/api/cluster-config/v1"
+	"github.com/liqoTech/liqo/pkg/clusterConfig"
+	"github.com/liqoTech/liqo/pkg/crdClient"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"k8s.io/klog/v2"
+	"os"
+)
+
+func (r *RouteController) WatchConfiguration(config *rest.Config, gv *schema.GroupVersion) {
+	config.ContentConfig.GroupVersion = gv
+	config.APIPath = "/apis"
+	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	config.UserAgent = rest.DefaultKubernetesUserAgent()
+	CRDclient, err := crdClient.NewFromConfig(config)
+	if err != nil {
+		klog.Error(err, err.Error())
+		os.Exit(1)
+	}
+	go clusterConfig.WatchConfiguration(func(configuration *policyv1.ClusterConfig) {
+		if !r.IsConfigured {
+			r.ClusterPodCIDR = configuration.Spec.LiqonetConfig.PodCIDR
+			r.Configured <- true
+		}
+		//check if the podCIDR is different from the one on the cluster config
+		//TODO: a go routine which removes all the configuration with the old podCIDR and triggers a new configuration for the new podCIDR
+		if r.ClusterPodCIDR != configuration.Spec.LiqonetConfig.PodCIDR {
+			r.ClusterPodCIDR = configuration.Spec.LiqonetConfig.PodCIDR
+		}
+	}, CRDclient, "")
+}

--- a/internal/liqonet/route-operator.go
+++ b/internal/liqonet/route-operator.go
@@ -67,6 +67,8 @@ type RouteController struct {
 	IPtables       liqonetOperator.IPTables
 	NetLink        liqonetOperator.NetLink
 	ClusterPodCIDR string
+	Configured     chan bool //channel to comunicate when the podCIDR has been set
+	IsConfigured   bool      //true when the operator is configured and ready to be started
 	//here we save only the rules that reference the custom chains added by us
 	//we need them at deletion time
 	IPTablesRuleSpecsReferencingChains map[string]liqonetOperator.IPtableRule //using a map to avoid duplicate entries. the key is the rulespec

--- a/internal/liqonet/route-operator_test.go
+++ b/internal/liqonet/route-operator_test.go
@@ -51,7 +51,7 @@ func getRouteController() *RouteController {
 		GatewayVxlanIP:                     "172.12.1.1",
 		VxlanIfaceName:                     "vxlanTest",
 		VxlanPort:                          0,
-		ClusterPodCIDR:                     "",
+		ClusterPodCIDR:                     "10.1.0.0/16",
 		IPTablesRuleSpecsReferencingChains: make(map[string]liqonet.IPtableRule),
 		IPTablesChains:                     make(map[string]liqonet.IPTableChain),
 		IPtablesRuleSpecsPerRemoteCluster:  make(map[string][]liqonet.IPtableRule),
@@ -171,9 +171,8 @@ func TestInsertRoutesPerCluster(t *testing.T) {
 	tep := GetTunnelEndpointCR()
 	err := r.InsertRoutesPerCluster(tep)
 	assert.Nil(t, err, "error should be nil")
-	assert.Equal(t, 2, len(r.RoutesPerRemoteCluster[tep.Spec.ClusterID]), "number of routes should be 2")
+	assert.Equal(t, 1, len(r.RoutesPerRemoteCluster[tep.Spec.ClusterID]), "number of routes should be 1")
 	assert.True(t, routePerDestination(r.RoutesPerRemoteCluster[tep.Spec.ClusterID], tep.Spec.PodCIDR), "the route for the remote pod cidr should be present")
-	assert.True(t, routePerDestination(r.RoutesPerRemoteCluster[tep.Spec.ClusterID], tep.Status.RemoteTunnelPrivateIP+"/32"), "the route for the remote gateway should be present")
 
 	//test2: same as above but the node is gateway node and the remote pod CIDR has been remapped
 	//the expected number of routes is 2
@@ -183,9 +182,8 @@ func TestInsertRoutesPerCluster(t *testing.T) {
 	tep.Status.RemoteRemappedPodCIDR = "10.100.0.0/16"
 	err = r.InsertRoutesPerCluster(tep)
 	assert.Nil(t, err, "error should be nil")
-	assert.Equal(t, 2, len(r.RoutesPerRemoteCluster[tep.Spec.ClusterID]), "number of routes should be 2")
+	assert.Equal(t, 1, len(r.RoutesPerRemoteCluster[tep.Spec.ClusterID]), "number of routes should be 1")
 	assert.True(t, routePerDestination(r.RoutesPerRemoteCluster[tep.Spec.ClusterID], "10.100.0.0/16"), "the route for the remote remapped pod cidr should be present")
-	assert.True(t, routePerDestination(r.RoutesPerRemoteCluster[tep.Spec.ClusterID], tep.Status.RemoteTunnelPrivateIP+"/32"), "the route for the remote gateway should be present")
 }
 
 func TestDeleteRoutesPerCluster(t *testing.T) {
@@ -196,9 +194,8 @@ func TestDeleteRoutesPerCluster(t *testing.T) {
 	tep := GetTunnelEndpointCR()
 	err := r.InsertRoutesPerCluster(tep)
 	assert.Nil(t, err, "error should be nil")
-	assert.Equal(t, 2, len(r.RoutesPerRemoteCluster[tep.Spec.ClusterID]), "number of routes should be 2")
+	assert.Equal(t, 1, len(r.RoutesPerRemoteCluster[tep.Spec.ClusterID]), "number of routes should be 1")
 	assert.True(t, routePerDestination(r.RoutesPerRemoteCluster[tep.Spec.ClusterID], tep.Spec.PodCIDR), "the route for the remote pod cidr should be present")
-	assert.True(t, routePerDestination(r.RoutesPerRemoteCluster[tep.Spec.ClusterID], tep.Status.RemoteTunnelPrivateIP+"/32"), "the route for the remote gateway should be present")
 	//here we delete all the routes for the cluster
 	err = r.deleteRoutesPerCluster(tep)
 	assert.Nil(t, err, "error should be nil")
@@ -211,9 +208,8 @@ func TestDeleteAllRoutes(t *testing.T) {
 	tep := GetTunnelEndpointCR()
 	err := r.InsertRoutesPerCluster(tep)
 	assert.Nil(t, err, "error should be nil")
-	assert.Equal(t, 2, len(r.RoutesPerRemoteCluster[tep.Spec.ClusterID]), "number of routes should be 2")
+	assert.Equal(t, 1, len(r.RoutesPerRemoteCluster[tep.Spec.ClusterID]), "number of routes should be 2")
 	assert.True(t, routePerDestination(r.RoutesPerRemoteCluster[tep.Spec.ClusterID], tep.Spec.PodCIDR), "the route for the remote pod cidr should be present")
-	assert.True(t, routePerDestination(r.RoutesPerRemoteCluster[tep.Spec.ClusterID], tep.Status.RemoteTunnelPrivateIP+"/32"), "the route for the remote gateway should be present")
 	//here we delete all the routes for the clusters
 	r.deleteAllRoutes()
 	assert.Zero(t, len(r.RoutesPerRemoteCluster), "routes for the cluster should be zero")

--- a/pkg/liqonet/tunnel.go
+++ b/pkg/liqonet/tunnel.go
@@ -83,15 +83,6 @@ func InstallGreTunnel(endpoint *v1.TunnelEndpoint) (int, string, error) {
 	if err != nil {
 		return 0, "", err
 	}
-	ownPrivateIP, err := GetLocalTunnelPrivateIPToString()
-	if err != nil {
-		return 0, "", err
-	}
-	address, network, err := net.ParseCIDR(ownPrivateIP + "/32")
-	if err != nil {
-		return 0, "", err
-	}
-	err = gretunnel.configureIPAddress(address, network.Mask)
 	if err != nil {
 		return 0, "", err
 	}

--- a/scripts/cluster-config/Makefile
+++ b/scripts/cluster-config/Makefile
@@ -32,7 +32,7 @@ deploy: manifests
 
 # Generate manifests e.g. CRD, RBAC etc.
 manifests: controller-gen
-	$(CONTROLLER_GEN) $(CRD_OPTIONS) paths="./api/cluster-config/v1" output:crd:artifacts:config=config/cluster-config/crd/bases
+	$(CONTROLLER_GEN) $(CRD_OPTIONS) paths="../../api/cluster-config/v1" output:crd:artifacts:config=../../config/cluster-config/crd/bases
 
 # Run go fmt against code
 fmt:
@@ -44,7 +44,7 @@ vet:
 
 # Generate code
 generate: controller-gen
-	$(CONTROLLER_GEN) object:headerFile=./hack/boilerplate.go.txt paths="./..."
+	$(CONTROLLER_GEN) object:headerFile=../../hack/boilerplate.go.txt paths="../../api/cluster-config/v1"
 
 # Build the docker image
 docker-build: test

--- a/test/unit/discovery/env_test.go
+++ b/test/unit/discovery/env_test.go
@@ -279,8 +279,8 @@ func getClusterConfig(config rest.Config) {
 				DnsServer:           "8.8.8.8:53",
 			},
 			LiqonetConfig: policyv1.LiqonetConfig{
-				ReservedSubnets:  []string{"10.0.0.0/16"},
-				GatewayPrivateIP: "192.168.1.1",
+				ReservedSubnets: []string{"10.0.0.0/16"},
+				PodCIDR:         "192.168.1.1",
 				VxlanNetConfig: liqonet.VxlanNetConfig{
 					Network:    "",
 					DeviceName: "",

--- a/test/unit/dispatcher/env_test.go
+++ b/test/unit/dispatcher/env_test.go
@@ -181,8 +181,7 @@ func getClusterConfig() *policyv1.ClusterConfig {
 				DnsServer:           "8.8.8.8:53",
 			},
 			LiqonetConfig: policyv1.LiqonetConfig{
-				ReservedSubnets:  []string{"10.0.0.0/16"},
-				GatewayPrivateIP: "192.168.1.1",
+				ReservedSubnets: []string{"10.0.0.0/16"},
 				VxlanNetConfig: liqonet.VxlanNetConfig{
 					Network:    "",
 					DeviceName: "",

--- a/test/unit/liqonet/env_test.go
+++ b/test/unit/liqonet/env_test.go
@@ -183,8 +183,8 @@ func getClusterConfig() *policyv1.ClusterConfig {
 				DnsServer:           "8.8.8.8:53",
 			},
 			LiqonetConfig: policyv1.LiqonetConfig{
-				ReservedSubnets:  []string{"10.0.0.0/16"},
-				GatewayPrivateIP: "192.168.1.1",
+				ReservedSubnets: []string{"10.0.0.0/16"},
+				PodCIDR:         "10.244.0.0/16",
 				VxlanNetConfig: liqonet.VxlanNetConfig{
 					Network:    "",
 					DeviceName: "",

--- a/test/unit/liqonet/tunnelEndpointCreator_test.go
+++ b/test/unit/liqonet/tunnelEndpointCreator_test.go
@@ -47,9 +47,9 @@ func getClusterConfigurationCR(reservedSubnets []string) *policyv1.ClusterConfig
 			AdvertisementConfig: policyv1.AdvertisementConfig{},
 			DiscoveryConfig:     policyv1.DiscoveryConfig{},
 			LiqonetConfig: policyv1.LiqonetConfig{
-				ReservedSubnets:  reservedSubnets,
-				GatewayPrivateIP: "",
-				VxlanNetConfig:   liqonetOperator.VxlanNetConfig{},
+				ReservedSubnets: reservedSubnets,
+				PodCIDR:         "",
+				VxlanNetConfig:  liqonetOperator.VxlanNetConfig{},
 			},
 		},
 		Status: policyv1.ClusterConfigStatus{},


### PR DESCRIPTION
# Description
This PR removes the GatewayPrivateIP parameter from the network module. The Linux kernel does not strictly require a IP address for the tunnel interface in order to route the traffic through it. By removing this parameter we greatly simplify the configuration of a LIQO cluster.
Now the traffic from hosts to remote pods is NATed in two different ways:
- the local cluster have not been NATed by the remote one: we take the first IP address of the podCIDR of the cluster
- the local cluster have be NATed by the remote one: we take the first IP address from the new subnet

The parameter have been removed from the install script and from the helm chart as well.

The route-operator gets the podCIDR parameters from the` clusterconfig.policy.liqo.io` CRD.

# How Has This Been Tested?
The unit tests of the network module have been updated to not consider the iptables rules and routes involving the GatewayPrivateIP parameter.

End to End tests with two k8s-clusters:
- without podCIDR conflicts, no NAT required
- with podCIDR conflicts, NAT configured

Both pod to pod traffic and node to pod traffic have been tested.

