### PR TITLE
Update CSR watcher

### DIFF
--- a/cmd/advertisement-operator/main.go
+++ b/cmd/advertisement-operator/main.go
@@ -101,7 +101,7 @@ func main() {
 		klog.Error(err)
 		os.Exit(1)
 	}
-	go csrApprover.WatchCSR(clientset, "liqo.io/csr=true")
+	go csrApprover.WatchCSR(clientset, "liqo.io/csr=true", 5*time.Second)
 
 	// get the number of already accepted advertisements
 	advClient, err := advtypes.CreateAdvertisementClient(localKubeconfig, nil)


### PR DESCRIPTION
# Description
The csr watcher for the virtualKubelet now is a `sharedInformer` to provide better reliability

Fixes #241 

# How Has This Been Tested?

Tested with KinD
