### PR TITLE
Move ClusterConfig watch to shared informer

### DIFF
--- a/api/config/v1alpha1/clusterConfigClient.go
+++ b/api/config/v1alpha1/clusterConfigClient.go
@@ -11,7 +11,7 @@ import (
 )
 
 // create a client for ClusterConfig CR using a provided kubeconfig
-func CreateClusterConfigClient(kubeconfig string) (*crdClient.CRDClient, error) {
+func CreateClusterConfigClient(kubeconfig string, watchResources bool) (*crdClient.CRDClient, error) {
 	var config *rest.Config
 	var err error
 
@@ -31,20 +31,22 @@ func CreateClusterConfigClient(kubeconfig string) (*crdClient.CRDClient, error) 
 		return nil, err
 	}
 
-	store, stop, err := crdClient.WatchResources(clientSet,
-		"clusterconfigs",
-		"",
-		0,
-		cache.ResourceEventHandlerFuncs{},
-		metav1.ListOptions{})
+	if watchResources {
+		store, stop, err := crdClient.WatchResources(clientSet,
+			"clusterconfigs",
+			"",
+			0,
+			cache.ResourceEventHandlerFuncs{},
+			metav1.ListOptions{})
 
-	if err != nil {
-		return nil, err
+		if err != nil {
+			return nil, err
+		}
+
+		clientSet.Store = store
+		clientSet.Stop = stop
+
 	}
-
-	clientSet.Store = store
-	clientSet.Stop = stop
-
 	return clientSet, nil
 }
 

--- a/pkg/clusterConfig/watchConfig.go
+++ b/pkg/clusterConfig/watchConfig.go
@@ -5,12 +5,14 @@ import (
 	"github.com/liqotech/liqo/pkg/crdClient"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog"
 	"os"
+	"time"
 )
 
 func WatchConfiguration(handler func(*configv1alpha1.ClusterConfig), client *crdClient.CRDClient, kubeconfigPath string) {
+	var rsyncPeriod = 1 * time.Second
 	if client == nil {
 		config, err := crdClient.NewKubeconfig(kubeconfigPath, &configv1alpha1.GroupVersion)
 		if err != nil {
@@ -25,30 +27,43 @@ func WatchConfiguration(handler func(*configv1alpha1.ClusterConfig), client *crd
 		}
 	}
 
-	watcher, err := client.Resource("clusterconfigs").Watch(metav1.ListOptions{})
-	if err != nil {
-		klog.Error(err, err.Error())
-		os.Exit(1)
-	}
+	var err error
 
-	for event := range watcher.ResultChan() {
-		configuration, ok := event.Object.(*configv1alpha1.ClusterConfig)
-		if !ok {
-			klog.Error("Received object is not a ClusterConfig")
-			continue
-		}
-		klog.V(3).Info("ClusterConfig changed")
-		switch event.Type {
-		case watch.Added, watch.Modified:
+	ehf := cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			configuration, ok := obj.(*configv1alpha1.ClusterConfig)
+			if !ok {
+				klog.Info("Error casting clusterConfig while handling creation")
+				os.Exit(1)
+			}
 			handler(configuration)
-		case watch.Deleted:
+		},
+		UpdateFunc: func(oldObj interface{}, newObj interface{}) {
+			configuration, ok := newObj.(*configv1alpha1.ClusterConfig)
+			if !ok {
+				klog.Info("Error casting clusterConfig while handling an update")
+				os.Exit(1)
+			}
+			handler(configuration)
+		},
+		DeleteFunc: func(config interface{}) {
 			klog.Error("please, do not delete ClusterConfigs")
+			configuration := config.(*configv1alpha1.ClusterConfig)
 			configuration.ResourceVersion = ""
 			_, err = client.Resource("clusterconfigs").Create(configuration, metav1.CreateOptions{})
 			if err != nil && !errors.IsAlreadyExists(err) {
 				klog.Error(err, err.Error())
-				continue
 			}
-		}
+		},
 	}
+	lo := metav1.ListOptions{}
+	client.Store, client.Stop, err = crdClient.WatchResources(client,
+		"clusterconfigs", "",
+		rsyncPeriod, ehf, lo)
+	if err != nil {
+		klog.Error(err)
+		os.Exit(1)
+	}
+	klog.Info("Cluster Config Informer initialized")
+
 }

--- a/pkg/crdClient/informer.go
+++ b/pkg/crdClient/informer.go
@@ -19,6 +19,7 @@ func WatchResources(clientSet NamespacedCRDClientInterface,
 	lo metav1.ListOptions) (cache.Store, chan struct{}, error) {
 
 	if Fake {
+
 		return WatchfakeResources(resource, handlers)
 	} else {
 		return WatchRealResources(clientSet, resource, namespace, resyncPeriod, handlers, lo)

--- a/test/unit/advertisement-operator/config-watcher_test.go
+++ b/test/unit/advertisement-operator/config-watcher_test.go
@@ -4,8 +4,13 @@ import (
 	"context"
 	configv1alpha1 "github.com/liqotech/liqo/api/config/v1alpha1"
 	advtypes "github.com/liqotech/liqo/api/sharing/v1alpha1"
+	"github.com/liqotech/liqo/pkg/crdClient"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/klog"
+	api "k8s.io/kubernetes/pkg/apis/core"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"strconv"
 	"testing"
@@ -41,31 +46,46 @@ func testModifySharingPercentage(t *testing.T) {
 	clusterConfig := createFakeClusterConfig()
 	b := createBroadcaster(clusterConfig.Spec)
 	// create fake client for configuration watcher
-	configClient, err := configv1alpha1.CreateClusterConfigClient("")
+	configClient, err := configv1alpha1.CreateClusterConfigClient("", false)
 	if err != nil {
 		t.Fatal(err)
 	}
 	// create resources on cluster
+	b.WatchConfiguration("", configClient)
+	deadline := time.Now().Add(10 * time.Second)
+
+	// Waiting for the correct initialization of the client
+	for {
+		if configClient.Store != nil || time.Now().After(deadline) {
+			break
+		} else {
+			time.Sleep(500 * time.Millisecond)
+		}
+	}
 	pNodes, vNodes, _, _, pods := createFakeResources()
 	err = createResourcesOnCluster(b.LocalClient, pNodes, vNodes, pods)
 	if err != nil {
 		t.Fatal(err)
 	}
 	// launch watcher over cluster config
-	b.WatchConfiguration("", configClient)
 	_, err = configClient.Resource("clusterconfigs").Create(&clusterConfig, v1.CreateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
-	time.Sleep(5 * time.Second)
+	err = waitEvent(configClient, "clusterconfigs", clusterConfig.Name)
+	if err != nil {
+		t.Fatal(err)
+	}
 	// create advertisement on foreign cluster
 	adv := prepareAdv(&b)
 	_, err = b.RemoteClient.Resource("advertisements").Create(&adv, v1.CreateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
-	time.Sleep(1 * time.Second)
-
+	err = waitEvent(b.RemoteClient, "advertisements", adv.Name)
+	if err != nil {
+		t.Fatal(err)
+	}
 	// get adv resources
 	cpu := adv.Spec.ResourceQuota.Hard.Cpu().Value()
 	mem := adv.Spec.ResourceQuota.Hard.Memory().Value()
@@ -75,7 +95,10 @@ func testModifySharingPercentage(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	time.Sleep(5 * time.Second)
+	err = waitEvent(b.RemoteClient, "advertisements", adv.Name)
+	if err != nil {
+		t.Fatal(err)
+	}
 	// get the new adv
 	tmp, err := b.RemoteClient.Resource("advertisements").Get(adv.Name, v1.GetOptions{})
 	if err != nil {
@@ -92,32 +115,48 @@ func testDisableBroadcaster(t *testing.T) {
 	clusterConfig := createFakeClusterConfig()
 	b := createBroadcaster(clusterConfig.Spec)
 	// create fake client for configuration watcher
-	configClient, err := configv1alpha1.CreateClusterConfigClient("")
+	configClient, err := configv1alpha1.CreateClusterConfigClient("", false)
 	if err != nil {
 		t.Fatal(err)
 	}
 	// launch watcher over cluster config
 	b.WatchConfiguration("", configClient)
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		if configClient.Store != nil || time.Now().After(deadline) {
+			break
+		} else {
+			time.Sleep(500 * time.Millisecond)
+		}
+	}
 	_, err = configClient.Resource("clusterconfigs").Create(&clusterConfig, v1.CreateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
-	time.Sleep(5 * time.Second)
+	err = waitEvent(configClient, "clusterconfigs", clusterConfig.Name)
+	if err != nil {
+		t.Fatal(err)
+	}
 	// create adv on foreign cluster
 	adv := prepareAdv(&b)
 	_, err = b.RemoteClient.Resource("advertisements").Create(&adv, v1.CreateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
-	time.Sleep(1 * time.Second)
-
+	err = waitEvent(b.RemoteClient, "advertisements", adv.Name)
+	if err != nil {
+		t.Fatal(err)
+	}
 	// disable advertisement
 	clusterConfig.Spec.AdvertisementConfig.OutgoingConfig.EnableBroadcaster = false
 	_, err = configClient.Resource("clusterconfigs").Update(clusterConfig.Name, &clusterConfig, v1.UpdateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
-	time.Sleep(5 * time.Second)
+	err = waitEvent(b.RemoteClient, "advertisements", adv.Name)
+	if err != nil {
+		t.Fatal(err)
+	}
 	// check adv status has been set
 	tmp, err := b.RemoteClient.Resource("advertisements").Get(adv.Name, v1.GetOptions{})
 	if err != nil {
@@ -125,6 +164,34 @@ func testDisableBroadcaster(t *testing.T) {
 	}
 	adv2 := tmp.(*advtypes.Advertisement)
 	assert.Equal(t, advtypes.AdvertisementDeleting, adv2.Status.AdvertisementStatus)
+}
+
+func waitEvent(client *crdClient.CRDClient, resourcetype string, name string) error {
+	var timeout int64 = 10
+	watcher, err := client.Resource(resourcetype).Watch(v1.ListOptions{
+		FieldSelector:  fields.OneTermEqualSelector(api.ObjectNameField, name).String(),
+		TimeoutSeconds: &timeout,
+	})
+	if err != nil {
+		return nil
+	}
+	for event := range watcher.ResultChan() {
+		switch event.Type {
+		case watch.Added:
+			klog.Infof("Resource of type %s Created", resourcetype)
+			return nil
+		case watch.Modified:
+			klog.Infof("Resource of type %s Modified", resourcetype)
+			return nil
+		case watch.Deleted:
+			klog.Infof("Resource of type %s Deleted", resourcetype)
+			return nil
+		default:
+			klog.Infof("Timeout Excedeed or Error Occurred watching resource of type %s", resourcetype)
+			return nil
+		}
+	}
+	return nil
 }
 
 func TestWatchAdvOperatorConfig(t *testing.T) {


### PR DESCRIPTION
# Description

This PR changes the way ClusterConfig is kept updated in watchConfig pkg moving to a shared informer.

# Testing

This PR was tested with Unit and E2E tests.
