### PR TITLE
Bug fixing and enhancement network operators

### DIFF
--- a/cmd/liqonet/main.go
+++ b/cmd/liqonet/main.go
@@ -38,6 +38,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"strconv"
+	"strings"
 	"time"
 	// +kubebuilder:scaffold:imports
 )
@@ -135,12 +136,11 @@ func main() {
 		if err != nil {
 			setupLog.Error(err, "unable to initialize iptables: %v. check if the ipatable are present in the system", err)
 		}
-
 		r := &liqonetOperators.RouteController{
 			Client:                             mgr.GetClient(),
 			Log:                                ctrl.Log.WithName("route-operator"),
 			Scheme:                             mgr.GetScheme(),
-			RouteOperator:                      runAsRouteOperator,
+			Recorder:                           mgr.GetEventRecorderFor(strings.Join([]string{"route-OP", nodeName}, "-")),
 			ClientSet:                          clientset,
 			RoutesPerRemoteCluster:             make(map[string][]netlink.Route),
 			IsGateway:                          isGatewayNode,
@@ -178,6 +178,7 @@ func main() {
 			Client:                       mgr.GetClient(),
 			Log:                          ctrl.Log.WithName("liqonetOperators").WithName("TunnelEndpoint"),
 			Scheme:                       mgr.GetScheme(),
+			Recorder:                     mgr.GetEventRecorderFor("tunnel-operator"),
 			TunnelIFacesPerRemoteCluster: make(map[string]int),
 		}
 		if err = r.SetupWithManager(mgr); err != nil {

--- a/deployments/liqo_chart/subcharts/networkModule_chart/templates/route-operator.yaml
+++ b/deployments/liqo_chart/subcharts/networkModule_chart/templates/route-operator.yaml
@@ -49,6 +49,13 @@ rules:
       - patch
       - update
       - watch
+  - apiGroups:
+     - ""
+    resources:
+     - events
+    verbs:
+      - create
+      - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/deployments/liqo_chart/subcharts/networkModule_chart/templates/tunnelEndpoint-operator.yaml
+++ b/deployments/liqo_chart/subcharts/networkModule_chart/templates/tunnelEndpoint-operator.yaml
@@ -29,6 +29,13 @@ rules:
       - get
       - patch
       - update
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/internal/liqonet/route-operator_test.go
+++ b/internal/liqonet/route-operator_test.go
@@ -39,7 +39,6 @@ func getRouteController() *RouteController {
 		Log:                                ctrl.Log.WithName("route-operator"),
 		Scheme:                             nil,
 		clientset:                          kubernetes.Clientset{},
-		RouteOperator:                      false,
 		NodeName:                           "test",
 		ClientSet:                          nil,
 		RemoteVTEPs:                        nil,
@@ -81,7 +80,7 @@ func TestCreateAndInsertIPTablesChains(t *testing.T) {
 	for i := 3; i >= 0; i-- {
 		err := r.createAndInsertIPTablesChains()
 		assert.Nil(t, err, "error should be nil")
-		assert.Equal(t, 3, len(r.IPTablesChains), "there should be three new chains")
+		assert.Equal(t, 4, len(r.IPTablesChains), "there should be 4 new chains")
 		assert.Equal(t, 4, len(r.IPTablesRuleSpecsReferencingChains), "there should be 4 new rules")
 	}
 }

--- a/internal/liqonet/tunnel-operator.go
+++ b/internal/liqonet/tunnel-operator.go
@@ -21,6 +21,8 @@ import (
 	liqonetOperator "github.com/liqotech/liqo/pkg/liqonet"
 	"github.com/vishvananda/netlink"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/retry"
 	"os"
 	"os/signal"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -33,6 +35,7 @@ type TunnelController struct {
 	client.Client
 	Log                          logr.Logger
 	Scheme                       *runtime.Scheme
+	Recorder                     record.EventRecorder
 	TunnelIFacesPerRemoteCluster map[string]int
 	RetryTimeout                 time.Duration
 }
@@ -46,14 +49,14 @@ func (r *TunnelController) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	var endpoint netv1alpha1.TunnelEndpoint
 	//name of our finalizer
 	tunnelEndpointFinalizer := "tunnelEndpointFinalizer.net.liqo.io"
-
 	if err := r.Get(ctx, req.NamespacedName, &endpoint); err != nil {
 		log.Error(err, "unable to fetch endpoint, probably it has been deleted")
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
-	//if the endpoint CR is not processed then return
-	if endpoint.Status.Phase != "Processed" && endpoint.Status.Phase != "Ready" {
-		log.Info("tunnelEndpoint is not ready ", "name", endpoint.Name, "phase", endpoint.Status.Phase)
+	//we wait for the resource to be ready. The resource is created in two steps, firt the spec and metadata fields
+	//then the status field. so we wait for the status to be ready.
+	if endpoint.Status.Phase != "Ready" {
+		log.Info("the resource", "with name", endpoint.Name, "is not ready")
 		return ctrl.Result{RequeueAfter: r.RetryTimeout}, nil
 	}
 	// examine DeletionTimestamp to determine if object is under deletion
@@ -72,8 +75,11 @@ func (r *TunnelController) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		//the object is being deleted
 		if liqonetOperator.ContainsString(endpoint.Finalizers, tunnelEndpointFinalizer) {
 			if err := liqonetOperator.RemoveGreTunnel(&endpoint); err != nil {
+				//record an event and return
+				r.Recorder.Event(&endpoint, "Warning", "Processing", err.Error())
 				return ctrl.Result{}, err
 			}
+			r.Recorder.Event(&endpoint, "Normal", "Processing", "tunnel network interface removed")
 			//safe to do, even if the key does not exist in the map
 			delete(r.TunnelIFacesPerRemoteCluster, endpoint.Spec.ClusterID)
 			log.Info("tunnel iface removed")
@@ -85,49 +91,41 @@ func (r *TunnelController) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		}
 		return ctrl.Result{RequeueAfter: r.RetryTimeout}, nil
 	}
-
-	//update the status of the endpoint custom resource
-	//and install the tunnel only
-	//check if the CR is newly created
-	if endpoint.Status.Phase == "Processed" {
-		iFaceIndex, iFaceName, err := liqonetOperator.InstallGreTunnel(&endpoint)
-		if err != nil {
-			log.Error(err, "unable to create the gre tunnel")
-			return ctrl.Result{RequeueAfter: r.RetryTimeout}, err
-		}
-		log.Info("gre tunnel installed", "index", iFaceIndex, "name", iFaceName)
-		//save the IFace index in the map
-		r.TunnelIFacesPerRemoteCluster[endpoint.Spec.ClusterID] = iFaceIndex
-		log.Info("installed gretunel with index: " + iFaceName)
-		//update the status of CR
-		localTunnelPublicIP, err := liqonetOperator.GetLocalTunnelPublicIPToString()
-		if err != nil {
-			log.Error(err, "unable to get localTunnelPublicIP")
-		}
-		endpoint.Status.TunnelIFaceName = iFaceName
-		endpoint.Status.TunnelIFaceIndex = iFaceIndex
-		endpoint.Status.LocalTunnelPublicIP = localTunnelPublicIP
-		endpoint.Status.RemoteTunnelPublicIP = endpoint.Spec.TunnelPublicIP
-		endpoint.Status.Phase = "Ready"
-		err = r.Client.Status().Update(ctx, &endpoint)
-		if err != nil {
-			return ctrl.Result{RequeueAfter: r.RetryTimeout}, err
-		}
-	} else if endpoint.Status.Phase == "Ready" {
-		//set the label that the resource have been processed by tunnel-operator
-		endpoint.ObjectMeta.SetLabels(liqonetOperator.SetLabelHandler(liqonetOperator.TunOpLabelKey, "ready", endpoint.ObjectMeta.GetLabels()))
-		err := r.Client.Update(ctx, &endpoint)
-		if err != nil {
-			return ctrl.Result{RequeueAfter: r.RetryTimeout}, err
-		}
-
-	} else {
-		return ctrl.Result{RequeueAfter: r.RetryTimeout}, nil
+	//try to install the GRE tunnel if it does not exist
+	iFaceIndex, iFaceName, err := liqonetOperator.InstallGreTunnel(&endpoint)
+	if err != nil {
+		log.Error(err, "unable to create the gre tunnel")
+		r.Recorder.Event(&endpoint, "Warning", "Processing", err.Error())
+		return ctrl.Result{RequeueAfter: r.RetryTimeout}, err
 	}
+	r.Recorder.Event(&endpoint, "Normal", "Processing", "tunnel network interface installed")
+	log.Info("gre tunnel installed", "index", iFaceIndex, "name", iFaceName)
 	//save the IFace index in the map
-	//we come here only if the tunnel is installed and the CR status has been updated
-	r.TunnelIFacesPerRemoteCluster[endpoint.Spec.ClusterID] = endpoint.Status.TunnelIFaceIndex
+	r.TunnelIFacesPerRemoteCluster[endpoint.Spec.ClusterID] = iFaceIndex
+	log.Info("installed gretunel with index: " + iFaceName)
 
+	//update the status of CR if needed
+	//here we recover from conflicting resource versions
+	retryError := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		toBeUpdated := false
+		if endpoint.Status.TunnelIFaceName != iFaceName {
+			endpoint.Status.TunnelIFaceName = iFaceName
+			toBeUpdated = true
+		}
+		if endpoint.Status.TunnelIFaceIndex != iFaceIndex {
+			endpoint.Status.TunnelIFaceIndex = iFaceIndex
+			toBeUpdated = true
+		}
+		if toBeUpdated {
+			err = r.Status().Update(context.Background(), &endpoint)
+			return err
+		}
+		return nil
+	})
+	if retryError != nil {
+		log.Error(retryError, "unable to create the gre tunnel")
+		return ctrl.Result{RequeueAfter: r.RetryTimeout}, retryError
+	}
 	return ctrl.Result{RequeueAfter: r.RetryTimeout}, nil
 }
 

--- a/pkg/liqonet/tunnel.go
+++ b/pkg/liqonet/tunnel.go
@@ -30,39 +30,6 @@ func GetLocalTunnelPublicIP() (net.IP, error) {
 	return net.ParseIP(ipAddress), nil
 }
 
-func GetLocalTunnelPublicIPToString() (string, error) {
-	ipAddress, isSet := os.LookupEnv("LOCAL_TUNNEL_PUBLIC_IP")
-	if !isSet {
-		return "", errdefs.NotFound("the pod IP is not set")
-	}
-	if ipAddress == "" {
-		return "", errors.New("pod IP is not yet set")
-	}
-	return ipAddress, nil
-}
-
-func GetLocalTunnelPrivateIP() (net.IP, error) {
-	ipAddress, isSet := os.LookupEnv("LOCAL_TUNNEL_PRIVATE_IP")
-	if !isSet {
-		return nil, errdefs.NotFound("the pod IP is not set")
-	}
-	if ipAddress == "" {
-		return nil, errors.New("pod IP is not yet set")
-	}
-	return net.ParseIP(ipAddress), nil
-}
-
-func GetLocalTunnelPrivateIPToString() (string, error) {
-	ipAddress, isSet := os.LookupEnv("LOCAL_TUNNEL_PRIVATE_IP")
-	if !isSet {
-		return "", errdefs.NotFound("the pod IP is not set")
-	}
-	if ipAddress == "" {
-		return "", errors.New("pod IP is not yet set")
-	}
-	return ipAddress, nil
-}
-
 func InstallGreTunnel(endpoint *netv1alpha1.TunnelEndpoint) (int, string, error) {
 	//TODO configure the name according to the max length permitted by the kernel
 	name := tunnelNamePrefix

--- a/test/unit/liqonet/tunnelEndpointCreator_test.go
+++ b/test/unit/liqonet/tunnelEndpointCreator_test.go
@@ -412,7 +412,7 @@ func getNetworkConfig() *netv1alpha1.NetworkConfig {
 			Name: "netconfig-1",
 		},
 		Spec: netv1alpha1.NetworkConfigSpec{
-			ClusterID:      "localClusterID",
+			ClusterID:      "localclusterid",
 			PodCIDR:        "10.2.0.0/16",
 			TunnelPublicIP: "192.168.1.1",
 		},
@@ -475,7 +475,7 @@ func TestNetConfigProcessing(t *testing.T) {
 	assert.Equal(t, netConfig2.Spec.ClusterID, tep.Spec.ClusterID)
 	assert.Equal(t, netConfig1.Spec.PodCIDR, tep.Spec.PodCIDR)
 	assert.Equal(t, netConfig1.Spec.TunnelPublicIP, tep.Spec.TunnelPublicIP)
-	assert.Equal(t, "Processed", tep.Status.Phase)
+	assert.Equal(t, "Ready", tep.Status.Phase)
 
 	//test4
 	//we change some fields in the remote netConfig status


### PR DESCRIPTION
# Description
This PR brings bugfixing and some refactoring  of the network operators

## TunnelEndpointCreator
The `tunnelendpoints.net.liqo.io` resource is created now in one step, specifying the spec and status field at once. It used to first create the resource with the spec field, wait for the creation and then update the status field. This process is now delegated to the client-go library.
A newly created `tunnelendpoint` resource has the status field named `phase` set to _Ready_. This is needed for the tunnel and route operators. Otherwise the resource may be consumed before that some status fields are set.

## Route-Operator

- Correcting some misleading information in log messages. 
- Fixing a bug causing the LIQONET-POSTROUTING chain not to be flushed when the operator pod is removed
- The reconcile function is idempotent with a resync period of 30 seconds where it checks that routing table and iptables rules are correctly configured.
- When iptables rules and routes are added or removed `events` are sent to the resource been reconciled 
![tep_events](https://user-images.githubusercontent.com/17413176/93497773-1d539a80-f911-11ea-8627-8135f1c16f39.png)
This way if an error occurs the user knows which instance/node to check for misconfiguration. If an error occurs while removing the external resources it is reported through an event on the related `tunnelendpoint` resource and waits for the user to solve the conflicts.

## Tunnel-Operator
- Fixing the bug which caused the operator not to reconcile the `tunnelendpoints` resources if restarted.
- Periodically ensures the existence of the tunnel network interface for the peering clusters
- The creation of the tunnel network interface is now idempotent: if it exists a check if the configuration is the same is done and it is recreated only when the existing one and the wanted one differs.
- Instal/uninstall of network interfaces is reported by means of events to the related `tunnelendpoint` resource. 


Fixes #(issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

Existing unit and integration test  have been updated to use the status field `phase` with new value which for now could be set to _Ready_ only.
