### PR TITLE
expose auth service

### DIFF
--- a/cmd/auth-service/main.go
+++ b/cmd/auth-service/main.go
@@ -16,11 +16,15 @@ func main() {
 	var kubeconfigPath string
 	var resyncSeconds int64
 	var listeningPort string
+	var certFile string
+	var keyFile string
 
 	flag.StringVar(&namespace, "namespace", "default", "Namespace where your configs are stored.")
 	flag.StringVar(&kubeconfigPath, "kubeconfigPath", filepath.Join(os.Getenv("HOME"), ".kube", "config"), "For debug purpose, set path to local kubeconfig")
 	flag.Int64Var(&resyncSeconds, "resyncSeconds", 30, "Resync seconds for the informers")
 	flag.StringVar(&listeningPort, "listeningPort", "5000", "Sets the port where the service will listen")
+	flag.StringVar(&certFile, "certFile", "/certs/cert.pem", "Path to cert file")
+	flag.StringVar(&keyFile, "keyFile", "/certs/key.pem", "Path to key file")
 	flag.Parse()
 
 	klog.Info("Namespace: ", namespace)
@@ -31,7 +35,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err = authService.Start(listeningPort); err != nil {
+	if err = authService.Start(listeningPort, certFile, keyFile); err != nil {
 		klog.Error(err)
 		os.Exit(1)
 	}

--- a/cmd/discovery/main.go
+++ b/cmd/discovery/main.go
@@ -37,11 +37,13 @@ func main() {
 	var requeueAfter int64 // seconds
 	var kubeconfigPath string
 	var resolveContextRefreshTime int // minutes
+	var dialTcpTimeout int64          // milliseconds
 
 	flag.StringVar(&namespace, "namespace", "default", "Namespace where your configs are stored.")
 	flag.Int64Var(&requeueAfter, "requeueAfter", 30, "Period after that PeeringRequests status is rechecked (seconds)")
 	flag.StringVar(&kubeconfigPath, "kubeconfigPath", filepath.Join(os.Getenv("HOME"), ".kube", "config"), "For debug purpose, set path to local kubeconfig")
 	flag.IntVar(&resolveContextRefreshTime, "resolveContextRefreshTime", 10, "Period after that mDNS resolve context is refreshed (minutes)")
+	flag.Int64Var(&dialTcpTimeout, "dialTcpTimeout", 500, "Time to wait for a TCP connection to a remote cluster before to consider it as not reachable (milliseconds)")
 	flag.Parse()
 
 	klog.Info("Namespace: ", namespace)
@@ -58,7 +60,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	discoveryCtl, err := discovery.NewDiscoveryCtrl(namespace, clusterId, kubeconfigPath, resolveContextRefreshTime)
+	discoveryCtl, err := discovery.NewDiscoveryCtrl(namespace, clusterId, kubeconfigPath, resolveContextRefreshTime, time.Duration(dialTcpTimeout)*time.Millisecond)
 	if err != nil {
 		klog.Error(err, err.Error())
 		os.Exit(1)

--- a/deployments/liqo/Chart.yaml
+++ b/deployments/liqo/Chart.yaml
@@ -58,3 +58,7 @@ dependencies:
   version: "0.1.0"
   repository: file://subcharts/crdReplicator/
   condition: crdreplicator.enabled
+- name: authService
+  version: "0.1.0"
+  repository: file://subcharts/authService/
+  condition: authService.enabled

--- a/deployments/liqo/subcharts/authService/.helmignore
+++ b/deployments/liqo/subcharts/authService/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/deployments/liqo/subcharts/authService/Chart.yaml
+++ b/deployments/liqo/subcharts/authService/Chart.yaml
@@ -1,0 +1,23 @@
+apiVersion: v2
+name: authService
+description: A Helm chart for Liqo Auth Service
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+appVersion: 1.16.0

--- a/deployments/liqo/subcharts/authService/templates/auth-service-deploy.yaml
+++ b/deployments/liqo/subcharts/authService/templates/auth-service-deploy.yaml
@@ -2,132 +2,59 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: discovery-sa
+  name: auth-service-sa
   namespace: {{ .Release.Namespace }}
   labels:
-    k8s-app: discovery
+    k8s-app: auth-service
     app: liqo.io
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: liqo-discovery
+  name: liqo-auth-service
 rules:
   - apiGroups:
-      - discovery.liqo.io
+      - ""
     resources:
-      - foreignclusters
-      - searchdomains
+      - nodes
     verbs:
       - get
       - list
-      - patch
-      - update
       - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterroles
+      - clusterrolebindings
+    verbs:
       - create
       - delete
+
+  # required to grant permissions
   - apiGroups:
       - discovery.liqo.io
     resources:
       - peeringrequests
     verbs:
       - get
-      - list
-      - watch
-  - apiGroups:
-      - config.liqo.io
-    resources:
-      - clusterconfigs
-    verbs:
-      - get
-      - list
-      - watch
       - create
-  - apiGroups:
-      - net.liqo.io
-    resources:
-      - networkconfigs
-      - tunnelendpoints
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - sharing.liqo.io
-    resources:
-      - advertisements
-    verbs:
-      - get
-      - list
-      - watch
       - delete
-  - apiGroups:
-      - ""
-    resources:
-      - nodes
-    verbs:
-      - list
-  - apiGroups:
-      - rbac.authorization.k8s.io
-    resources:
-      - clusterroles
-    verbs:
-      - get
-      - create
       - update
-  - apiGroups:
-      - rbac.authorization.k8s.io
-    resources:
-      - clusterrolebindings
-    verbs:
-      - get
-      - create
-
-  # to satisfy ClusterRoles creation
-  - apiGroups:
-      - ""
-      - sharing.liqo.io
-    resources:
-      - advertisements
-      - advertisements/status
-    verbs:
-      - get
-      - list
-      - create
-      - update
-      - delete
-      - watch
-  - apiGroups:
-      - net.liqo.io
-    resources:
-      - networkconfigs
-      - networkconfigs/status
-    verbs:
-      - "*"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: liqo-discovery
+  name: liqo-auth-service
 rules:
   - apiGroups:
       - ""
     resources:
-      - services
-    verbs:
-      - get
-  - apiGroups:
-      - ""
-    resources:
-      - configmaps
       - secrets
     verbs:
       - get
       - list
       - watch
       - create
-      - update
-      - delete
   - apiGroups:
       - ""
     resources:
@@ -141,81 +68,84 @@ rules:
       - rbac.authorization.k8s.io
     resources:
       - roles
-    verbs:
-      - get
-      - create
-      - update
-  - apiGroups:
-      - rbac.authorization.k8s.io
-    resources:
       - rolebindings
     verbs:
-      - get
       - create
+      - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: discovery
+  name: auth-service
   namespace: {{ .Release.Namespace }}
   labels:
-    k8s-app: discovery
+    k8s-app: auth-service
     app: liqo.io
 subjects:
   - kind: ServiceAccount
-    name: discovery-sa
+    name: auth-service-sa
     namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: liqo-discovery
+  name: liqo-auth-service
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: discovery
+  name: auth-service
   namespace: {{ .Release.Namespace }}
   labels:
-    k8s-app: discovery
+    k8s-app: auth-service
     app: liqo.io
 subjects:
   - kind: ServiceAccount
-    name: discovery-sa
+    name: auth-service-sa
     namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: liqo-discovery
+  name: liqo-auth-service
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    run: discovery
+    run: auth-service
     app: liqo.io
-  name: discovery
+  name: auth-service
   namespace: {{ .Release.Namespace }}
 spec:
   replicas: 1
   selector:
     matchLabels:
-      run: discovery
+      run: auth-service
   template:
     metadata:
       labels:
-        run: discovery
+        run: auth-service
     spec:
-      serviceAccountName: discovery-sa
+      serviceAccountName: auth-service-sa
+      initContainers:
+        - name: cert-creator
+          image: nginx
+          volumeMounts:
+            - mountPath: '/certs'
+              name: certs
+          command: [ "/bin/sh" ]
+          args: [ "-c", 'openssl req -x509 -subj "/C=IT/ST=Turin/O=Liqo" -nodes -days 365 -newkey rsa:4096 -keyout /certs/key.pem -out /certs/cert.pem' ]
       containers:
         - image: {{ .Values.image.repository }}{{ .Values.global.suffix | default .Values.suffix }}:{{ .Values.global.version | default .Values.version }}
-          name: discovery
+          name: auth-service
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command: ["/usr/bin/entrypoint.sh", "/usr/bin/discovery"]
+          command: ["/usr/bin/auth-service"]
           args:
           - "--namespace"
           - "$(POD_NAMESPACE)"
-          - "--requeueAfter"
+          - "--resyncSeconds"
           - "30"
+          - "--listeningPort"
+          - "5000"
           env:
             - name: POD_NAMESPACE
               valueFrom:
@@ -229,9 +159,6 @@ spec:
             - name: APISERVER_PORT
               value: {{ .Values.apiServerPort }}
             {{ end }}
-          volumeMounts:
-            - mountPath: /usr/local/share/ca-certificates
-              name: ca-certificates
           resources:
             limits:
               cpu: 50m
@@ -239,9 +166,26 @@ spec:
             requests:
               cpu: 50m
               memory: 50M
+          volumeMounts:
+            - mountPath: '/certs'
+              name: certs
       volumes:
-        - name: ca-certificates
-          configMap:
-            name: trusted-ca-certificates
-      hostNetwork: true
-
+        - name: certs
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    run: auth-service
+  name: auth-service
+  namespace: {{ .Release.Namespace }}
+spec:
+  type: NodePort
+  selector:
+    run: auth-service
+  ports:
+    - name: https
+      protocol: TCP
+      port: 443
+      targetPort: 5000

--- a/deployments/liqo/subcharts/authService/values.yaml
+++ b/deployments/liqo/subcharts/authService/values.yaml
@@ -1,0 +1,14 @@
+# Default values for discoveryOperator.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+
+image:
+  repository: "liqo/auth-service"
+  pullPolicy: "IfNotPresent"
+
+suffix: ""
+version: "latest"
+
+apiServerIp: ""
+apiServerPort: ""

--- a/deployments/liqo/values.yaml
+++ b/deployments/liqo/values.yaml
@@ -97,6 +97,12 @@ crdReplicator:
     pullPolicy: "IfNotPresent"
   enabled: true
 
+authService:
+  image:
+    repository: "liqo/auth-service"
+    pullPolicy: "IfNotPresent"
+  enabled: true
+
 global:
   configmapName: "liqo-configmap"
   dashboard_ingress: ""

--- a/internal/auth-service/auth-service.go
+++ b/internal/auth-service/auth-service.go
@@ -58,7 +58,7 @@ func NewAuthServiceCtrl(namespace string, kubeconfigPath string, resyncTime time
 	}, nil
 }
 
-func (authService *AuthServiceCtrl) Start(listeningPort string) error {
+func (authService *AuthServiceCtrl) Start(listeningPort string, certFile string, keyFile string) error {
 	if err := authService.configureToken(); err != nil {
 		return err
 	}
@@ -67,7 +67,7 @@ func (authService *AuthServiceCtrl) Start(listeningPort string) error {
 
 	router.POST("/role", authService.role)
 
-	err := http.ListenAndServe(strings.Join([]string{":", listeningPort}, ""), router)
+	err := http.ListenAndServeTLS(strings.Join([]string{":", listeningPort}, ""), certFile, keyFile, router)
 	if err != nil {
 		klog.Error(err)
 		return err

--- a/internal/discovery/authData.go
+++ b/internal/discovery/authData.go
@@ -2,10 +2,12 @@ package discovery
 
 import (
 	"errors"
+	"fmt"
 	"github.com/grandcat/zeroconf"
 	"k8s.io/klog"
 	"net"
 	"sync"
+	"time"
 )
 
 type AuthData struct {
@@ -14,26 +16,42 @@ type AuthData struct {
 }
 
 func (authData *AuthData) Get(discovery *DiscoveryCtrl, entry *zeroconf.ServiceEntry) error {
-	return authData.Decode(entry)
+	if discovery.isForeign(entry.AddrIPv4) {
+		return authData.Decode(entry, discovery.dialTcpTimeout)
+	}
+	return nil
 }
 
-func (authData *AuthData) Decode(entry *zeroconf.ServiceEntry) error {
+// check if both address and port are correctly set
+func (authData *AuthData) IsComplete() bool {
+	return authData.address != "" && authData.port > 0
+}
+
+// populate the AuthData struct from a DNS entry
+// takes as argument the DNS entry and a timeout used to find reachable remote services
+func (authData *AuthData) Decode(entry *zeroconf.ServiceEntry, timeout time.Duration) error {
 	authData.port = entry.Port
 
-	ip, err := getReachable(entry.AddrIPv4, entry.Port)
+	// checks if there is an IPv4 reachable
+	ip, err := getReachable(entry.AddrIPv4, entry.Port, timeout)
 	if err != nil {
-		ip, err = getReachable(entry.AddrIPv6, entry.Port)
+		// checks if there is an IPv6 reachable
+		ip, err = getReachable(entry.AddrIPv6, entry.Port, timeout)
 	}
 	if err != nil {
-		klog.Error(err)
+		klog.Errorf("%v %v %v", err, entry.AddrIPv4, entry.Port)
 		return err
 	}
 
+	// use the reachable IP
+	// this is the IP that will be contacted to get the required permissions from the remote cluster
 	authData.address = ip.String()
 	return nil
 }
 
-func getReachable(ips []net.IP, port int) (*net.IP, error) {
+// look for a reachable IP in the ips array
+// this is done in an async and parallel way to not to take too much time if the IP list is long
+func getReachable(ips []net.IP, port int, timeout time.Duration) (*net.IP, error) {
 	resChan := make(chan int, len(ips))
 	defer close(resChan)
 	wg := sync.WaitGroup{}
@@ -42,7 +60,7 @@ func getReachable(ips []net.IP, port int) (*net.IP, error) {
 	// search in an async way for all reachable ips
 	for i, ip := range ips {
 		go func(ip net.IP, port int, index int, ch chan int) {
-			if !ip.IsLoopback() && !ip.IsMulticast() && isReachable(ip.String(), port) {
+			if !ip.IsLoopback() && !ip.IsMulticast() && isReachable(ip.String(), port, timeout) {
 				ch <- index
 			}
 			wg.Done()
@@ -50,7 +68,7 @@ func getReachable(ips []net.IP, port int) (*net.IP, error) {
 	}
 	wg.Wait()
 
-	// if someone is reachable return its index
+	// if someone is reachable (the first reachable) return its index
 	select {
 	case i := <-resChan:
 		return &ips[i], nil
@@ -59,9 +77,10 @@ func getReachable(ips []net.IP, port int) (*net.IP, error) {
 	}
 }
 
-func isReachable(address string, port int) bool {
-	//_, err := net.DialTimeout("tcp", fmt.Sprintf("%s:%d", address, port), 500*time.Millisecond)
-	//return err == nil
-	// TODO: no service is available yet
-	return true
+// check if this address + port is reachable with TCP
+// the service is reachable if we are able to establish a TCP connection before the timeout
+func isReachable(address string, port int, timeout time.Duration) bool {
+	_, err := net.DialTimeout("tcp", fmt.Sprintf("%s:%d", address, port), timeout)
+	klog.V(4).Infof("%s:%d %v", address, port, err)
+	return err == nil
 }

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/klog"
 	"os"
 	"sync"
+	"time"
 )
 
 type DiscoveryCtrl struct {
@@ -26,9 +27,11 @@ type DiscoveryCtrl struct {
 	mdnsServerAuth            *zeroconf.Server
 	serverMux                 sync.Mutex
 	resolveContextRefreshTime int
+
+	dialTcpTimeout time.Duration
 }
 
-func NewDiscoveryCtrl(namespace string, clusterId *clusterID.ClusterID, kubeconfigPath string, resolveContextRefreshTime int) (*DiscoveryCtrl, error) {
+func NewDiscoveryCtrl(namespace string, clusterId *clusterID.ClusterID, kubeconfigPath string, resolveContextRefreshTime int, dialTcpTimeout time.Duration) (*DiscoveryCtrl, error) {
 	config, err := crdClient.NewKubeconfig(kubeconfigPath, &discoveryv1alpha1.GroupVersion)
 	if err != nil {
 		return nil, err
@@ -50,6 +53,7 @@ func NewDiscoveryCtrl(namespace string, clusterId *clusterID.ClusterID, kubeconf
 		advClient,
 		clusterId,
 		resolveContextRefreshTime,
+		dialTcpTimeout,
 	)
 	if discoveryCtrl.GetDiscoveryConfig(nil, kubeconfigPath) != nil {
 		os.Exit(1)
@@ -57,7 +61,7 @@ func NewDiscoveryCtrl(namespace string, clusterId *clusterID.ClusterID, kubeconf
 	return &discoveryCtrl, nil
 }
 
-func GetDiscoveryCtrl(namespace string, crdClient *crdClient.CRDClient, advClient *crdClient.CRDClient, clusterId *clusterID.ClusterID, resolveContextRefreshTime int) DiscoveryCtrl {
+func GetDiscoveryCtrl(namespace string, crdClient *crdClient.CRDClient, advClient *crdClient.CRDClient, clusterId *clusterID.ClusterID, resolveContextRefreshTime int, dialTcpTimeout time.Duration) DiscoveryCtrl {
 	return DiscoveryCtrl{
 		Namespace:                 namespace,
 		crdClient:                 crdClient,
@@ -66,6 +70,7 @@ func GetDiscoveryCtrl(namespace string, crdClient *crdClient.CRDClient, advClien
 		stopMDNS:                  make(chan bool, 1),
 		stopMDNSClient:            make(chan bool, 1),
 		resolveContextRefreshTime: resolveContextRefreshTime,
+		dialTcpTimeout:            dialTcpTimeout,
 	}
 }
 

--- a/internal/discovery/discoveryCache.go
+++ b/internal/discovery/discoveryCache.go
@@ -11,6 +11,7 @@ type discoveryData struct {
 	AuthData *AuthData
 }
 
+// cache used to match different services coming for the same Liqo instance
 type discoveryCache struct {
 	discoveredServices map[string]discoveryData
 	lock               sync.RWMutex
@@ -51,6 +52,14 @@ func (discoveryCache *discoveryCache) add(key string, data DiscoverableData) {
 		}
 		discoveryCache.discoveredServices[key] = oldData
 	}
+}
+
+// after that the ForeignCluster is create we can delete the entry in the cache,
+// the cache is clean again for the next discovery (and TTL update)
+func (discoveryCache *discoveryCache) delete(key string) {
+	discoveryCache.lock.Lock()
+	defer discoveryCache.lock.Unlock()
+	delete(discoveryCache.discoveredServices, key)
 }
 
 func (discoveryCache *discoveryCache) get(key string) (*discoveryData, error) {

--- a/internal/discovery/discoveryData.go
+++ b/internal/discovery/discoveryData.go
@@ -3,5 +3,6 @@ package discovery
 import "github.com/grandcat/zeroconf"
 
 type DiscoverableData interface {
-	Get(discovery *DiscoveryCtrl, entry *zeroconf.ServiceEntry) error
+	Get(discovery *DiscoveryCtrl, entry *zeroconf.ServiceEntry) error // populate the struct from a DNS entry
+	IsComplete() bool                                                 // the struct has all the required fields
 }

--- a/internal/discovery/foreignClusterGarbageCollector.go
+++ b/internal/discovery/foreignClusterGarbageCollector.go
@@ -33,6 +33,7 @@ func (discovery *DiscoveryCtrl) CollectGarbage() error {
 
 	for _, fc := range fcs.Items {
 		if fc.IsExpired() {
+			klog.V(4).Infof("delete foreignCluster %v (TTL expired)", fc.Name)
 			err = discovery.crdClient.Resource("foreignclusters").Delete(fc.Name, metav1.DeleteOptions{})
 			if err != nil {
 				klog.Error(err)

--- a/internal/discovery/txtData.go
+++ b/internal/discovery/txtData.go
@@ -115,3 +115,7 @@ func (txtData *TxtData) Get(discovery *DiscoveryCtrl, entry *zeroconf.ServiceEnt
 	}
 	return nil
 }
+
+func (txtData *TxtData) IsComplete() bool {
+	return txtData.ApiUrl != "" && txtData.Namespace != "" && txtData.Name != "" && txtData.ID != ""
+}

--- a/test/unit/discovery/env_test.go
+++ b/test/unit/discovery/env_test.go
@@ -83,6 +83,7 @@ func getClientCluster() *Cluster {
 		cluster.advClient,
 		cluster.clusterId,
 		10,
+		500,
 	)
 	cluster.discoveryCtrl.Config = &cc.Spec.DiscoveryConfig
 
@@ -149,6 +150,7 @@ func getServerCluster() *Cluster {
 		cluster.advClient,
 		cluster.clusterId,
 		10,
+		500,
 	)
 	cluster.discoveryCtrl.Config = &cc.Spec.DiscoveryConfig
 

--- a/test/unit/discovery/mdns_test.go
+++ b/test/unit/discovery/mdns_test.go
@@ -5,8 +5,10 @@ import (
 	"github.com/liqotech/liqo/apis/discovery/v1alpha1"
 	"github.com/liqotech/liqo/internal/discovery"
 	"gotest.tools/assert"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/klog"
 	"strconv"
 	"strings"
@@ -17,6 +19,27 @@ import (
 var txtData discovery.TxtData
 
 func TestMdns(t *testing.T) {
+	authSvc := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "auth-service",
+		},
+		Spec: v1.ServiceSpec{
+			Type: v1.ServiceTypeNodePort,
+			Ports: []v1.ServicePort{
+				{
+					Name:       "https",
+					Port:       12345,
+					TargetPort: intstr.FromInt(12345),
+					NodePort:   32123,
+				},
+			},
+		},
+	}
+	_, err := clientCluster.client.Client().CoreV1().Services(metav1.NamespaceDefault).Create(context.TODO(), authSvc, metav1.CreateOptions{})
+	if err != nil {
+		klog.Fatal(err)
+	}
+
 	t.Run("testTxtData", testTxtData)
 	t.Run("testMDNS", testMdns)
 	t.Run("testForeignClusterCreation", testForeignClusterCreation)


### PR DESCRIPTION
# Description

Provide a way to contact the auth service form outside of the cluster

## What's new

* add the auth service to helm chart
  * add a NodePort service
  * set its port in mDNS discovery
* provide a TLS certificate to the service with an initContainer

Ref. issue #371
