### PR TITLE
LAN Discovery Refactoring

### DIFF
--- a/apis/config/v1alpha1/clusterconfig_types.go
+++ b/apis/config/v1alpha1/clusterconfig_types.go
@@ -109,21 +109,14 @@ type DiscoveryConfig struct {
 	// +kubebuilder:validation:Maximum=65355
 	// +kubebuilder:validation:Minimum=1
 	Port int `json:"port"`
-
-	// +kubebuilder:validation:Minimum=1
-	WaitTime int `json:"waitTime"`
-	// +kubebuilder:validation:Minimum=2
-	UpdateTime int `json:"updateTime"`
+	// +kubebuilder:validation:Minimum=30
+	Ttl uint32 `json:"ttl"`
 
 	EnableDiscovery     bool `json:"enableDiscovery"`
 	EnableAdvertisement bool `json:"enableAdvertisement"`
 
 	AutoJoin          bool `json:"autojoin"`
 	AutoJoinUntrusted bool `json:"autojoinUntrusted"`
-
-	// --- CA ---
-
-	AllowUntrustedCA bool `json:"allowUntrustedCA"`
 }
 
 type LiqonetConfig struct {

--- a/apis/discovery/v1alpha1/foreigncluster_types.go
+++ b/apis/discovery/v1alpha1/foreigncluster_types.go
@@ -45,6 +45,10 @@ const (
 	TrustModeUntrusted TrustMode = "Untrusted"
 )
 
+const (
+	LastUpdateAnnotation string = "LastUpdate"
+)
+
 // ForeignClusterSpec defines the desired state of ForeignCluster
 type ForeignClusterSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
@@ -77,7 +81,7 @@ type ForeignClusterStatus struct {
 	Outgoing Outgoing `json:"outgoing,omitempty"`
 	Incoming Incoming `json:"incoming,omitempty"`
 	// If discoveryType is LAN and this counter reach 0 value, this FC will be removed
-	Ttl int `json:"ttl,omitempty"`
+	Ttl uint32 `json:"ttl,omitempty"`
 	// +kubebuilder:validation:Enum="Unknown";"Trusted";"Untrusted"
 	// +kubebuilder:default="Unknown"
 	// Indicates if this remote cluster is trusted or not

--- a/apis/discovery/v1alpha1/peeringrequest_types.go
+++ b/apis/discovery/v1alpha1/peeringrequest_types.go
@@ -42,14 +42,6 @@ type PeeringRequestSpec struct {
 	KubeConfigRef *v1.ObjectReference `json:"kubeConfigRef,omitempty"`
 }
 
-type ReverseJoin string
-
-const (
-	NoReverseJoin      ReverseJoin = "NoReverseJoin"      // this cluster will not allow remote cluster to send its PeeringRequest
-	AllowReverseJoin   ReverseJoin = "AllowReverseJoin"   // this cluster will accept remote cluster PeeringRequest
-	RequireReverseJoin ReverseJoin = "RequireReverseJoin" // this cluster asks to remote cluster to send its PeeringRequest
-)
-
 // PeeringRequestStatus defines the observed state of PeeringRequest
 type PeeringRequestStatus struct {
 	BroadcasterRef      *object_references.DeploymentReference `json:"broadcasterRef,omitempty"`

--- a/cmd/discovery/main.go
+++ b/cmd/discovery/main.go
@@ -36,10 +36,12 @@ func main() {
 	var namespace string
 	var requeueAfter int64 // seconds
 	var kubeconfigPath string
+	var resolveContextRefreshTime int // minutes
 
 	flag.StringVar(&namespace, "namespace", "default", "Namespace where your configs are stored.")
 	flag.Int64Var(&requeueAfter, "requeueAfter", 30, "Period after that PeeringRequests status is rechecked (seconds)")
 	flag.StringVar(&kubeconfigPath, "kubeconfigPath", filepath.Join(os.Getenv("HOME"), ".kube", "config"), "For debug purpose, set path to local kubeconfig")
+	flag.IntVar(&resolveContextRefreshTime, "resolveContextRefreshTime", 10, "Period after that mDNS resolve context is refreshed (minutes)")
 	flag.Parse()
 
 	klog.Info("Namespace: ", namespace)
@@ -56,7 +58,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	discoveryCtl, err := discovery.NewDiscoveryCtrl(namespace, clusterId, kubeconfigPath)
+	discoveryCtl, err := discovery.NewDiscoveryCtrl(namespace, clusterId, kubeconfigPath, resolveContextRefreshTime)
 	if err != nil {
 		klog.Error(err, err.Error())
 		os.Exit(1)

--- a/deployments/liqo/crds/config.liqo.io_clusterconfigs.yaml
+++ b/deployments/liqo/crds/config.liqo.io_clusterconfigs.yaml
@@ -107,8 +107,6 @@ spec:
                 type: object
               discoveryConfig:
                 properties:
-                  allowUntrustedCA:
-                    type: boolean
                   autojoin:
                     type: boolean
                   autojoinUntrusted:
@@ -130,14 +128,11 @@ spec:
                     type: integer
                   service:
                     type: string
-                  updateTime:
-                    minimum: 2
-                    type: integer
-                  waitTime:
-                    minimum: 1
+                  ttl:
+                    format: int32
+                    minimum: 30
                     type: integer
                 required:
-                - allowUntrustedCA
                 - autojoin
                 - autojoinUntrusted
                 - domain
@@ -146,8 +141,7 @@ spec:
                 - name
                 - port
                 - service
-                - updateTime
-                - waitTime
+                - ttl
                 type: object
               dispatcherConfig:
                 properties:

--- a/deployments/liqo/crds/discovery.liqo.io_foreignclusters.yaml
+++ b/deployments/liqo/crds/discovery.liqo.io_foreignclusters.yaml
@@ -342,6 +342,7 @@ spec:
                 type: string
               ttl:
                 description: If discoveryType is LAN and this counter reach 0 value, this FC will be removed
+                format: int32
                 type: integer
             type: object
         type: object

--- a/deployments/liqo/templates/clusterconfig.yaml
+++ b/deployments/liqo/templates/clusterconfig.yaml
@@ -23,10 +23,8 @@ spec:
     enableDiscovery: true
     name: MyLiqo
     port: 6443
-    allowUntrustedCA: true
     service: _liqo._tcp
-    updateTime: 3
-    waitTime: 2
+    ttl: 90
   liqonetConfig:
     podCIDR: {{ .Values.podCIDR }}
     serviceCIDR: {{ .Values.serviceCIDR }}

--- a/go.mod
+++ b/go.mod
@@ -95,3 +95,5 @@ replace k8s.io/node-api => k8s.io/node-api v0.18.6
 replace k8s.io/sample-cli-plugin => k8s.io/sample-cli-plugin v0.18.6
 
 replace k8s.io/sample-controller => k8s.io/sample-controller v0.18.6
+
+replace github.com/grandcat/zeroconf => github.com/liqotech/zeroconf v1.0.1-0.20201020081245-6384f3f21ffb

--- a/go.sum
+++ b/go.sum
@@ -584,6 +584,10 @@ github.com/libopenstorage/openstorage v1.0.0/go.mod h1:Sp1sIObHjat1BeXhfMqLZ14wn
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de/go.mod h1:zAbeS9B/r2mtpb6U+EI2rYA5OAXxsYw6wTamcNW+zcE=
 github.com/lightstep/lightstep-tracer-common/golang/gogo v0.0.0-20190605223551-bc2310a04743/go.mod h1:qklhhLq1aX+mtWk9cPHPzaBjWImj5ULL6C7HFJtXQMM=
 github.com/lightstep/lightstep-tracer-go v0.18.1/go.mod h1:jlF1pusYV4pidLvZ+XD0UBX0ZE6WURAspgAczcDHrL4=
+github.com/liqotech/zeroconf v1.0.0 h1:PmterK8YQySR2VD1xTmEXq088MP7oc59y38vlK1rRS4=
+github.com/liqotech/zeroconf v1.0.0/go.mod h1:lTKmG1zh86XyCoUeIHSA4FJMBwCJiQmGfcP2PdzytEs=
+github.com/liqotech/zeroconf v1.0.1-0.20201020081245-6384f3f21ffb h1:FokBo/2VZRYP72Y030Z5bQXiIr7gs/nt/ISqnuCsiq0=
+github.com/liqotech/zeroconf v1.0.1-0.20201020081245-6384f3f21ffb/go.mod h1:lTKmG1zh86XyCoUeIHSA4FJMBwCJiQmGfcP2PdzytEs=
 github.com/lithammer/dedent v1.1.0/go.mod h1:jrXYCQtgg0nJiN+StA2KgR7w6CiQNv9Fd/Z9BP0jIOc=
 github.com/logrusorgru/aurora v0.0.0-20181002194514-a7b3b318ed4e/go.mod h1:7rIyQOR62GCctdiQpZ/zOJlFyk6y+94wXzv6RNZgaR4=
 github.com/lpabon/godbc v0.1.1/go.mod h1:Jo9QV0cf3U6jZABgiJ2skINAXb9j8m51r07g4KI92ZA=

--- a/internal/discovery/foreignClusterGarbageCollector.go
+++ b/internal/discovery/foreignClusterGarbageCollector.go
@@ -1,0 +1,44 @@
+package discovery
+
+import (
+	goerrors "errors"
+	"github.com/liqotech/liqo/apis/discovery/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog"
+	"strings"
+	"time"
+)
+
+func (discovery *DiscoveryCtrl) StartGarbageCollector() {
+	for range time.NewTicker(30 * time.Second).C {
+		_ = discovery.CollectGarbage()
+	}
+}
+
+// The GarbageCollector deletes all ForeignClusters discovered with LAN that have expired TTL
+func (discovery *DiscoveryCtrl) CollectGarbage() error {
+	tmp, err := discovery.crdClient.Resource("foreignclusters").List(metav1.ListOptions{
+		LabelSelector: strings.Join([]string{"discovery-type", string(v1alpha1.LanDiscovery)}, "="),
+	})
+	if err != nil {
+		klog.Error(err)
+		return err
+	}
+	fcs, ok := tmp.(*v1alpha1.ForeignClusterList)
+	if !ok {
+		err = goerrors.New("retrieved object is not a ForeignCluster")
+		klog.Error(err)
+		return err
+	}
+
+	for _, fc := range fcs.Items {
+		if fc.IsExpired() {
+			err = discovery.crdClient.Resource("foreignclusters").Delete(fc.Name, metav1.DeleteOptions{})
+			if err != nil {
+				klog.Error(err)
+				continue
+			}
+		}
+	}
+	return nil
+}

--- a/internal/discovery/gratuitous-answers.go
+++ b/internal/discovery/gratuitous-answers.go
@@ -1,0 +1,19 @@
+package discovery
+
+import "time"
+
+func (discovery *DiscoveryCtrl) StartGratuitousAnswers() {
+	for range time.NewTicker(12 * time.Second).C {
+		if discovery.Config.EnableAdvertisement {
+			discovery.sendAnswer()
+		}
+	}
+}
+
+func (discovery *DiscoveryCtrl) sendAnswer() {
+	discovery.serverMux.Lock()
+	defer discovery.serverMux.Unlock()
+	if discovery.mdnsServer != nil {
+		discovery.mdnsServer.SendMulticast()
+	}
+}

--- a/internal/discovery/search-domain-operator/search-domain-controller.go
+++ b/internal/discovery/search-domain-operator/search-domain-controller.go
@@ -59,7 +59,7 @@ func (r *SearchDomainReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error
 			RequeueAfter: r.requeueAfter,
 		}, err
 	}
-	fcs := r.DiscoveryCtrl.UpdateForeign(txts, sd)
+	fcs := r.DiscoveryCtrl.UpdateForeignWAN(txts, sd)
 	if len(fcs) > 0 {
 		// new FCs added, so update the list
 		AddToList(sd, ForeignClustersToObjectReferences(fcs))

--- a/internal/discovery/search-domain-operator/wan.go
+++ b/internal/discovery/search-domain-operator/wan.go
@@ -81,7 +81,13 @@ func ResolveWan(c *dns.Client, dnsAddr string, ptr *dns.PTR) (*discovery.TxtData
 		return nil, err
 	}
 
-	return discovery.Decode(srv.Target, strconv.Itoa(int(srv.Port)), txt)
+	txtData, err := discovery.Decode(srv.Target, strconv.Itoa(int(srv.Port)), txt)
+	if err != nil {
+		klog.Error(err, err.Error())
+		return nil, err
+	}
+	txtData.Ttl = srv.Header().Ttl
+	return txtData, nil
 }
 
 func GetDnsMsg(name string, qType uint16) *dns.Msg {

--- a/internal/discovery/txtData.go
+++ b/internal/discovery/txtData.go
@@ -14,6 +14,7 @@ type TxtData struct {
 	Name      string
 	Namespace string
 	ApiUrl    string
+	Ttl       uint32
 }
 
 func (txtData TxtData) Encode() ([]string, error) {

--- a/internal/peering-request-operator/peering-request-controller.go
+++ b/internal/peering-request-operator/peering-request-controller.go
@@ -39,7 +39,6 @@ type PeeringRequestReconciler struct {
 	crdClient                 *crdClient.CRDClient
 	Namespace                 string
 	clusterId                 *clusterID.ClusterID
-	configMapName             string
 	broadcasterImage          string
 	broadcasterServiceAccount string
 	vkServiceAccount          string

--- a/test/unit/crdReplicator/env_test.go
+++ b/test/unit/crdReplicator/env_test.go
@@ -209,8 +209,7 @@ func getClusterConfig() *configv1alpha1.ClusterConfig {
 				Name:                "MyLiqo",
 				Port:                6443,
 				Service:             "_liqo._tcp",
-				UpdateTime:          3,
-				WaitTime:            2,
+				Ttl:                 30,
 			},
 			LiqonetConfig: configv1alpha1.LiqonetConfig{
 				ReservedSubnets: []string{"10.0.0.0/16"},

--- a/test/unit/discovery/discovery_test.go
+++ b/test/unit/discovery/discovery_test.go
@@ -156,7 +156,8 @@ func testDiscoveryConfig(t *testing.T) {
 	cc = tmp.(*configv1alpha1.ClusterConfig)
 
 	time.Sleep(1 * time.Second)
-	assert.Equal(t, *clientCluster.discoveryCtrl.Config, cc.Spec.DiscoveryConfig)
+	cnf := clientCluster.discoveryCtrl.Config
+	assert.Equal(t, *cnf, cc.Spec.DiscoveryConfig)
 }
 
 // ------
@@ -374,8 +375,9 @@ func testMergeClusters(t *testing.T) {
 		Namespace: fc.Spec.Namespace,
 		ApiUrl:    strings.Replace(fc.Spec.ApiUrl, "127.0.0.1", "127.0.0.2", -1),
 	}
-	fc, err = clientCluster.discoveryCtrl.CheckUpdate(txt, fc, fc.Spec.DiscoveryType, nil)
+	fc, updated, err := clientCluster.discoveryCtrl.CheckUpdate(txt, fc, fc.Spec.DiscoveryType, nil)
 	assert.NilError(t, err)
+	assert.Assert(t, updated)
 	assert.Equal(t, fc.Spec.ApiUrl, txt.ApiUrl, "API URL not changed")
 
 	time.Sleep(100 * time.Millisecond)

--- a/test/unit/discovery/env_test.go
+++ b/test/unit/discovery/env_test.go
@@ -82,6 +82,7 @@ func getClientCluster() *Cluster {
 		cluster.client,
 		cluster.advClient,
 		cluster.clusterId,
+		10,
 	)
 	cluster.discoveryCtrl.Config = &cc.Spec.DiscoveryConfig
 
@@ -147,6 +148,7 @@ func getServerCluster() *Cluster {
 		cluster.client,
 		cluster.advClient,
 		cluster.clusterId,
+		10,
 	)
 	cluster.discoveryCtrl.Config = &cc.Spec.DiscoveryConfig
 
@@ -276,10 +278,8 @@ func getClusterConfig(config rest.Config) *configv1alpha1.ClusterConfig {
 				EnableDiscovery:     true,
 				Name:                "MyLiqo",
 				Port:                6443,
-				AllowUntrustedCA:    false,
 				Service:             "_liqo._tcp",
-				UpdateTime:          3,
-				WaitTime:            2,
+				Ttl:                 30,
 			},
 			LiqonetConfig: configv1alpha1.LiqonetConfig{
 				ReservedSubnets: []string{"10.0.0.0/16"},

--- a/test/unit/liqonet/env_test.go
+++ b/test/unit/liqonet/env_test.go
@@ -144,8 +144,7 @@ func getClusterConfig() *configv1alpha1.ClusterConfig {
 				Name:                "MyLiqo",
 				Port:                6443,
 				Service:             "_liqo._tcp",
-				UpdateTime:          3,
-				WaitTime:            2,
+				Ttl:                 30,
 			},
 			LiqonetConfig: configv1alpha1.LiqonetConfig{
 				ReservedSubnets: []string{"10.0.0.0/16"},


### PR DESCRIPTION
# Description

This PR makes a refactoring of how LAN discovery works. Now the client has no more to do polling asking the server for changes. Ths mDNS server now is in charge to send periodically broadcast messages to each client

The entire refactoring is done basing on this schema
![lan_discovery_interaction](https://user-images.githubusercontent.com/36957454/96973802-aebdba00-1518-11eb-8f8c-6ea233bedc10.png)

# How Has This Been Tested?

- [x] On local kind clusters
- [x] Add some tests on ForeignCluster garbage collection (where their TTL expires)
- [x] Deploy on 2 kind clusters and delete one of the two, to see how it is working
