### PR TITLE
Updated Advertisement documentation

### DIFF
--- a/docs/pages/Architecture/Advertisement Management/_index.md
+++ b/docs/pages/Architecture/Advertisement Management/_index.md
@@ -1,6 +1,4 @@
 ---
 title: "Advertisement Management"
-weight: 2
-chapter: true
 ---
 

--- a/docs/pages/Architecture/Advertisement Management/advertisement_protocol.md
+++ b/docs/pages/Architecture/Advertisement Management/advertisement_protocol.md
@@ -13,18 +13,19 @@ These messages are then used to build a local virtual-node where jobs can be sch
 actually sent to the respective foreign cluster. 
 
 ## Architecture and workflow
+
 ![](/images/advertisement-protocol/architecture.png)
 
 ### Components
-* The [broadcaster](broadcaster.md) is in charge of sending to other clusters the Advertisement message, containing the
+* The [broadcaster](/architecture/advertisement-management/broadcaster) is in charge of sending to other clusters the Advertisement message, containing the
   resources made available for sharing and (optionally) their prices
-* The [advertisement operator](controller.md) (briefly called **controller**) is the module that receives Advertisement 
+* The [advertisement operator](/architecture/advertisement-management/controller) (briefly called **controller**) is the module that receives Advertisement 
   messages and creates the virtual nodes with the announced resources.
   
 ### Workflow
 
 #### Outgoing chain
-1. A foreign cluster is provided (manually by the admin or through the [discovery protocol](Discovery and Peering/discovery.md)).
+1. A foreign cluster is provided (manually by the admin or through the [discovery protocol](/architecture/discovery-and-peering/)).
 2. When the foreign cluster requests some resources, the discovery logic creates the broadcaster
 3. The broadcaster retrieves the available cluster resources and, after applying some policies, creates an Advertisement.
 4. The Advertisement is pushed to the foreign cluster.
@@ -33,4 +34,4 @@ actually sent to the respective foreign cluster.
 1. An Advertisement is received from the foreign cluster
 2. The Advertisement is checked by a policy block: if it is accepted, it is further processed by the controller
 3. The controller creates a virtual node with the information taken by the Advertisement
-4. The virtual node will masquerade the foreign cluster and the resources created on it will be reflected according to the [sharing process](Cluster Sharing/_index.md)
+4. The virtual node will masquerade the foreign cluster and the resources created on it will be reflected according to the [sharing process](/architecture/cluster-sharing/)

--- a/docs/pages/Architecture/Advertisement Management/broadcaster.md
+++ b/docs/pages/Architecture/Advertisement Management/broadcaster.md
@@ -32,6 +32,7 @@ After having created the Advertisement on the remote cluster, the broadcaster st
 * MetricsAPI to have more precise values of available resources
 
 ## Architecture and workflow
+
 ![](/images/advertisement-protocol/broadcaster-workflow.png)
 
 1. A `PeeringRequest` is created by the foreign cluster: a broadcaster deployment is launched

--- a/docs/pages/Architecture/Advertisement Management/controller.md
+++ b/docs/pages/Architecture/Advertisement Management/controller.md
@@ -14,10 +14,7 @@ The operator watches `ClusterConfig` CR to know the maximum number of Advertisem
 If the `AutoAccept` flag is set to true, the behaviour is the following:
  - if MaxAcceptableAdvertisements increases, check if there are refused Advertisements: if so, they are accepted until
    the new maximum is reached.
- - if MaxAcceptableAdvertisements decreases
-   - if the current number of accepted Advertisements is lower than the new maximum, nothing changes
-   - if the current number of accepted Advertisements is higher than the new maximum, some of them are deleted until
-     the new maximum is respected.
+ - if MaxAcceptableAdvertisements decreases, Advertisements already accepted are left and from now on the new Advertisements that arrive will follow the new policy.
 
 ### Limitations
 * Manual acceptance of Advertisement
@@ -26,6 +23,7 @@ If the `AutoAccept` flag is set to true, the behaviour is the following:
 * Recreation of virtual-kubelet if it is unexpectedly deleted
 
 ## Architecture and workflow
+
 ![](/images/advertisement-protocol/controller-workflow.png)
 
 1. An `Advertisement` is created by the foreign cluster

--- a/docs/pages/Architecture/_index.md
+++ b/docs/pages/Architecture/_index.md
@@ -39,10 +39,10 @@ The discovery phase is presented in details [here](discovery-and-peering/).
 The Advertisement operator can be split in two main components.
 
 - **Broadcaster**: the module which creates and sends the Advertisement message
-- **Controller**: the module which is triggered when receiving an Advertisement and spawns a virtual node (using Virtual 
+- **Advertisement Operator**: the module which is triggered when receiving an Advertisement and spawns a virtual node (using Virtual 
 Kubelet)
 
- You can find more details about the [here](advertisement_protocol.md).
+ You can find more details about the [here](advertisement-management/).
 
 ## Resource Sharing
 


### PR DESCRIPTION
# Description
This PR fixes some broken links in the documentation
The images in `advertisement management` section are still not displayed for unknown reason