### PR TITLE
Broadcaster periodic creation of secret

### DIFF
--- a/test/unit/advertisement-operator/broadcaster_test.go
+++ b/test/unit/advertisement-operator/broadcaster_test.go
@@ -301,7 +301,7 @@ func TestGetResourceForAdv(t *testing.T) {
 	assert.Equal(t, images, images2)
 }
 
-func TestSendAdvertisementCreation(t *testing.T) {
+func TestSendAdvertisement(t *testing.T) {
 	config := createFakeClusterConfig()
 	b := createBroadcaster(config.Spec)
 	_, err := b.RemoteClient.Client().CoreV1().Secrets(b.KubeconfigSecretForForeign.Namespace).Create(context.TODO(), b.KubeconfigSecretForForeign, metav1.CreateOptions{})
@@ -319,6 +319,20 @@ func TestSendAdvertisementCreation(t *testing.T) {
 	adv3, err := b.SendAdvertisementToForeignCluster(adv)
 	assert.Nil(t, err)
 	assert.Equal(t, adv.Spec.ResourceQuota.Hard.Cpu().Value(), adv3.Spec.ResourceQuota.Hard.Cpu().Value())
+}
+
+func TestSendSecret(t *testing.T) {
+	config := createFakeClusterConfig()
+	b := createBroadcaster(config.Spec)
+	sec, err := b.SendSecretToForeignCluster(b.KubeconfigSecretForForeign)
+	assert.Nil(t, err)
+	assert.Equal(t, b.KubeconfigSecretForForeign, sec)
+
+	// update adv on foreign cluster
+	sec.StringData = nil
+	sec2, err := b.SendSecretToForeignCluster(sec)
+	assert.Nil(t, err)
+	assert.Equal(t, sec.StringData, sec2.StringData)
 }
 
 func TestNotifyAdvertisementDeletion(t *testing.T) {


### PR DESCRIPTION
# Description
This PR fixes a problem in the Advertisement broadcaster.
When 2 clusters are peered, if a network error occurs the broadcaster continues to work, logging an error when trying to create the Advertisement.
If the Advertisement expires it is deleted, and the secret containing the kubeconfig for the virtualKubelet is deleted as well. However, when the connection between the clusters is re-established, the Advertisement is recreated but the secret isn't, therefore the VirtualKubelet cannot start.

Now the secret for the VirtualKubelet is periodically created (or updated) along with the Advertisement.

## Other changes
- added a backoff when the creation of Advertisement fails (to reduce the logging)
- in the Advertisement operator, when the Advertisement expires try to gracefully delete it before removing it directly