### PR TITLE
Draft PRs test execution

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -116,6 +116,8 @@ jobs:
            -H 'Accept: application/vnd.github.everest-preview+json' \
            -u ${{ secrets.CI_TOKEN }} \
            --data '{"event_type": "dev-event", "client_payload": { "actor": "${{ env.branch_owner }}", "ref": "${{ env.branch_name }}", "commit":"${{ env.commit_ref }}" }}'
+     if: github.event.pull_request.draft == false
+
   release:
     runs-on: ubuntu-latest
     needs: [build, test]
@@ -166,4 +168,4 @@ jobs:
       uses: shogo82148/actions-goveralls@v1
       with:
         path-to-profile: coverage.txt
-
+    if: github.event.pull_request.draft == false


### PR DESCRIPTION
# Description
This commit prevents both the unit tests and e2e tests to be executed
for draft PRs.
