### PR TITLE
demo: support other architecture that linux-amd64

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,9 @@ Liqo leverages the same highly successful “peering” model of the Internet, w
 
 ## Quickstart
 
-Create two [KinD](kind.sigs.k8s.io/) clusters via our script or bring your own clusters. 
-N.B. Using our cluster, Docker has to be installed on your test machine and user should have permission to issue commands.
+Create two [KinD](https://kind.sigs.k8s.io/) clusters via our script or bring your own clusters.  
+N.B. Using our cluster, Docker has to be installed on your test machine and user should have permission to issue commands.  
+N.B. Scripts are also compatible with `Windows` if you use `Mingw` (provided by default with `git bash`)
 
 ```bash
 source <(curl -L https://get.liqo.io/clusters.sh)

--- a/docs/examples/kind.sh
+++ b/docs/examples/kind.sh
@@ -1,4 +1,36 @@
 #!/bin/bash
+
+function setup_arch_and_os(){
+  ARCH=$(uname -m)
+  case $ARCH in
+    armv5*) ARCH="armv5";;
+    armv6*) ARCH="armv6";;
+    armv7*) ARCH="arm";;
+    aarch64) ARCH="arm64";;
+    x86) ARCH="386";;
+    x86_64) ARCH="amd64";;
+    i686) ARCH="386";;
+    i386) ARCH="386";;
+    *) echo "Error architecture '${ARCH}' unknown"; exit 1 ;;
+  esac
+
+  OS=$(uname |tr '[:upper:]' '[:lower:]')
+  case "$OS" in
+    # Minimalist GNU for Windows
+    "mingw"*) OS='windows'; return ;;
+  esac
+
+  # list is available at https://github.com/kubernetes-sigs/kind/releases
+  local supported="darwin-amd64\n\nlinux-amd64\nlinux-arm64\nlinux-ppc64le\nwindows-amd64"
+  if ! echo "${supported}" | grep -q "${OS}-${ARCH}"; then
+    echo "Error: No version of kind for '${OS}-${ARCH}'"
+    exit 1
+  fi
+
+}
+
+setup_arch_and_os
+
 CLUSTER_NAME=cluster
 CLUSTER_NAME_1=${CLUSTER_NAME}1
 CLUSTER_NAME_2=${CLUSTER_NAME}2
@@ -6,8 +38,8 @@ KIND_VERSION="v0.9.0"
 echo "Downloading Kind ${KIND_VERSION}"
 TMPDIR=$(mktemp -d -t liqo-install.XXXXXXXXXX)
 BINDIR="${TMPDIR}/bin"
-mkdir --parent "${BINDIR}"
-curl -Lo "${BINDIR}"/kind https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-amd64
+mkdir -p "${BINDIR}"
+curl -Lo "${BINDIR}"/kind https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-${OS}-${ARCH}
 chmod +x "${BINDIR}"/kind
 KIND="${BINDIR}/kind"
 

--- a/test/installer/install-test.sh
+++ b/test/installer/install-test.sh
@@ -523,3 +523,30 @@ setup() {
 	export -f kubectl
 	all_clusters_unjoined
 }
+
+@test "setup_arch_and_os fails if ARCH is unknown" {
+    function uname() { echo 'does_not_exist'; }
+    export -f uname
+
+    run setup_arch_and_os
+    assert_failure 
+    assert_line --partial "[PRE-FLIGHT] architecture 'does_not_exist' unknown [FATAL]"
+}
+
+@test "setup_arch_and_os fails if combination arch and os is not supported" {
+    function uname() { if [ "$*" == "-m" ] ; then echo "armv7"; else echo "mingw"; fi; }
+    export -f uname
+
+    run setup_arch_and_os
+    assert_failure
+    assert_line --partial "[PRE-FLIGHT] System 'windows-arm' not supported."
+}
+
+@test "setup_arch_and_os success if combination arch and os is supported" {
+    function uname() { if [ "$*" == "-m" ] ; then echo "x86_64"; else echo "linux"; fi; }
+    export -f uname
+
+    run setup_arch_and_os
+    assert_success
+}
+


### PR DESCRIPTION
# Description
Make demo compatible with multiple platforms (eg darwin, linux-arm, windows...) the compatibility is limited by the binary compatibility of `kind` and `helm``

on mac os 
* install packages that contain gnu tool (eg grep, getopts...) because some options do not exist on BSD version

on windows (Mingw)
* make extraction of helm compatible with windows



Fixes #352

# How Has This Been Tested?

- [X] Running demo on linux
- [X] Running demo on macos
- [X] Running demo in windows through `Mingw  (git bash)`
