### PR TITLE
Bugfix: crdReplicator now handles correctly namespaced resources

### DIFF
--- a/internal/crdReplicator/crdReplicator-config.go
+++ b/internal/crdReplicator/crdReplicator-config.go
@@ -31,8 +31,8 @@ func (d *CRDReplicatorReconciler) UpdateConfig(cfg *configv1alpha1.ClusterConfig
 		klog.Info("updating the list of registered resources to be replicated")
 		d.UnregisteredResources = d.GetRemovedResources(resources)
 		d.RegisteredResources = resources
+		klog.Infof("%s -> current registered resources %s", d.ClusterID, d.RegisteredResources)
 	}
-	klog.Infof("%s -> current registered resources %s", d.ClusterID, d.RegisteredResources)
 }
 
 func (d *CRDReplicatorReconciler) GetConfig(cfg *configv1alpha1.ClusterConfig) []schema.GroupVersionResource {

--- a/internal/crdReplicator/crdReplicator-operator.go
+++ b/internal/crdReplicator/crdReplicator-operator.go
@@ -635,7 +635,7 @@ func (d *CRDReplicatorReconciler) UpdateResource(client dynamic.Interface, gvr s
 
 func (d *CRDReplicatorReconciler) DeleteResource(client dynamic.Interface, gvr schema.GroupVersionResource, obj *unstructured.Unstructured, clusterID string) error {
 	klog.Infof("%s -> deleting resource %s of type %s", clusterID, obj.GetName(), gvr.String())
-	err := client.Resource(gvr).Delete(context.TODO(), obj.GetName(), metav1.DeleteOptions{})
+	err := client.Resource(gvr).Namespace(obj.GetNamespace()).Delete(context.TODO(), obj.GetName(), metav1.DeleteOptions{})
 	if err != nil {
 		klog.Errorf("%s -> an error occurred while deleting resource %s of type %s: %s", clusterID, obj.GetName(), gvr.String(), err)
 		return err


### PR DESCRIPTION
# Description
This PR fixes a bug which prevented the namespaced resources replicated in a remote cluster to be deleted when the copy of the resource is removed from the home cluster.
The logs messages are emitted only when new resources are subscribed or unsubscribed to the crdReplicator.

