### PR TITLE
add kubeconfig reference in ForeignCluster status for outgoing and incoming

### DIFF
--- a/api/discovery/v1/foreigncluster_types.go
+++ b/api/discovery/v1/foreigncluster_types.go
@@ -65,6 +65,7 @@ type Outgoing struct {
 	CaDataRef                *v1.ObjectReference `json:"caDataRef,omitempty"`
 	Advertisement            *v1.ObjectReference `json:"advertisement,omitempty"`
 	AvailableIdentity        bool                `json:"availableIdentity,omitempty"`
+	IdentityRef              *v1.ObjectReference `json:"identityRef,omitempty"`
 	AdvertisementStatus      string              `json:"advertisementStatus,omitempty"`
 }
 
@@ -72,6 +73,7 @@ type Incoming struct {
 	Joined              bool                `json:"joined"`
 	PeeringRequest      *v1.ObjectReference `json:"peeringRequest,omitempty"`
 	AvailableIdentity   bool                `json:"availableIdentity,omitempty"`
+	IdentityRef         *v1.ObjectReference `json:"identityRef,omitempty"`
 	AdvertisementStatus string              `json:"advertisementStatus,omitempty"`
 }
 

--- a/deployments/liqo_chart/crds/foreign-cluster-crd.yaml
+++ b/deployments/liqo_chart/crds/foreign-cluster-crd.yaml
@@ -81,6 +81,9 @@ spec:
                 availableIdentity:
                   type: boolean
                   description: Indicates if related identity is available
+                identityRef:
+                  type: object
+                  description: Object reference to related identity
                 advertisementStatus:
                   type: string
                   description: Advertisement status
@@ -96,6 +99,9 @@ spec:
                 availableIdentity:
                   type: boolean
                   description: Indicates if related identity is available
+                identityRef:
+                  type: object
+                  description: Object reference to related identity
                 advertisementStatus:
                   type: string
                   description: Status of Advertisement created from this PeeringRequest

--- a/test/unit/discovery/discovery_test.go
+++ b/test/unit/discovery/discovery_test.go
@@ -227,6 +227,7 @@ func testJoin(t *testing.T) {
 	assert.Assert(t, remoteFcList.Items[0].Status.Incoming.PeeringRequest != nil, "PeeringRequest reference is not set")
 	assert.Assert(t, remoteFcList.Items[0].Status.Incoming.Joined, "IncomingJoin flag not set on remote cluster")
 	assert.Assert(t, remoteFcList.Items[0].Status.Incoming.AvailableIdentity, "AvailableIdentity not correctly set on remote cluster")
+	assert.Assert(t, remoteFcList.Items[0].Status.Incoming.IdentityRef != nil, "IdentityRef not correctly set on remote cluster")
 
 	// add local advertisement related to ForeignCluster,
 	// we have to add it manually because we have no Advertisement Operator running in this test


### PR DESCRIPTION
# Description

This PR adds a reference to Identity Secrets coming with Advertisements and PeeringRequests respectively in `ForeignCluster > Status > Outgoing > IdentityRef` and  `ForeignCluster > Status > Incoming > IdentityRef`

This will allow components that want to access these identities to not to have permissions on `Advertisement`s and `PeeringRequest`s