### PR TITLE
Associate a Cluster Name to Home and Foreign Clusters

### DIFF
--- a/api/config/v1alpha1/clusterconfig_types.go
+++ b/api/config/v1alpha1/clusterconfig_types.go
@@ -85,6 +85,7 @@ type AdvOperatorConfig struct {
 }
 
 type DiscoveryConfig struct {
+	// ClusterName is a nickname for your cluster that can be easily understood by a user
 	ClusterName string `json:"clusterName,omitempty"`
 
 	// --- mDNS ---

--- a/api/config/v1alpha1/clusterconfig_types.go
+++ b/api/config/v1alpha1/clusterconfig_types.go
@@ -85,6 +85,8 @@ type AdvOperatorConfig struct {
 }
 
 type DiscoveryConfig struct {
+	ClusterName string `json:"clusterName,omitempty"`
+
 	// --- mDNS ---
 
 	Name    string `json:"name"`

--- a/api/discovery/v1alpha1/foreigncluster_types.go
+++ b/api/discovery/v1alpha1/foreigncluster_types.go
@@ -42,12 +42,17 @@ type ForeignClusterSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
-	ClusterID        string        `json:"clusterID"`
-	Namespace        string        `json:"namespace"`
-	Join             bool          `json:"join"`
-	ApiUrl           string        `json:"apiUrl"`
-	DiscoveryType    DiscoveryType `json:"discoveryType"`
-	AllowUntrustedCA bool          `json:"allowUntrustedCA"`
+	ClusterIdentity  ClusterIdentity `json:"clusterIdentity"`
+	Namespace        string          `json:"namespace"`
+	Join             bool            `json:"join"`
+	ApiUrl           string          `json:"apiUrl"`
+	DiscoveryType    DiscoveryType   `json:"discoveryType"`
+	AllowUntrustedCA bool            `json:"allowUntrustedCA"`
+}
+
+type ClusterIdentity struct {
+	ClusterID   string `json:"clusterID"`
+	ClusterName string `json:"clusterName,omitempty"`
 }
 
 // ForeignClusterStatus defines the observed state of ForeignCluster

--- a/api/discovery/v1alpha1/peeringrequest_types.go
+++ b/api/discovery/v1alpha1/peeringrequest_types.go
@@ -34,7 +34,7 @@ type PeeringRequestSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
-	ClusterID         string              `json:"clusterID"`
+	ClusterIdentity   ClusterIdentity     `json:"clusterIdentity"`
 	Namespace         string              `json:"namespace"`
 	KubeConfigRef     *v1.ObjectReference `json:"kubeConfigRef,omitempty"`
 	OriginClusterSets OriginClusterSets   `json:"originClusterSets"`

--- a/deployments/liqo_chart/crds/config.liqo.io_clusterconfigs.yaml
+++ b/deployments/liqo_chart/crds/config.liqo.io_clusterconfigs.yaml
@@ -120,6 +120,8 @@ spec:
                   type: boolean
                 autojoinUntrusted:
                   type: boolean
+                clusterName:
+                  type: string
                 domain:
                   type: string
                 enableAdvertisement:

--- a/deployments/liqo_chart/crds/foreign-cluster-crd.yaml
+++ b/deployments/liqo_chart/crds/foreign-cluster-crd.yaml
@@ -34,9 +34,18 @@ spec:
           type: object
         spec:
           properties:
-            clusterID:
-              type: string
-              description: Foreign Cluster ID
+            clusterIdentity:
+              type: object
+              description: Foreign Cluster Identity
+              properties:
+                clusterID:
+                  type: string
+                  description: Foreign Cluster ID, this is a unique identifier of that cluster
+                clusterName:
+                  type: string
+                  description: Foreign Cluster Name to be shown in GUIs
+              required:
+                - clusterID
             namespace:
               type: string
               description: Namespace where Liqo is deployed
@@ -60,6 +69,7 @@ spec:
             - join
             - discoveryType
             - allowUntrustedCA
+            - clusterIdentity
           type: object
         status:
           properties:

--- a/deployments/liqo_chart/crds/peering-request-crd.yaml
+++ b/deployments/liqo_chart/crds/peering-request-crd.yaml
@@ -34,9 +34,18 @@ spec:
         spec:
           type: object
           properties:
-            clusterID:
-              type: string
-              description: Cluster ID
+            clusterIdentity:
+              type: object
+              description: Foreign Cluster Identity
+              properties:
+                clusterID:
+                  type: string
+                  description: Foreign Cluster ID, this is a unique identifier of that cluster
+                clusterName:
+                  type: string
+                  description: Foreign Cluster Name to be shown in GUIs
+              required:
+                - clusterID
             namespace:
               type: string
               description: Namespace where Liqo is deployed
@@ -53,7 +62,7 @@ spec:
               required:
                 - allowUntrustedCA
           required:
-            - clusterID
+            - clusterIdentity
         status:
           description: PeeringRequestStatus defines the observed state of PeeringRequest
           properties:

--- a/deployments/liqo_chart/templates/clusterconfig.yaml
+++ b/deployments/liqo_chart/templates/clusterconfig.yaml
@@ -15,6 +15,7 @@ spec:
     keepaliveThreshold: 3
     keepaliveRetryTime: 20
   discoveryConfig:
+    clusterName: {{ .Values.clusterName}}
     autojoin: true
     autojoinUntrusted: true
     domain: local.

--- a/deployments/liqo_chart/values.yaml
+++ b/deployments/liqo_chart/values.yaml
@@ -3,6 +3,7 @@
 # Declare variables to be passed into your templates.
 
 clusterID: "lab9"
+clusterName: "Lab9Cluster"
 podCIDR: "10.244.0.0/16"
 serviceCIDR: "10.96.0.0/12"
 

--- a/install.sh
+++ b/install.sh
@@ -40,6 +40,7 @@ function print_help()
    echo "   GATEWAY_IP: the public IP that will be used by LIQO to establish the interconnection with other clusters"
    echo "   NAMESPACE: the namespace where LIQO control plane resources will be created"
    echo "   DASHBOARD_INGRESS: the name of the host you want to assign to the LIQO dashboard"
+   echo "   CLUSTER_NAME: the nickname for your cluster"
 }
 
 function set_gateway_node() {
@@ -110,6 +111,7 @@ function install() {
   GATEWAY_IP=$(set_gateway_node)
   echo "[PRE-INSTALL]: GATEWAY_IP is set to: $GATEWAY_IP"
 
+
   POD_CIDR_COMMAND='kubectl cluster-info dump | grep -m 1 -Po "(?<=--cluster-cidr=)[0-9.\/]+"'
   set_variable_from_command POD_CIDR "${POD_CIDR_COMMAND}" "[ERROR]: Unable to find POD_CIDR"
   SERVICE_CIDR_COMMAND='kubectl cluster-info dump | grep -m 1 -Po "(?<=--service-cluster-ip-range=)[0-9.\/]+"'
@@ -117,13 +119,14 @@ function install() {
   NAMESPACE=${NAMESPACE:-$NAMESPACE_DEFAULT}
   LIQO_SUFFIX=${LIQO_SUFFIX:-$LIQO_SUFFIX_DEFAULT}
   LIQO_VERSION=${LIQO_VERSION:-$LIQO_VERSION_DEFAULT}
+  CLUSTER_NAME=${CLUSTER_NAME:-$CLUSTER_NAME_DEFAULT}
 
-
+  echo "[PRE-INSTALL]: CLUSTER_NAME is set to: $CLUSTER_NAME"
 
   #Wait for the installation to complete
   kubectl create ns "$NAMESPACE" || true
   $HELM_PATH dependency update "$TMPDIR"/liqo/deployments/liqo_chart
-  $HELM_PATH install liqo -n "$NAMESPACE" "$TMPDIR/liqo/deployments/liqo_chart" --set podCIDR="$POD_CIDR" --set serviceCIDR="$SERVICE_CIDR" \
+  $HELM_PATH install liqo -n "$NAMESPACE" "$TMPDIR/liqo/deployments/liqo_chart" --set podCIDR="$POD_CIDR" --set serviceCIDR="$SERVICE_CIDR" --set clusterName="$CLUSTER_NAME"\
     --set gatewayIP="$GATEWAY_IP" --set global.suffix="$LIQO_SUFFIX" --set global.version="$LIQO_VERSION" --set global.dashboard_ingress="$DASHBOARD_INGRESS"
   echo "[INSTALL]: Installing LIQO on your cluster..."
 }
@@ -184,6 +187,7 @@ NAMESPACE_DEFAULT="liqo"
 # - Export LIQO_VERSION to the id of your commit
 LIQO_VERSION_DEFAULT="latest"
 LIQO_SUFFIX_DEFAULT=""
+CLUSTER_NAME_DEFAULT="LiqoCluster"$RANDOM
 
 # Check necessary commands to be installed before installing Liqo
 commands="curl kubectl"

--- a/internal/crdReplicator/crdReplicator-operator.go
+++ b/internal/crdReplicator/crdReplicator-operator.go
@@ -78,7 +78,7 @@ func (d *CRDReplicatorReconciler) Reconcile(req ctrl.Request) (ctrl.Result, erro
 		klog.Errorf("%s -> resource %s not present, probably deleted: %s", d.ClusterID, req.NamespacedName, err)
 		return ctrl.Result{}, nil
 	}
-	remoteClusterID := fc.Spec.ClusterID
+	remoteClusterID := fc.Spec.ClusterIdentity.ClusterID
 	//check if the client already exists
 	//check if the dynamic dynamic client and informer factory exists
 	_, dynClientOk := d.RemoteDynClients[remoteClusterID]

--- a/internal/discovery/discovery-config.go
+++ b/internal/discovery/discovery-config.go
@@ -78,6 +78,11 @@ func (discovery *DiscoveryCtrl) handleConfiguration(config configv1alpha1.Discov
 		discovery.Config = &config
 	} else {
 		// other iterations
+		if discovery.Config.ClusterName != config.ClusterName {
+			discovery.Config.ClusterName = config.ClusterName
+			reloadClient = true
+			reloadServer = true
+		}
 		if discovery.Config.Domain != config.Domain {
 			discovery.Config.Domain = config.Domain
 			reloadServer = true

--- a/internal/discovery/foreign-cluster-operator/foreign-cluster-controller.go
+++ b/internal/discovery/foreign-cluster-operator/foreign-cluster-controller.go
@@ -90,7 +90,7 @@ func (r *ForeignClusterReconciler) Reconcile(req ctrl.Request) (ctrl.Result, err
 	// set cluster-id label to easy retrieve ForeignClusters by ClusterId,
 	// if it is added manually, the name maybe not coincide with ClusterId
 	if fc.ObjectMeta.Labels["cluster-id"] == "" {
-		fc.ObjectMeta.Labels["cluster-id"] = fc.Spec.ClusterID
+		fc.ObjectMeta.Labels["cluster-id"] = fc.Spec.ClusterIdentity.ClusterID
 		requireUpdate = true
 	}
 
@@ -434,7 +434,10 @@ func (r *ForeignClusterReconciler) createPeeringRequestIfNotExists(clusterID str
 					Name: localClusterID,
 				},
 				Spec: discoveryv1alpha1.PeeringRequestSpec{
-					ClusterID:         localClusterID,
+					ClusterIdentity: discoveryv1alpha1.ClusterIdentity{
+						ClusterID:   localClusterID,
+						ClusterName: r.DiscoveryCtrl.Config.ClusterName,
+					},
 					Namespace:         r.Namespace,
 					KubeConfigRef:     nil,
 					OriginClusterSets: r.getOriginClusterSets(),

--- a/internal/discovery/foreign.go
+++ b/internal/discovery/foreign.go
@@ -84,7 +84,7 @@ func (discovery *DiscoveryCtrl) UpdateTtl(txts []*TxtData) error {
 		// find the ones that are not in the last retrieved list on LAN
 		found := false
 		for _, txt := range txts {
-			if txt.ID == fc.Spec.ClusterID {
+			if txt.ID == fc.Spec.ClusterIdentity.ClusterID {
 				found = true
 				// if cluster TTL was decreased, reset it to default value
 				if fc.Status.Ttl != 3 {
@@ -127,7 +127,10 @@ func (discovery *DiscoveryCtrl) createForeign(txtData *TxtData, sd *v1alpha1.Sea
 			Name: txtData.ID,
 		},
 		Spec: v1alpha1.ForeignClusterSpec{
-			ClusterID:        txtData.ID,
+			ClusterIdentity: v1alpha1.ClusterIdentity{
+				ClusterID:   txtData.ID,
+				ClusterName: txtData.Name,
+			},
 			Namespace:        txtData.Namespace,
 			ApiUrl:           txtData.ApiUrl,
 			DiscoveryType:    discoveryType,

--- a/internal/discovery/txtData.go
+++ b/internal/discovery/txtData.go
@@ -11,6 +11,7 @@ import (
 
 type TxtData struct {
 	ID               string
+	Name             string
 	Namespace        string
 	AllowUntrustedCA bool
 	ApiUrl           string
@@ -22,6 +23,9 @@ func (txtData TxtData) Encode() ([]string, error) {
 		"namespace=" + txtData.Namespace,
 		"untrusted-ca=" + txtData.GetAllowUntrustedCA(),
 		"url=" + txtData.ApiUrl,
+	}
+	if txtData.Name != "" {
+		res = append(res, "name="+txtData.Name)
 	}
 	return res, nil
 }
@@ -41,6 +45,8 @@ func Decode(address string, port string, data []string) (*TxtData, error) {
 			res.ID = d[len("id="):]
 		} else if strings.HasPrefix(d, "namespace=") {
 			res.Namespace = d[len("namespace="):]
+		} else if strings.HasPrefix(d, "name=") {
+			res.Name = d[len("name="):]
 		} else if strings.HasPrefix(d, "untrusted-ca=") {
 			res.AllowUntrustedCA = d[len("untrusted-ca="):] == "true"
 		} else if strings.HasPrefix(d, "url=") {
@@ -64,12 +70,16 @@ func (discovery *DiscoveryCtrl) GetTxtData() (*TxtData, error) {
 		klog.Error(err)
 		return nil, err
 	}
-	return &TxtData{
+	txtData := &TxtData{
 		ID:               discovery.ClusterId.GetClusterID(),
 		Namespace:        discovery.Namespace,
 		AllowUntrustedCA: discovery.Config.AllowUntrustedCA,
 		ApiUrl:           apiUrl,
-	}, nil
+	}
+	if discovery.Config.ClusterName != "" {
+		txtData.Name = discovery.Config.ClusterName
+	}
+	return txtData, nil
 }
 
 // get API Server Url for this cluster

--- a/internal/liqonet/tunnelEndpointCreator-operator.go
+++ b/internal/liqonet/tunnelEndpointCreator-operator.go
@@ -489,9 +489,9 @@ func (r *TunnelEndpointCreator) ForeignClusterHandlerAdd(obj interface{}) {
 		return
 	}
 	if fc.Status.Incoming.Joined || fc.Status.Outgoing.Joined {
-		_ = r.createNetConfig(fc.Spec.ClusterID)
+		_ = r.createNetConfig(fc.Spec.ClusterIdentity.ClusterID)
 	} else if !fc.Status.Incoming.Joined && !fc.Status.Outgoing.Joined {
-		_ = r.deleteNetConfig(fc.Spec.ClusterID)
+		_ = r.deleteNetConfig(fc.Spec.ClusterIdentity.ClusterID)
 	}
 }
 
@@ -511,7 +511,7 @@ func (r *TunnelEndpointCreator) ForeignClusterHandlerDelete(obj interface{}) {
 		klog.Errorf("an error occurred while converting resource %s of type %s to typed object: %s", objUnstruct.GetName(), objUnstruct.GetKind(), err)
 		return
 	}
-	_ = r.deleteNetConfig(fc.Spec.ClusterID)
+	_ = r.deleteNetConfig(fc.Spec.ClusterIdentity.ClusterID)
 }
 
 func (r *TunnelEndpointCreator) GetTunnelEndpoint(name string) (*netv1alpha1.TunnelEndpoint, bool, error) {

--- a/internal/peering-request-operator/foreign-cluster.go
+++ b/internal/peering-request-operator/foreign-cluster.go
@@ -12,7 +12,7 @@ import (
 
 func (r *PeeringRequestReconciler) UpdateForeignCluster(pr *v1alpha1.PeeringRequest) error {
 	tmp, err := r.crdClient.Resource("foreignclusters").List(metav1.ListOptions{
-		LabelSelector: "cluster-id=" + pr.Spec.ClusterID,
+		LabelSelector: "cluster-id=" + pr.Spec.ClusterIdentity.ClusterID,
 	})
 	if err != nil {
 		klog.Error(err, err.Error())
@@ -73,10 +73,10 @@ func (r *PeeringRequestReconciler) createForeignCluster(pr *v1alpha1.PeeringRequ
 
 	fc := &v1alpha1.ForeignCluster{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: pr.Spec.ClusterID,
+			Name: pr.Spec.ClusterIdentity.ClusterID,
 		},
 		Spec: v1alpha1.ForeignClusterSpec{
-			ClusterID:        pr.Spec.ClusterID,
+			ClusterIdentity:  pr.Spec.ClusterIdentity,
 			Namespace:        pr.Spec.Namespace,
 			Join:             false,
 			ApiUrl:           cnf.Host,

--- a/test/unit/advertisement-operator/remote-watcher_test.go
+++ b/test/unit/advertisement-operator/remote-watcher_test.go
@@ -21,7 +21,9 @@ func TestWatchAdvertisementAcceptance(t *testing.T) {
 			Name: b.PeeringRequestName,
 		},
 		Spec: discoveryv1alpha1.PeeringRequestSpec{
-			ClusterID:     b.PeeringRequestName,
+			ClusterIdentity: discoveryv1alpha1.ClusterIdentity{
+				ClusterID: b.PeeringRequestName,
+			},
 			Namespace:     "test",
 			KubeConfigRef: nil,
 		},

--- a/test/unit/crdReplicator/crdReplicator-operator_test.go
+++ b/test/unit/crdReplicator/crdReplicator-operator_test.go
@@ -86,7 +86,9 @@ func getForeignClusterResource() *unstructured.Unstructured {
 				"labels": map[string]string{},
 			},
 			"spec": map[string]interface{}{
-				"clusterID":        "foreign-cluster",
+				"clusterIdentity": map[string]interface{}{
+					"clusterID": "foreign-cluster",
+				},
 				"join":             true,
 				"namespace":        "default",
 				"apiUrl":           "https://192.168.2.100:6443",

--- a/test/unit/discovery/discovery_test.go
+++ b/test/unit/discovery/discovery_test.go
@@ -90,7 +90,9 @@ func testClient(t *testing.T) {
 			Name: "fc-test",
 		},
 		Spec: v1alpha1.ForeignClusterSpec{
-			ClusterID:     "test-cluster",
+			ClusterIdentity: v1alpha1.ClusterIdentity{
+				ClusterID: "test-cluster",
+			},
 			Namespace:     "default",
 			Join:          false,
 			ApiUrl:        serverCluster.cfg.Host,
@@ -310,7 +312,9 @@ func testBidirectionalJoin(t *testing.T) {
 			Name: "server-cluster",
 		},
 		Spec: v1alpha1.ForeignClusterSpec{
-			ClusterID:     "server-cluster",
+			ClusterIdentity: v1alpha1.ClusterIdentity{
+				ClusterID: "server-cluster",
+			},
 			Namespace:     "default",
 			Join:          true,
 			ApiUrl:        serverCluster.cfg.Host,
@@ -365,7 +369,7 @@ func testMergeClusters(t *testing.T) {
 	assert.Equal(t, ok, true)
 
 	txt := &discovery.TxtData{
-		ID:               fc.Spec.ClusterID,
+		ID:               fc.Spec.ClusterIdentity.ClusterID,
 		Namespace:        fc.Spec.Namespace,
 		ApiUrl:           strings.Replace(fc.Spec.ApiUrl, "127.0.0.1", "127.0.0.2", -1),
 		AllowUntrustedCA: true,

--- a/test/unit/discovery/mdns_test.go
+++ b/test/unit/discovery/mdns_test.go
@@ -25,6 +25,7 @@ func TestMdns(t *testing.T) {
 func testTxtData(t *testing.T) {
 	txtData = discovery.TxtData{
 		ID:               clientCluster.clusterId.GetClusterID(),
+		Name:             "Cluster 1",
 		Namespace:        "default",
 		ApiUrl:           "https://" + serverCluster.cfg.Host,
 		AllowUntrustedCA: true,
@@ -68,6 +69,7 @@ func testForeignClusterCreation(t *testing.T) {
 	txts := []*discovery.TxtData{
 		{
 			ID:               "test",
+			Name:             "Test Cluster 1",
 			Namespace:        "default",
 			ApiUrl:           "http://" + serverCluster.cfg.Host,
 			AllowUntrustedCA: true,
@@ -91,6 +93,8 @@ func testForeignClusterCreation(t *testing.T) {
 	assert.Equal(t, ok, true)
 	assert.Equal(t, fc.Spec.ApiUrl, "http://"+serverCluster.cfg.Host, "ApiUrl doesn't match the specified one")
 	assert.Equal(t, fc.Spec.Namespace, "default", "Foreign Namesapce doesn't match the specified one")
+	assert.Equal(t, fc.Spec.ClusterIdentity.ClusterID, txts[0].ID)
+	assert.Equal(t, fc.Spec.ClusterIdentity.ClusterName, txts[0].Name)
 }
 
 // ------
@@ -101,7 +105,9 @@ func testTtl(t *testing.T) {
 			Name: "fc-test-ttl",
 		},
 		Spec: v1alpha1.ForeignClusterSpec{
-			ClusterID:     "test-cluster-ttl",
+			ClusterIdentity: v1alpha1.ClusterIdentity{
+				ClusterID: "test-cluster-ttl",
+			},
 			Namespace:     "default",
 			Join:          false,
 			ApiUrl:        serverCluster.cfg.Host,
@@ -135,7 +141,7 @@ func testTtl(t *testing.T) {
 
 	txts := []*discovery.TxtData{
 		{
-			ID:               fc.Spec.ClusterID,
+			ID:               fc.Spec.ClusterIdentity.ClusterID,
 			Namespace:        "default",
 			ApiUrl:           "",
 			AllowUntrustedCA: true,

--- a/test/unit/liqonet/tunnelEndpointCreator_test.go
+++ b/test/unit/liqonet/tunnelEndpointCreator_test.go
@@ -321,7 +321,9 @@ func TestCreateNetConfigFromForeignClusterOutgoingJoined(t *testing.T) {
 			Name: "foreigncluster-testing",
 		},
 		Spec: discoveryv1alpha1.ForeignClusterSpec{
-			ClusterID:        "testing",
+			ClusterIdentity: discoveryv1alpha1.ClusterIdentity{
+				ClusterID: "testing",
+			},
 			Namespace:        "",
 			Join:             false,
 			ApiUrl:           "",
@@ -363,15 +365,15 @@ func TestCreateNetConfigFromForeignClusterOutgoingJoined(t *testing.T) {
 			netConfig := &netv1alpha1.NetworkConfig{}
 			err = tec.Get(context.TODO(), types.NamespacedName{
 				Namespace: fc.Namespace,
-				Name:      controller.NetConfigNamePrefix + fc.Spec.ClusterID,
+				Name:      controller.NetConfigNamePrefix + fc.Spec.ClusterIdentity.ClusterID,
 			}, netConfig)
 			assert.Nil(t, err, "error should be nil")
-			assert.Equal(t, fc.Spec.ClusterID, netConfig.Spec.ClusterID, "should be equal")
+			assert.Equal(t, fc.Spec.ClusterIdentity.ClusterID, netConfig.Spec.ClusterID, "should be equal")
 			assert.Equal(t, tec.PodCIDR, netConfig.Spec.PodCIDR, "should be equal")
 			assert.Equal(t, tec.GatewayIP, netConfig.Spec.TunnelPublicIP, "should be equal")
 			labels := netConfig.GetLabels()
 			assert.Equal(t, "true", labels[crdReplicator.LocalLabelSelector])
-			assert.Equal(t, fc.Spec.ClusterID, labels[crdReplicator.DestinationLabel])
+			assert.Equal(t, fc.Spec.ClusterIdentity.ClusterID, labels[crdReplicator.DestinationLabel])
 			err = tec.Delete(context.TODO(), netConfig)
 			assert.Nil(t, err)
 			err = tec.DynClient.Resource(controller.ForeignClusterGVR).Delete(context.TODO(), fc.Name, metav1.DeleteOptions{})
@@ -380,7 +382,7 @@ func TestCreateNetConfigFromForeignClusterOutgoingJoined(t *testing.T) {
 			//check that the netconfig has been deleted
 			err = tec.Get(context.TODO(), types.NamespacedName{
 				Namespace: fc.Namespace,
-				Name:      controller.NetConfigNamePrefix + fc.Spec.ClusterID,
+				Name:      controller.NetConfigNamePrefix + fc.Spec.ClusterIdentity.ClusterID,
 			}, netConfig)
 			assert.True(t, apierrors.IsNotFound(err))
 		} else {
@@ -393,7 +395,7 @@ func TestCreateNetConfigFromForeignClusterOutgoingJoined(t *testing.T) {
 			netConfig := &netv1alpha1.NetworkConfig{}
 			err = tec.Get(context.TODO(), types.NamespacedName{
 				Namespace: fc.Namespace,
-				Name:      controller.NetConfigNamePrefix + fc.Spec.ClusterID,
+				Name:      controller.NetConfigNamePrefix + fc.Spec.ClusterIdentity.ClusterID,
 			}, netConfig)
 			assert.True(t, apierrors.IsNotFound(err))
 			err = tec.DynClient.Resource(controller.ForeignClusterGVR).Delete(context.TODO(), fc.Name, metav1.DeleteOptions{})


### PR DESCRIPTION
# Description

This PR adds a "nice" name for our cluster. This can be set in the `ClusterConfig` CR

The remote clusters that will discover us will found our name in ForeignCluster in `Spec.ClusterIdentity.ClusterName`

If the `ClusterName` is updated in the ClusterConfig, the `ForeignCluster` on the already peered remote clusters is not updated, but the future clusters will discover it with the new name.