### PR TITLE
[WIP] Reflection boilerplate cleanup

### DIFF
--- a/internal/kubernetes/virtualNodeupdater.go
+++ b/internal/kubernetes/virtualNodeupdater.go
@@ -303,7 +303,7 @@ func (p *KubernetesProvider) updateNode(node *v1.Node) error {
 }
 
 func (p *KubernetesProvider) deleteAdv(adv *advtypes.Advertisement) error {
-	p.apiController.StopReflection()
+	p.apiController.StopController()
 
 	// remove finalizer
 	if slice.ContainsString(adv.Finalizers, advertisementOperator.FinalizerString, nil) {

--- a/pkg/virtualKubelet/apiReflection/const.go
+++ b/pkg/virtualKubelet/apiReflection/const.go
@@ -2,7 +2,6 @@ package apiReflection
 
 const (
 	Configmaps = iota
-	Endpoints
 	EndpointSlices
 	Pods
 	Services
@@ -12,7 +11,7 @@ const (
 type ApiType int
 
 const (
-	LiqoLabelKey   = "liqo/reflection"
+	LiqoLabelKey   = "virtualkubelet.liqo.io/reflection"
 	LiqoLabelValue = "reflected"
 )
 

--- a/pkg/virtualKubelet/apiReflection/controller/incomingReflectorsController.go
+++ b/pkg/virtualKubelet/apiReflection/controller/incomingReflectorsController.go
@@ -122,9 +122,6 @@ func (c *IncomingReflectorsController) startNamespaceReflection(namespace string
 		c.homeInformerFactories[namespace].Start(c.namespacedStops[namespace])
 
 		<-c.namespacedStops[namespace]
-		for _, reflector := range c.apiReflectors {
-			reflector.(ri.IncomingAPIReflector).CleanupNamespace(namespace)
-		}
 		delete(c.homeInformerFactories, namespace)
 		c.homeWaitGroup.Done()
 	}()
@@ -134,6 +131,9 @@ func (c *IncomingReflectorsController) startNamespaceReflection(namespace string
 		c.foreignInformerFactories[nattedNs].Start(c.namespacedStops[namespace])
 
 		<-c.namespacedStops[namespace]
+		for _, reflector := range c.apiReflectors {
+			reflector.(ri.IncomingAPIReflector).CleanupNamespace(namespace)
+		}
 		delete(c.foreignInformerFactories, nattedNs)
 		c.foreignWaitGroup.Done()
 	}()

--- a/pkg/virtualKubelet/apiReflection/controller/outgoingReflectorsController.go
+++ b/pkg/virtualKubelet/apiReflection/controller/outgoingReflectorsController.go
@@ -132,7 +132,6 @@ func (c *OutgoingReflectorsController) startNamespaceReflection(namespace string
 	c.foreignWaitGroup.Add(1)
 	go func() {
 		c.foreignInformerFactories[nattedNs].Start(c.namespacedStops[namespace])
-
 		<-c.namespacedStops[namespace]
 		delete(c.foreignInformerFactories, nattedNs)
 		c.foreignWaitGroup.Done()

--- a/pkg/virtualKubelet/apiReflection/reflectors/apiReflector.go
+++ b/pkg/virtualKubelet/apiReflection/reflectors/apiReflector.go
@@ -4,6 +4,7 @@ import (
 	apimgmt "github.com/liqotech/liqo/pkg/virtualKubelet/apiReflection"
 	ri "github.com/liqotech/liqo/pkg/virtualKubelet/apiReflection/reflectors/reflectorsInterfaces"
 	"github.com/liqotech/liqo/pkg/virtualKubelet/namespacesMapping"
+	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
@@ -153,4 +154,26 @@ func (r *GenericAPIReflector) SetPreProcessingHandlers(handlers ri.PreProcessing
 
 func (r *GenericAPIReflector) Keyer(namespace, name string) string {
 	return strings.Join([]string{namespace, name}, "/")
+}
+
+func (r *GenericAPIReflector) GetObjFromForeignCache(namespace, key string) (interface{}, error) {
+	obj, exists, err := r.ForeignInformer(namespace).GetStore().GetByKey(key)
+	if err != nil {
+		return nil, errors.Wrap(err, "error while getting by key object from foreign cache")
+	}
+	if !exists {
+		err = r.ForeignInformer(namespace).GetStore().Resync()
+		if err != nil {
+			return nil, errors.Wrap(err, "error while resyncing foreign cache")
+		}
+		obj, exists, err = r.ForeignInformer(namespace).GetStore().GetByKey(key)
+		if err != nil {
+			return nil, errors.Wrap(err, "error while retrieving object from foreign cache")
+		}
+		if !exists {
+			return nil, errors.New("object not found after cache resync")
+		}
+	}
+
+	return obj, nil
 }

--- a/pkg/virtualKubelet/apiReflection/reflectors/outgoing/configmaps.go
+++ b/pkg/virtualKubelet/apiReflection/reflectors/outgoing/configmaps.go
@@ -2,14 +2,15 @@ package outgoing
 
 import (
 	"context"
-	"errors"
 	apimgmt "github.com/liqotech/liqo/pkg/virtualKubelet/apiReflection"
 	ri "github.com/liqotech/liqo/pkg/virtualKubelet/apiReflection/reflectors/reflectorsInterfaces"
+	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/klog"
 	"strings"
 )
@@ -106,27 +107,12 @@ func (r *ConfigmapsReflector) PreUpdate(newObj, _ interface{}) interface{} {
 		return nil
 	}
 
-	name := r.KeyerFromObj(newObj, nattedNs)
-	oldRemoteObj, exists, err := r.ForeignInformer(nattedNs).GetStore().GetByKey(r.Keyer(nattedNs, name))
+	key := r.KeyerFromObj(newObj, nattedNs)
+	oldRemoteObj, err := r.GetObjFromForeignCache(nattedNs, key)
 	if err != nil {
+		err = errors.Wrapf(err, "configmap %v", key)
 		klog.Error(err)
 		return nil
-	}
-	if !exists {
-		err = r.ForeignInformer(nattedNs).GetStore().Resync()
-		if err != nil {
-			klog.Errorf("error while resyncing pods foreign cache - ERR: %v", err)
-			return nil
-		}
-		oldRemoteObj, exists, err = r.ForeignInformer(nattedNs).GetStore().GetByKey(r.Keyer(nattedNs, name))
-		if err != nil {
-			klog.Errorf("error while retrieving pod from foreign cache - ERR: %v", err)
-			return nil
-		}
-		if !exists {
-			klog.V(3).Infof("pod %v/%v not found after cache resync", nattedNs, name)
-			return nil
-		}
 	}
 	oldRemoteCm := oldRemoteObj.(*corev1.ConfigMap)
 
@@ -182,11 +168,28 @@ func (r *ConfigmapsReflector) CleanupNamespace(localNamespace string) {
 		return
 	}
 
+	// resync for ensuring to be remotely aligned with the foreign cluster state
+	err = r.ForeignInformer(foreignNamespace).GetStore().Resync()
+	if err != nil {
+		klog.Errorf("error while resyncing configmaps foreign cache - ERR: %v", err)
+		return
+	}
+
 	objects := r.ForeignInformer(foreignNamespace).GetStore().List()
+
+	retriable := func(err error)bool {
+		if err != nil {
+			klog.Warningf("retrying while deleting remote configmap because of - ERR; %v", err)
+			return true
+		}
+		return false
+	}
 	for _, obj := range objects {
 		cm := obj.(*corev1.ConfigMap)
-		if err := r.GetForeignClient().CoreV1().ConfigMaps(foreignNamespace).Delete(context.TODO(), cm.Name, metav1.DeleteOptions{}); err != nil {
-			klog.Errorf("error while deleting configmap %v/%v - ERR: %v", cm.Name, cm.Namespace, err)
+		if err := retry.OnError(retry.DefaultBackoff, retriable, func() error {
+			return r.GetForeignClient().CoreV1().ConfigMaps(foreignNamespace).Delete(context.TODO(), cm.Name, metav1.DeleteOptions{})
+		}); err != nil {
+			klog.Errorf("Error while deleting remote configmap %v/%v", cm.Namespace, cm.Name)
 		}
 	}
 }

--- a/pkg/virtualKubelet/apiReflection/reflectors/reflectorsInterfaces/interfaces.go
+++ b/pkg/virtualKubelet/apiReflection/reflectors/reflectorsInterfaces/interfaces.go
@@ -26,6 +26,7 @@ type APIReflector interface {
 
 	Inform(obj apimgmt.ApiEvent)
 	Keyer(namespace, name string) string
+	GetObjFromForeignCache(string, string) (interface{}, error)
 	LocalInformer(string) cache.SharedIndexInformer
 	ForeignInformer(string) cache.SharedIndexInformer
 	GetForeignClient() kubernetes.Interface


### PR DESCRIPTION
# Reflection cleanup

The reflection mechanism in the virtualKubelet makes heavy use of foreign informers. Each reflector needs to access those objects for retrieving the remote objects to update/delete. This portion of code has been grouped under a unique method implemented by the `GenericReflector` and used by each `SpecializedReflector`.
This operation makes the code more generic, clearer, and easier to maintain.