### PR TITLE
Establishing the network connection based on the join/unjoin flow

### DIFF
--- a/deployments/liqo_chart/subcharts/tunnelEndpointCreator_chart/templates/tunnelEndpointCreator.yaml
+++ b/deployments/liqo_chart/subcharts/tunnelEndpointCreator_chart/templates/tunnelEndpointCreator.yaml
@@ -39,30 +39,9 @@ rules:
     - update
 
   - apiGroups:
-    - sharing.liqo.io
-    resources:
-    - advertisements
-    verbs:
-    - create
-    - delete
-    - get
-    - list
-    - patch
-    - update
-    - watch
-  - apiGroups:
-    - sharing.liqo.io
-    resources:
-    - advertisements/status
-    verbs:
-    - get
-    - patch
-    - update
-
-  - apiGroups:
       - discovery.liqo.io
     resources:
-      - peeringrequests
+      - foreignclusters
     verbs:
       - create
       - delete

--- a/internal/liqonet/tunnelEndpointCreator-config.go
+++ b/internal/liqonet/tunnelEndpointCreator-config.go
@@ -273,8 +273,7 @@ func (r *TunnelEndpointCreator) WatchConfiguration(config *rest.Config, gv *sche
 		}
 		r.SetNetParameters(configuration)
 		if !r.RunningWatchers {
-			r.AdvStartWatcher <- true
-			r.PReqStartWatcher <- true
+			r.ForeignClusterStartWatcher <- true
 		}
 
 	}, CRDclient, "")

--- a/test/unit/liqonet/env_test.go
+++ b/test/unit/liqonet/env_test.go
@@ -8,7 +8,6 @@ import (
 	controllers "github.com/liqotech/liqo/internal/liqonet"
 	"github.com/liqotech/liqo/pkg/crdClient"
 	"github.com/liqotech/liqo/pkg/liqonet"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
@@ -125,28 +124,6 @@ func tearDown() {
 	if err != nil {
 		klog.Error(err, err.Error())
 		os.Exit(1)
-	}
-}
-
-func getAdv() *advtypes.Advertisement {
-	return &advtypes.Advertisement{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Advertisement",
-			APIVersion: "sharing.liqo.io/v1alpha1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "testadv",
-		},
-		Spec: advtypes.AdvertisementSpec{
-			ClusterId: "cluster1",
-			KubeConfigRef: corev1.SecretReference{
-				Namespace: "fake",
-				Name:      "fake-kubeconfig",
-			},
-			LimitRange: corev1.LimitRangeSpec{Limits: []corev1.LimitRangeItem{}},
-			Timestamp:  metav1.NewTime(time.Now()),
-			TimeToLive: metav1.NewTime(time.Now().Add(30 * time.Minute)),
-		},
 	}
 }
 


### PR DESCRIPTION
# Description
The network connection is now handled based on the status of the foreign cluster. If at least one of the incoming or outgoing connections is set to "joined = true" then the connection is established. When they are both false then the operator tears down the network connection.

Ref. #246

# How Has This Been Tested?
Given a foreign cluster with the following status:
1. {outgoingJoined: true, incomingJoined: false}
2. {outgoingJoined: false, incomingJoined: true}
3. {outgoingJoined: true, incomingJoined: true}
4. {outgoingJoined: false, incomingJoined: false}

we check that for the cases 1, 2 and 3 the networkconfigs.net.liqo.io is created and removed when the foreigncluster.discovery.liqo.io is removed.
For the fourth case we check that the networkconfigs.net.liqo.io is not created at all.
