### PR TITLE
Dashboard ingress and custom view

### DIFF
--- a/deployments/liqo_chart/Chart.lock
+++ b/deployments/liqo_chart/Chart.lock
@@ -23,5 +23,8 @@ dependencies:
 - name: liqodash_chart
   repository: file://subcharts/liqodash_chart/
   version: 0.1.0
-digest: sha256:9a937b23181275cfc00e0d34d3f6c51f02d0ef2227644a11c7d3b88ad019effe
-generated: "2020-08-26T17:03:44.2572446+02:00"
+- name: crdReplicator_chart
+  repository: file://subcharts/crdReplicator_chart/
+  version: 0.1.0
+digest: sha256:131a968257923aae0bf7fa2c489b49b4cf6decf6ab95f87043eb1a3246e1b9da
+generated: "2020-09-08T12:21:48.2836765+02:00"

--- a/deployments/liqo_chart/crds/dashboard.liqo.io_views.yaml
+++ b/deployments/liqo_chart/crds/dashboard.liqo.io_views.yaml
@@ -1,0 +1,60 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: views.dashboard.liqo.com
+  annotations:
+    description: 'This CRD is used to create custom views from a set of CRDs'
+spec:
+  group: dashboard.liqo.com
+  scope: Namespaced
+  names:
+    plural: views
+    singular: view
+    kind: View
+    listKind: ViewList
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              viewName:
+                description: The name of the view showed in the sidebar
+                type: string
+              layout:
+                description: Layout of the view
+                type: object
+              crds:
+                description: Collection of CRDs to show
+                items:
+                  properties:
+                    crdAltName:
+                      description: The name showed in the custom view for this CRD
+                      type: string
+                    crdName:
+                      description: The name of the CRD that will be in the view
+                      type: string
+                    template:
+                      description: The path of a type template CRD custom resource (if empty will use the template specified in the CRD)
+                      type: string
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/deployments/liqo_chart/subcharts/liqodash_chart/templates/liqodash_deployment.yaml
+++ b/deployments/liqo_chart/subcharts/liqodash_chart/templates/liqodash_deployment.yaml
@@ -117,3 +117,28 @@ subjects:
 - kind: ServiceAccount
   name: liqodash-admin-sa
   namespace: {{ .Release.Namespace }}
+
+---
+
+{{- if (.Values.global.dashboard_ingress)}}
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  labels:
+    app: liqo-dashboard
+  name: liqo-dashboard-ingress
+  namespace: {{ .Release.Namespace }}
+spec:
+  rules:
+    - host: {{ .Values.global.dashboard_ingress }}
+      http:
+        paths:
+          - backend:
+              serviceName: liqo-dashboard
+              servicePort: 443
+            path: /
+  tls:
+    - hosts:
+        - {{ .Values.global.dashboard_ingress }}
+      secretName: liqodash-tls-cert
+{{- end }}

--- a/deployments/liqo_chart/subcharts/liqodash_chart/values.yaml
+++ b/deployments/liqo_chart/subcharts/liqodash_chart/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: liqo/dashboard
-  pullPolicy: IfNotPresent
+  pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
 
 suffix: ""

--- a/deployments/liqo_chart/values.yaml
+++ b/deployments/liqo_chart/values.yaml
@@ -96,5 +96,7 @@ crdReplicator_chart:
   enabled: true
 
 global:
+  configmapName: "liqo-configmap"
+  dashboard_ingress: ""
   suffix: ""
   version: ""

--- a/install.sh
+++ b/install.sh
@@ -39,6 +39,7 @@ function print_help()
    echo "   SERVICE_CIDR: the POD CIDR of your cluster (e.g.; 10.96.0.0/12) . The script will try to detect it, but you can override this by having this variable already set"
    echo "   GATEWAY_IP: the public IP that will be used by LIQO to establish the interconnection with other clusters"
    echo "   NAMESPACE: the namespace where LIQO control plane resources will be created"
+   echo "   DASHBOARD_INGRESS: the name of the host you want to assign to the LIQO dashboard"
 }
 
 function set_gateway_node() {
@@ -108,7 +109,7 @@ function install() {
   kubectl create ns "$NAMESPACE" || true
   $HELM_PATH dependency update "$TMPDIR"/liqo/deployments/liqo_chart
   $HELM_PATH install liqo -n "$NAMESPACE" "$TMPDIR/liqo/deployments/liqo_chart" --set podCIDR="$POD_CIDR" --set serviceCIDR="$SERVICE_CIDR" \
-    --set gatewayIP="$GATEWAY_IP" --set global.suffix="$LIQO_SUFFIX" --set global.version="$LIQO_VERSION"
+    --set gatewayIP="$GATEWAY_IP" --set global.suffix="$LIQO_SUFFIX" --set global.version="$LIQO_VERSION" --set global.dashboard_ingress="$DASHBOARD_INGRESS"
   echo "[INSTALL]: Installing LIQO on your cluster..."
 }
 


### PR DESCRIPTION
# Description

This PR adds:
- an ingress for the dashboard during the installation of liqo. The user will have to input the `host` as a variable (DASHBOARD_INGRESS) exported before the installation and add a certificate (and key) in the secret created with the ingress.
- the custom views CRD, used by the dashboard to create views that show a subset of CRDs selected by the user.

ref #230 