### PR TITLE
Discovery Type Priority

### DIFF
--- a/apis/discovery/v1alpha1/foreigncluster_methods.go
+++ b/apis/discovery/v1alpha1/foreigncluster_methods.go
@@ -156,3 +156,10 @@ func (fc *ForeignCluster) DeleteAdvertisement(advClient *crdClient.CRDClient) er
 	}
 	return nil
 }
+
+// if we discovered a cluster with IncomingPeering we can upgrade this discovery
+// when we found it also in other way, for example inserting a SearchDomain or
+// adding it manually
+func (fc *ForeignCluster) HasHigherPriority(discoveryType DiscoveryType) bool {
+	return fc.Spec.DiscoveryType == IncomingPeeringDiscovery && discoveryType != IncomingPeeringDiscovery
+}

--- a/internal/discovery/foreign-cluster-operator/foreign-cluster-controller.go
+++ b/internal/discovery/foreign-cluster-operator/foreign-cluster-controller.go
@@ -83,7 +83,7 @@ func (r *ForeignClusterReconciler) Reconcile(req ctrl.Request) (ctrl.Result, err
 	requireUpdate := false
 
 	// set trust property
-	if fc.Status.TrustMode == discoveryv1alpha1.TrustModeUnknown {
+	if fc.Status.TrustMode == discoveryv1alpha1.TrustModeUnknown || fc.Status.TrustMode == "" {
 		trust, err := fc.CheckTrusted()
 		if err != nil {
 			klog.Error(err)
@@ -99,7 +99,7 @@ func (r *ForeignClusterReconciler) Reconcile(req ctrl.Request) (ctrl.Result, err
 		}
 		// set join flag
 		// if it was discovery with WAN discovery, this value is overwritten by SearchDomain value
-		if fc.Spec.DiscoveryType != discoveryv1alpha1.WanDiscovery && fc.Spec.DiscoveryType != discoveryv1alpha1.IncomingPeeringDiscovery {
+		if fc.Spec.DiscoveryType != discoveryv1alpha1.WanDiscovery && fc.Spec.DiscoveryType != discoveryv1alpha1.IncomingPeeringDiscovery && fc.Spec.DiscoveryType != discoveryv1alpha1.ManualDiscovery {
 			fc.Spec.Join = (r.getAutoJoin(fc) && fc.Status.TrustMode == discoveryv1alpha1.TrustModeTrusted) || (r.getAutoJoinUntrusted(fc) && fc.Status.TrustMode == discoveryv1alpha1.TrustModeUntrusted)
 		}
 

--- a/internal/discovery/search-domain-operator/search-domain-controller.go
+++ b/internal/discovery/search-domain-operator/search-domain-controller.go
@@ -20,6 +20,8 @@ type SearchDomainReconciler struct {
 	requeueAfter  time.Duration
 	crdClient     *crdClient.CRDClient
 	DiscoveryCtrl *discovery.DiscoveryCtrl
+
+	DnsAddress string
 }
 
 func (r *SearchDomainReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
@@ -49,7 +51,7 @@ func (r *SearchDomainReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error
 
 	update := false
 
-	txts, err := Wan("", sd.Spec.Domain, false)
+	txts, err := Wan(r.DnsAddress, sd.Spec.Domain)
 	if err != nil {
 		klog.Error(err, err.Error())
 		return ctrl.Result{

--- a/test/unit/discovery/discovery_test.go
+++ b/test/unit/discovery/discovery_test.go
@@ -374,7 +374,7 @@ func testMergeClusters(t *testing.T) {
 		Namespace: fc.Spec.Namespace,
 		ApiUrl:    strings.Replace(fc.Spec.ApiUrl, "127.0.0.1", "127.0.0.2", -1),
 	}
-	fc, err = clientCluster.discoveryCtrl.CheckUpdate(txt, fc, fc.Spec.DiscoveryType)
+	fc, err = clientCluster.discoveryCtrl.CheckUpdate(txt, fc, fc.Spec.DiscoveryType, nil)
 	assert.NilError(t, err)
 	assert.Equal(t, fc.Spec.ApiUrl, txt.ApiUrl, "API URL not changed")
 

--- a/test/unit/discovery/env_test.go
+++ b/test/unit/discovery/env_test.go
@@ -90,6 +90,7 @@ func getClientCluster() *Cluster {
 		&cluster.discoveryCtrl,
 		1*time.Minute,
 	)
+	cluster.sdReconciler.DnsAddress = "127.0.0.1:8053"
 	err = cluster.sdReconciler.SetupWithManager(mgr)
 	if err != nil {
 		klog.Error(err, err.Error())


### PR DESCRIPTION
# Description

This PR adds a priority in Discover Types.

If a cluster was already discovered with `IncomingPeering` type (and so not automatically joined) and it is discovered again in another way (`WAN`, `LAN` or `Manual`) the discovery type is overwritten.

If the new Discovery Type is `WAN` the join flag is set accordingly to the value set in the `SearchDomain`.

Fixes #307 

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Local K3s deployment
