### PR TITLE
Fixing a bug in IPAM module

### DIFF
--- a/cmd/liqonet/main.go
+++ b/cmd/liqonet/main.go
@@ -225,7 +225,6 @@ func main() {
 				FreeSubnets:        make(map[string]*net.IPNet),
 				SubnetPerCluster:   make(map[string]*net.IPNet),
 				ConflictingSubnets: make(map[string]*net.IPNet),
-				Log:                ctrl.Log.WithName("IPAM"),
 			},
 			RetryTimeout: 30 * time.Second,
 		}

--- a/pkg/liqonet/ipam_test.go
+++ b/pkg/liqonet/ipam_test.go
@@ -1,0 +1,130 @@
+package liqonet
+
+import (
+	"github.com/stretchr/testify/assert"
+	"net"
+	"testing"
+)
+
+func TestIpManager_GetNewSubnetPerCluster(t *testing.T) {
+	//init ipam
+	ipam := IpManager{
+		UsedSubnets:        make(map[string]*net.IPNet),
+		FreeSubnets:        make(map[string]*net.IPNet),
+		ConflictingSubnets: make(map[string]*net.IPNet),
+		SubnetPerCluster:   make(map[string]*net.IPNet),
+	}
+	err := ipam.Init()
+	assert.Nil(t, err, "should be nil")
+	//test without conflicting
+	//expect the same net to be returned and error to be nil
+	clusterID := "test1"
+	_, clusterSubnet, err := net.ParseCIDR("10.1.0.0/16")
+	assert.Nil(t, err, "error should be nil")
+	newSubnet, err := ipam.GetNewSubnetPerCluster(clusterSubnet, clusterID)
+	assert.Nil(t, err, "error should be nil")
+	assert.Equal(t, clusterSubnet.String(), newSubnet.String(), "should be equal")
+	_, exists := ipam.UsedSubnets[newSubnet.String()]
+	assert.True(t, exists)
+	reserved, exists := ipam.SubnetPerCluster[clusterID]
+	assert.True(t, exists)
+	assert.Equal(t, newSubnet, reserved, "should be equal")
+	overlap := VerifyNoOverlap(ipam.FreeSubnets, newSubnet)
+	assert.False(t, overlap, "should be true")
+	overlap = VerifyNoOverlap(ipam.FreeSubnets, clusterSubnet)
+	assert.False(t, overlap, "should be true")
+
+	//test2 with conflicting subnets
+	//expecting a new net to be returned and error to be nil
+	clusterID = "test2"
+	_, clusterSubnet, err = net.ParseCIDR("10.1.0.0/16")
+	assert.Nil(t, err, "error should be nil")
+	newSubnet, err = ipam.GetNewSubnetPerCluster(clusterSubnet, clusterID)
+	assert.Nil(t, err, "error should be nil")
+	assert.NotEqual(t, clusterSubnet.String(), newSubnet.String(), "should be different")
+	_, exists = ipam.UsedSubnets[newSubnet.String()]
+	assert.True(t, exists)
+	reserved, exists = ipam.SubnetPerCluster[clusterID]
+	assert.True(t, exists)
+	assert.Equal(t, newSubnet.String(), reserved.String(), "should be equal")
+	overlap = VerifyNoOverlap(ipam.FreeSubnets, newSubnet)
+	assert.False(t, overlap, "should be false")
+	overlap = VerifyNoOverlap(ipam.FreeSubnets, clusterSubnet)
+	assert.False(t, overlap, "should be false")
+
+	//test3 requiring a new address for a cluster that we already have processed
+	//expecting to receive the already allocated address and error to be nil
+	alreadyAssignedSubnet, err := ipam.GetNewSubnetPerCluster(clusterSubnet, clusterID)
+	assert.Nil(t, err, "error should be nil")
+	//check that is equal to the one assigned before
+	assert.Equal(t, newSubnet.String(), alreadyAssignedSubnet.String(), "should be equal")
+	assert.NotEqual(t, clusterSubnet.String(), alreadyAssignedSubnet.String(), "should be different")
+	_, exists = ipam.UsedSubnets[alreadyAssignedSubnet.String()]
+	assert.True(t, exists)
+	reserved, exists = ipam.SubnetPerCluster[clusterID]
+	assert.True(t, exists)
+	assert.Equal(t, alreadyAssignedSubnet.String(), reserved.String(), "should be equal")
+	overlap = VerifyNoOverlap(ipam.FreeSubnets, alreadyAssignedSubnet)
+	assert.False(t, overlap, "should be false")
+	overlap = VerifyNoOverlap(ipam.FreeSubnets, clusterSubnet)
+	assert.False(t, overlap, "should be false")
+
+	//test4 no more subnets available in the free pool
+	//the cluster subnet does not need to be NATed
+	//expect the same subnet to be returned and error to be nil
+	clusterID = "test4"
+	_, clusterSubnet, err = net.ParseCIDR("10.3.0.0/16")
+	assert.Nil(t, err, "should be nil")
+	ipam.FreeSubnets = map[string]*net.IPNet{}
+	newSubnet, err = ipam.GetNewSubnetPerCluster(clusterSubnet, clusterID)
+	assert.Nil(t, err, "error should be nil")
+	assert.Equal(t, clusterSubnet.String(), newSubnet.String(), "should be equal")
+	_, exists = ipam.UsedSubnets[newSubnet.String()]
+	assert.True(t, exists)
+	reserved, exists = ipam.SubnetPerCluster[clusterID]
+	assert.True(t, exists)
+	assert.Equal(t, newSubnet, reserved, "should be equal")
+
+	//test5 no more subnets available in the free pool
+	//the cluster subnet needs to be NATed
+	//expect subnet to be nil and an error to be returned
+	clusterID = "test5"
+	_, clusterSubnet, err = net.ParseCIDR("10.3.0.0/16")
+	assert.Nil(t, err, "should be nil")
+	ipam.FreeSubnets = map[string]*net.IPNet{}
+	_, err = ipam.GetNewSubnetPerCluster(clusterSubnet, clusterID)
+	assert.NotNil(t, err, "should be not nil")
+}
+
+func TestIpManager_RemoveReservedSubnet(t *testing.T) {
+	//init ipam
+	ipam := IpManager{
+		UsedSubnets:        make(map[string]*net.IPNet),
+		FreeSubnets:        make(map[string]*net.IPNet),
+		ConflictingSubnets: make(map[string]*net.IPNet),
+		SubnetPerCluster:   make(map[string]*net.IPNet),
+	}
+	err := ipam.Init()
+	assert.Nil(t, err, "should be nil")
+
+	//test1 we reserve a subnet for a peering cluster
+	//expecting the reserved subnet to be made again available
+	clusterID := "test1"
+	_, clusterSubnet, err := net.ParseCIDR("10.1.0.0/16")
+	assert.Nil(t, err, "error should be nil")
+	newSubnet, err := ipam.GetNewSubnetPerCluster(clusterSubnet, clusterID)
+	assert.Nil(t, err, "error should be nil")
+	ipam.RemoveReservedSubnet(clusterID)
+	_, exists := ipam.UsedSubnets[newSubnet.String()]
+	assert.False(t, exists)
+	_, exists = ipam.SubnetPerCluster[clusterID]
+	assert.False(t, exists)
+
+	//test2 we try to free a reserved subnet for a cluster that we did not processed
+	clusterID = "test2"
+	ipam.RemoveReservedSubnet(clusterID)
+	_, exists = ipam.UsedSubnets[newSubnet.String()]
+	assert.False(t, exists)
+	_, exists = ipam.SubnetPerCluster[clusterID]
+	assert.False(t, exists)
+}

