### PR TITLE
Fix LAN discovery

### DIFF
--- a/internal/discovery/register.go
+++ b/internal/discovery/register.go
@@ -10,7 +10,12 @@ import (
 
 func (discovery *DiscoveryCtrl) Register() {
 	if discovery.Config.EnableAdvertisement {
-		txt, err := discovery.GetTxtData().Encode()
+		txtData, err := discovery.GetTxtData()
+		if err != nil {
+			klog.Error(err)
+			return
+		}
+		txt, err := txtData.Encode()
 		if err != nil {
 			klog.Error(err, err.Error())
 			return

--- a/internal/discovery/txtData.go
+++ b/internal/discovery/txtData.go
@@ -1,7 +1,11 @@
 package discovery
 
 import (
+	"context"
 	"errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog"
+	"os"
 	"strings"
 )
 
@@ -17,6 +21,7 @@ func (txtData TxtData) Encode() ([]string, error) {
 		"id=" + txtData.ID,
 		"namespace=" + txtData.Namespace,
 		"untrusted-ca=" + txtData.GetAllowUntrustedCA(),
+		"url=" + txtData.ApiUrl,
 	}
 	return res, nil
 }
@@ -38,19 +43,62 @@ func Decode(address string, port string, data []string) (*TxtData, error) {
 			res.Namespace = d[len("namespace="):]
 		} else if strings.HasPrefix(d, "untrusted-ca=") {
 			res.AllowUntrustedCA = d[len("untrusted-ca="):] == "true"
+		} else if strings.HasPrefix(d, "url=") {
+			// used in LAN discovery
+			res.ApiUrl = d[len("url="):]
 		}
 	}
-	res.ApiUrl = "https://" + address + ":" + port
+	// used in WAN discovery
+	if address != "" && port != "" {
+		res.ApiUrl = "https://" + address + ":" + port
+	}
 	if res.ID == "" || res.Namespace == "" || res.ApiUrl == "" {
 		return nil, errors.New("TxtData missing required field")
 	}
 	return &res, nil
 }
 
-func (discovery *DiscoveryCtrl) GetTxtData() TxtData {
-	return TxtData{
+func (discovery *DiscoveryCtrl) GetTxtData() (*TxtData, error) {
+	apiUrl, err := discovery.GetAPIUrl()
+	if err != nil {
+		klog.Error(err)
+		return nil, err
+	}
+	return &TxtData{
 		ID:               discovery.ClusterId.GetClusterID(),
 		Namespace:        discovery.Namespace,
 		AllowUntrustedCA: discovery.Config.AllowUntrustedCA,
+		ApiUrl:           apiUrl,
+	}, nil
+}
+
+// get API Server Url for this cluster
+// if APISERVER env variable is set we read it's ip form this variable
+//     (this can be useful on managed k8s services where we have no master node)
+// else get the IP of first master
+// if APISERVER_PORT env variable is set we use it has port
+// else we fallback to default port
+func (discovery *DiscoveryCtrl) GetAPIUrl() (string, error) {
+	address, ok := os.LookupEnv("APISERVER")
+	if !ok || address == "" {
+		nodes, err := discovery.crdClient.Client().CoreV1().Nodes().List(context.TODO(), v1.ListOptions{
+			LabelSelector: "node-role.kubernetes.io/master",
+		})
+		if err != nil {
+			return "", err
+		}
+		if len(nodes.Items) == 0 || len(nodes.Items[0].Status.Addresses) == 0 {
+			err = errors.New("no APISERVER env variable found and no master node found, one of the two values must be present")
+			klog.Error(err)
+			return "", err
+		}
+		address = nodes.Items[0].Status.Addresses[0].Address
 	}
+
+	port, ok := os.LookupEnv("APISERVER_PORT")
+	if !ok {
+		port = "6443"
+	}
+
+	return "https://" + address + ":" + port, nil
 }


### PR DESCRIPTION
# Description

This PR fixes a problem in LAN discovery when hosts have some overlapping IPs. This PR changes the logic of how a cluster is considered local or remote. Previously if there was at least an equal IP on both, they were considered the same. Now if they have at least a different IP they are considered different hosts

Fixes #194 
