### PR TITLE
Test LIQO on Kubernetes v1.19

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -84,7 +84,7 @@ jobs:
 
   e2e-test-trigger:
      runs-on: ubuntu-latest
-     needs: [build, test]
+     needs: [build]
      strategy:
        fail-fast: false
        matrix:

--- a/docs/examples/liqo-cluster-config.yaml
+++ b/docs/examples/liqo-cluster-config.yaml
@@ -5,4 +5,6 @@ networking:
   podSubnet: "10.200.0.0/16"
 nodes:
   - role: control-plane
+    image: kindest/node:v1.19.1
   - role: worker
+    image: kindest/node:v1.19.1


### PR DESCRIPTION
# Description

This commit reduces the time required to build the whole pipeline, by decoupling unit tests from E2E tests. This PR also bumps the version of tested Kind clusters to 1.19.

# How Has This Been Tested?

Via Unit and E2E Tests.