### PR TITLE
discover auth service

### DIFF
--- a/apis/config/v1alpha1/clusterconfig_types.go
+++ b/apis/config/v1alpha1/clusterconfig_types.go
@@ -107,7 +107,9 @@ type DiscoveryConfig struct {
 
 	Name    string `json:"name"`
 	Service string `json:"service"`
-	Domain  string `json:"domain"`
+	// +kubebuilder:default="_auth._tcp"
+	AuthService string `json:"authService,omitempty"`
+	Domain      string `json:"domain"`
 	// +kubebuilder:validation:Maximum=65355
 	// +kubebuilder:validation:Minimum=1
 	Port int `json:"port"`

--- a/deployments/liqo/crds/config.liqo.io_clusterconfigs.yaml
+++ b/deployments/liqo/crds/config.liqo.io_clusterconfigs.yaml
@@ -138,6 +138,9 @@ spec:
                 type: object
               discoveryConfig:
                 properties:
+                  authService:
+                    default: _auth._tcp
+                    type: string
                   autojoin:
                     type: boolean
                   autojoinUntrusted:

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/gorilla/mux v1.7.4
 	github.com/grandcat/zeroconf v1.0.0
 	github.com/gruntwork-io/terratest v0.30.7
+	github.com/jinzhu/copier v0.0.0-20201025035756-632e723a6687
 	github.com/joho/godotenv v1.3.0
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/miekg/dns v1.1.27

--- a/go.sum
+++ b/go.sum
@@ -566,6 +566,8 @@ github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANyt
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
 github.com/jellevandenhooff/dkim v0.0.0-20150330215556-f50fe3d243e1/go.mod h1:E0B/fFc00Y+Rasa88328GlI/XbtyysCtTHZS8h7IrBU=
 github.com/jimstudt/http-authentication v0.0.0-20140401203705-3eca13d6893a/go.mod h1:wK6yTYYcgjHE1Z1QtXACPDjcFJyBskHEdagmnq3vsP8=
+github.com/jinzhu/copier v0.0.0-20201025035756-632e723a6687 h1:bWXum+xWafUxxJpcXnystwg5m3iVpPYtrGJFc1rjfLc=
+github.com/jinzhu/copier v0.0.0-20201025035756-632e723a6687/go.mod h1:24xnZezI2Yqac9J61UC6/dG/k76ttpq0DdJI3QmUvro=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5imkbgOkpRUYLnmbU7UEFbjtDA2hxJ1ichM=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/joefitzgerald/rainbow-reporter v0.1.0/go.mod h1:481CNgqmVHQZzdIbN52CupLJyoVwB10FQ/IQlF1pdL8=
@@ -1093,6 +1095,9 @@ golang.org/x/net v0.0.0-20200625001655-4c5254603344 h1:vGXIOMxbNfDTk/aXCmfdLgkrS
 golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20201006153459-a7d1128ccaa0 h1:wBouT66WTYFXdxfVdz9sVWARVd/2vfGcmI45D2gj45M=
 golang.org/x/net v0.0.0-20201006153459-a7d1128ccaa0/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
+golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
+golang.org/x/net v0.0.0-20201110031124-69a78807bb2b h1:uwuIcX0g4Yl1NC5XAz37xsr2lTtcqevgzYNVt49waME=
+golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190402181905-9f3314589c9a/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -1160,8 +1165,8 @@ golang.org/x/sys v0.0.0-20191228213918-04cbcbbfeed8/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200106162015-b016eb3dc98e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200107162124-548cf772de50/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200113162924-86b910548bc1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200120151820-655fe14d7479/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-202012000122134326-e047566fdf82 h1:ywK/j/KkyTHcdyYSZNXGjMwgmDSfjglYZ3vStQ/gSCU=
 golang.org/x/sys v0.0.0-20200122134326-e047566fdf82/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200212091648-12a6c2dcc1e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -1181,6 +1186,7 @@ golang.org/x/sys v0.0.0-20201015000850-e3ed0017c211 h1:9UQO31fZ+0aKQOFldThf7BKPM
 golang.org/x/sys v0.0.0-20201015000850-e3ed0017c211/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201113233024-12cec1faf1ba h1:xmhUJGQGbxlod18iJGqVEp9cHIPLl7QiX2aA3to708s=
 golang.org/x/sys v0.0.0-20201113233024-12cec1faf1ba/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-202012000122134326-e047566fdf82 h1:ywK/j/KkyTHcdyYSZNXGjMwgmDSfjglYZ3vStQ/gSCU=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.0.0-20170915090833-1cbadb444a80/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/internal/discovery/authData.go
+++ b/internal/discovery/authData.go
@@ -1,0 +1,67 @@
+package discovery
+
+import (
+	"errors"
+	"github.com/grandcat/zeroconf"
+	"k8s.io/klog"
+	"net"
+	"sync"
+)
+
+type AuthData struct {
+	address string
+	port    int
+}
+
+func (authData *AuthData) Get(discovery *DiscoveryCtrl, entry *zeroconf.ServiceEntry) error {
+	return authData.Decode(entry)
+}
+
+func (authData *AuthData) Decode(entry *zeroconf.ServiceEntry) error {
+	authData.port = entry.Port
+
+	ip, err := getReachable(entry.AddrIPv4, entry.Port)
+	if err != nil {
+		ip, err = getReachable(entry.AddrIPv6, entry.Port)
+	}
+	if err != nil {
+		klog.Error(err)
+		return err
+	}
+
+	authData.address = ip.String()
+	return nil
+}
+
+func getReachable(ips []net.IP, port int) (*net.IP, error) {
+	resChan := make(chan int, len(ips))
+	defer close(resChan)
+	wg := sync.WaitGroup{}
+	wg.Add(len(ips))
+
+	// search in an async way for all reachable ips
+	for i, ip := range ips {
+		go func(ip net.IP, port int, index int, ch chan int) {
+			if !ip.IsLoopback() && !ip.IsMulticast() && isReachable(ip.String(), port) {
+				ch <- index
+			}
+			wg.Done()
+		}(ip, port, i, resChan)
+	}
+	wg.Wait()
+
+	// if someone is reachable return its index
+	select {
+	case i := <-resChan:
+		return &ips[i], nil
+	default:
+		return nil, errors.New("server not reachable")
+	}
+}
+
+func isReachable(address string, port int) bool {
+	//_, err := net.DialTimeout("tcp", fmt.Sprintf("%s:%d", address, port), 500*time.Millisecond)
+	//return err == nil
+	// TODO: no service is available yet
+	return true
+}

--- a/internal/discovery/discovery-config.go
+++ b/internal/discovery/discovery-config.go
@@ -98,6 +98,11 @@ func (discovery *DiscoveryCtrl) handleConfiguration(config configv1alpha1.Discov
 			discovery.Config.Port = config.Port
 			reloadServer = true
 		}
+		if discovery.Config.AuthService != config.AuthService {
+			discovery.Config.AuthService = config.AuthService
+			reloadServer = true
+			reloadClient = true
+		}
 		if discovery.Config.Service != config.Service {
 			discovery.Config.Service = config.Service
 			reloadServer = true

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -23,6 +23,7 @@ type DiscoveryCtrl struct {
 	ClusterId      *clusterID.ClusterID
 
 	mdnsServer                *zeroconf.Server
+	mdnsServerAuth            *zeroconf.Server
 	serverMux                 sync.Mutex
 	resolveContextRefreshTime int
 }

--- a/internal/discovery/discoveryCache.go
+++ b/internal/discovery/discoveryCache.go
@@ -1,0 +1,82 @@
+package discovery
+
+import (
+	"errors"
+	"github.com/jinzhu/copier"
+	"sync"
+)
+
+type discoveryData struct {
+	TxtData  *TxtData
+	AuthData *AuthData
+}
+
+type discoveryCache struct {
+	discoveredServices map[string]discoveryData
+	lock               sync.RWMutex
+}
+
+var resolvedData = discoveryCache{
+	discoveredServices: map[string]discoveryData{},
+}
+
+func NewDiscoveryData(txtData *TxtData, authData *AuthData) *discoveryData {
+	return &discoveryData{
+		TxtData:  txtData,
+		AuthData: authData,
+	}
+}
+
+func (discoveryCache *discoveryCache) add(key string, data DiscoverableData) {
+	discoveryCache.lock.Lock()
+	defer discoveryCache.lock.Unlock()
+	if _, ok := discoveryCache.discoveredServices[key]; !ok {
+		switch data := data.(type) {
+		case *TxtData:
+			discoveryCache.discoveredServices[key] = discoveryData{
+				TxtData: data,
+			}
+		case *AuthData:
+			discoveryCache.discoveredServices[key] = discoveryData{
+				AuthData: data,
+			}
+		}
+	} else {
+		oldData := discoveryCache.discoveredServices[key]
+		switch data := data.(type) {
+		case *TxtData:
+			oldData.TxtData = data
+		case *AuthData:
+			oldData.AuthData = data
+		}
+		discoveryCache.discoveredServices[key] = oldData
+	}
+}
+
+func (discoveryCache *discoveryCache) get(key string) (*discoveryData, error) {
+	discoveryCache.lock.RLock()
+	defer discoveryCache.lock.RUnlock()
+	if v, ok := discoveryCache.discoveredServices[key]; !ok {
+		return nil, errors.New("key not found")
+	} else {
+		res := &discoveryData{}
+		if err := copier.Copy(res, v); err != nil {
+			return nil, err
+		}
+		return res, nil
+	}
+}
+
+func (discoveryCache *discoveryCache) isComplete(key string) bool {
+	discoveryCache.lock.RLock()
+	defer discoveryCache.lock.RUnlock()
+	if v, ok := discoveryCache.discoveredServices[key]; !ok {
+		return false
+	} else {
+		return v.isComplete()
+	}
+}
+
+func (discoveryData *discoveryData) isComplete() bool {
+	return discoveryData.TxtData != nil && discoveryData.AuthData != nil
+}

--- a/internal/discovery/discoveryData.go
+++ b/internal/discovery/discoveryData.go
@@ -1,0 +1,7 @@
+package discovery
+
+import "github.com/grandcat/zeroconf"
+
+type DiscoverableData interface {
+	Get(discovery *DiscoveryCtrl, entry *zeroconf.ServiceEntry) error
+}

--- a/internal/discovery/gratuitous-answers.go
+++ b/internal/discovery/gratuitous-answers.go
@@ -16,4 +16,7 @@ func (discovery *DiscoveryCtrl) sendAnswer() {
 	if discovery.mdnsServer != nil {
 		discovery.mdnsServer.SendMulticast()
 	}
+	if discovery.mdnsServerAuth != nil {
+		discovery.mdnsServerAuth.SendMulticast()
+	}
 }

--- a/internal/discovery/search-domain-operator/wan.go
+++ b/internal/discovery/search-domain-operator/wan.go
@@ -81,8 +81,8 @@ func ResolveWan(c *dns.Client, dnsAddr string, ptr *dns.PTR) (*discovery.TxtData
 		return nil, err
 	}
 
-	txtData, err := discovery.Decode(srv.Target, strconv.Itoa(int(srv.Port)), txt)
-	if err != nil {
+	txtData := &discovery.TxtData{}
+	if err = txtData.Decode(srv.Target, strconv.Itoa(int(srv.Port)), txt); err != nil {
 		klog.Error(err, err.Error())
 		return nil, err
 	}

--- a/test/unit/discovery/discovery_test.go
+++ b/test/unit/discovery/discovery_test.go
@@ -370,15 +370,16 @@ func testMergeClusters(t *testing.T) {
 	fc, ok := tmp.(*v1alpha1.ForeignCluster)
 	assert.Equal(t, ok, true)
 
-	txt := &discovery.TxtData{
-		ID:        fc.Spec.ClusterIdentity.ClusterID,
-		Namespace: fc.Spec.Namespace,
-		ApiUrl:    strings.Replace(fc.Spec.ApiUrl, "127.0.0.1", "127.0.0.2", -1),
-	}
-	fc, updated, err := clientCluster.discoveryCtrl.CheckUpdate(txt, fc, fc.Spec.DiscoveryType, nil)
+	data := discovery.NewDiscoveryData(
+		&discovery.TxtData{
+			ID:        fc.Spec.ClusterIdentity.ClusterID,
+			Namespace: fc.Spec.Namespace,
+			ApiUrl:    strings.Replace(fc.Spec.ApiUrl, "127.0.0.1", "127.0.0.2", -1),
+		}, nil)
+	fc, updated, err := clientCluster.discoveryCtrl.CheckUpdate(data, fc, fc.Spec.DiscoveryType, nil)
 	assert.NilError(t, err)
 	assert.Assert(t, updated)
-	assert.Equal(t, fc.Spec.ApiUrl, txt.ApiUrl, "API URL not changed")
+	assert.Equal(t, fc.Spec.ApiUrl, data.TxtData.ApiUrl, "API URL not changed")
 
 	time.Sleep(100 * time.Millisecond)
 


### PR DESCRIPTION
# Description

Before to contact the remote auth service we have to discover it. With this pr we will be able to know the IP and the port of this service

## What's new

A new service is added to mDNS discovery, the two services (API server host+port and Auth service host+port) are linked by the same instance id. When the mDNS client discover both of them it is able to create the new ForeignCluster CR

To be able to match services by instance name, this pr adds a new cache map:
* key: string
* value:
  * auth service data
  * API server data

Ref. issue #371
