### PR TITLE
Test endpoints reflection

### DIFF
--- a/internal/kubernetes/configmapReflection_e2e_test.go
+++ b/internal/kubernetes/configmapReflection_e2e_test.go
@@ -50,7 +50,7 @@ func TestHandleConfigmapEvents(t *testing.T) {
 	}
 
 	// create a new namespaceNattingTable and deploy it in the fake cache
-	nt := test.CreateNamespaceNattingTable()
+	nt := test.CreateNamespaceNattingTable(p.foreignClusterId)
 	if err = p.ntCache.Store.Add(nt); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/kubernetes/secretReflection_e2e_test.go
+++ b/internal/kubernetes/secretReflection_e2e_test.go
@@ -50,7 +50,7 @@ func TestHandleSecretEvents(t *testing.T) {
 	}
 
 	// create a new namespaceNattingTable and deploy it in the fake cache
-	nt := test.CreateNamespaceNattingTable()
+	nt := test.CreateNamespaceNattingTable(p.foreignClusterId)
 	if err = p.ntCache.Store.Add(nt); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/kubernetes/serviceReflection_e2e_test.go
+++ b/internal/kubernetes/serviceReflection_e2e_test.go
@@ -50,7 +50,7 @@ func TestHandleServiceEvents(t *testing.T) {
 	}
 
 	// create a new namespaceNattingTable and deploy it in the fake cache
-	nt := test.CreateNamespaceNattingTable()
+	nt := test.CreateNamespaceNattingTable(p.foreignClusterId)
 	if err = p.ntCache.Store.Add(nt); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/kubernetes/test/const.go
+++ b/internal/kubernetes/test/const.go
@@ -6,14 +6,15 @@ import (
 )
 
 const (
-	Namespace        = "test"
-	NattedNamespace  = Namespace + "-" + HomeClusterId
-	HostName         = "testHost"
-	NodeName         = "testNode"
-	AdvName          = "advertisement-" + ForeignClusterId
-	TepName          = controllers.TunEndpointNamePrefix + ForeignClusterId
-	EndpointsName    = "testEndpoints"
-	HomeClusterId    = "homeClusterID"
-	ForeignClusterId = "foreignClusterID"
-	Timeout          = 10 * time.Second
+	Namespace            = "test"
+	NattedNamespace      = Namespace + "-" + HomeClusterId
+	HostName             = "testHost"
+	NodeName             = "testNode"
+	AdvName              = "advertisement-" + ForeignClusterId
+	TepName              = controllers.TunEndpointNamePrefix + ForeignClusterId
+	EndpointsName        = "testEndpoints"
+	HomeClusterId        = "homeClusterID"
+	ForeignClusterId     = "foreignClusterID"
+	LocalRemappedPodCIDR = "100.200.0.0/16"
+	Timeout              = 10 * time.Second
 )

--- a/internal/kubernetes/test/endpointsTestCases.go
+++ b/internal/kubernetes/test/endpointsTestCases.go
@@ -12,13 +12,13 @@ var (
 )
 
 var EndpointsTestCases = struct {
-	InputEndpoints         *corev1.Endpoints
+	InputEndpoints         corev1.Endpoints
 	InputSubsets           [][]corev1.EndpointSubset
-	ExpectedEndpoints      *corev1.Endpoints
+	ExpectedEndpoints      corev1.Endpoints
 	ExpectedNumberOfEvents int
 }{
 	ExpectedNumberOfEvents: 2,
-	InputEndpoints: &corev1.Endpoints{
+	InputEndpoints: corev1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: EndpointsName,
 		},
@@ -72,7 +72,7 @@ var EndpointsTestCases = struct {
 			},
 		},
 	},
-	ExpectedEndpoints: &corev1.Endpoints{
+	ExpectedEndpoints: corev1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "serviceTest",
 			Namespace: Namespace,

--- a/internal/kubernetes/test/namespaceNattingTable.go
+++ b/internal/kubernetes/test/namespaceNattingTable.go
@@ -5,14 +5,14 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func CreateNamespaceNattingTable() *v1.NamespaceNattingTable {
+func CreateNamespaceNattingTable(foreignClusterId string) *v1.NamespaceNattingTable {
 	return &v1.NamespaceNattingTable{
 		TypeMeta: metav1.TypeMeta{},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: ForeignClusterId,
+			Name: foreignClusterId,
 		},
 		Spec: v1.NamespaceNattingTableSpec{
-			ClusterId: ForeignClusterId,
+			ClusterId: foreignClusterId,
 			NattingTable: map[string]string{
 				Namespace: NattedNamespace,
 			},


### PR DESCRIPTION
This PR replaces the endpoints unique test with a pair of tests that differ in their natting behavior: in the first test, local and
remote `podCIDR` are the same, therefore the natting is applied. In the second one, local and remote `podCIDR` are different,
hence, no natting required.
