### PR TITLE
Liqo installer - dashboard subchart

### DIFF
--- a/deployments/liqo_chart/Chart.lock
+++ b/deployments/liqo_chart/Chart.lock
@@ -20,5 +20,8 @@ dependencies:
 - name: peeringRequestOperator_chart
   repository: file://subcharts/peeringRequestOperator_chart/
   version: 0.1.0
-digest: sha256:d33c46b9d72d488a05d9dd06cf33bf2807e7d97667664e3163a7e1c1470a6843
-generated: "2020-07-20T17:21:35.393517096+02:00"
+- name: liqodash_chart
+  repository: file://subcharts/liqodash_chart/
+  version: 0.1.0
+digest: sha256:9a937b23181275cfc00e0d34d3f6c51f02d0ef2227644a11c7d3b88ad019effe
+generated: "2020-08-26T17:03:44.2572446+02:00"

--- a/deployments/liqo_chart/Chart.yaml
+++ b/deployments/liqo_chart/Chart.yaml
@@ -50,3 +50,7 @@ dependencies:
   version: "0.1.0"
   repository: file://subcharts/peeringRequestOperator_chart/
   condition: peeringRequestOperator_chart.enabled
+- name: liqodash_chart
+  version: "0.1.0"
+  repository: file://subcharts/liqodash_chart/
+  condition: liqodash_chart.enabled

--- a/deployments/liqo_chart/README.md
+++ b/deployments/liqo_chart/README.md
@@ -16,6 +16,7 @@ Current chart version is `0.1.0`
 | file://subcharts/peeringRequestOperator_chart/ | peeringRequestOperator_chart | 0.1.0 |
 | file://subcharts/schedulingNodeOperator_chart/ | schedulingNodeOperator_chart | 0.1.0 |
 | file://subcharts/tunnelEndpointCreator_chart/ | tunnelEndpointCreator_chart | 0.1.0 |
+| file://subcharts/liqodash_chart/ | liqodash_chart | 0.1.0 |
 
 ## Chart Values
 
@@ -50,3 +51,7 @@ Current chart version is `0.1.0`
 | tunnelEndpointCreator_chart.enabled | bool | `true` |  |
 | tunnelEndpointCreator_chart.image.pullPolicy | string | `"IfNotPresent"` |  |
 | tunnelEndpointCreator_chart.image.repository | string | `"liqo/liqonet"` |  |
+| liqodash_chart.enabled | bool | `true` |  |
+| liqodash_chart.image.pullPolicy | string | `"IfNotPresent"` |  |
+| liqodash_chart.image.repository | string | `"liqo/dashboard"` |  |
+| global.apiServerURL | string | `""` |  |

--- a/deployments/liqo_chart/subcharts/liqodash_chart/.helmignore
+++ b/deployments/liqo_chart/subcharts/liqodash_chart/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/deployments/liqo_chart/subcharts/liqodash_chart/Chart.yaml
+++ b/deployments/liqo_chart/subcharts/liqodash_chart/Chart.yaml
@@ -1,0 +1,23 @@
+apiVersion: v2
+name: liqodash_chart
+description: A Helm chart for Liqo Dashboard
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+appVersion: 1.16.0

