### PR TITLE
kubernetes service env var translation

### DIFF
--- a/internal/advertisement-operator/controller.go
+++ b/internal/advertisement-operator/controller.go
@@ -22,6 +22,7 @@ import (
 	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
 	advtypes "github.com/liqotech/liqo/apis/sharing/v1alpha1"
 	advpkg "github.com/liqotech/liqo/pkg/advertisement-operator"
+	"github.com/liqotech/liqo/pkg/apiServerUtils"
 	"github.com/liqotech/liqo/pkg/crdClient"
 	objectreferences "github.com/liqotech/liqo/pkg/object-references"
 	"github.com/liqotech/liqo/pkg/virtualKubelet"
@@ -295,8 +296,13 @@ func (r *AdvertisementReconciler) createVirtualKubelet(ctx context.Context, adv 
 	if err != nil {
 		return err
 	}
+	homeApiServerAddress, err := apiServerUtils.GetAddress(r.AdvClient.Client())
+	if err != nil {
+		return err
+	}
+	homeApiServerPort := apiServerUtils.GetPort()
 	// Create the virtual Kubelet
-	deploy := advpkg.CreateVkDeployment(adv, name, r.KubeletNamespace, r.VKImage, r.InitVKImage, nodeName, r.HomeClusterId)
+	deploy := advpkg.CreateVkDeployment(adv, name, r.KubeletNamespace, r.VKImage, r.InitVKImage, nodeName, r.HomeClusterId, homeApiServerAddress, homeApiServerPort)
 	err = advpkg.CreateOrUpdate(r.Client, ctx, deploy)
 	if err != nil {
 		return err

--- a/internal/discovery/kubeconfig/kubeconfig.go
+++ b/internal/discovery/kubeconfig/kubeconfig.go
@@ -2,14 +2,12 @@ package kubeconfig
 
 import (
 	"context"
-	"errors"
+	"github.com/liqotech/liqo/pkg/apiServerUtils"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
 	clientcmdlatest "k8s.io/client-go/tools/clientcmd/api/latest"
-	"k8s.io/klog"
 	kubeconfigutil "k8s.io/kubernetes/cmd/kubeadm/app/util/kubeconfig"
-	"os"
 )
 
 // this function creates a kube-config file for a specified ServiceAccount
@@ -24,26 +22,12 @@ func CreateKubeConfig(clientset kubernetes.Interface, serviceAccountName string,
 		return "", err
 	}
 
-	address, ok := os.LookupEnv("APISERVER")
-	if !ok || address == "" {
-		nodes, err := clientset.CoreV1().Nodes().List(context.TODO(), v1.ListOptions{
-			LabelSelector: "node-role.kubernetes.io/master",
-		})
-		if err != nil {
-			return "", err
-		}
-		if len(nodes.Items) == 0 || len(nodes.Items[0].Status.Addresses) == 0 {
-			err = errors.New("no APISERVER env variable found and no master node found, one of the two values must be present")
-			klog.Error(err, err.Error())
-			return "", err
-		}
-		address = nodes.Items[0].Status.Addresses[0].Address
+	address, err := apiServerUtils.GetAddress(clientset)
+	if err != nil {
+		return "", err
 	}
 
-	port, ok := os.LookupEnv("APISERVER_PORT")
-	if !ok {
-		port = "6443"
-	}
+	port := apiServerUtils.GetPort()
 
 	token := string(secret.Data["token"])
 	server := "https://" + address + ":" + port

--- a/pkg/advertisement-operator/creation.go
+++ b/pkg/advertisement-operator/creation.go
@@ -15,7 +15,7 @@ import (
 )
 
 // create deployment for a virtual-kubelet
-func CreateVkDeployment(adv *advtypes.Advertisement, vkName, vkNamespace, vkImage, initVKImage, nodeName, homeClusterId string) *appsv1.Deployment {
+func CreateVkDeployment(adv *advtypes.Advertisement, vkName, vkNamespace, vkImage, initVKImage, nodeName, homeClusterId string, homeApiServerAddress string, homeApiServerPort string) *appsv1.Deployment {
 
 	command := []string{
 		"/usr/bin/virtual-kubelet",
@@ -165,6 +165,14 @@ func CreateVkDeployment(adv *advtypes.Advertisement, vkName, vkNamespace, vkImag
 								{
 									Name:  "VKUBELET_TAINT_EFFECT",
 									Value: "NoExecute",
+								},
+								{
+									Name:  "HOME_KUBERNETES_IP",
+									Value: homeApiServerAddress,
+								},
+								{
+									Name:  "HOME_KUBERNETES_PORT",
+									Value: homeApiServerPort,
 								},
 							},
 						},

--- a/pkg/apiServerUtils/apiServerUtils.go
+++ b/pkg/apiServerUtils/apiServerUtils.go
@@ -1,0 +1,37 @@
+package apiServerUtils
+
+import (
+	"context"
+	"errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog"
+	"os"
+)
+
+func GetAddress(clientset kubernetes.Interface) (string, error) {
+	address, ok := os.LookupEnv("APISERVER")
+	if !ok || address == "" {
+		nodes, err := clientset.CoreV1().Nodes().List(context.TODO(), v1.ListOptions{
+			LabelSelector: "node-role.kubernetes.io/master",
+		})
+		if err != nil {
+			return "", err
+		}
+		if len(nodes.Items) == 0 || len(nodes.Items[0].Status.Addresses) == 0 {
+			err = errors.New("no APISERVER env variable found and no master node found, one of the two values must be present")
+			klog.Error(err)
+			return "", err
+		}
+		address = nodes.Items[0].Status.Addresses[0].Address
+	}
+	return address, nil
+}
+
+func GetPort() string {
+	port, ok := os.LookupEnv("APISERVER_PORT")
+	if !ok {
+		port = "6443"
+	}
+	return port
+}

--- a/test/unit/advertisement-operator/creation_test.go
+++ b/test/unit/advertisement-operator/creation_test.go
@@ -123,7 +123,7 @@ func TestCreateVkDeployment(t *testing.T) {
 	initVkImage := "liqo/init-vk"
 	homeClusterId := "cluster2"
 
-	deploy := pkg.CreateVkDeployment(adv, vkName, vkNamespace, vkImage, initVkImage, nodeName, homeClusterId)
+	deploy := pkg.CreateVkDeployment(adv, vkName, vkNamespace, vkImage, initVkImage, nodeName, homeClusterId, "127.0.0.1", "6443")
 
 	assert.Equal(t, vkName, deploy.Name)
 	assert.Equal(t, vkNamespace, deploy.Namespace)


### PR DESCRIPTION
# Description

Insert the IP of the home API server in the environment variables of the offloaded pods. In this way, the offloaded pods are able to contact our home cluster in the same way if they were scheduled locally

# How Has This Been Tested?

- [x] new unit test added
