### PR TITLE
Improve Advertisement Generation and Broadcasting

### DIFF
--- a/api/config/v1alpha1/clusterconfig_types.go
+++ b/api/config/v1alpha1/clusterconfig_types.go
@@ -114,10 +114,9 @@ type DiscoveryConfig struct {
 }
 
 type LiqonetConfig struct {
-	//this field is used by the IPAM embedded in the tunnelEndpointCreator
-	//if the podCIDR of a peering cluster needs to be NATed a new subnet from the 10.0.0.0/8
-	//is used. if subnets belonging to that range are used in the local cluster then it is necessary to
-	//declare them as a list in CIDR notation. ex. [10.1.0.0/16, 10.200.1.0/24]
+	//This field is used by the IPAM embedded in the tunnelEndpointCreator.
+	//Subnets listed in this field are excluded from the list of possible subnets used for natting POD CIDR.
+	//Add here the subnets already used in your environment as a list in CIDR notation (e.g. [10.1.0.0/16, 10.200.1.0/24]).
 	ReservedSubnets []string `json:"reservedSubnets"`
 	//the subnet used by the cluster for the pods, in CIDR notation
 	PodCIDR string `json:"podCIDR"`

--- a/deployments/liqo_chart/crds/config.liqo.io_clusterconfigs.yaml
+++ b/deployments/liqo_chart/crds/config.liqo.io_clusterconfigs.yaml
@@ -121,6 +121,8 @@ spec:
                 autojoinUntrusted:
                   type: boolean
                 clusterName:
+                  description: ClusterName is a nickname for your cluster that can
+                    be easily understood by a user
                   type: string
                 domain:
                   type: string
@@ -178,16 +180,26 @@ spec:
             liqonetConfig:
               properties:
                 podCIDR:
+                  description: the subnet used by the cluster for the pods, in CIDR
+                    notation
                   type: string
                 reservedSubnets:
-                  description: contains a list of reserved subnets in CIDR notation
-                    used by the k8s cluster like the podCIDR and ClusterCIDR
+                  description: This field is used by the IPAM embedded in the tunnelEndpointCreator.
+                    Subnets listed in this field are excluded from the list of possible
+                    subnets used for natting POD CIDR. Add here the subnets already
+                    used in your environment as a list in CIDR notation (e.g. [10.1.0.0/16,
+                    10.200.1.0/24]).
                   items:
                     type: string
                   type: array
                 serviceCIDR:
+                  description: the subnet used by the cluster for the services, in
+                    CIDR notation
                   type: string
                 vxlanNetConfig:
+                  description: the configuration for the VXLAN overlay network which
+                    handles the traffic in the local cluster destined to remote peering
+                    clusters
                   properties:
                     DeviceName:
                       type: string

--- a/internal/advertisement-operator/config-watcher.go
+++ b/internal/advertisement-operator/config-watcher.go
@@ -3,6 +3,7 @@ package advertisementOperator
 import (
 	configv1alpha1 "github.com/liqotech/liqo/api/config/v1alpha1"
 	advtypes "github.com/liqotech/liqo/api/sharing/v1alpha1"
+	"github.com/liqotech/liqo/pkg"
 	"github.com/liqotech/liqo/pkg/clusterConfig"
 	"github.com/liqotech/liqo/pkg/crdClient"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -25,7 +26,7 @@ func (b *AdvertisementBroadcaster) WatchConfiguration(kubeconfigPath string, cli
 			} else {
 				// wait for advertisement to be deleted to delete the peering request
 				for retry := 0; retry < 3; retry++ {
-					advName := "advertisement-" + b.HomeClusterId
+					advName := pkg.AdvertisementPrefix + b.HomeClusterId
 					if _, err := b.RemoteClient.Resource("advertisements").Get(advName, metav1.GetOptions{}); err != nil && k8serrors.IsNotFound(err) {
 						break
 					}

--- a/internal/kubernetes/test/const.go
+++ b/internal/kubernetes/test/const.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	controllers "github.com/liqotech/liqo/internal/liqonet"
+	"github.com/liqotech/liqo/pkg"
 	"time"
 )
 
@@ -10,7 +11,7 @@ const (
 	NattedNamespace       = Namespace + "-" + HomeClusterId
 	HostName              = "testHost"
 	NodeName              = "testNode"
-	AdvName               = "advertisement-" + ForeignClusterId
+	AdvName               = pkg.AdvertisementPrefix + ForeignClusterId
 	TepName               = controllers.TunEndpointNamePrefix + ForeignClusterId
 	EndpointsName         = "testEndpoints"
 	HomeClusterId         = "homeClusterID"

--- a/internal/kubernetes/virtualNodeupdater.go
+++ b/internal/kubernetes/virtualNodeupdater.go
@@ -7,6 +7,7 @@ import (
 	advtypes "github.com/liqotech/liqo/api/sharing/v1alpha1"
 	controllers "github.com/liqotech/liqo/internal/liqonet"
 	"github.com/liqotech/liqo/internal/node"
+	"github.com/liqotech/liqo/pkg"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
@@ -16,7 +17,7 @@ import (
 
 func (p *KubernetesProvider) StartNodeUpdater(nodeRunner *node.NodeController) (chan struct{}, chan struct{}, error) {
 	stop := make(chan struct{}, 1)
-	advName := strings.Join([]string{"advertisement", p.foreignClusterId}, "-")
+	advName := strings.Join([]string{pkg.AdvertisementPrefix, p.foreignClusterId}, "")
 	advWatcher, err := p.advClient.Resource("advertisements").Watch(metav1.ListOptions{
 		FieldSelector: strings.Join([]string{"metadata.name", advName}, "="),
 		Watch:         true,

--- a/pkg/const.go
+++ b/pkg/const.go
@@ -1,6 +1,8 @@
 package pkg
 
 const (
-	VirtualNodePrefix    = "liqo-"
-	VirtualKubeletPrefix = "virtual-kubelet-"
+	VirtualNodePrefix       = "liqo-"
+	VirtualKubeletPrefix    = "virtual-kubelet-"
+	VirtualKubeletSecPrefix = "vk-kubeconfig-secret-"
+	AdvertisementPrefix     = "advertisement-"
 )

--- a/test/unit/advertisement-operator/remote-watcher_test.go
+++ b/test/unit/advertisement-operator/remote-watcher_test.go
@@ -43,7 +43,7 @@ func TestWatchAdvertisementAcceptance(t *testing.T) {
 	time.Sleep(1 * time.Second)
 
 	// after having created home adv on foreign cluster, start watching it
-	go b.WatchAdvertisement(homeAdv.Name, "")
+	go b.WatchAdvertisement(homeAdv.Name)
 
 	// set adv status and update it: this will trigger the watcher
 	homeAdv.Status.AdvertisementStatus = advtypes.AdvertisementAccepted


### PR DESCRIPTION
# Description

In this PR 
- fix a bug in the remote-watcher, when we update the `PeeringRequest` with the status of the `Advertisement`. 
- improve the creation of images in the `Advertisement` filtering images with the same name

## Minor changes
- added Prefix constants to avoid typos errors in the name of resources

# How Has This Been Tested?
- Unit test to check image filtering
- KinD test to check the `PeeringRequest` is correctly updated