### PR TITLE
ci labeler update

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -19,14 +19,11 @@ networking:
 virtual-node:
   - build/virtual-kubelet/**/*
   - build/init-vkubelet/**/*
-  - cmd/virtual-kubelet/**/*
-  - internal/kubernetes/**/*
-  - internal/errdefs/**/*
-  - internal/manager/**/*
-  - internal/node/**/*
-  - internal/trace/**/*
-  - test/kubernetes_provider/**/*
   - build/pod-mutator/**/*
+  - cmd/virtual-kubelet/**/*
+  - internal/virtualKubelet/**/*
+  - pkg/virtualKubelet/**/*
+  - test/virtualKubelet/**/*
 
 discovery:
   - internal/discovery/**/*

--- a/test/unit/reflector/reflector.go
+++ b/test/unit/reflector/reflector.go
@@ -1,1 +1,0 @@
-package reflector


### PR DESCRIPTION
# Description

This PR:
* updates the directories observed for labeling PRs with the `virtual node` label
* removes a useless reflector package under `/test/unit`
