### PR TITLE
Update virtual node version

### DIFF
--- a/build/virtual-kubelet/Dockerfile
+++ b/build/virtual-kubelet/Dockerfile
@@ -8,11 +8,9 @@ WORKDIR /go/src/github.com/liqotech/liqo
 ARG BUILD_TAGS=""
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build ./cmd/virtual-kubelet/
 RUN cp virtual-kubelet /usr/bin/virtual-kubelet
-RUN cp go.mod /usr/local/
 
 FROM busybox
 COPY --from=builder /usr/bin/virtual-kubelet /usr/bin/virtual-kubelet
-COPY --from=builder /usr/local/go.mod /usr/local/go.mod
 COPY --from=builder /etc/ssl/certs/ /etc/ssl/certs
 ENTRYPOINT [ "/usr/bin/virtual-kubelet" ]
 CMD [ "--help" ]

--- a/build/virtual-kubelet/Dockerfile
+++ b/build/virtual-kubelet/Dockerfile
@@ -8,9 +8,11 @@ WORKDIR /go/src/github.com/liqotech/liqo
 ARG BUILD_TAGS=""
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build ./cmd/virtual-kubelet/
 RUN cp virtual-kubelet /usr/bin/virtual-kubelet
+RUN cp go.mod /usr/local/
 
-FROM scratch
+FROM busybox
 COPY --from=builder /usr/bin/virtual-kubelet /usr/bin/virtual-kubelet
+COPY --from=builder /usr/local/go.mod /usr/local/go.mod
 COPY --from=builder /etc/ssl/certs/ /etc/ssl/certs
 ENTRYPOINT [ "/usr/bin/virtual-kubelet" ]
 CMD [ "--help" ]


### PR DESCRIPTION
# Description
The k8s version of virtualKubelet node is now taken from the api-server or, if that cannot be found, set to a default value.

VirtualKubelet base image has been modified from `scratch` to `busybox` to allow execution of minimal bash commands