### PR TITLE
Tunnel-Operator switching to klog

### DIFF
--- a/cmd/liqonet/main.go
+++ b/cmd/liqonet/main.go
@@ -176,7 +176,6 @@ func main() {
 	case "tunnel-operator":
 		r := &liqonetOperators.TunnelController{
 			Client:                       mgr.GetClient(),
-			Log:                          ctrl.Log.WithName("liqonetOperators").WithName("TunnelEndpoint"),
 			Scheme:                       mgr.GetScheme(),
 			Recorder:                     mgr.GetEventRecorderFor("tunnel-operator"),
 			TunnelIFacesPerRemoteCluster: make(map[string]int),


### PR DESCRIPTION
# Description

This PR ditches the  logf.ZapLogger and uses klog

Fixes #(issue)
#271 
# How Has This Been Tested?

Deploying liqo in two clusters and checking that tunnel operator does not crashes due to logging issues.