--- a/test/unit/liqonet/tunnelEndpointCreator_test.go
+++ b/test/unit/liqonet/tunnelEndpointCreator_test.go
@@ -476,21 +476,6 @@ func TestNetConfigProcessing(t *testing.T) {
 	assert.Equal(t, "Ready", tep.Status.Phase)
 
 	//test4
-	//we change some fields in the remote netConfig status
-	//expect that the tunnelEndpoint is updated
-	err = tec.Get(context.Background(), types.NamespacedName{Name: netConfig1.Name}, netConfig1)
-	assert.Nil(t, err)
-	newNATPodCIDR := "10.100.0.0/16"
-	netConfig1.Status.PodCIDRNAT = newNATPodCIDR
-	err = tec.Status().Update(context.Background(), netConfig1)
-	assert.Nil(t, err)
-	time.Sleep(10 * time.Second)
-	tep, found, err = tec.GetTunnelEndpoint(tepName)
-	assert.True(t, found)
-	assert.Nil(t, err)
-	assert.Equal(t, newNATPodCIDR, tep.Status.RemoteRemappedPodCIDR)
-
-	//test5
 	//we change some fields on the remote netConfig spec and some on the local netConfig status
 	//expect that the tunnelEndpoint is updated
 	err = tec.Get(context.Background(), types.NamespacedName{Name: netConfig1.Name}, netConfig1)
@@ -501,7 +486,7 @@ func TestNetConfigProcessing(t *testing.T) {
 	assert.Nil(t, err)
 	err = tec.Get(context.Background(), types.NamespacedName{Name: netConfig2.Name}, netConfig2)
 	assert.Nil(t, err)
-	newNATPodCIDR = "10.300.0.0/16"
+	newNATPodCIDR := "10.300.0.0/16"
 	netConfig2.Status.PodCIDRNAT = newNATPodCIDR
 	err = tec.Status().Update(context.Background(), netConfig2)
 	assert.Nil(t, err)

--- a/test/unit/liqonet/tunnelEndpointCreator_test.go
+++ b/test/unit/liqonet/tunnelEndpointCreator_test.go
@@ -39,7 +39,6 @@ func getTunnelEndpointCreator() *controller.TunnelEndpointCreator {
 			FreeSubnets:        make(map[string]*net.IPNet),
 			ConflictingSubnets: make(map[string]*net.IPNet),
 			SubnetPerCluster:   nil,
-			Log:                nil,
 		},
 		Mutex:        sync.Mutex{},
 		IsConfigured: false,
@@ -85,7 +84,6 @@ func setupTunnelEndpointCreatorOperator() error {
 			FreeSubnets:        make(map[string]*net.IPNet),
 			SubnetPerCluster:   make(map[string]*net.IPNet),
 			ConflictingSubnets: make(map[string]*net.IPNet),
-			Log:                ctrl.Log.WithName("IPAM"),
 		},
 		RetryTimeout: 30 * time.Second,
 	}


### PR DESCRIPTION


# Description

This PR fixes a bug which caused the IPAM module not to free reserved subnets for a peering cluster when it unjoins.

Fixes #(issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

Unit tests for the IPAM module
