### PR TITLE
Fix Integration Pipeline: Docker action context is wrongly set

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -103,6 +103,7 @@ jobs:
       - name: Build (and Publish) ${{ matrix.component }} image
         uses: docker/build-push-action@v2
         with:
+          context: .
           tags: |
             liqo/${{ matrix.component }}${{ needs.configure.outputs.repo-suffix }}:latest
             liqo/${{ matrix.component }}${{ needs.configure.outputs.repo-suffix }}:${{ needs.configure.outputs.commit_ref }}


### PR DESCRIPTION
# Description

This PR fixes the context parameter of docker action in build pipeline. This issue prevents the build of a container image for any Liqo container for a branch different from master.
