### PR TITLE
CI tagging pipeline

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,6 +1,8 @@
 name: Integration Pipeline
 on:
   push:
+    tags:
+      - '*'
     branches:
       - master
   pull_request:
@@ -48,6 +50,19 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
           tags: "latest,${{ env.commit_ref }}"
         if: github.ref == 'refs/heads/master' && github.event.repository.full_name == 'liqotech/liqo'
+      - name: Get the version
+        id: get_version
+        run: echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d / -f 3)
+      - name: Build and Publish ${{ matrix.component }} image (Versioned)
+        uses: elgohr/Publish-Docker-Github-Action@master
+        with:
+          name: liqo/${{ matrix.component }}
+          username: ${{ secrets.DOCKER_USERNAME }}
+          dockerfile: build/${{ matrix.component }}/Dockerfile
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          tags: "latest,${{ steps.get_version.outputs.VERSION }}"
+        if: github.ref == 'refs/heads/master' && github.event.repository.full_name == 'liqotech/liqo' &&
+          startsWith(github.ref, 'refs/tags/v')
       - name: Push ${{ matrix.component }} image on repo (Development)
         uses: elgohr/Publish-Docker-Github-Action@master
         with:
@@ -56,14 +71,17 @@ jobs:
           dockerfile: build/${{ matrix.component }}/Dockerfile
           password: ${{ secrets.DOCKER_PASSWORD }}
           tags: "${{ env.commit_ref }}"
-        if: github.ref != 'refs/heads/master' && github.event.pull_request.head.repo.full_name == 'liqotech/liqo'
+        if: github.ref != 'refs/heads/master' && github.event.pull_request.head.repo.full_name == 'liqotech/liqo' &&
+            !startsWith(github.ref, 'refs/tags/v')
       - name: Build Only ${{ matrix.component }} image (Forked Repositories)
         uses: docker/build-push-action@v1
         with:
           name: liqo/${{ matrix.component }}-ci
           dockerfile: build/${{ matrix.component }}/Dockerfile
           push: false
-        if: github.ref != 'refs/heads/master' && github.event.pull_request.head.repo.full_name != 'liqotech/liqo'
+        if: github.ref != 'refs/heads/master' && github.event.pull_request.head.repo.full_name != 'liqotech/liqo' &&
+            !startsWith(github.ref, 'refs/tags/v')
+
   e2e-test-trigger:
      runs-on: ubuntu-latest
      needs: [build, test]


### PR DESCRIPTION
# Description

This PR modifies the CI-CD pipeline by adding a new step in which
the docker image is built and pushed to dockerhub subsequently to a
tagging operation.