### PR TITLE
Update dashboard subchart and installer

### DIFF
--- a/deployments/liqo_chart/README.md
+++ b/deployments/liqo_chart/README.md
@@ -54,4 +54,3 @@ Current chart version is `0.1.0`
 | liqodash_chart.enabled | bool | `true` |  |
 | liqodash_chart.image.pullPolicy | string | `"IfNotPresent"` |  |
 | liqodash_chart.image.repository | string | `"liqo/dashboard"` |  |
-| global.apiServerURL | string | `""` |  |

--- a/deployments/liqo_chart/subcharts/liqodash_chart/templates/liqodash_deployment.yaml
+++ b/deployments/liqo_chart/subcharts/liqodash_chart/templates/liqodash_deployment.yaml
@@ -8,17 +8,16 @@ data:
   oidc_provider_url: ""
   oidc_client_secret: ""
   oidc_redirect_uri: ""
-  apiserver_url: {{ .Values.global.apiServerURL }}
 
 ---
 
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  namespace: {{ .Release.Namespace }}
   labels:
     app: liqo-dashboard
   name: liqo-dashboard
-  namespace: {{ .Release.Namespace }}
 spec:
   replicas: 1
   selector:
@@ -29,8 +28,22 @@ spec:
       labels:
         app: liqo-dashboard
     spec:
+      volumes:
+        - name: shared-data
+          emptyDir: { }
+      initContainers:
+        - name: proxy-cert
+          image: nginx
+          volumeMounts:
+            - name: shared-data
+              mountPath: /etc/nginx/ssl/
+          command: [ "/bin/sh" ]
+          args: [ "-c", 'openssl req -x509 -subj "/C=IT/ST=Turin/O=Liqo" -nodes -days 365 -newkey rsa:2048 -keyout /etc/nginx/ssl/nginx.key -out /etc/nginx/ssl/nginx.cert' ]
       containers:
-        - image: {{ .Values.image.repository }}{{ .Values.global.suffix | default .Values.suffix }}:{{ .Values.version }}
+        - image: {{ .Values.image.repository }}:{{ .Values.version }}
+          volumeMounts:
+            - name: shared-data
+              mountPath: /etc/nginx/ssl/
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           name: liqo-dashboard
           ports:
@@ -58,11 +71,6 @@ spec:
                 configMapKeyRef:
                   name: liqo-dashboard-configmap
                   key: oidc_redirect_uri
-            - name: APISERVER_URL
-              valueFrom:
-                configMapKeyRef:
-                  name: liqo-dashboard-configmap
-                  key: apiserver_url  
 
 ---
 
@@ -78,10 +86,10 @@ spec:
   selector:
     app: liqo-dashboard
   ports:
-    - name: http
+    - name: https
       protocol: TCP
-      port: 80
-      targetPort: 80
+      port: 443
+      targetPort: 443
 
 ---
 

--- a/deployments/liqo_chart/values.yaml
+++ b/deployments/liqo_chart/values.yaml
@@ -97,6 +97,5 @@ crdReplicator_chart:
 
 global:
   configmapName: "liqo-configmap"
-  apiServerURL: ""
   suffix: ""
   version: ""

--- a/install.sh
+++ b/install.sh
@@ -144,15 +144,12 @@ LIQO_SUFFIX_COMMAND="echo $LIQO_SUFFIX_DEFAULT"
 set_variable_from_command LIQO_SUFFIX LIQO_SUFFIX_COMMAND "[ERROR]: Error setting the Liqo suffix... "
 LIQO_VERSION_COMMAND="echo $LIQO_VERSION_DEFAULT"
 set_variable_from_command LIQO_VERSION LIQO_VERSION_COMMAND "[ERROR]: Error setting the Liqo version... "
-DASHBOARD_APISERVER_COMMAND='kubectl config view -o jsonpath='{.clusters[].cluster.server}''
-set_variable_from_command DASHBOARD_APISERVER DASHBOARD_APISERVER_COMMAND "[ERROR]: Error setting the api server... "
 
 #Wait for the installation to complete
 kubectl create ns $NAMESPACE
 $TMPDIR/bin/helm dependency update $TMPDIR/liqo/deployments/liqo_chart
 $TMPDIR/bin/helm install liqo -n liqo $TMPDIR/liqo/deployments/liqo_chart --set podCIDR=$POD_CIDR --set serviceCIDR=$SERVICE_CIDR \
---set gatewayIP=$GATEWAY_IP --set global.suffix="$LIQO_SUFFIX" --set global.version="$LIQO_VERSION" \
---set global.apiServerURL=$DASHBOARD_APISERVER
+--set gatewayIP=$GATEWAY_IP --set global.suffix="$LIQO_SUFFIX" --set global.version="$LIQO_VERSION"
 echo "[INSTALL]: Installing LIQO on your cluster..."
 sleep 30
 


### PR DESCRIPTION
# Description

This PR updates the installer of Liqo in regard of the last changes on the dashboard.
The parameter apiServerURL of the helm chart (as well as the installer variable that set it) has been deleted because no longer needed.