### PR TITLE
change section's title

### DIFF
--- a/docs/pages/User/GettingStarted/test.md
+++ b/docs/pages/User/GettingStarted/test.md
@@ -1,5 +1,5 @@
 ---
-title: Exploit foreign resources
+title: Deploy simple resources
 weight: 3
 ---
 

--- a/docs/pages/User/GettingStarted/test.md
+++ b/docs/pages/User/GettingStarted/test.md
@@ -1,5 +1,5 @@
 ---
-title: Deploy simple resources
+title: Use foreign resources
 weight: 3
 ---
 


### PR DESCRIPTION
# Description

Skimming the liqo documentation, I noticed that the title for this section could be misinterpreted or confuse the reader because of the word `exploit`. In the IT industry, the word `exploit` has usually a negative connotation - this is especially true in the field of security. That's why I would suggest to change the title for this lovely section.

Following some suggestions for a new title:
- Hello, foreign cluster!
- Test the configuration
- Smoke test
- Deploy simple resources
- Run a simple workload

What do you think?

# How Has This Been Tested?

No tests.