### PR TITLE
Fixing broken links in documentation

### DIFF
--- a/docs/pages/Architecture/Cluster Sharing/Networking/_index.md
+++ b/docs/pages/Architecture/Cluster Sharing/Networking/_index.md
@@ -2,13 +2,13 @@
 title: Networking 
 ---
 
-Liqonet is in charge of connecting networks of different Kubernetes clusters. It is made of three Kubernetes operators:
-* [tunnelEndpointCreator-operator](liqonet_tunEndCreator.md);
-* [route-operator](liqonet_routeOperator.md);
-* [tunnelEndpoint-operator](liqonet_tunnelEndpoint.md).
 
+The Liqo networking module is in charge of connecting networks of different Kubernetes clusters. It aims to extend the Pod-to-Pod communications to multiple clusters.
+In a single cluster scenario pods on a node can communicate with all pods on all nodes without NAT. The Liqo Networking extends this functionality: all pods in a cluster can 
+communicate with all pods on all nodes on another cluster with or without NAT. The NAT is used when pod and service CIDRS of the two peering clusters have conflicts.
+Also all the nodes of a cluster can communicate with all the pods on all nodes on a remote cluster with NAT. The NAT solution is always used in this case.
 The module enables Kubernetes clusters to exchange only the POD traffic, which means that only the POD CIDR subnet of a remote cluster is reachable by a local cluster.
-Thanks to the [resource reflection](../_index.md) pods and nodes of a local cluster can reach also the pods running behind a service in a remote cluster.
+Thanks to the [resource reflection](/architecture/cluster-sharing/computing/) pods and nodes of a local cluster can reach also the pods running behind a service in a remote cluster.
 
 ## Architecture
 The following image shows the basic architecture of liqonet.
@@ -29,7 +29,7 @@ After that it is sent through the VPN tunnel and reaches the remote cluster gate
 
 The initialization network connection between two cluster goes through the following steps:
 1. a `sharing.liqo.io` custom resource called **Advertisement** is created in the local cluster by peering cluster;
-2. the tunnelEndpointCreator reacts and from this **Advertisement** derives a **TunnelEndpoint** custom resource of type `liqonet.liqo.io`;
+2. the tunnelEndpointCreator reacts and from this **Advertisement** derives a **TunnelEndpoint** custom resource of type `net.liqo.io`;
 3. the IPAM embedded in the tunnelEndpointCreator resolves possible conflicts between the subnet used in the local cluster and the pod CIDR used by the peering cluster;
 4. the Remote Watcher on the peering cluster checks the **TunnelEndpoint CR** on the local cluster if the NAT is enabled and updates the **CR** on the peering cluster accordingly;
 5. the local Remote Watcher does the same thing with the **TunnelEndpoint CR** on the peering cluster to check if the NAT has been enabled by the peering cluster and updates the **CR** on the local cluster;
@@ -37,3 +37,8 @@ The initialization network connection between two cluster goes through the follo
 7. the TunnelOperator updates the **CR** with information about the VPN Tunnel
 8. the RouteOperator has now all the required info to insert the routing and iptables rules in order to reach the peering cluster's pods.
 
+### More Information
+Network operators:
+* [tunnelEndpointCreator-operator](liqonet_tunendcreator);
+* [route-operator](liqonet_routeoperator);
+* [tunnelEndpoint-operator](liqonet_tunnelendpoint).

--- a/docs/pages/Architecture/Cluster Sharing/Networking/liqonet_routeOperator.md
+++ b/docs/pages/Architecture/Cluster Sharing/Networking/liqonet_routeOperator.md
@@ -1,14 +1,17 @@
-# Route-Operator
+---
+title: "Route Operator"
+---
+
 ## Overview
 The Route-Operator runs as a DaemonSet on all Kubernetes nodes and coordinates the setup of all the routes that allow each local pod/node to communicate with the pods of the peering cluster, through the elected gateway node.
 It will ensure state and react on tunnelEndpoint CR changes, which means that it is able to add/remove routes as soon as a new cluster peers/de-peers with the local cluster.
 
