### PR TITLE
Add watcher recreation in VirtualKubelet

### DIFF
--- a/cmd/virtual-kubelet/internal/commands/root/root.go
+++ b/cmd/virtual-kubelet/internal/commands/root/root.go
@@ -16,6 +16,7 @@ package root
 
 import (
 	"context"
+	"github.com/liqotech/liqo/pkg"
 	"k8s.io/klog"
 	"os"
 	"path"
@@ -152,7 +153,7 @@ func runRootCommand(ctx context.Context, s *provider.Store, c Opts) error {
 		leaseClient = client.CoordinationV1beta1().Leases(corev1.NamespaceNodeLease)
 	}
 
-	deployName := strings.Join([]string{"liqo", c.ClusterId}, "-")
+	deployName := strings.Join([]string{pkg.VirtualKubeletPrefix, c.ClusterId}, "")
 	refs := createOwnerReference(client, deployName, c.KubeletNamespace)
 
 	var nodeRunner *node.NodeController

--- a/internal/kubernetes/test/const.go
+++ b/internal/kubernetes/test/const.go
@@ -6,15 +6,18 @@ import (
 )
 
 const (
-	Namespace            = "test"
-	NattedNamespace      = Namespace + "-" + HomeClusterId
-	HostName             = "testHost"
-	NodeName             = "testNode"
-	AdvName              = "advertisement-" + ForeignClusterId
-	TepName              = controllers.TunEndpointNamePrefix + ForeignClusterId
-	EndpointsName        = "testEndpoints"
-	HomeClusterId        = "homeClusterID"
-	ForeignClusterId     = "foreignClusterID"
-	LocalRemappedPodCIDR = "100.200.0.0/16"
-	Timeout              = 10 * time.Second
+	Namespace             = "test"
+	NattedNamespace       = Namespace + "-" + HomeClusterId
+	HostName              = "testHost"
+	NodeName              = "testNode"
+	AdvName               = "advertisement-" + ForeignClusterId
+	TepName               = controllers.TunEndpointNamePrefix + ForeignClusterId
+	EndpointsName         = "testEndpoints"
+	HomeClusterId         = "homeClusterID"
+	ForeignClusterId      = "foreignClusterID"
+	PodCIDR               = "1.2.3.4/16"
+	RemoteRemappedPodCIDR = "5.6.7.8/16"
+	TunnelPublicIP        = "5.6.7.8"
+	LocalRemappedPodCIDR  = "100.200.0.0/16"
+	Timeout               = 10 * time.Second
 )

--- a/internal/kubernetes/test/node.go
+++ b/internal/kubernetes/test/node.go
@@ -27,5 +27,17 @@ func AssertNodeCoherency(received, expected *corev1.Node) bool {
 		}
 	}
 
+	if len(received.Status.Conditions) != len(expected.Status.Conditions) {
+		return false
+	}
+
+	for _, c1 := range received.Status.Conditions {
+		for _, c2 := range expected.Status.Conditions {
+			if c1.Type == c2.Type && c1.Status != c2.Status {
+				return false
+			}
+		}
+	}
+
 	return true
 }

--- a/internal/kubernetes/test/nodeTestCases.go
+++ b/internal/kubernetes/test/nodeTestCases.go
@@ -11,6 +11,50 @@ var (
 	Cpu2, _    = resource.ParseQuantity("2")
 	Memory1, _ = resource.ParseQuantity("1000")
 	Memory2, _ = resource.ParseQuantity("2000")
+	Condition1 = []corev1.NodeCondition{
+		{
+			Type:   corev1.NodeReady,
+			Status: corev1.ConditionFalse,
+		},
+		{
+			Type:   corev1.NodeMemoryPressure,
+			Status: corev1.ConditionFalse,
+		},
+		{
+			Type:   corev1.NodeDiskPressure,
+			Status: corev1.ConditionFalse,
+		},
+		{
+			Type:   corev1.NodePIDPressure,
+			Status: corev1.ConditionFalse,
+		},
+		{
+			Type:   corev1.NodeNetworkUnavailable,
+			Status: corev1.ConditionTrue,
+		},
+	}
+	Condition2 = []corev1.NodeCondition{
+		{
+			Type:   corev1.NodeReady,
+			Status: corev1.ConditionTrue,
+		},
+		{
+			Type:   corev1.NodeMemoryPressure,
+			Status: corev1.ConditionFalse,
+		},
+		{
+			Type:   corev1.NodeDiskPressure,
+			Status: corev1.ConditionFalse,
+		},
+		{
+			Type:   corev1.NodePIDPressure,
+			Status: corev1.ConditionFalse,
+		},
+		{
+			Type:   corev1.NodeNetworkUnavailable,
+			Status: corev1.ConditionFalse,
+		},
+	}
 )
 
 var NodeTestCases = struct {
@@ -22,6 +66,11 @@ var NodeTestCases = struct {
 			Name: NodeName,
 		},
 	},
