### PR TITLE
Update AdvertisementConfig

### DIFF
--- a/api/config/v1alpha1/clusterconfig_types.go
+++ b/api/config/v1alpha1/clusterconfig_types.go
@@ -48,11 +48,13 @@ type AdvertisementConfig struct {
 }
 
 type BroadcasterConfig struct {
-	//ResourceSharingPercentage defines the percentage of your cluster resources that you will share with foreign clusters
+	//ResourceSharingPercentage defines the percentage of your cluster resources that you will share with foreign clusters.
 	// +kubebuilder:validation:Maximum=100
 	// +kubebuilder:validation:Minimum=0
 	ResourceSharingPercentage int32 `json:"resourceSharingPercentage"`
-	//EnableBroadcaster flag allows you to enable/disable the broadcasting of your Advertisement to the foreign clusters
+	//EnableBroadcaster flag allows you to enable/disable the broadcasting of your Advertisement to the foreign clusters.
+	//When EnableBroadcaster is set to false, the home cluster notifies to the foreign he wants to stop sharing resources
+	//by setting the Advertisement status to Deleting. This will trigger the deletion of the virtual-kubelet and, after that, of the Advertisement,
 	EnableBroadcaster bool `json:"enableBroadcaster"`
 }
 
@@ -60,23 +62,25 @@ type BroadcasterConfig struct {
 type AcceptPolicy string
 
 const (
-	// AutoAcceptWithinMaximum means all the Advertisement received will be accepted until the MaxAcceptableAdvertisement limit is reached
-	// AutoAcceptAll can be achieved by setting MaxAcceptableAdvertisement to infinite
+	// AutoAcceptMax means all the Advertisement received will be accepted until the MaxAcceptableAdvertisement limit is reached
+	// AutoAcceptAll can be achieved by setting MaxAcceptableAdvertisement to 1000000
 	// AutoRefuseAll can be achieved by setting MaxAcceptableAdvertisement to 0
-	AutoAcceptWithinMaximum AcceptPolicy = "AutoAcceptWithinMaximum"
+	AutoAcceptMax AcceptPolicy = "AutoAcceptMax"
 	// ManualAccept means every Advertisement received will need a manual accept/refuse, which can be done by updating its status
 	ManualAccept AcceptPolicy = "Manual"
 )
 
 type AdvOperatorConfig struct {
-	// MaxAcceptableAdvertisement defines the maximum number of Advertisements that can be accepted
+	// MaxAcceptableAdvertisement defines the maximum number of Advertisements that can be accepted over time.
+	// The maximum value for this field is set to 1000000, a symbolic value that implements the AcceptAll policy.
 	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=1000000
 	MaxAcceptableAdvertisement int32 `json:"maxAcceptableAdvertisement"`
 	// AcceptPolicy defines the policy to accept/refuse an Advertisement.
-	// Possible values are AutoAcceptWithinMaximum and Manual.
-	// AutoAcceptWithinMaximum means all the Advertisement received will be accepted until the MaxAcceptableAdvertisement limit is reached;
+	// Possible values are AutoAcceptMax and Manual.
+	// AutoAcceptMax means all the Advertisement received will be accepted until the MaxAcceptableAdvertisement limit is reached;
 	// Manual means every Advertisement received will need a manual accept/refuse, which can be done by updating its status.
-	// +kubebuilder:validation:Enum="AutoAcceptWithinMaximum";"Manual"
+	// +kubebuilder:validation:Enum="AutoAcceptMax";"Manual"
 	AcceptPolicy AcceptPolicy `json:"acceptPolicy"`
 }
 

--- a/deployments/liqo_chart/crds/config.liqo.io_clusterconfigs.yaml
+++ b/deployments/liqo_chart/crds/config.liqo.io_clusterconfigs.yaml
@@ -46,20 +46,22 @@ spec:
                   properties:
                     acceptPolicy:
                       description: AcceptPolicy defines the policy to accept/refuse
-                        an Advertisement. Possible values are AutoAcceptWithinMaximum
-                        and Manual. AutoAcceptWithinMaximum means all the Advertisement
-                        received will be accepted until the MaxAcceptableAdvertisement
-                        limit is reached; Manual means every Advertisement received
-                        will need a manual accept/refuse, which can be done by updating
-                        its status.
+                        an Advertisement. Possible values are AutoAcceptMax and Manual.
+                        AutoAcceptMax means all the Advertisement received will be
+                        accepted until the MaxAcceptableAdvertisement limit is reached;
+                        Manual means every Advertisement received will need a manual
+                        accept/refuse, which can be done by updating its status.
                       enum:
-                      - AutoAcceptWithinMaximum
+                      - AutoAcceptMax
                       - Manual
                       type: string
                     maxAcceptableAdvertisement:
                       description: MaxAcceptableAdvertisement defines the maximum
-                        number of Advertisements that can be accepted
+                        number of Advertisements that can be accepted over time. The
+                        maximum value for this field is set to 1000000, a symbolic
+                        value that implements the AcceptAll policy.
                       format: int32
+                      maximum: 1000000
                       minimum: 0
                       type: integer
                   required:
@@ -88,12 +90,16 @@ spec:
                   properties:
                     enableBroadcaster:
                       description: EnableBroadcaster flag allows you to enable/disable
-                        the broadcasting of your Advertisement to the foreign clusters
+                        the broadcasting of your Advertisement to the foreign clusters.
+                        When EnableBroadcaster is set to false, the home cluster notifies
+                        to the foreign he wants to stop sharing resources by setting
+                        the Advertisement status to Deleting. This will trigger the
+                        deletion of the virtual-kubelet and, after that, of the Advertisement,
                       type: boolean
                     resourceSharingPercentage:
                       description: ResourceSharingPercentage defines the percentage
                         of your cluster resources that you will share with foreign
-                        clusters
+                        clusters.
                       format: int32
                       maximum: 100
                       minimum: 0

--- a/deployments/liqo_chart/templates/clusterconfig.yaml
+++ b/deployments/liqo_chart/templates/clusterconfig.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   advertisementConfig:
     ingoingConfig:
-      acceptPolicy: AutoAcceptWithinMaximum
+      acceptPolicy: AutoAcceptMax
       maxAcceptableAdvertisement: 5
     outgoingConfig:
       resourceSharingPercentage: 30

--- a/docs/pages/User/Configure/cluster-config.md
+++ b/docs/pages/User/Configure/cluster-config.md
@@ -18,9 +18,10 @@ and the parameters for the [keepalive check](#keepalive-check):
   - `enableBroadcaster` flag allows you to enable/disable the broadcasting of your Advertisement to the foreign clusters your cluster knows
   - `resourceSharingPercentage` defines the percentage of your cluster resources that you will share with other clusters
 * **IngoingConfig** defines the behaviour for the acceptance of Advertisements from other clusters.
-  - `maxAcceptableAdvertisement` defines the maximum number of Advertisements that can be accepted.
+  - `maxAcceptableAdvertisement` defines the maximum number of Advertisements that can be accepted over time
   - `acceptPolicy` defines the policy to accept or refuse a new Advertisement from a foreign cluster. The possible policies are:
-    - `AutoAcceptWthinMaximum`: every Advertisement is automatically checked considering the configured maximum.
+    - `AutoAcceptMax`: every Advertisement is automatically checked considering the configured maximum; 
+    AutoAcceptAll policy can be achieved by setting MaxAcceptableAdvertisement to 1000000, a symbolic value representing infinite; AutoRefuseAll can be achieved by setting MaxAcceptableAdvertisement to 0
     - `ManualAccept`: every Advertisement needs to be manually accepted or refused; this mode is not implemented yet.
 
 ### Keepalive check

--- a/internal/advertisement-operator/broadcaster.go
+++ b/internal/advertisement-operator/broadcaster.go
@@ -1,4 +1,4 @@
-package advertisement_operator
+package advertisementOperator
 
 import (
 	"context"

--- a/internal/advertisement-operator/config-watcher.go
+++ b/internal/advertisement-operator/config-watcher.go
@@ -1,4 +1,4 @@
-package advertisement_operator
+package advertisementOperator
 
 import (
 	configv1alpha1 "github.com/liqoTech/liqo/api/config/v1alpha1"
@@ -72,8 +72,8 @@ func (r *AdvertisementReconciler) WatchConfiguration(kubeconfigPath string, clie
 			}
 			advList := obj.(*advtypes.AdvertisementList)
 
-			if newConfig.IngoingConfig.AcceptPolicy == configv1alpha1.AutoAcceptWithinMaximum && newConfig.IngoingConfig.MaxAcceptableAdvertisement != r.ClusterConfig.IngoingConfig.MaxAcceptableAdvertisement {
-				// the accept policy is set to AutoAcceptWithinMaximum and the Maximum has changed: re-check all Advertisements and update if needed
+			if newConfig.IngoingConfig.AcceptPolicy == configv1alpha1.AutoAcceptMax && newConfig.IngoingConfig.MaxAcceptableAdvertisement != r.ClusterConfig.IngoingConfig.MaxAcceptableAdvertisement {
+				// the accept policy is set to AutoAcceptMax and the Maximum has changed: re-check all Advertisements and update if needed
 				klog.Infof("AdvertisementConfig changed: the AcceptPolicy is %v and the MaxAcceptableAdvertisement has changed from %v to %v",
 					newConfig.IngoingConfig.AcceptPolicy, r.ClusterConfig.IngoingConfig.MaxAcceptableAdvertisement, newConfig.IngoingConfig.MaxAcceptableAdvertisement)
 				err, advToUpdate := r.ManageMaximumUpdate(newConfig, advList)

--- a/internal/advertisement-operator/controller.go
+++ b/internal/advertisement-operator/controller.go
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package advertisement_operator
+package advertisementOperator
 
 import (
 	"context"
@@ -226,7 +226,7 @@ func (r *AdvertisementReconciler) CheckAdvertisement(adv *advtypes.Advertisement
 	}
 
 	switch r.ClusterConfig.IngoingConfig.AcceptPolicy {
-	case configv1alpha1.AutoAcceptWithinMaximum:
+	case configv1alpha1.AutoAcceptMax:
 		if r.AcceptedAdvNum < r.ClusterConfig.IngoingConfig.MaxAcceptableAdvertisement {
 			// the adv accepted so far are less than the configured maximum
 			adv.Status.AdvertisementStatus = AdvertisementAccepted

--- a/internal/advertisement-operator/remote-watcher.go
+++ b/internal/advertisement-operator/remote-watcher.go
@@ -1,4 +1,4 @@
-package advertisement_operator
+package advertisementOperator
 
 import (
 	discoveryv1alpha1 "github.com/liqoTech/liqo/api/discovery/v1alpha1"

--- a/scripts/cluster-config/Makefile
+++ b/scripts/cluster-config/Makefile
@@ -11,7 +11,7 @@ else
 GOBIN=$(shell go env GOBIN)
 endif
 
-all: generate fmt vet
+all: test
 
 # Run tests
 test: generate fmt vet manifests
@@ -27,7 +27,7 @@ uninstall: manifests
 
 # Generate manifests e.g. CRD, RBAC etc.
 manifests: controller-gen
-	$(CONTROLLER_GEN) $(CRD_OPTIONS) paths="./api/cluster-config/v1" output:crd:artifacts:config=deployments/liqo_chart/crds
+	$(CONTROLLER_GEN) $(CRD_OPTIONS) paths="./api/config/v1alpha1" output:crd:artifacts:config=deployments/liqo_chart/crds
 
 # Run go fmt against code
 fmt:
@@ -39,7 +39,7 @@ vet:
 
 # Generate code
 generate: controller-gen
-	$(CONTROLLER_GEN) object:headerFile=./hack/boilerplate.go.txt paths="./api/cluster-config/v1"
+	$(CONTROLLER_GEN) object:headerFile=./hack/boilerplate.go.txt paths="./api/config/v1alpha1"
 
 # Build the docker image
 docker-build: test

--- a/test/unit/advertisement-operator/config-watcher_test.go
+++ b/test/unit/advertisement-operator/config-watcher_test.go
@@ -26,7 +26,7 @@ func createFakeClusterConfig() configv1alpha1.ClusterConfig {
 				},
 				IngoingConfig: configv1alpha1.AdvOperatorConfig{
 					MaxAcceptableAdvertisement: 5,
-					AcceptPolicy:               configv1alpha1.AutoAcceptWithinMaximum,
+					AcceptPolicy:               configv1alpha1.AutoAcceptMax,
 				},
 			},
 		},
@@ -133,7 +133,7 @@ func TestWatchAdvOperatorConfig(t *testing.T) {
 }
 
 func testManageMaximumUpdate(t *testing.T) {
-	r := createReconciler(0, 10, configv1alpha1.AutoAcceptWithinMaximum)
+	r := createReconciler(0, 10, configv1alpha1.AutoAcceptMax)
 	advList := advtypes.AdvertisementList{
 		Items: []advtypes.Advertisement{},
 	}
@@ -160,7 +160,7 @@ func testManageMaximumUpdate(t *testing.T) {
 			AdvertisementConfig: configv1alpha1.AdvertisementConfig{
 				IngoingConfig: configv1alpha1.AdvOperatorConfig{
 					MaxAcceptableAdvertisement: int32(advCount),
-					AcceptPolicy:               configv1alpha1.AutoAcceptWithinMaximum,
+					AcceptPolicy:               configv1alpha1.AutoAcceptMax,
 				},
 			},
 		},
@@ -197,7 +197,7 @@ func testManageMaximumUpdate(t *testing.T) {
 			AdvertisementConfig: configv1alpha1.AdvertisementConfig{
 				IngoingConfig: configv1alpha1.AdvOperatorConfig{
 					MaxAcceptableAdvertisement: int32(advCount),
-					AcceptPolicy:               configv1alpha1.AutoAcceptWithinMaximum,
+					AcceptPolicy:               configv1alpha1.AutoAcceptMax,
 				},
 			},
 		},

--- a/test/unit/advertisement-operator/controller_test.go
+++ b/test/unit/advertisement-operator/controller_test.go
@@ -43,13 +43,13 @@ func createReconciler(acceptedAdv, maxAcceptableAdv int32, acceptPolicy configv1
 }
 
 func TestCheckAdvertisement(t *testing.T) {
-	t.Run("testAutoAcceptWithinMaximum", testAutoAcceptWithinMaximum)
+	t.Run("testAutoAcceptMax", testAutoAcceptMax)
 	t.Run("testManualAccept", testManualAccept)
 	t.Run("testRefuseInvalidAdvertisement", testRefuseInvalidAdvertisement)
 }
 
-func testAutoAcceptWithinMaximum(t *testing.T) {
-	r := createReconciler(0, 10, configv1alpha1.AutoAcceptWithinMaximum)
+func testAutoAcceptMax(t *testing.T) {
+	r := createReconciler(0, 10, configv1alpha1.AutoAcceptMax)
 
 	// given a configuration with max 10 Advertisements, create 10 Advertisements
 	for i := 0; i < 10; i++ {
@@ -81,7 +81,7 @@ func testManualAccept(t *testing.T) {
 }
 
 func testRefuseInvalidAdvertisement(t *testing.T) {
-	r := createReconciler(0, 10, configv1alpha1.AutoAcceptWithinMaximum)
+	r := createReconciler(0, 10, configv1alpha1.AutoAcceptMax)
 
 	// create 5 advertisements with negative values in ResourceQuota field and check they are refused
 	for i := 1; i <= 5; i++ {

--- a/test/unit/crdReplicator/env_test.go
+++ b/test/unit/crdReplicator/env_test.go
@@ -185,7 +185,7 @@ func getClusterConfig() *configv1alpha1.ClusterConfig {
 		Spec: configv1alpha1.ClusterConfigSpec{
 			AdvertisementConfig: configv1alpha1.AdvertisementConfig{
 				IngoingConfig: configv1alpha1.AdvOperatorConfig{
-					AcceptPolicy:               configv1alpha1.AutoAcceptWithinMaximum,
+					AcceptPolicy:               configv1alpha1.AutoAcceptMax,
 					MaxAcceptableAdvertisement: 5,
 				},
 				OutgoingConfig: configv1alpha1.BroadcasterConfig{

--- a/test/unit/discovery/env_test.go
+++ b/test/unit/discovery/env_test.go
@@ -260,7 +260,7 @@ func getClusterConfig(config rest.Config) {
 		Spec: configv1alpha1.ClusterConfigSpec{
 			AdvertisementConfig: configv1alpha1.AdvertisementConfig{
 				IngoingConfig: configv1alpha1.AdvOperatorConfig{
-					AcceptPolicy:               configv1alpha1.AutoAcceptWithinMaximum,
+					AcceptPolicy:               configv1alpha1.AutoAcceptMax,
 					MaxAcceptableAdvertisement: 5,
 				},
 				OutgoingConfig: configv1alpha1.BroadcasterConfig{

--- a/test/unit/liqonet/env_test.go
+++ b/test/unit/liqonet/env_test.go
@@ -166,7 +166,7 @@ func getClusterConfig() *configv1alpha1.ClusterConfig {
 		Spec: configv1alpha1.ClusterConfigSpec{
 			AdvertisementConfig: configv1alpha1.AdvertisementConfig{
 				IngoingConfig: configv1alpha1.AdvOperatorConfig{
-					AcceptPolicy:               configv1alpha1.AutoAcceptWithinMaximum,
+					AcceptPolicy:               configv1alpha1.AutoAcceptMax,
 					MaxAcceptableAdvertisement: 5,
 				},
 				OutgoingConfig: configv1alpha1.BroadcasterConfig{


### PR DESCRIPTION
# Description
This PR slightly updates `AdvertisementConfig` 
- changed `AutoAcceptWithinMaximum` policy name to `AutoAcceptMax`
- set the maximum number of acceptable Advertisements to 1000000, a value symbolizing "Accept all" policy