### PR TITLE
Add EndpointSlice support

### DIFF
--- a/internal/kubernetes/pod.go
+++ b/internal/kubernetes/pod.go
@@ -54,27 +54,6 @@ func (p *KubernetesProvider) CreatePod(ctx context.Context, pod *v1.Pod) error {
 
 // UpdatePod accepts a Pod definition and updates its reference.
 func (p *KubernetesProvider) UpdatePod(ctx context.Context, pod *v1.Pod) error {
-	if pod == nil {
-		return errors.New("pod cannot be nil")
-	}
-	// Add the pod's coordinates to the current span.
-	nattedNS, err := p.namespaceMapper.NatNamespace(pod.Namespace, false)
-	if err != nil {
-		return err
-	}
-
-	podTranslated := translation.H2FTranslate(pod, nattedNS)
-	foreignPod := p.apiController.GetMirroredObjectByKey(apimgmgt.Pods, nattedNS, podTranslated.Name).(*v1.Pod)
-
-	podTranslated.Spec = foreignPod.Spec
-
-	_, err = p.foreignClient.Client().CoreV1().Pods(nattedNS).Update(context.TODO(), podTranslated, metav1.UpdateOptions{})
-	if err != nil {
-		klog.Warningf("Cannot update pod \"%s\" in provider namespace \"%s\"", podTranslated.Name, podTranslated.Namespace)
-		return err
-	}
-	klog.V(3).Infof("Updated pod \"%s\" in provider namespace \"%s\"", podTranslated.Name, podTranslated.Namespace)
-
 	return nil
 }
 

--- a/pkg/virtualKubelet/apiReflection/const.go
+++ b/pkg/virtualKubelet/apiReflection/const.go
@@ -2,9 +2,11 @@ package apiReflection
 
 const (
 	Configmaps = iota
+	Endpoints
 	EndpointSlices
 	Pods
 	Services
+	Secrets
 )
 
 type ApiType int

--- a/pkg/virtualKubelet/apiReflection/reflectors/incoming/apiTypes.go
+++ b/pkg/virtualKubelet/apiReflection/reflectors/incoming/apiTypes.go
@@ -17,12 +17,16 @@ var ApiMapping = map[apimgmt.ApiType]func(reflector ri.APIReflector, opts map[op
 	},
 }
 
-var InformerBuilders = map[apimgmt.ApiType]func(informers.SharedInformerFactory) cache.SharedIndexInformer{
+var HomeInformerBuilders = map[apimgmt.ApiType]func(informers.SharedInformerFactory) cache.SharedIndexInformer{
 	apimgmt.Pods: func(factory informers.SharedInformerFactory) cache.SharedIndexInformer {
 		return factory.Core().V1().Pods().Informer()
 	},
 }
 
-var Indexers = map[apimgmt.ApiType]func() cache.Indexers{
+var HomeIndexers = map[apimgmt.ApiType]func() cache.Indexers{
 	apimgmt.Pods: AddPodsIndexers,
 }
+
+var ForeignInformerBuilders = map[apimgmt.ApiType]func(informers.SharedInformerFactory) cache.SharedIndexInformer{}
+
+var ForeignIndexers = map[apimgmt.ApiType]func() cache.Indexers{}

--- a/pkg/virtualKubelet/apiReflection/reflectors/outgoing/apiTypes.go
+++ b/pkg/virtualKubelet/apiReflection/reflectors/outgoing/apiTypes.go
@@ -4,6 +4,7 @@ import (
 	apimgmt "github.com/liqotech/liqo/pkg/virtualKubelet/apiReflection"
 	ri "github.com/liqotech/liqo/pkg/virtualKubelet/apiReflection/reflectors/reflectorsInterfaces"
 	"github.com/liqotech/liqo/pkg/virtualKubelet/options"
+	"github.com/liqotech/liqo/pkg/virtualKubelet/options/types"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/tools/cache"
 )
@@ -12,31 +13,56 @@ var ApiMapping = map[apimgmt.ApiType]func(reflector ri.APIReflector, opts map[op
 	apimgmt.Configmaps: func(reflector ri.APIReflector, opts map[options.OptionKey]options.Option) ri.OutgoingAPIReflector {
 		return &ConfigmapsReflector{APIReflector: reflector}
 	},
-	/*
-		apimgmt.EndpointSlices: func(reflector ri.APIReflector, opts map[options.OptionKey]options.Option) ri.OutgoingAPIReflector {
-			return &EndpointSlicesReflector{
-				APIReflector: reflector,
-				localRemappedPodCIDR: opts[types.LocalRemappedPodCIDR],
-				nodeName: opts[types.NodeName],
-			}
-		},
-	*/
+	apimgmt.EndpointSlices: func(reflector ri.APIReflector, opts map[options.OptionKey]options.Option) ri.OutgoingAPIReflector {
+		return &EndpointSlicesReflector{
+			APIReflector:         reflector,
+			LocalRemappedPodCIDR: opts[types.LocalRemappedPodCIDR],
+			NodeName:             opts[types.NodeName],
+		}
+	},
+	apimgmt.Services: func(reflector ri.APIReflector, opts map[options.OptionKey]options.Option) ri.OutgoingAPIReflector {
+		return &ServicesReflector{APIReflector: reflector}
+	},
+	apimgmt.Secrets: func(reflector ri.APIReflector, opts map[options.OptionKey]options.Option) ri.OutgoingAPIReflector {
+		return &SecretsReflector{APIReflector: reflector}
+	},
 }
 
-var InformerBuilders = map[apimgmt.ApiType]func(informers.SharedInformerFactory) cache.SharedIndexInformer{
+var HomeInformerBuilders = map[apimgmt.ApiType]func(informers.SharedInformerFactory) cache.SharedIndexInformer{
 	apimgmt.Configmaps: func(factory informers.SharedInformerFactory) cache.SharedIndexInformer {
 		return factory.Core().V1().ConfigMaps().Informer()
 	},
-	/*
-		apimgmt.EndpointSlices: func(factory informers.SharedInformerFactory) cache.SharedIndexInformer {
-			return factory.Discovery().V1beta1().EndpointSlices().Informer()
-		},
-		apimgmt.Services: func(factory informers.SharedInformerFactory) cache.SharedIndexInformer {
-			return factory.Core().V1().Services().Informer()
-		},*/
+	apimgmt.EndpointSlices: func(factory informers.SharedInformerFactory) cache.SharedIndexInformer {
+		return factory.Discovery().V1beta1().EndpointSlices().Informer()
+	},
+	apimgmt.Services: func(factory informers.SharedInformerFactory) cache.SharedIndexInformer {
+		return factory.Core().V1().Services().Informer()
+	},
+	apimgmt.Secrets: func(factory informers.SharedInformerFactory) cache.SharedIndexInformer {
+		return factory.Core().V1().Secrets().Informer()
+	},
 }
 
-var Indexers = map[apimgmt.ApiType]func() cache.Indexers{
-	apimgmt.Configmaps: addConfigmapsIndexers,
-	apimgmt.Services:   addServicesIndexers,
+var ForeignInformerBuilders = map[apimgmt.ApiType]func(informers.SharedInformerFactory) cache.SharedIndexInformer{
+	apimgmt.Configmaps: func(factory informers.SharedInformerFactory) cache.SharedIndexInformer {
+		return factory.Core().V1().ConfigMaps().Informer()
+	},
+	apimgmt.EndpointSlices: func(factory informers.SharedInformerFactory) cache.SharedIndexInformer {
+		return factory.Discovery().V1beta1().EndpointSlices().Informer()
+	},
+	apimgmt.Services: func(factory informers.SharedInformerFactory) cache.SharedIndexInformer {
+		return factory.Core().V1().Services().Informer()
+	},
+	apimgmt.Secrets: func(factory informers.SharedInformerFactory) cache.SharedIndexInformer {
+		return factory.Core().V1().Secrets().Informer()
+	},
 }
+
+var HomeIndexers = map[apimgmt.ApiType]func() cache.Indexers{
+	apimgmt.Configmaps:     addConfigmapsIndexers,
+	apimgmt.EndpointSlices: addEndpointSlicesIndexers,
+	apimgmt.Secrets:        addSecretsIndexers,
+	apimgmt.Services:       addServicesIndexers,
+}
+
+var ForeignIndexers = map[apimgmt.ApiType]func() cache.Indexers{}

--- a/pkg/virtualKubelet/apiReflection/reflectors/outgoing/blacklists.go
+++ b/pkg/virtualKubelet/apiReflection/reflectors/outgoing/blacklists.go
@@ -1,0 +1,16 @@
+package outgoing
+
+import (
+	apimgmt "github.com/liqotech/liqo/pkg/virtualKubelet/apiReflection"
+)
+
+type blackList map[string]bool
+
+var blacklist = map[apimgmt.ApiType]blackList{
+	apimgmt.EndpointSlices: {
+		"default/kubernetes": true,
+	},
+	apimgmt.Services: {
+		"default/kubernetes": true,
+	},
+}

--- a/pkg/virtualKubelet/apiReflection/reflectors/outgoing/secrets.go
+++ b/pkg/virtualKubelet/apiReflection/reflectors/outgoing/secrets.go
@@ -1,0 +1,221 @@
+package outgoing
+
+import (
+	"context"
+	"errors"
+	apimgmt "github.com/liqotech/liqo/pkg/virtualKubelet/apiReflection"
+	ri "github.com/liqotech/liqo/pkg/virtualKubelet/apiReflection/reflectors/reflectorsInterfaces"
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog"
+	"strings"
+)
+
+type SecretsReflector struct {
+	ri.APIReflector
+}
+
+func (r *SecretsReflector) SetSpecializedPreProcessingHandlers() {
+	r.SetPreProcessingHandlers(ri.PreProcessingHandlers{
+		IsAllowed:  r.isAllowed,
+		AddFunc:    r.PreAdd,
+		UpdateFunc: r.PreUpdate,
+		DeleteFunc: r.PreDelete})
+}
+
+func (r *SecretsReflector) HandleEvent(e interface{}) {
+	var err error
+
+	event := e.(watch.Event)
+	secret, ok := event.Object.(*corev1.Secret)
+	if !ok {
+		klog.Error("REFLECTION: cannot cast object to Secret")
+		return
+	}
+	klog.V(3).Infof("REFLECTION: received %v for Secret %v/%v", event.Type, secret.Namespace, secret.Name)
+
+	switch event.Type {
+	case watch.Added:
+		_, err := r.GetForeignClient().CoreV1().Secrets(secret.Namespace).Create(context.TODO(), secret, metav1.CreateOptions{})
+		if kerrors.IsAlreadyExists(err) {
+			klog.V(3).Infof("REFLECTION: The remote Secret %v/%v has not been created: %v", secret.Namespace, secret.Name, err)
+		}
+		if err != nil && !kerrors.IsAlreadyExists(err) {
+			klog.Errorf("REFLECTION: Error while updating the remote Secret %v/%v - ERR: %v", secret.Namespace, secret.Name, err)
+		} else {
+			klog.V(3).Infof("REFLECTION: remote Secret %v/%v correctly created", secret.Namespace, secret.Name)
+		}
+
+	case watch.Modified:
+		if _, err = r.GetForeignClient().CoreV1().Secrets(secret.Namespace).Update(context.TODO(), secret, metav1.UpdateOptions{}); err != nil {
+			klog.Errorf("REFLECTION: Error while updating the remote Secret %v/%v - ERR: %v", secret.Namespace, secret.Name, err)
+		} else {
+			klog.V(3).Infof("REFLECTION: remote Secret %v/%v correctly updated", secret.Namespace, secret.Name)
+		}
+
+	case watch.Deleted:
+		if err := r.GetForeignClient().CoreV1().Secrets(secret.Namespace).Delete(context.TODO(), secret.Name, metav1.DeleteOptions{}); err != nil {
+			klog.Errorf("REFLECTION: Error while deleting the remote Secret %v/%v - ERR: %v", secret.Namespace, secret.Name, err)
+		} else {
+			klog.V(3).Infof("REFLECTION: remote Secret %v/%v correctly deleted", secret.Namespace, secret.Name)
+		}
+	}
+}
+
+func (r *SecretsReflector) KeyerFromObj(obj interface{}, remoteNamespace string) string {
+	cm, ok := obj.(*corev1.Secret)
+	if !ok {
+		return ""
+	}
+	return strings.Join([]string{remoteNamespace, cm.Name}, "/")
+}
+
+func (r *SecretsReflector) CleanupNamespace(localNamespace string) {
+	foreignNamespace, err := r.NattingTable().NatNamespace(localNamespace, false)
+	if err != nil {
+		klog.Error(err)
+		return
+	}
+
+	objects := r.ForeignInformer(foreignNamespace).GetStore().List()
+	for _, obj := range objects {
+		secret := obj.(*corev1.Secret)
+		if err := r.GetForeignClient().CoreV1().Secrets(foreignNamespace).Delete(context.TODO(), secret.Name, metav1.DeleteOptions{}); err != nil {
+			klog.Errorf("error while deleting Secret %v/%v - ERR: %v", secret.Name, secret.Namespace, err)
+		}
+	}
+}
+
+func (r *SecretsReflector) PreAdd(obj interface{}) interface{} {
+	secretLocal := obj.(*corev1.Secret).DeepCopy()
+	klog.V(3).Infof("PreAdd routine started for Secret %v/%v", secretLocal.Namespace, secretLocal.Name)
+
+	nattedNs, err := r.NattingTable().NatNamespace(secretLocal.Namespace, false)
+	if err != nil {
+		klog.Error(err)
+		return nil
+	}
+
+	secretRemote := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        secretLocal.Name,
+			Namespace:   nattedNs,
+			Labels:      make(map[string]string),
+			Annotations: make(map[string]string),
+		},
+		Data:       secretLocal.Data,
+		StringData: secretLocal.StringData,
+		Type:       secretLocal.Type,
+	}
+
+	for k, v := range secretLocal.Annotations {
+		secretRemote.Annotations[k] = v
+	}
+	for k, v := range secretLocal.Labels {
+		secretRemote.Labels[k] = v
+	}
+	secretRemote.Labels[apimgmt.LiqoLabelKey] = apimgmt.LiqoLabelValue
+
+	klog.V(3).Infof("PreAdd routine completed for secret %v/%v", secretLocal.Namespace, secretLocal.Name)
+	return secretRemote
+}
+
+func (r *SecretsReflector) PreUpdate(newObj interface{}, _ interface{}) interface{} {
+	newSecret := newObj.(*corev1.Secret).DeepCopy()
+
+	nattedNs, err := r.NattingTable().NatNamespace(newSecret.Namespace, false)
+	if err != nil {
+		klog.Error(err)
+		return nil
+	}
+
+	name := r.KeyerFromObj(newObj, nattedNs)
+	oldRemoteObj, exists, err := r.ForeignInformer(nattedNs).GetStore().GetByKey(name)
+	if err != nil {
+		klog.Error(err)
+		return nil
+	}
+	if !exists {
+		err = r.ForeignInformer(nattedNs).GetStore().Resync()
+		if err != nil {
+			klog.Errorf("error while resyncing secrets foreign cache - ERR: %v", err)
+			return nil
+		}
+		oldRemoteObj, exists, err = r.ForeignInformer(nattedNs).GetStore().GetByKey(r.Keyer(nattedNs, name))
+		if err != nil {
+			klog.Errorf("error while retrieving secret from foreign cache - ERR: %v", err)
+			return nil
+		}
+		if !exists {
+			klog.V(3).Infof("secret %v/%v not found after cache resync", nattedNs, name)
+			return nil
+		}
+	}
+	oldRemoteSec := oldRemoteObj.(*corev1.Secret)
+
+	newSecret.SetNamespace(nattedNs)
+	newSecret.SetResourceVersion(oldRemoteSec.ResourceVersion)
+	newSecret.SetUID(oldRemoteSec.UID)
+
+	if newSecret.Labels == nil {
+		newSecret.Labels = make(map[string]string)
+	}
+	for k, v := range oldRemoteSec.Labels {
+		newSecret.Labels[k] = v
+	}
+	newSecret.Labels[apimgmt.LiqoLabelKey] = apimgmt.LiqoLabelValue
+
+	if newSecret.Annotations == nil {
+		newSecret.Annotations = make(map[string]string)
+	}
+	for k, v := range oldRemoteSec.Annotations {
+		newSecret.Annotations[k] = v
+	}
+
+	return newSecret
+}
+
+func (r *SecretsReflector) PreDelete(obj interface{}) interface{} {
+	serviceLocal := obj.(*corev1.Secret).DeepCopy()
+
+	klog.V(3).Infof("PreDelete routine started for secret %v/%v", serviceLocal.Namespace, serviceLocal.Name)
+
+	nattedNs, err := r.NattingTable().NatNamespace(serviceLocal.Namespace, false)
+	if err != nil {
+		klog.Error(err)
+		return nil
+	}
+	serviceLocal.Namespace = nattedNs
+
+	klog.V(3).Infof("PreDelete routine completed for secret %v/%v", serviceLocal.Namespace, serviceLocal.Name)
+	return serviceLocal
+}
+
+func (r *SecretsReflector) isAllowed(obj interface{}) bool {
+	sec, ok := obj.(*corev1.Secret)
+	if !ok {
+		klog.Error("cannot convert obj to secret")
+		return false
+	}
+	if sec.Type == corev1.SecretTypeServiceAccountToken {
+		return false
+	}
+	return true
+}
+
+func addSecretsIndexers() cache.Indexers {
+	i := cache.Indexers{}
+	i["secrets"] = func(obj interface{}) ([]string, error) {
+		secret, ok := obj.(*corev1.Secret)
+		if !ok {
+			return []string{}, errors.New("cannot convert obj to secret")
+		}
+		return []string{
+			strings.Join([]string{secret.Namespace, secret.Name}, "/"),
+		}, nil
+	}
+	return i
+}

--- a/pkg/virtualKubelet/apiReflection/reflectors/outgoing/services.go
+++ b/pkg/virtualKubelet/apiReflection/reflectors/outgoing/services.go
@@ -3,6 +3,7 @@ package outgoing
 import (
 	"context"
 	"errors"
+	apimgmt "github.com/liqotech/liqo/pkg/virtualKubelet/apiReflection"
 	ri "github.com/liqotech/liqo/pkg/virtualKubelet/apiReflection/reflectors/reflectorsInterfaces"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -19,6 +20,7 @@ type ServicesReflector struct {
 
 func (r *ServicesReflector) SetSpecializedPreProcessingHandlers() {
 	r.SetPreProcessingHandlers(ri.PreProcessingHandlers{
+		IsAllowed:  r.isAllowed,
 		AddFunc:    r.PreAdd,
 		UpdateFunc: r.PreUpdate,
 		DeleteFunc: r.PreDelete})
@@ -42,7 +44,7 @@ func (r *ServicesReflector) HandleEvent(e interface{}) {
 			klog.V(3).Infof("REFLECTION: The remote service %v/%v has not been created: %v", svc.Namespace, svc.Name, err)
 		}
 		if err != nil && !kerrors.IsAlreadyExists(err) {
-			klog.Errorf("REFLECTION: Error while updating the remote service %v/%v - ERR: %v", svc.Namespace, svc.Name, err)
+			klog.Errorf("REFLECTION: Error while creating the remote service %v/%v - ERR: %v", svc.Namespace, svc.Name, err)
 		} else {
 			klog.V(3).Infof("REFLECTION: remote service %v/%v correctly created", svc.Namespace, svc.Name)
 		}
@@ -78,9 +80,15 @@ func (r *ServicesReflector) CleanupNamespace(localNamespace string) {
 		return
 	}
 
+	err = r.ForeignInformer(foreignNamespace).GetStore().Resync()
+	if err != nil {
+		klog.Errorf("error while resyncing services foreign cache - ERR: %v", err)
+		return
+	}
+
 	objects := r.ForeignInformer(foreignNamespace).GetStore().List()
 	for _, obj := range objects {
-		cm := obj.(*corev1.ConfigMap)
+		cm := obj.(*corev1.Service)
 		if err := r.GetForeignClient().CoreV1().Services(foreignNamespace).Delete(context.TODO(), cm.Name, metav1.DeleteOptions{}); err != nil {
 			klog.Errorf("error while deleting service %v/%v - ERR: %v", cm.Name, cm.Namespace, err)
 		}
@@ -88,15 +96,115 @@ func (r *ServicesReflector) CleanupNamespace(localNamespace string) {
 }
 
 func (r *ServicesReflector) PreAdd(obj interface{}) interface{} {
-	return obj
+	svcLocal := obj.(*corev1.Service)
+	klog.V(3).Infof("PreAdd routine started for service %v/%v", svcLocal.Namespace, svcLocal.Name)
+
+	nattedNs, err := r.NattingTable().NatNamespace(svcLocal.Namespace, false)
+	if err != nil {
+		klog.Error(err)
+		return nil
+	}
+
+	svcRemote := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      svcLocal.Name,
+			Namespace: nattedNs,
+			Labels:    make(map[string]string),
+		},
+		Spec: corev1.ServiceSpec{
+			Ports:    svcLocal.Spec.Ports,
+			Selector: svcLocal.Spec.Selector,
+			Type:     svcLocal.Spec.Type,
+		},
+	}
+	for k, v := range svcLocal.Labels {
+		svcRemote.Labels[k] = v
+	}
+	svcRemote.Labels[apimgmt.LiqoLabelKey] = apimgmt.LiqoLabelValue
+
+	klog.V(3).Infof("PreAdd routine completed for service %v/%v", svcLocal.Namespace, svcLocal.Name)
+	return svcRemote
 }
 
 func (r *ServicesReflector) PreUpdate(newObj interface{}, _ interface{}) interface{} {
-	return newObj
+	newSvc := newObj.(*corev1.Service).DeepCopy()
+
+	nattedNs, err := r.NattingTable().NatNamespace(newSvc.Namespace, false)
+	if err != nil {
+		klog.Error(err)
+		return nil
+	}
+
+	key := r.Keyer(nattedNs, newSvc.Name)
+	oldRemoteObj, exists, err := r.ForeignInformer(nattedNs).GetStore().GetByKey(key)
+	if err != nil {
+		klog.Error(err)
+		return nil
+	}
+	if !exists {
+		err = r.ForeignInformer(nattedNs).GetStore().Resync()
+		if err != nil {
+			klog.Errorf("error while resyncing services foreign cache - ERR: %v", err)
+			return nil
+		}
+		oldRemoteObj, exists, err = r.ForeignInformer(nattedNs).GetStore().GetByKey(key)
+		if err != nil {
+			klog.Errorf("error while retrieving service from foreign cache - ERR: %v", err)
+			return nil
+		}
+		if !exists {
+			klog.V(3).Infof("service %v not found after cache resync", key)
+			return nil
+		}
+	}
+	RemoteSvc := oldRemoteObj.(*corev1.Service).DeepCopy()
+
+	if RemoteSvc.Labels == nil {
+		RemoteSvc.Labels = make(map[string]string)
+	}
+	for k, v := range newSvc.Labels {
+		RemoteSvc.Labels[k] = v
+	}
+	RemoteSvc.Labels[apimgmt.LiqoLabelKey] = apimgmt.LiqoLabelValue
+
+	if RemoteSvc.Annotations == nil {
+		RemoteSvc.Annotations = make(map[string]string)
+	}
+	for k, v := range newSvc.Annotations {
+		RemoteSvc.Annotations[k] = v
+	}
+
+	RemoteSvc.Spec.Ports = newSvc.Spec.Ports
+	RemoteSvc.Spec.Selector = newSvc.Spec.Selector
+	RemoteSvc.Spec.Type = newSvc.Spec.Type
+
+	return RemoteSvc
 }
 
 func (r *ServicesReflector) PreDelete(obj interface{}) interface{} {
-	return obj
+	svcLocal := obj.(*corev1.Service).DeepCopy()
+	klog.V(3).Infof("PreDelete routine started for service %v/%v", svcLocal.Namespace, svcLocal.Name)
+
+	nattedNs, err := r.NattingTable().NatNamespace(svcLocal.Namespace, false)
+	if err != nil {
+		klog.Error(err)
+		return nil
+	}
+	svcLocal.Namespace = nattedNs
+
+	klog.V(3).Infof("PreDelete routine completed for service %v/%v", svcLocal.Namespace, svcLocal.Name)
+	return svcLocal
+}
+
+func (r *ServicesReflector) isAllowed(obj interface{}) bool {
+	svc, ok := obj.(*corev1.Service)
+	if !ok {
+		klog.Error("cannot convert obj to service")
+		return false
+	}
+	key := r.Keyer(svc.Namespace, svc.Name)
+	_, ok = blacklist[apimgmt.Services][key]
+	return ok
 }
 
 func addServicesIndexers() cache.Indexers {
@@ -104,7 +212,7 @@ func addServicesIndexers() cache.Indexers {
 	i["services"] = func(obj interface{}) ([]string, error) {
 		svc, ok := obj.(*corev1.Service)
 		if !ok {
-			return []string{}, errors.New("cannot convert obj to configmap")
+			return []string{}, errors.New("cannot convert obj to service")
 		}
 		return []string{
 			strings.Join([]string{svc.Namespace, svc.Name}, "/"),

--- a/pkg/virtualKubelet/apiReflection/reflectors/reflectorsInterfaces/interfaces.go
+++ b/pkg/virtualKubelet/apiReflection/reflectors/reflectorsInterfaces/interfaces.go
@@ -15,6 +15,7 @@ const (
 )
 
 type APIPreProcessing interface {
+	PreProcessIsAllowed(obj interface{}) bool
 	PreProcessAdd(obj interface{}) interface{}
 	PreProcessUpdate(newObj, oldObj interface{}) interface{}
 	PreProcessDelete(obj interface{}) interface{}
@@ -56,6 +57,7 @@ type IncomingAPIReflector interface {
 }
 
 type PreProcessingHandlers struct {
+	IsAllowed  func(obj interface{}) bool
 	AddFunc    func(obj interface{}) interface{}
 	UpdateFunc func(newObj, oldObj interface{}) interface{}
 	DeleteFunc func(obj interface{}) interface{}

--- a/pkg/virtualKubelet/translation/mutation.go
+++ b/pkg/virtualKubelet/translation/mutation.go
@@ -5,7 +5,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/klog"
 	"strconv"
 	"strings"
 	"time"
@@ -29,8 +28,6 @@ func F2HTranslate(podForeignIn *v1.Pod, newCidr, namespace string) (podHomeOut *
 		podHomeOut.Status.PodIP = newIp
 		podHomeOut.Status.PodIPs[0].IP = newIp
 	}
-
-	klog.Info(podForeignIn.Status.Phase)
 
 	podHomeOut.SetCreationTimestamp(metav1.NewTime(t))
 	podHomeOut.Spec.NodeName = podForeignIn.Annotations["home_nodename"]

--- a/test/unit/reflection/endpointslices_test.go
+++ b/test/unit/reflection/endpointslices_test.go
@@ -1,0 +1,143 @@
+package reflection
+
+import (
+	"context"
+	"gotest.tools/assert"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/discovery/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog"
+	"testing"
+)
+
+func TestEndpointAdd(t *testing.T) {
+	epReflector := InitTest("endpointSlices")
+	if epReflector == nil {
+		t.Fail()
+	}
+
+	epslice := v1beta1.EndpointSlice{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "name",
+			Namespace: "namespace",
+			Labels: map[string]string{
+				"test": "true",
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "v1",
+					Kind:       "Service",
+					Name:       "name",
+					UID:        "f677f233-2cf8-4cae-8r5d-bbf3ea1d8671",
+				},
+			},
+		},
+		Endpoints: []v1beta1.Endpoint{
+			{
+				Addresses:  []string{"10.0.0.15"},
+				Conditions: v1beta1.EndpointConditions{},
+				Hostname:   nil,
+				TargetRef:  nil,
+				Topology:   map[string]string{"kubernetes.io/hostname": "worker-3"},
+			},
+			{
+				Addresses:  []string{"10.0.0.20"},
+				Conditions: v1beta1.EndpointConditions{},
+				Hostname:   nil,
+				TargetRef:  nil,
+				Topology:   map[string]string{"kubernetes.io/hostname": "vk-node"},
+			}},
+		Ports: nil,
+	}
+
+	svc := v1.Service{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "name",
+			Namespace: "test",
+			Labels:    nil,
+			UID:       "f677f0a3-2ce8-4cae-810d-bbf3ea1d8671",
+		},
+		Spec:   v1.ServiceSpec{},
+		Status: v1.ServiceStatus{},
+	}
+
+	_, err := epReflector.GetForeignClient().CoreV1().Services("test").Create(context.TODO(), &svc, metav1.CreateOptions{})
+	if err != nil {
+		klog.Error(err)
+		t.Fail()
+	}
+
+	postadd := epReflector.PreProcessAdd(&epslice).(*v1beta1.EndpointSlice)
+
+	assert.Equal(t, postadd.Namespace, "test", "Asserting namespace natting")
+	assert.Equal(t, len(postadd.Endpoints), 1, "Asserting node-based filtering")
+	assert.Equal(t, postadd.Endpoints[0].Addresses[0], "10.0.0.15", "Asserting no pod IP natting")
+}
+
+func TestEndpointAdd2(t *testing.T) {
+	epReflector := InitTest("endpointSlices")
+	if epReflector == nil {
+		t.Fail()
+	}
+
+	epslice := v1beta1.EndpointSlice{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "name",
+			Namespace: "namespace",
+			Labels: map[string]string{
+				"test": "true",
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "v1",
+					Kind:       "Service",
+					Name:       "name",
+					UID:        "f677f233-2cf8-4cae-8r5d-bbf3ea1d8671",
+				},
+			},
+		},
+		Endpoints: []v1beta1.Endpoint{
+			{
+				Addresses:  []string{"10.10.0.15"},
+				Conditions: v1beta1.EndpointConditions{},
+				Hostname:   nil,
+				TargetRef:  nil,
+				Topology:   map[string]string{"kubernetes.io/hostname": "worker-3"},
+			},
+			{
+				Addresses:  []string{"10.10.0.20"},
+				Conditions: v1beta1.EndpointConditions{},
+				Hostname:   nil,
+				TargetRef:  nil,
+				Topology:   map[string]string{"kubernetes.io/hostname": "vk-node"},
+			}},
+		Ports: nil,
+	}
+
+	svc := v1.Service{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "name",
+			Namespace: "test",
+			Labels:    nil,
+			UID:       "f677f0a3-2ce8-4cae-810d-bbf3ea1d8671",
+		},
+		Spec:   v1.ServiceSpec{},
+		Status: v1.ServiceStatus{},
+	}
+
+	_, err := epReflector.GetForeignClient().CoreV1().Services("test").Create(context.TODO(), &svc, metav1.CreateOptions{})
+	if err != nil {
+		klog.Error(err)
+		t.Fail()
+	}
+
+	postadd := epReflector.PreProcessAdd(&epslice).(*v1beta1.EndpointSlice)
+
+	assert.Equal(t, postadd.Namespace, "test", "Asserting namespace natting")
+	assert.Equal(t, len(postadd.Endpoints), 1, "Asserting node-based filtering")
+	assert.Equal(t, postadd.Endpoints[0].Addresses[0], "10.0.0.15", "Asserting pod IP natting")
+}

--- a/test/unit/reflection/secrets_test.go
+++ b/test/unit/reflection/secrets_test.go
@@ -1,0 +1,49 @@
+package reflection
+
+import (
+	"gotest.tools/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
+)
+
+func TestSecretAdd(t *testing.T) {
+	secretsReflector := InitTest("secrets")
+
+	secret := v1.Secret{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "name",
+			Namespace: "namespace",
+		},
+		Data: map[string][]byte{
+			"thesecret": []byte("ILoveLiqo"),
+		},
+		Type: "Opaque",
+	}
+
+	postadd := secretsReflector.PreProcessAdd(&secret).(*v1.Secret)
+
+	assert.Equal(t, postadd.Namespace, "test")
+}
+
+func TestSecretUpdate(t *testing.T) {
+	secretsReflector := InitTest("secrets")
+
+	secret := v1.Secret{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "name",
+			Namespace: "namespace",
+		},
+		Data: map[string][]byte{
+			"thesecret": []byte("ILoveLiqo"),
+		},
+		Type: "Opaque",
+	}
+
+	postadd := secretsReflector.PreProcessAdd(&secret).(*v1.Secret)
+
+	assert.Equal(t, postadd.Namespace, "test")
+
+}

--- a/test/unit/reflection/util.go
+++ b/test/unit/reflection/util.go
@@ -1,0 +1,55 @@
+package reflection
+
+import (
+	api "github.com/liqotech/liqo/pkg/virtualKubelet/apiReflection/reflectors"
+	"github.com/liqotech/liqo/pkg/virtualKubelet/apiReflection/reflectors/outgoing"
+	ri "github.com/liqotech/liqo/pkg/virtualKubelet/apiReflection/reflectors/reflectorsInterfaces"
+	"github.com/liqotech/liqo/pkg/virtualKubelet/namespacesMapping"
+	"github.com/liqotech/liqo/pkg/virtualKubelet/options/types"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+type FakeNatter struct {
+	namespace map[string]string
+}
+
+func (f FakeNatter) NatNamespace(namespace string, create bool) (string, error) {
+	return "test", nil
+}
+
+func (f FakeNatter) DeNatNamespace(namespace string) (string, error) {
+	return "test", nil
+}
+
+func NewFakeNatter() namespacesMapping.NamespaceNatter { return FakeNatter{} }
+
+func InitTest(typeRequired string) ri.APIReflector {
+	kubeClient := fake.NewSimpleClientset()
+
+	Greflector := &api.GenericAPIReflector{
+		Api:              0,
+		OutputChan:       nil,
+		ForeignClient:    kubeClient,
+		LocalInformers:   nil,
+		ForeignInformers: nil,
+		NamespaceNatting: NewFakeNatter(),
+	}
+
+	if typeRequired == "secrets" {
+
+		reflector := &outgoing.SecretsReflector{
+			APIReflector: Greflector,
+		}
+		reflector.SetSpecializedPreProcessingHandlers()
+		return reflector
+	} else if typeRequired == "endpointSlices" {
+		reflector := &outgoing.EndpointSlicesReflector{
+			APIReflector:         Greflector,
+			LocalRemappedPodCIDR: types.NewNetworkingOption("localRemappedPodCIDR", "10.0.0.0/16"),
+			NodeName:             types.NewNetworkingOption("NodeName", "vk-node"),
+		}
+		reflector.SetSpecializedPreProcessingHandlers()
+		return reflector
+	}
+	return nil
+}


### PR DESCRIPTION
This PR is complementary to #267, where the entire reflection process has been changed. This contribution introduces `secrets`, `services`, and `endpointslices` reflection by exploiting the reflection controller. Also, some tests related to the `endpontslices` have been created.