### PR TITLE
Fix bug in vk podCIDR setting

### DIFF
--- a/internal/kubernetes/virtualNodeupdater.go
+++ b/internal/kubernetes/virtualNodeupdater.go
@@ -173,6 +173,8 @@ func (p *KubernetesProvider) updateFromAdv(adv advtypes.Advertisement) error {
 func (p *KubernetesProvider) updateFromTep(tep nettypes.TunnelEndpoint) error {
 	if tep.Status.RemoteRemappedPodCIDR != "" && tep.Status.RemoteRemappedPodCIDR != "None" {
 		p.RemoteRemappedPodCidr = tep.Status.RemoteRemappedPodCIDR
+	} else {
+		p.RemoteRemappedPodCidr = tep.Spec.PodCIDR
 	}
 
 	if tep.Status.LocalRemappedPodCIDR != "" && tep.Status.LocalRemappedPodCIDR != "None" {


### PR DESCRIPTION
# Description

This PR fixes a bug in the setting of pod CIDR in the virtualKubelet: if no remapping occurs, the podCIDR announced by the TunnelEndpoint is used