### PR TITLE
CRDReplicator Enhancement

### DIFF
--- a/cmd/crdReplicator/main.go
+++ b/cmd/crdReplicator/main.go
@@ -49,6 +49,7 @@ func main() {
 	clusterID, err := util.GetClusterID(k8sClient, clusterIDConfMap, namespaceName)
 	if err != nil {
 		klog.Errorf("an error occurred while retrieving the clusterID: %s", err)
+		os.Exit(-1)
 	} else {
 		klog.Infof("setting local clusterID to: %s", clusterID)
 	}
@@ -62,7 +63,7 @@ func main() {
 		LocalDynClient:        dynamic.NewForConfigOrDie(cfg),
 		RegisteredResources:   nil,
 		UnregisteredResources: nil,
-		LocalWatchers:         make(map[string]chan bool),
+		LocalWatchers:         make(map[string]map[string]chan bool),
 		RemoteWatchers:        make(map[string]map[string]chan bool),
 	}
 	if err = d.SetupWithManager(mgr); err != nil {

--- a/test/unit/crdReplicator/crdReplicator-operator_test.go
+++ b/test/unit/crdReplicator/crdReplicator-operator_test.go
@@ -42,7 +42,7 @@ func setupDispatcherOperator() error {
 		LocalDynClient:        localDynClient,
 		RegisteredResources:   nil,
 		UnregisteredResources: nil,
-		LocalWatchers:         make(map[string]chan bool),
+		LocalWatchers:         make(map[string]map[string]chan bool),
 		RemoteWatchers:        make(map[string]map[string]chan bool),
 	}
 	err = dOperator.SetupWithManager(k8sManagerLocal)


### PR DESCRIPTION
# Description
The "update" functions used to update a resource now can recover from "Conflicting" when trying to perform an update on the status or spec fields.

Fixing a minor bug which caused the operator to run even if the clusterID configmap is not found

Fixing race conditions on the creation and replication of the local resources on the remote peering clusters. With this fix, given a remote peering cluster, for each type of resource there is a local and remote watcher. The local watcher is created after that a connection to the API server of the remote peering cluster exists.  

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.
- added a test where the spec and status fields of a resource are modified in order to check that the conflicting errors are handled properly

- updated the unit tests on the functions that start and stop the watchers for a given resource.