+	// ExpectedNodes[0] : cpu1, mem1, condition1 (NodeNetworkUnavailable)
+	// ExpectedNodes[1] : cpu2, mem2, condition1 (NodeNetworkUnavailable)
+	// ExpectedNodes[2] : cpu2, mem2, condition2 (NodeReady)
+	// ExpectedNodes[0] -> ExpectedNodes[1] : Advertisement update  => different resources, same node conditions
+	// ExpectedNodes[1] -> ExpectedNodes[2] : TunnelEndpoint update => same resources, different node conditions
 	ExpectedNodes: []*corev1.Node{
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -36,6 +85,7 @@ var NodeTestCases = struct {
 					"cpu":    Cpu1,
 					"memory": Memory1,
 				},
+				Conditions: Condition1,
 			},
 		},
 		{
@@ -51,6 +101,23 @@ var NodeTestCases = struct {
 					"cpu":    Cpu2,
 					"memory": Memory2,
 				},
+				Conditions: Condition1,
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: NodeName,
+			},
+			Status: corev1.NodeStatus{
+				Capacity: corev1.ResourceList{
+					"cpu":    Cpu2,
+					"memory": Memory2,
+				},
+				Allocatable: corev1.ResourceList{
+					"cpu":    Cpu2,
+					"memory": Memory2,
+				},
+				Conditions: Condition2,
 			},
 		},
 	},

--- a/internal/kubernetes/virtualNodeupdater.go
+++ b/internal/kubernetes/virtualNodeupdater.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	nettypes "github.com/liqotech/liqo/api/net/v1alpha1"
 	advtypes "github.com/liqotech/liqo/api/sharing/v1alpha1"
-	"github.com/liqotech/liqo/internal/kubernetes/test"
 	controllers "github.com/liqotech/liqo/internal/liqonet"
 	"github.com/liqotech/liqo/internal/node"
 	v1 "k8s.io/api/core/v1"
@@ -190,7 +189,28 @@ func (p *KubernetesProvider) updateFromAdv(adv advtypes.Advertisement) error {
 		no.Status.Allocatable[k] = v
 	}
 	if no.Status.Conditions == nil {
-		no.Status.Conditions = test.Condition1
+		no.Status.Conditions = []v1.NodeCondition{
+			{
+				Type:   v1.NodeReady,
+				Status: v1.ConditionFalse,
+			},
+			{
+				Type:   v1.NodeMemoryPressure,
+				Status: v1.ConditionFalse,
+			},
+			{
+				Type:   v1.NodeDiskPressure,
+				Status: v1.ConditionFalse,
+			},
+			{
+				Type:   v1.NodePIDPressure,
+				Status: v1.ConditionFalse,
+			},
+			{
+				Type:   v1.NodeNetworkUnavailable,
+				Status: v1.ConditionTrue,
+			},
+		}
 	}
 
 	no.Status.Images = []v1.ContainerImage{}
@@ -216,7 +236,28 @@ func (p *KubernetesProvider) updateFromTep(tep nettypes.TunnelEndpoint) error {
 	}
 
 	if no.Status.Conditions == nil {
-		no.Status.Conditions = test.Condition1
+		no.Status.Conditions = []v1.NodeCondition{
+			{
+				Type:   v1.NodeReady,
+				Status: v1.ConditionFalse,
+			},
+			{
+				Type:   v1.NodeMemoryPressure,
+				Status: v1.ConditionFalse,
+			},
+			{
+				Type:   v1.NodeDiskPressure,
+				Status: v1.ConditionFalse,
+			},
+			{
+				Type:   v1.NodePIDPressure,
+				Status: v1.ConditionFalse,
+			},
+			{
+				Type:   v1.NodeNetworkUnavailable,
+				Status: v1.ConditionTrue,
+			},
+		}
 	}
 
 	return p.updateNode(no)

--- a/pkg/const.go
+++ b/pkg/const.go
@@ -1,0 +1,6 @@
+package pkg
+
+const (
+	VirtualNodePrefix    = "liqo-"
+	VirtualKubeletPrefix = "virtual-kubelet-"
+)


### PR DESCRIPTION
# Description
This PR adds the recreation of the watchers over `Advertisement` and `TunnelEndpoint` in the VirtualKubelet when a casting error occurs.
It also adds tests on network updates in the VirtualKubelet.

Fixes #250 

## Other changes
Fix ownerReference in the virtual node: it pointed to `liqo-<clusterID>` deployment, whereas the virtualKubelet deployment is named `virtual-kubelet-<clusterID>`

# How Has This Been Tested?

- [x] Tests on VirtualKubelet network update after the creation of a `TunnelEndpoint` with no remapping
- [x] Test VirtualKubelet network update with remapping