### PR TITLE
Fix build pipeline for forked repositories

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -41,7 +41,7 @@ jobs:
           echo "::set-output name=repo-suffix::"
 
         # Do not push the resulting images to DockerHub if triggered by a fork
-        [[  "${{ github.event.repository.full_name }}" != 'liqotech/liqo' ]] && \
+        [[  "${{ github.event.pull_request.head.repo.full_name }}" != 'liqotech/liqo' ]] && \
             echo "::set-output name=repo-push::false" || \
             echo "::set-output name=repo-push::true"
 


### PR DESCRIPTION
# Description

This PR introduces a fix for Forked repositories, avoiding crash in case of missing secrets access.

# How Has This Been Tested?

- [ ] Tested with E2E tests.
