### PR TITLE
fixing Helm Chart

### DIFF
--- a/deployments/liqo_chart/templates/clusterconfig.yaml
+++ b/deployments/liqo_chart/templates/clusterconfig.yaml
@@ -33,8 +33,6 @@ spec:
     reservedSubnets:
     - {{ .Values.podCIDR }}
     - {{ .Values.serviceCIDR }}
-    - "10.96.0.0/12" # #needed to run the network tests
-    - "10.244.0.0/16" # #needed to run the network tests
   dispatcherConfig:
     resourcesToReplicate:
     - group: net.liqo.io

--- a/deployments/liqo_chart/values.yaml
+++ b/deployments/liqo_chart/values.yaml
@@ -87,13 +87,13 @@ peeringRequestOperator_chart:
 liqodash_chart:
   image:
     repository: "liqo/dashboard"
-    pullpolicy: "Always"
+    pullPolicy: "Always"
   enabled: true
 
 crdReplicator_chart:
   image:
     repository: "liqo/crdreplicator"
-    pullpolicy: "Always"
+    pullPolicy: "Always"
   enabled: true
 
 global:


### PR DESCRIPTION

# Description
This PR fixes the `pullPolicy` for liqoDashboard and crdReplicator in the global `values.yaml` file of the Helm Chart. It
removes some debug values from the `clusterconfig.yaml` template.