-It creates a VxLan overlay network to whom all the cluster nodes belong and uses it to direct all the network traffic to the [gateway node](liqonet_tunnelEndpoint.md).
+It creates a VxLan overlay network to whom all the cluster nodes belong and uses it to direct all the network traffic to the [gateway node](/architecture/cluster-sharing/networking/liqonet_tunnelendpoint).
 
 The operator manages a set of iptables rules in order to achieve the communication between two peering clusters so that:
-* the NAT service is enabled for a peering cluster having [overlapping address spaces](liqonet_tunEndCreator.md);
+* the NAT service is enabled for a peering cluster having [overlapping address spaces](/architecture/cluster-sharing/networking/liqonet_tunnelendpoint);
 * each pod communicates with the other pods using its IP address, or the NATed one;
-* each local node communicates with the remote pods using the private IP given to the [VPN interface](liqonet_tunnelEndpoint.md).
+* each local node communicates with the remote pods using the private IP given to the [VPN interface](/architecture/cluster-sharing/networking/liqonet_tunnelendpoint).
 
 
 ### Features
@@ -21,5 +24,4 @@ The operator manages a set of iptables rules in order to achieve the communicati
 * No support for dynamic gateway node.
 * New nodes added to the local cluster are not dynamically added by the operator to the VxLan network.
 
-## Architecture and workflow
-Will be included in the general overview of the network module.
+

--- a/docs/pages/Architecture/Cluster Sharing/Networking/liqonet_tunEndCreator.md
+++ b/docs/pages/Architecture/Cluster Sharing/Networking/liqonet_tunEndCreator.md
@@ -1,4 +1,8 @@
-# TunnelEndpointCreator-Operator
+---
+title: "TunnelEndpointCreator Operator"
+
+---
+
 ## Overview
 The TunnelEndpointCreator is part of the network module and runs as a deployment. It reacts to **Advertisements Custom Resources (CR)**
 and for each one it creates a **TunnelEndpoint CR**. The **advertisement CR** carries all the required data
@@ -26,6 +30,3 @@ being an a.b.c.d/16 CIDR block.
 * NAT is supported only on peering clusters that have a pod CIDR with subnet mask 255.255.0.0.
 * The maximum number of peering clusters using the NAT service is 256.
 
-## Architecture and workflow
-
-Wtill be included in the general overview of the network module.

--- a/docs/pages/Architecture/Cluster Sharing/Networking/liqonet_tunnelEndpoint.md
+++ b/docs/pages/Architecture/Cluster Sharing/Networking/liqonet_tunnelEndpoint.md
@@ -1,10 +1,12 @@
-# TunnelEndpoint-Operator
+---
+title: "TunnelEndpoint Operator"
+---
 ## Overview
 This component is in charge of establishing a VPN tunnel with the peering clusters, which is created between the (local)
 Gateway Node and the Gateway Node of the remote cluster. All the traffic between the local and remote cluster is first 
 delivered to the Gateway Node, then tunneled towards the remote gateway and finally delivered to the desired destination.
 The traffic can leave the local cluster as is in case the home and remote addressing spaces do not overlap; otherwise, 
-the traffic crosses a properly [configurated NAT](liqonet_routeOperator.md) in order to avoid overlapped spaces.
+the traffic crosses a properly [configurated NAT](/architecture/cluster-sharing/networking/liqonet_routeoperator) in order to avoid overlapped spaces.
 
 The TunnelEndpoint-Operator runs as deployment only on the local Gateway Node, this node has to be labelled with
 **'net.liqo.io/gateway=true'**.
@@ -14,8 +16,8 @@ The TunnelEndpoint-Operator runs as deployment only on the local Gateway Node, t
 
 ### Limitations
 * Only GRE tunnel as VPN tunnel
+* The VPN tunnel is unencrypted
 * Unsupported security policies
 * The Gateway Node is not dynamic, and no active fallback is available if the node crashes.
 
-## Architecture and workflow
-Will be included in the general overview of the network module.
+


### PR DESCRIPTION
# Description
Fixing broken links in documentation, section "ClusterSharing"
Small update of the tunnelEndpoint-operator documentation

Ref. #230 
