### PR TITLE
Dashboard version install

### DIFF
--- a/deployments/liqo_chart/crds/dashboard.liqo.io_views.yaml
+++ b/deployments/liqo_chart/crds/dashboard.liqo.io_views.yaml
@@ -1,11 +1,11 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: views.dashboard.liqo.com
+  name: views.dashboard.liqo.io
   annotations:
     description: 'This CRD is used to create custom views from a set of CRDs'
 spec:
-  group: dashboard.liqo.com
+  group: dashboard.liqo.io
   scope: Namespaced
   names:
     plural: views

--- a/deployments/liqo_chart/subcharts/liqodash_chart/templates/liqodash_deployment.yaml
+++ b/deployments/liqo_chart/subcharts/liqodash_chart/templates/liqodash_deployment.yaml
@@ -40,7 +40,7 @@ spec:
           command: [ "/bin/sh" ]
           args: [ "-c", 'openssl req -x509 -subj "/C=IT/ST=Turin/O=Liqo" -nodes -days 365 -newkey rsa:2048 -keyout /etc/nginx/ssl/nginx.key -out /etc/nginx/ssl/nginx.cert' ]
       containers:
-        - image: {{ .Values.image.repository }}:{{ .Values.version }}
+        - image: {{ .Values.image.repository }}:{{ .Values.global.dashboard_version | default .Values.version }}
           volumeMounts:
             - name: shared-data
               mountPath: /etc/nginx/ssl/

--- a/deployments/liqo_chart/values.yaml
+++ b/deployments/liqo_chart/values.yaml
@@ -99,5 +99,6 @@ crdReplicator_chart:
 global:
   configmapName: "liqo-configmap"
   dashboard_ingress: ""
+  dashboard_version: ""
   suffix: ""
   version: ""


### PR DESCRIPTION
# Description
This PR fixes the dashboard not installing with the version given during installation.
- If a version is specified, the dashboard and liqo will be installed with the same version.
- If a commit is specified, the dashboard will be installed with the master tag image, while liqo will be installed with the commit specified, as always.
- If nothing is specified, the master images will be installed for every component.

ref. #305 