--- a/deployments/liqo_chart/subcharts/liqodash_chart/templates/liqodash_deployment.yaml
+++ b/deployments/liqo_chart/subcharts/liqodash_chart/templates/liqodash_deployment.yaml
@@ -1,0 +1,111 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: liqo-dashboard-configmap
+  namespace: {{ .Release.Namespace }}
+data:
+  oidc_client_id: ""
+  oidc_provider_url: ""
+  oidc_client_secret: ""
+  oidc_redirect_uri: ""
+  apiserver_url: {{ .Values.global.apiServerURL }}
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: liqo-dashboard
+  name: liqo-dashboard
+  namespace: {{ .Release.Namespace }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: liqo-dashboard
+  template:
+    metadata:
+      labels:
+        app: liqo-dashboard
+    spec:
+      containers:
+        - image: {{ .Values.image.repository }}{{ .Values.global.suffix | default .Values.suffix }}:{{ .Values.version }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          name: liqo-dashboard
+          ports:
+            - containerPort: 80
+              name: http
+              protocol: TCP
+          env:
+            - name: OIDC_PROVIDER_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: liqo-dashboard-configmap
+                  key: oidc_provider_url
+            - name: OIDC_CLIENT_ID
+              valueFrom:
+                configMapKeyRef:
+                  name: liqo-dashboard-configmap
+                  key: oidc_client_id
+            - name: OIDC_CLIENT_SECRET
+              valueFrom:
+                configMapKeyRef:
+                  name: liqo-dashboard-configmap
+                  key: oidc_client_secret
+            - name: OIDC_REDIRECT_URI
+              valueFrom:
+                configMapKeyRef:
+                  name: liqo-dashboard-configmap
+                  key: oidc_redirect_uri
+            - name: APISERVER_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: liqo-dashboard-configmap
+                  key: apiserver_url  
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: liqo-dashboard
+  name: liqo-dashboard
+  namespace: {{ .Release.Namespace }}
+spec:
+  type: NodePort
+  selector:
+    app: liqo-dashboard
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: 80
+
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: liqo-dashboard
+  name: liqodash-admin-sa
+  namespace: {{ .Release.Namespace }}
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: liqo-dashboard
+  name: liqodash-admin-sa
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: liqodash-admin-sa
+  namespace: {{ .Release.Namespace }}

--- a/deployments/liqo_chart/subcharts/liqodash_chart/values.yaml
+++ b/deployments/liqo_chart/subcharts/liqodash_chart/values.yaml
@@ -1,0 +1,11 @@
+# Default values for liqodash_chart.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+image:
+  repository: liqo/dashboard
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+
+suffix: ""
+version: "latest"

--- a/deployments/liqo_chart/values.yaml
+++ b/deployments/liqo_chart/values.yaml
@@ -7,7 +7,6 @@ podCIDR: "10.244.0.0/16"
 serviceCIDR: "10.96.0.0/12"
 gatewayPrivateIP: "192.168.1.1"
 
-
 ##### Needed
 suffix: ""
 version: "latest"
@@ -85,7 +84,14 @@ peeringRequestOperator_chart:
       pullPolicy: "Always"
   enabled: true
 
+liqodash_chart:
+  image:
+    repository: "liqo/dashboard"
+    pullpolicy: "Always"
+  enabled: true  
+
 global:
   configmapName: "liqo-configmap"
+  apiServerURL: ""
   suffix: ""
   version: ""

--- a/install.sh
+++ b/install.sh
@@ -148,13 +148,15 @@ LIQO_SUFFIX_COMMAND="echo $LIQO_SUFFIX_DEFAULT"
 set_variable_from_command LIQO_SUFFIX LIQO_SUFFIX_COMMAND "[ERROR]: Error setting the Liqo suffix... "
 LIQO_VERSION_COMMAND="echo $LIQO_VERSION_DEFAULT"
 set_variable_from_command LIQO_VERSION LIQO_VERSION_COMMAND "[ERROR]: Error setting the Liqo version... "
-
+DASHBOARD_APISERVER_COMMAND='kubectl config view -o jsonpath='{.clusters[].cluster.server}''
+set_variable_from_command DASHBOARD_APISERVER DASHBOARD_APISERVER_COMMAND "[ERROR]: Error setting the api server... "
 
 #Wait for the installation to complete
 kubectl create ns $NAMESPACE
 $TMPDIR/bin/helm dependency update $TMPDIR/liqo/deployments/liqo_chart
 $TMPDIR/bin/helm install liqo -n liqo $TMPDIR/liqo/deployments/liqo_chart --set podCIDR=$POD_CIDR --set serviceCIDR=$SERVICE_CIDR \
---set gatewayPrivateIP=$GATEWAY_PRIVATE_IP --set gatewayIP=$GATEWAY_IP --set global.suffix="$LIQO_SUFFIX" --set global.version="$LIQO_VERSION"
+--set gatewayPrivateIP=$GATEWAY_PRIVATE_IP --set gatewayIP=$GATEWAY_IP --set global.suffix="$LIQO_SUFFIX" --set global.version="$LIQO_VERSION" \
+--set global.apiServerURL=$DASHBOARD_APISERVER
 echo "[INSTALL]: Installing LIQO on your cluster..."
 sleep 30
 


### PR DESCRIPTION
# Description

This PR updates the helm chart for liqo and adds the dashboard subchart, needed to install the dashboard.
It requires a global value: "apiServerURL" (passed as an extra arg in the installer), that will be used to configure the dashboard's configmap.
The apiServerURL default value is the cluster's api server where liqo is being installed.
