### PR TITLE
Virtual kubelet for-select pattern fix

### DIFF
--- a/internal/kubernetes/virtualNodeupdater.go
+++ b/internal/kubernetes/virtualNodeupdater.go
@@ -78,8 +78,6 @@ func (p *KubernetesProvider) StartNodeUpdater(nodeRunner *node.NodeController) (
 				advWatcher.Stop()
 				tepWatcher.Stop()
 				return
-			default:
-				break
 			}
 		}
 	}()

--- a/pkg/virtualKubelet/apiReflection/controller/controller.go
+++ b/pkg/virtualKubelet/apiReflection/controller/controller.go
@@ -62,8 +62,6 @@ func NewApiController(homeClient, foreignClient kubernetes.Interface, mapper nam
 			case <-c.stopController:
 				c.mainControllerRoutine.Done()
 				return
-			default:
-				break
 			}
 		}
 	}()
@@ -77,11 +75,8 @@ func (c *Controller) outgoingReflectionControlLoop() {
 		case <-c.stopReflection:
 			c.outgoingReflectionGroup.Done()
 			return
-
 		case e := <-c.outgoingReflectionInforming:
 			c.outgoingReflectorsController.DispatchEvent(e)
-		default:
-			break
 		}
 	}
 }
@@ -92,11 +87,8 @@ func (c *Controller) incomingReflectionControlLoop() {
 		case <-c.stopReflection:
 			c.incomingReflectionGroup.Done()
 			return
-
 		case e := <-c.incomingReflectionInforming:
 			c.incomingReflectorsController.DispatchEvent(e)
-		default:
-			break
 		}
 	}
 }

--- a/pkg/virtualKubelet/apiReflection/controller/incomingReflectorsController.go
+++ b/pkg/virtualKubelet/apiReflection/controller/incomingReflectorsController.go
@@ -66,8 +66,6 @@ func (c *IncomingReflectorsController) Start() {
 			c.startNamespaceReflection(ns)
 		case ns := <-c.namespaceNatting.PollStopIncomingReflection():
 			c.stopNamespaceReflection(ns)
-		default:
-			break
 		}
 	}
 }

--- a/pkg/virtualKubelet/apiReflection/controller/outgoingReflectorsController.go
+++ b/pkg/virtualKubelet/apiReflection/controller/outgoingReflectorsController.go
@@ -66,8 +66,6 @@ func (c *OutgoingReflectorsController) Start() {
 			c.startNamespaceReflection(ns)
 		case ns := <-c.namespaceNatting.PollStopOutgoingReflection():
 			c.stopNamespaceReflection(ns)
-		default:
-			break
 		}
 	}
 }


### PR DESCRIPTION
# Description

This commit removes all the default statements from the for-select constructs. That approach led to a spinlock resulting in a very high CPU consumption.