### PR TITLE
Fix TunnelEndpointCreator broken watchers on CRD

### DIFF
--- a/internal/liqonet/route-operator-config.go
+++ b/internal/liqonet/route-operator-config.go
@@ -1,4 +1,4 @@
-package controllers
+package liqonetOperators
 
 import (
 	configv1alpha1 "github.com/liqotech/liqo/api/config/v1alpha1"

--- a/internal/liqonet/route-operator.go
+++ b/internal/liqonet/route-operator.go
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package controllers
+package liqonetOperators
 
 import (
 	"context"

--- a/internal/liqonet/route-operator_test.go
+++ b/internal/liqonet/route-operator_test.go
@@ -1,4 +1,4 @@
-package controllers
+package liqonetOperators
 
 import (
 	netv1alpha1 "github.com/liqotech/liqo/api/net/v1alpha1"

--- a/internal/liqonet/tunnel-operator.go
+++ b/internal/liqonet/tunnel-operator.go
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package controllers
+package liqonetOperators
 
 import (
 	"context"

--- a/internal/liqonet/tunnelEndpointCreator-config.go
+++ b/internal/liqonet/tunnelEndpointCreator-config.go
@@ -1,4 +1,4 @@
-package controllers
+package liqonetOperators
 
 import (
 	"context"
@@ -273,8 +273,8 @@ func (r *TunnelEndpointCreator) WatchConfiguration(config *rest.Config, gv *sche
 		}
 		r.SetNetParameters(configuration)
 		if !r.RunningWatchers {
-			r.AdvWatcher <- true
-			r.PReqWatcher <- true
+			r.AdvStartWatcher <- true
+			r.PReqStartWatcher <- true
 		}
 
 	}, CRDclient, "")

--- a/test/unit/liqonet/env_test.go
+++ b/test/unit/liqonet/env_test.go
@@ -26,7 +26,7 @@ var (
 	k8sManager          ctrl.Manager
 	testEnv             *envtest.Environment
 	ctx                 = context.Background()
-	tunEndpointCreator  *controllers.TunnelEndpointCreator
+	tec                 *controllers.TunnelEndpointCreator
 	configClusterClient *crdClient.CRDClient
 	routeOperator       *controllers.RouteController
 )


### PR DESCRIPTION
# Description

The operator used watchers to monitor the creation of `peeringrequests.discovery.liqo.io` and `advertisements.sharing.liqo.io` and eventually create a `networkconfigs.net.liqo.io` to send to the peering cluster. Watchers may miss events (e.g. network problems), to avoid this scenario Informers are used instead of the more primitive watcher construct.

Fixes #(issue)


# How Has This Been Tested?
Old tests are still valid, changed the way to do things but the outcome is the same.
