### PR TITLE
Migrate advertisement remote-watcher to informer

### DIFF
--- a/api/sharing/v1alpha1/advertisementClient.go
+++ b/api/sharing/v1alpha1/advertisementClient.go
@@ -42,20 +42,21 @@ func CreateAdvertisementClient(kubeconfig string, secret *v1.Secret) (*crdClient
 		return nil, err
 	}
 
-	store, stop, err := crdClient.WatchResources(clientSet,
-		"advertisements",
-		"",
-		0,
-		cache.ResourceEventHandlerFuncs{},
-		metav1.ListOptions{})
+	if crdClient.Fake {
+		store, stop, err := crdClient.WatchResources(clientSet,
+			"advertisements",
+			"",
+			0,
+			cache.ResourceEventHandlerFuncs{},
+			metav1.ListOptions{})
 
-	if err != nil {
-		return nil, err
+		if err != nil {
+			return nil, err
+		}
+
+		clientSet.Store = store
+		clientSet.Stop = stop
 	}
-
-	clientSet.Store = store
-	clientSet.Stop = stop
-
 	return clientSet, nil
 }
 

--- a/test/unit/advertisement-operator/broadcaster_test.go
+++ b/test/unit/advertisement-operator/broadcaster_test.go
@@ -24,7 +24,6 @@ import (
 func createBroadcaster(configv1alpha1 configv1alpha1.ClusterConfigSpec) advop.AdvertisementBroadcaster {
 	// set the client in fake mode
 	crdClient.Fake = true
-
 	// create fake client for the home cluster
 	homeClient, err := advtypes.CreateAdvertisementClient("", nil)
 	if err != nil {
@@ -313,7 +312,10 @@ func TestSendAdvertisement(t *testing.T) {
 	adv := prepareAdv(&b)
 	adv2, err := b.SendAdvertisementToForeignCluster(adv)
 	assert.Nil(t, err)
-	assert.Equal(t, b.KubeconfigSecretForForeign.OwnerReferences, advpkg.GetOwnerReference(adv2))
+
+	secretForeign, err := b.RemoteClient.Client().CoreV1().Secrets(b.KubeconfigSecretForForeign.Namespace).Get(context.TODO(), b.KubeconfigSecretForForeign.Name, metav1.GetOptions{})
+	assert.Nil(t, err)
+	assert.Equal(t, secretForeign.OwnerReferences, advpkg.GetOwnerReference(adv2))
 
 	// update adv on foreign cluster
 	adv.Spec.ResourceQuota.Hard[corev1.ResourceCPU] = resource.MustParse("10")


### PR DESCRIPTION
# Description
In this PR the remote-watcher in the broadcaster has been upgraded to use an informer.

## Other changes
- Fix #290 bug in broadcaster that prevented `Secret` recreation