### PR TITLE
Fix DNS Discovery

### DIFF
--- a/api/config/v1alpha1/clusterconfig_types.go
+++ b/api/config/v1alpha1/clusterconfig_types.go
@@ -105,10 +105,6 @@ type DiscoveryConfig struct {
 	AutoJoin          bool `json:"autojoin"`
 	AutoJoinUntrusted bool `json:"autojoinUntrusted"`
 
-	// --- DNS ---
-
-	DnsServer string `json:"dnsServer"`
-
 	// --- CA ---
 
 	AllowUntrustedCA bool `json:"allowUntrustedCA"`

--- a/deployments/liqo_chart/crds/config.liqo.io_clusterconfigs.yaml
+++ b/deployments/liqo_chart/crds/config.liqo.io_clusterconfigs.yaml
@@ -120,8 +120,6 @@ spec:
                   type: boolean
                 autojoinUntrusted:
                   type: boolean
-                dnsServer:
-                  type: string
                 domain:
                   type: string
                 enableAdvertisement:
@@ -146,7 +144,6 @@ spec:
               - allowUntrustedCA
               - autojoin
               - autojoinUntrusted
-              - dnsServer
               - domain
               - enableAdvertisement
               - enableDiscovery

--- a/deployments/liqo_chart/templates/clusterconfig.yaml
+++ b/deployments/liqo_chart/templates/clusterconfig.yaml
@@ -26,7 +26,6 @@ spec:
     service: _liqo._tcp
     updateTime: 3
     waitTime: 2
-    dnsServer: '8.8.8.8:53'
   liqonetConfig:
     podCIDR: {{ .Values.podCIDR }}
     serviceCIDR: {{ .Values.serviceCIDR }}

--- a/internal/discovery/search-domain-operator/search-domain-controller.go
+++ b/internal/discovery/search-domain-operator/search-domain-controller.go
@@ -49,7 +49,7 @@ func (r *SearchDomainReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error
 
 	update := false
 
-	txts, err := Wan(r.DiscoveryCtrl.Config.DnsServer, sd.Spec.Domain, false)
+	txts, err := Wan("", sd.Spec.Domain, false)
 	if err != nil {
 		klog.Error(err, err.Error())
 		return ctrl.Result{

--- a/internal/discovery/search-domain-operator/wan.go
+++ b/internal/discovery/search-domain-operator/wan.go
@@ -5,12 +5,27 @@ import (
 	"github.com/liqotech/liqo/internal/discovery"
 	"github.com/miekg/dns"
 	"k8s.io/klog"
+	"net"
 	"strconv"
 	"time"
 )
 
 func Wan(dnsAddr string, name string, test bool) ([]*discovery.TxtData, error) {
 	txtData := []*discovery.TxtData{}
+
+	if dnsAddr == "" {
+		clientConfig, err := dns.ClientConfigFromFile("/etc/resolv.conf")
+		if err != nil {
+			klog.Error(err)
+			return nil, err
+		}
+		if len(clientConfig.Servers) == 0 {
+			err = errors.New("no DNS server config found")
+			klog.Error(err)
+			return nil, err
+		}
+		dnsAddr = net.JoinHostPort(clientConfig.Servers[0], "53")
+	}
 
 	c := new(dns.Client)
 	c.DialTimeout = 30 * time.Second

--- a/test/unit/crdReplicator/env_test.go
+++ b/test/unit/crdReplicator/env_test.go
@@ -211,7 +211,6 @@ func getClusterConfig() *configv1alpha1.ClusterConfig {
 				Service:             "_liqo._tcp",
 				UpdateTime:          3,
 				WaitTime:            2,
-				DnsServer:           "8.8.8.8:53",
 			},
 			LiqonetConfig: configv1alpha1.LiqonetConfig{
 				ReservedSubnets: []string{"10.0.0.0/16"},

--- a/test/unit/discovery/env_test.go
+++ b/test/unit/discovery/env_test.go
@@ -255,7 +255,6 @@ func getClusterConfig(config rest.Config) {
 				Service:             "_liqo._tcp",
 				UpdateTime:          3,
 				WaitTime:            2,
-				DnsServer:           "8.8.8.8:53",
 			},
 			LiqonetConfig: configv1alpha1.LiqonetConfig{
 				ReservedSubnets: []string{"10.0.0.0/16"},

--- a/test/unit/liqonet/env_test.go
+++ b/test/unit/liqonet/env_test.go
@@ -153,7 +153,6 @@ func getClusterConfig() *configv1alpha1.ClusterConfig {
 				Service:             "_liqo._tcp",
 				UpdateTime:          3,
 				WaitTime:            2,
-				DnsServer:           "8.8.8.8:53",
 			},
 			LiqonetConfig: configv1alpha1.LiqonetConfig{
 				ReservedSubnets: []string{"10.0.0.0/16"},


### PR DESCRIPTION
# Description

Now DNS discovery uses the default pod's DNS server (i.e. the one that is indicated in `/etc/resolv.conf`)

## Changes
* The DNS server is no more needed in ClusterConfig
* A new finalizer has been added on ForeignCluster to avoid accidentally (or not) delete of peered ones, they will be unpeered and then deleted
