### PR TITLE
PeeringRequest and Broadcaster Roles

### DIFF
--- a/cmd/advertisement-broadcaster/main.go
+++ b/cmd/advertisement-broadcaster/main.go
@@ -15,7 +15,7 @@ func main() {
 	flag.StringVar(&localKubeconfig, "local-kubeconfig", "", "The path to the kubeconfig of your local cluster.")
 	flag.StringVar(&clusterId, "cluster-id", "", "The cluster ID of your cluster")
 	flag.StringVar(&peeringRequestName, "peering-request", "", "Name of PeeringRequest CR containing configurations")
-	flag.StringVar(&saName, "service-account", "broadcaster", "The name of the ServiceAccount used to create the kubeconfig that will be sent to the foreign cluster")
+	flag.StringVar(&saName, "service-account", "vk-remote", "The name of the ServiceAccount used to create the kubeconfig that will be sent to the foreign cluster")
 	flag.Parse()
 
 	if peeringRequestName == "" {

--- a/cmd/peering-request-operator/main.go
+++ b/cmd/peering-request-operator/main.go
@@ -13,13 +13,14 @@ import (
 func main() {
 	klog.Info("Starting")
 
-	var broadcasterImage, broadcasterServiceAccount string
+	var broadcasterImage, broadcasterServiceAccount, vkServiceAccount string
 	var inputEnvFile string
 	var kubeconfigPath string
 
 	flag.StringVar(&inputEnvFile, "input-env-file", "/etc/environment/liqo/env", "The environment variable file to source at startup")
 	flag.StringVar(&broadcasterImage, "broadcaster-image", "liqo/advertisement-broadcaster", "Broadcaster-operator image name")
 	flag.StringVar(&broadcasterServiceAccount, "broadcaster-sa", "broadcaster", "Broadcaster-operator ServiceAccount name")
+	flag.StringVar(&vkServiceAccount, "vk-sa", "vk-remote", "Remote VirtualKubelet ServiceAccount name")
 	flag.StringVar(&kubeconfigPath, "kubeconfigPath", filepath.Join(os.Getenv("HOME"), ".kube", "config"), "For debug purpose, set path to local kubeconfig")
 	flag.Parse()
 
@@ -45,5 +46,5 @@ func main() {
 	_ = peering_request_admission.StartWebhook(certPath, keyPath, namespace, kubeconfigPath)
 
 	klog.Info("Starting peering-request operator")
-	peering_request_operator.StartOperator(namespace, broadcasterImage, broadcasterServiceAccount, kubeconfigPath)
+	peering_request_operator.StartOperator(namespace, broadcasterImage, broadcasterServiceAccount, vkServiceAccount, kubeconfigPath)
 }

--- a/deployments/liqo/subcharts/peeringRequestOperator/templates/broadcaster.yaml
+++ b/deployments/liqo/subcharts/peeringRequestOperator/templates/broadcaster.yaml
@@ -6,8 +6,62 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     k8s-app: broadcaster
+
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: broadcaster
+rules:
+  - apiGroups:
+      - discovery.liqo.io
+    resources:
+      - peeringrequests
+    verbs:
+      - get
+      - update
+      - delete
+  - apiGroups:
+      - config.liqo.io
+    resources:
+      - clusterconfigs
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+      - pods
+    verbs:
+      - list
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: broadcaster
+  namespace: {{ .Release.Namespace }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts
+    verbs:
+      - get
+    resourceNames:
+      - vk-remote
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: broadcaster
@@ -15,6 +69,46 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: broadcaster
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: broadcaster
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: broadcaster
+  namespace: {{ .Release.Namespace }}
+subjects:
+  - kind: ServiceAccount
+    name: broadcaster
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: broadcaster
+
+---
+# Remote VirtualKubelet
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: vk-remote
+  namespace: {{ .Release.Namespace }}
+  labels:
+    k8s-app: broadcaster
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: vk-remote
+  namespace: {{ .Release.Namespace }}
+subjects:
+  - kind: ServiceAccount
+    name: vk-remote
     namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/deployments/liqo/subcharts/peeringRequestOperator/templates/peering-request-deploy.yaml
+++ b/deployments/liqo/subcharts/peeringRequestOperator/templates/peering-request-deploy.yaml
@@ -9,6 +9,87 @@ metadata:
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: peering-request-operator
+rules:
+  - apiGroups:
+      - discovery.liqo.io
+    resources:
+      - peeringrequests
+    verbs:
+      - get
+      - list
+      - patch
+      - update
+      - watch
+      - create
+      - delete
+  - apiGroups:
+      - discovery.liqo.io
+    resources:
+      - foreignclusters
+    verbs:
+      - list
+      - update
+      - create
+  - apiGroups:
+      - certificates.k8s.io
+    resources:
+      - certificatesigningrequests
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - validatingwebhookconfigurations
+    verbs:
+      - get
+      - patch
+      - create
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: peering-request-operator
+  namespace: {{ .Release.Namespace }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - patch
+      - create
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: peering-request-operator
@@ -20,7 +101,22 @@ subjects:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: cluster-admin
+  name: peering-request-operator
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: peering-request-operator
+  namespace: {{ .Release.Namespace }}
+subjects:
+  - kind: ServiceAccount
+    name: peering-request-operator
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: peering-request-operator
 
 ---
 apiVersion: apps/v1

--- a/go.sum
+++ b/go.sum
@@ -494,6 +494,7 @@ github.com/gruntwork-io/gruntwork-cli v0.7.0 h1:YgSAmfCj9c61H+zuvHwKfYUwlMhu5arn
 github.com/gruntwork-io/gruntwork-cli v0.7.0/go.mod h1:jp6Z7NcLF2avpY8v71fBx6hds9eOFPELSuD/VPv7w00=
 github.com/gruntwork-io/terratest v0.30.6 h1:CApJ/auCKe5it8M739nTHpfK6fEH3VleMqzInadu/Bk=
 github.com/gruntwork-io/terratest v0.30.6/go.mod h1:7dNmTD2zDKUEVqfmvcUU5c9mZi+986mcXNzhzqPYPg8=
+github.com/gruntwork-io/terratest v0.30.7 h1:RmvfWTngHv9Mat2AF4++Znte8Znkz585/IzDvUgz84o=
 github.com/gruntwork-io/terratest v0.30.7/go.mod h1:7dNmTD2zDKUEVqfmvcUU5c9mZi+986mcXNzhzqPYPg8=
 github.com/hashicorp/consul/api v1.3.0/go.mod h1:MmDNSzIMUjNpY/mQ398R4bk2FnqQLoPndWW5VkKPlCE=
 github.com/hashicorp/consul/sdk v0.3.0/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=

--- a/internal/advertisement-operator/broadcaster.go
+++ b/internal/advertisement-operator/broadcaster.go
@@ -119,15 +119,8 @@ func StartBroadcaster(homeClusterId, localKubeconfigPath, peeringRequestName, sa
 
 	kubeconfigSecretName := pkg.VirtualKubeletSecPrefix + homeClusterId
 
-	// get the ServiceAccount with the permissions that will be given to the foreign cluster
-	sa, err := localClient.Client().CoreV1().ServiceAccounts(pr.Spec.Namespace).Get(context.TODO(), saName, metav1.GetOptions{})
-	if err != nil {
-		klog.Errorln(err, "Unable to get ServiceAccount "+saName)
-		return err
-	}
-
 	// create the kubeconfig to allow the foreign cluster to create resources on local cluster
-	kubeconfigForForeignCluster, err := kubeconfig.CreateKubeConfig(localClient.Client(), sa.Name, sa.Namespace)
+	kubeconfigForForeignCluster, err := kubeconfig.CreateKubeConfig(localClient.Client(), saName, pr.Spec.Namespace)
 	if err != nil {
 		klog.Errorln(err, "Unable to create Kubeconfig")
 		return err
@@ -137,7 +130,7 @@ func StartBroadcaster(homeClusterId, localKubeconfigPath, peeringRequestName, sa
 		TypeMeta: metav1.TypeMeta{},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      kubeconfigSecretName,
-			Namespace: sa.Namespace,
+			Namespace: pr.Spec.Namespace,
 		},
 		Data: nil,
 		StringData: map[string]string{

--- a/internal/peering-request-operator/broadcaster.go
+++ b/internal/peering-request-operator/broadcaster.go
@@ -31,14 +31,14 @@ func (r *PeeringRequestReconciler) BroadcasterExists(request *discoveryv1alpha1.
 	return true, nil
 }
 
-func GetBroadcasterDeployment(request *discoveryv1alpha1.PeeringRequest, nameSA string, namespace string, image string, clusterId string) *appsv1.Deployment {
+func GetBroadcasterDeployment(request *discoveryv1alpha1.PeeringRequest, nameSA string, remoteSA string, namespace string, image string, clusterId string) *appsv1.Deployment {
 	args := []string{
 		"--peering-request",
 		request.Name,
 		"--cluster-id",
 		clusterId,
 		"--service-account",
-		nameSA, //TODO: using this SA, we pass to the foreign cluster a kubeconfig with the same permissions of the broadcaster deployment; if we want to pass a different one we have to forge it
+		remoteSA,
 	}
 
 	deploy := &appsv1.Deployment{

--- a/internal/peering-request-operator/peering-request-controller.go
+++ b/internal/peering-request-operator/peering-request-controller.go
@@ -42,6 +42,7 @@ type PeeringRequestReconciler struct {
 	configMapName             string
 	broadcasterImage          string
 	broadcasterServiceAccount string
+	vkServiceAccount          string
 	retryTimeout              time.Duration
 
 	// testing
@@ -88,7 +89,7 @@ func (r *PeeringRequestReconciler) Reconcile(req ctrl.Request) (ctrl.Result, err
 	}
 	if !exists {
 		klog.Info("Deploy Broadcaster")
-		deploy := GetBroadcasterDeployment(pr, r.broadcasterServiceAccount, r.Namespace, r.broadcasterImage, r.clusterId.GetClusterID())
+		deploy := GetBroadcasterDeployment(pr, r.broadcasterServiceAccount, r.vkServiceAccount, r.Namespace, r.broadcasterImage, r.clusterId.GetClusterID())
 		deploy, err = r.crdClient.Client().AppsV1().Deployments(r.Namespace).Create(context.TODO(), deploy, metav1.CreateOptions{})
 		if err != nil {
 			klog.Error(err, err.Error())

--- a/internal/peering-request-operator/setup.go
+++ b/internal/peering-request-operator/setup.go
@@ -22,7 +22,7 @@ func init() {
 	// +kubebuilder:scaffold:scheme
 }
 
-func StartOperator(namespace string, broadcasterImage string, broadcasterServiceAccount string, kubeconfigPath string) {
+func StartOperator(namespace string, broadcasterImage string, broadcasterServiceAccount string, vkServiceAccount string, kubeconfigPath string) {
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:           scheme,
 		Port:             9443,
@@ -58,6 +58,7 @@ func StartOperator(namespace string, broadcasterImage string, broadcasterService
 		clusterId,
 		broadcasterImage,
 		broadcasterServiceAccount,
+		vkServiceAccount,
 	)).SetupWithManager(mgr); err != nil {
 		klog.Error(err, "unable to create controller")
 		os.Exit(1)
@@ -70,7 +71,7 @@ func StartOperator(namespace string, broadcasterImage string, broadcasterService
 	}
 }
 
-func GetPRReconciler(scheme *runtime.Scheme, crdClient *crdClient.CRDClient, namespace string, clusterId *clusterID.ClusterID, broadcasterImage string, broadcasterServiceAccount string) *PeeringRequestReconciler {
+func GetPRReconciler(scheme *runtime.Scheme, crdClient *crdClient.CRDClient, namespace string, clusterId *clusterID.ClusterID, broadcasterImage string, broadcasterServiceAccount string, vkServiceAccount string) *PeeringRequestReconciler {
 	return &PeeringRequestReconciler{
 		Scheme:                    scheme,
 		crdClient:                 crdClient,
@@ -78,6 +79,7 @@ func GetPRReconciler(scheme *runtime.Scheme, crdClient *crdClient.CRDClient, nam
 		clusterId:                 clusterId,
 		broadcasterImage:          broadcasterImage,
 		broadcasterServiceAccount: broadcasterServiceAccount,
+		vkServiceAccount:          vkServiceAccount,
 		retryTimeout:              1 * time.Minute,
 		ForeignConfig:             nil,
 	}

--- a/test/unit/discovery/env_test.go
+++ b/test/unit/discovery/env_test.go
@@ -69,6 +69,7 @@ func getClientCluster() *Cluster {
 		cluster.clusterId,
 		"broadcaster",
 		"br-sa",
+		"br-sa",
 	)
 	err = cluster.prReconciler.SetupWithManager(mgr)
 	if err != nil {
@@ -132,6 +133,7 @@ func getServerCluster() *Cluster {
 		"default",
 		cluster.clusterId,
 		"broadcaster",
+		"br-sa",
 		"br-sa",
 	)
 	err = cluster.prReconciler.SetupWithManager(mgr)


### PR DESCRIPTION
# Description

This PR reduces the amount of privileges provided to the peering request service account and to the broadcaster service account

* Privileges of the PeeringRequestOperator
* Privileges of the Broadcaster
* Create a new role for remote VirtualKubelet with cluster-admin access (previously it was using the broadcaster service account)

Ref. #303 

# How Has This Been Tested?

- [x] E2E
- [x] Locally on kind
