### PR TITLE
Blacklist inverted bool fix

### DIFF
--- a/pkg/virtualKubelet/apiReflection/reflectors/outgoing/endpointSlices.go
+++ b/pkg/virtualKubelet/apiReflection/reflectors/outgoing/endpointSlices.go
@@ -234,7 +234,10 @@ func (r *EndpointSlicesReflector) isAllowed(obj interface{}) bool {
 	}
 	key := r.Keyer(eps.Namespace, eps.Name)
 	_, ok = blacklist[apimgmt.EndpointSlices][key]
-	return ok
+	if ok {
+		klog.V(4).Infof("endpointslice %v blacklisted", key)
+	}
+	return !ok
 }
 
 func addEndpointSlicesIndexers() cache.Indexers {

--- a/pkg/virtualKubelet/apiReflection/reflectors/outgoing/services.go
+++ b/pkg/virtualKubelet/apiReflection/reflectors/outgoing/services.go
@@ -204,7 +204,10 @@ func (r *ServicesReflector) isAllowed(obj interface{}) bool {
 	}
 	key := r.Keyer(svc.Namespace, svc.Name)
 	_, ok = blacklist[apimgmt.Services][key]
-	return ok
+	if ok {
+		klog.V(4).Infof("service %v blacklisted", key)
+	}
+	return !ok
 }
 
 func addServicesIndexers() cache.Indexers {


### PR DESCRIPTION
# Description

A small bug blacklisted all `endpointslices` and services. This resulted in the service and `endpointslices` reflection prevention.
