### PR TITLE
fix documentation

### DIFF
--- a/docs/pages/User/GettingStarted/install.md
+++ b/docs/pages/User/GettingStarted/install.md
@@ -34,8 +34,8 @@ curl https://raw.githubusercontent.com/LiqoTech/liqo/master/install.sh | bash
 
 If you did not use `kubeadm` to install your Kubernetes, or you are running another distribution of Kubernetes (such as [K3s](https://k3s.io/)), you should explicitly define the parameters required by Liqo by exporting the following variables **before** launching the installer:
 
-* `POD_CIDR`: range of IP addresses for the pod network (K3s default: 10.32.0.0/16)
-* `SERVICE_CIDR`: range of IP addresses for service VIPs (k3s default: 10.10.0.0/16)
+* `POD_CIDR`: range of IP addresses for the pod network (K3s default: 10.42.0.0/16)
+* `SERVICE_CIDR`: range of IP addresses for service VIPs (k3s default: 10.43.0.0/16)
 * `GATEWAY_IP`: public IP address of the node that will be used as a gateway for all the traffic toward the foreign cluster. If you do not specify one, the installer will pick one among your nodes.
 
 Then, you can run the Liqo installer script, which will use the above settings to configure your Liqo instance.
@@ -45,8 +45,8 @@ Please remember to export your K3s `kubeconfig` before launching the script, as 
 A possible example of installation is the following (please replace the IP addresses with the ones related to your Kubernetes instance):
 ```bash
 export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
-export POD_CIDR=10.32.0.0/16
-export SERVICE_CIDR=10.10.0.0/16
+export POD_CIDR=10.42.0.0/16
+export SERVICE_CIDR=10.43.0.0/16
 curl https://raw.githubusercontent.com/LiqoTech/liqo/master/install.sh | bash
 ```
 

--- a/docs/pages/User/GettingStarted/test.md
+++ b/docs/pages/User/GettingStarted/test.md
@@ -44,7 +44,7 @@ In case the above tag is missing, the Kubernetes scheduler will select the best 
 Now you can check the state of your pod; the output confirms that the pod is running on a virtual node (i.e. a node whose name that starts with `vk`, i.e. *virtual kubelet*):
 
 ```
-kubectl get po -o wide -n test
+kubectl get po -o wide -n test-liqo
 NAME    READY   STATUS    RESTARTS   AGE   IP           NODE                                      NOMINATED NODE   READINESS GATES
 nginx   1/1     Running   0          41m   10.45.0.12   liqo-1dfa22f9-1cdd-4401-9e7a-c5342ec90059   <none>           <none>
 ```


### PR DESCRIPTION
# Description

This PR fixes two issues in Liqo documentation:
* default k3s CIDR was wrong
* there was a typo in a namespace
