### PR TITLE
Uninstall E2E

### DIFF
--- a/test/e2e/join_e2e/join_test.go
+++ b/test/e2e/join_e2e/join_test.go
@@ -12,12 +12,12 @@ import (
 
 func TestPodsUp1(t *testing.T) {
 	context := util.GetTester()
-	ArePodsUp(context.Client1, context.Namespace, t, "cluster1")
+	util.ArePodsUp(context.Client1, context.Namespace, t, "cluster1")
 }
 
 func TestPodsUp2(t *testing.T) {
 	context := util.GetTester()
-	ArePodsUp(context.Client2, context.Namespace, t, "cluster2")
+	util.ArePodsUp(context.Client2, context.Namespace, t, "cluster2")
 }
 
 func TestNodeVK1(t *testing.T) {
@@ -28,20 +28,6 @@ func TestNodeVK1(t *testing.T) {
 func TestNodeVK2(t *testing.T) {
 	context := util.GetTester()
 	CheckVkNode(context.Client2, context.Client1, context.Namespace, t)
-}
-
-func ArePodsUp(clientset *kubernetes.Clientset, namespace string, t *testing.T, clustername string) {
-	pods, err := clientset.CoreV1().Pods(namespace).List(context2.TODO(), metav1.ListOptions{})
-	if err != nil {
-		klog.Error(err)
-		t.Fail()
-	}
-	for _, num := range pods.Items {
-		for _, container := range num.Status.ContainerStatuses {
-			assert.Equal(t, true, container.Ready, "Asserting "+container.Name+"pods is running "+
-				"on "+clustername)
-		}
-	}
 }
 
 func CheckVkNode(client1 *kubernetes.Clientset, client2 *kubernetes.Clientset, namespace string, t *testing.T) {

--- a/test/e2e/unjoin_e2e/unjoin_test.go
+++ b/test/e2e/unjoin_e2e/unjoin_test.go
@@ -1,0 +1,39 @@
+package unjoin_e2e
+
+import (
+	context2 "context"
+	"github.com/liqotech/liqo/test/e2e/util"
+	"gotest.tools/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog"
+	"testing"
+)
+
+func TestUnjoin(t *testing.T) {
+	context := util.GetTester()
+	NoPods(context.Client1, context.Namespace, t, "cluster1")
+
+	NoJoined(context.Client2, t, "cluster2")
+	util.ArePodsUp(context.Client2, context.Namespace, t, "cluster2")
+}
+
+func NoPods(clientset *kubernetes.Clientset, namespace string, t *testing.T, clustername string) {
+	pods, err := clientset.CoreV1().Pods(namespace).List(context2.TODO(), metav1.ListOptions{})
+	if err != nil {
+		klog.Error(err)
+		t.Fail()
+	}
+	assert.Equal(t, len(pods.Items), 0, "There are still running pods on "+clustername)
+}
+
+func NoJoined(clientset *kubernetes.Clientset, t *testing.T, clustername string) {
+	nodes, err := clientset.CoreV1().Nodes().List(context2.TODO(), metav1.ListOptions{
+		LabelSelector: "type=virtual-node",
+	})
+	if err != nil {
+		klog.Error(err)
+		t.Fail()
+	}
+	assert.Equal(t, len(nodes.Items), 0, "There are still virtual nodes on "+clustername)
+}


### PR DESCRIPTION
# Description

This PR adds E2E tests for Liqo uninstall.

1. Liqo is uninstalled on the cluster1 using the script (2 minutes of timeout)
   * the timeout will make tests to fail if some finalizers were not correctly removed and resources can not be deleted
2. Runs e2e tests to assert pods are still running on the cluster2 and that there are no more virtual nodes
3. Liqo is uninstalled on the cluster1 using the script (2 minutes of timeout)
