### PR TITLE
peering process improvements

### DIFF
--- a/api/discovery/v1alpha1/peeringrequest_types.go
+++ b/api/discovery/v1alpha1/peeringrequest_types.go
@@ -19,6 +19,7 @@ package v1alpha1
 import (
 	advtypes "github.com/liqotech/liqo/api/sharing/v1alpha1"
 	"github.com/liqotech/liqo/pkg/crdClient"
+	object_references "github.com/liqotech/liqo/pkg/object-references"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -53,7 +54,8 @@ type OriginClusterSets struct {
 
 // PeeringRequestStatus defines the observed state of PeeringRequest
 type PeeringRequestStatus struct {
-	AdvertisementStatus advtypes.AdvPhase `json:"advertisementStatus,omitempty"`
+	BroadcasterRef      *object_references.DeploymentReference `json:"broadcasterRef,omitempty"`
+	AdvertisementStatus advtypes.AdvPhase                      `json:"advertisementStatus,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/deployments/liqo_chart/crds/peering-request-crd.yaml
+++ b/deployments/liqo_chart/crds/peering-request-crd.yaml
@@ -59,3 +59,14 @@ spec:
           properties:
             advertisementStatus:
               type: string
+            broadcasterRef:
+              properties:
+                name:
+                  description: Name is unique within a namespace to reference a deployment
+                    resource.
+                  type: string
+                namespace:
+                  description: Namespace defines the space within which the deployment
+                    name must be unique.
+                  type: string
+              type: object

--- a/internal/discovery/foreign.go
+++ b/internal/discovery/foreign.go
@@ -101,7 +101,7 @@ func (discovery *DiscoveryCtrl) UpdateTtl(txts []*TxtData) error {
 		if !found {
 			// if ForeignCluster is not in Txt list, reduce its TTL
 			fc.Status.Ttl -= 1
-			if fc.Status.Ttl <= 0 {
+			if fc.Status.Ttl <= 0 && !fc.Status.Outgoing.Joined && !fc.Status.Incoming.Joined {
 				// delete ForeignCluster
 				err = discovery.crdClient.Resource("foreignclusters").Delete(fc.Name, metav1.DeleteOptions{})
 				if err != nil {

--- a/internal/liqonet/tunnelEndpointCreator-operator.go
+++ b/internal/liqonet/tunnelEndpointCreator-operator.go
@@ -486,6 +486,8 @@ func (r *TunnelEndpointCreator) ForeignClusterHandlerAdd(obj interface{}) {
 	}
 	if fc.Status.Incoming.Joined || fc.Status.Outgoing.Joined {
 		_ = r.createNetConfig(fc.Spec.ClusterID)
+	} else if !fc.Status.Incoming.Joined && !fc.Status.Outgoing.Joined {
+		_ = r.deleteNetConfig(fc.Spec.ClusterID)
 	}
 }
 

--- a/internal/peering-request-operator/broadcaster.go
+++ b/internal/peering-request-operator/broadcaster.go
@@ -8,10 +8,11 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
+	"strings"
 )
 
 func (r *PeeringRequestReconciler) BroadcasterExists(request *discoveryv1alpha1.PeeringRequest) (bool, error) {
-	_, err := r.crdClient.Client().AppsV1().Deployments(r.Namespace).Get(context.TODO(), "broadcaster-"+request.Name, metav1.GetOptions{})
+	_, err := r.crdClient.Client().AppsV1().Deployments(request.Status.BroadcasterRef.Namespace).Get(context.TODO(), request.Status.BroadcasterRef.Name, metav1.GetOptions{})
 	if k8serrors.IsNotFound(err) {
 		// does not exist
 		return false, nil
@@ -24,7 +25,7 @@ func (r *PeeringRequestReconciler) BroadcasterExists(request *discoveryv1alpha1.
 	return true, nil
 }
 
-func GetBroadcasterDeployment(request *discoveryv1alpha1.PeeringRequest, nameSA string, namespace string, image string, clusterId string) appsv1.Deployment {
+func GetBroadcasterDeployment(request *discoveryv1alpha1.PeeringRequest, nameSA string, namespace string, image string, clusterId string) *appsv1.Deployment {
 	args := []string{
 		"--peering-request",
 		request.Name,
@@ -34,16 +35,17 @@ func GetBroadcasterDeployment(request *discoveryv1alpha1.PeeringRequest, nameSA 
 		nameSA, //TODO: using this SA, we pass to the foreign cluster a kubeconfig with the same permissions of the broadcaster deployment; if we want to pass a different one we have to forge it
 	}
 
-	deploy := appsv1.Deployment{
+	deploy := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "broadcaster-" + request.Name,
-			Namespace: namespace,
+			GenerateName: strings.Join([]string{"broadcaster", request.Name, ""}, "-"),
+			Namespace:    namespace,
 			OwnerReferences: []metav1.OwnerReference{
 				{
 					APIVersion: "v1alpha1",
 					Kind:       "PeeringRequest",
 					Name:       request.Name,
 					UID:        request.UID,
+					Controller: pointer.BoolPtr(true),
 				},
 			},
 		},

--- a/test/unit/discovery/discovery_test.go
+++ b/test/unit/discovery/discovery_test.go
@@ -292,7 +292,8 @@ func testUnjoin(t *testing.T) {
 	assert.NilError(t, err, "Error listing Advertisements")
 	advs, ok := tmp.(*advtypes.AdvertisementList)
 	assert.Equal(t, ok, true)
-	assert.Equal(t, len(advs.Items), 0, "Advertisement has not been deleted on local cluster")
+	assert.Equal(t, len(advs.Items), 1, "There is no Advertisement in local cluster")
+	assert.Equal(t, advs.Items[0].Status.AdvertisementStatus, advtypes.AdvertisementDeleting, "The Advertisement is not in Deleting state")
 
 	tmp, err = serverCluster.client.Resource("foreignclusters").List(metav1.ListOptions{})
 	assert.NilError(t, err)


### PR DESCRIPTION
# Description

This PR improves the stability of the peering/unjoin process

## Peering/Unjoin
* previously, in some situation the advertisement was deleted instead of setting the delete flag, this was leading to incorrect delete of the virtualkubelet related resources
* now in PeeringRequest status is available the reference to the created broadcaster
  * a PeeringRequest is now owner and controller of broadcaster deployment, so if it is deleted it is immediately recreated
* during PeeringRequest creation the secret name is generated by API Server, avoiding name collisions
  * it's now possible to peer n clusters (tested with 3 kind clusters), we will see n-1 new nodes in each one

## Uninstall - Ref #246
Some networking resources are no more deleted with unjoin after the CrdReplicator addition, these resources are now deleted in the uninstall script before Liqo operators uninstall

### Problem
If we delete all CRD before uninstall, during uninstallation is still possible that a remote CrdReplicator is sending us new replicas with its finalizers, at the moment there is no way to avoid it
