### PR TITLE
Network operators supporting peering sessions with more than two clusters

### DIFF
--- a/internal/kubernetes/virtualNodeupdater.go
+++ b/internal/kubernetes/virtualNodeupdater.go
@@ -6,7 +6,6 @@ import (
 	nettypes "github.com/liqotech/liqo/apis/net/v1alpha1"
 	advtypes "github.com/liqotech/liqo/apis/sharing/v1alpha1"
 	advertisementOperator "github.com/liqotech/liqo/internal/advertisement-operator"
-	controllers "github.com/liqotech/liqo/internal/liqonet"
 	"github.com/liqotech/liqo/internal/node"
 	"github.com/liqotech/liqo/pkg/virtualKubelet"
 	"github.com/liqotech/liqo/pkg/virtualKubelet/options"
@@ -31,9 +30,8 @@ func (p *KubernetesProvider) StartNodeUpdater(nodeRunner *node.NodeController) (
 		return nil, nil, err
 	}
 
-	tepName := strings.Join([]string{controllers.TunEndpointNamePrefix, p.foreignClusterId}, "")
 	tepWatcher, err := p.tunEndClient.Resource("tunnelendpoints").Watch(metav1.ListOptions{
-		FieldSelector: strings.Join([]string{"metadata.name", tepName}, "="),
+		LabelSelector: strings.Join([]string{"clusterID", p.foreignClusterId}, "="),
 		Watch:         true,
 	})
 	if err != nil {
@@ -67,7 +65,7 @@ func (p *KubernetesProvider) StartNodeUpdater(nodeRunner *node.NodeController) (
 					klog.Error(err)
 					tepWatcher.Stop()
 					tepWatcher, err = p.tunEndClient.Resource("tunnelendpoints").Watch(metav1.ListOptions{
-						FieldSelector: strings.Join([]string{"metadata.name", tepName}, "="),
+						LabelSelector: strings.Join([]string{"clusterID", p.foreignClusterId}, "="),
 						Watch:         true,
 					})
 					if err != nil {

--- a/pkg/liqonet/tunnel.go
+++ b/pkg/liqonet/tunnel.go
@@ -8,10 +8,11 @@ import (
 	"github.com/vishvananda/netlink"
 	"net"
 	"os"
+	"strings"
 )
 
 const (
-	tunnelNamePrefix = "gretun_"
+	tunnelNamePrefix = "liqo-"
 	tunnelTtl        = 255
 )
 
@@ -31,8 +32,8 @@ func GetLocalTunnelPublicIP() (net.IP, error) {
 }
 
 func InstallGreTunnel(endpoint *netv1alpha1.TunnelEndpoint) (int, string, error) {
-	//TODO configure the name according to the max length permitted by the kernel
-	name := tunnelNamePrefix
+	tokens := strings.Split(endpoint.Name, "-")
+	name := strings.Join([]string{tunnelNamePrefix, tokens[2]}, "")
 	//get the local ip address and use it as local ip for the gre tunnel
 	local, err := GetLocalTunnelPublicIP()
 	if err != nil {


### PR DESCRIPTION
# Description

The resources of type `networkconfigs.net.liqo.io` used to exchange the network parameters are now identified by using `labels` and not their name. The name is generated automatically at creation time. Before the clusterID of a remote cluster was used to name a `networkconfig` resource causing conflicts when multiple clusters were sending their parameters to a remote cluster.

The VPN tunnels are now named based on the last 5 characters of the related `tunnelendpoints.net.liqo.io` resource.

# How Has This Been Tested?

The unit tests have been updated to use labels instead of fixed names for the resources involved.
