### PR TITLE
LiqoAgent dynamic lists discovered peers

### DIFF
--- a/apis/discovery/v1alpha1/foreignClusterClient.go
+++ b/apis/discovery/v1alpha1/foreignClusterClient.go
@@ -1,0 +1,36 @@
+package v1alpha1
+
+import (
+	"errors"
+	"github.com/liqotech/liqo/pkg/crdClient"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+)
+
+//CreateForeignClusterClient creates a client for ForeignCluster CR using a provided kubeconfig.
+func CreateForeignClusterClient(kubeconfig string) (*crdClient.CRDClient, error) {
+	var config *rest.Config
+	var err error
+	if err = AddToScheme(scheme.Scheme); err != nil {
+		panic(err)
+	}
+	crdClient.AddToRegistry("foreignclusters", &ForeignCluster{}, &ForeignClusterList{}, ForeignClusterKeyer, ForeignClusterGroupResource)
+	config, err = crdClient.NewKubeconfig(kubeconfig, &GroupVersion)
+	if err != nil {
+		panic(err)
+	}
+	clientSet, err := crdClient.NewFromConfig(config)
+	if err != nil {
+		return nil, err
+	}
+	return clientSet, nil
+}
+
+func ForeignClusterKeyer(obj runtime.Object) (string, error) {
+	fc, ok := obj.(*ForeignCluster)
+	if !ok {
+		return "", errors.New("cannot cast received object to ForeignCluster")
+	}
+	return fc.Name, nil
+}

--- a/apis/discovery/v1alpha1/groupversion_info.go
+++ b/apis/discovery/v1alpha1/groupversion_info.go
@@ -34,6 +34,9 @@ var (
 
 	// AddToScheme adds the types in this group-version to the given scheme.
 	AddToScheme = SchemeBuilder.AddToScheme
+
+	//ForeignClusterGroupResource is the group resource used to register ForeignCluster CRD.
+	ForeignClusterGroupResource = schema.GroupResource{Group: GroupVersion.Group, Resource: "foreignclusters"}
 )
 
 func init() {

--- a/internal/tray-agent/agent/client/crdClients.go
+++ b/internal/tray-agent/agent/client/crdClients.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"errors"
-	"fmt"
 	"github.com/liqotech/liqo/pkg/crdClient"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
@@ -45,23 +44,27 @@ func (ctrl *AgentController) initCRDManager() error {
 	if !set {
 		return errors.New("no kubeconfig provided")
 	}
-	//creation of each single CRDController
+	//creation of each single CRDController and registration to the manager
 	var err error
 	var crdCtrl *CRDController
-	for _, cr := range customResources {
-		switch cr {
-		case CRClusterConfig:
-			crdCtrl, err = createClusterConfigController(kubeconfig)
-		case CRAdvertisement:
-			crdCtrl, err = createAdvertisementController(kubeconfig)
-		case CRForeignCluster:
-			crdCtrl, err = createForeignClusterController(kubeconfig)
-		}
-		if err != nil {
-			return errors.New(fmt.Sprint("connection error on ", cr, " client creation"))
-		}
-		manager.clientMap[cr] = crdCtrl
+	//	CLUSTERCONFIG
+	crdCtrl, err = createClusterConfigController(kubeconfig)
+	if err != nil {
+		return errors.New("connection error on clusterconfigs client creation")
 	}
+	manager.clientMap[CRClusterConfig] = crdCtrl
+	//	ADVERTISEMENT
+	crdCtrl, err = createAdvertisementController(kubeconfig)
+	if err != nil {
+		return errors.New("connection error on advertisements client creation")
+	}
+	manager.clientMap[CRAdvertisement] = crdCtrl
+	//	FOREIGNCLUSTER
+	crdCtrl, err = createForeignClusterController(kubeconfig)
+	if err != nil {
+		return errors.New("connection error on foreignclusters client creation")
+	}
+	manager.clientMap[CRForeignCluster] = crdCtrl
 	return nil
 }
 

--- a/internal/tray-agent/agent/client/foreignClusterController.go
+++ b/internal/tray-agent/agent/client/foreignClusterController.go
@@ -1,0 +1,45 @@
+package client
+
+import (
+	discovery "github.com/liqotech/liqo/apis/discovery/v1alpha1"
+)
+
+//createForeignClusterController creates a new CRDController for the Liqo ForeignCluster CRD.
+func createForeignClusterController(kubeconfig string) (*CRDController, error) {
+	controller := &CRDController{
+		addFunc:    foreignclusterAddFunc,
+		updateFunc: foreignclusterUpdateFunc,
+		deleteFunc: foreignclusterDeleteFunc,
+	}
+	newClient, err := discovery.CreateForeignClusterClient(kubeconfig)
+	if err != nil {
+		return nil, err
+	}
+	controller.CRDClient = newClient
+	controller.resource = string(CRForeignCluster)
+	return controller, nil
+}
+
+//foreignclusterAddFunc is the ADD event handler for the ForeignCluster CRDController.
+func foreignclusterAddFunc(obj interface{}) {
+	fc := obj.(*discovery.ForeignCluster)
+	agentCtrl.NotifyChannel(ChanPeerAdded) <- fc.Name
+}
+
+//foreignclusterUpdateFunc is the UPDATE event handler for the ForeignCluster CRDController.
+func foreignclusterUpdateFunc(oldObj interface{}, newObj interface{}) {
+	fcOld := oldObj.(*discovery.ForeignCluster)
+	fcNew := newObj.(*discovery.ForeignCluster)
+	//currently the handler only monitors updates on cluster information, not
+	//a peering workflow
+	//updates on foreign cluster data
+	if fcNew.Spec.ClusterIdentity.ClusterName != fcOld.Spec.ClusterIdentity.ClusterName {
+		agentCtrl.NotifyChannel(ChanPeerUpdated) <- fcNew.Name
+	}
+}
+
+//foreignclusterDeleteFunc is the DELETE event handler for the ForeignCluster CRDController.
+func foreignclusterDeleteFunc(obj interface{}) {
+	fc := obj.(*discovery.ForeignCluster)
+	agentCtrl.NotifyChannel(ChanPeerDeleted) <- fc.Name
+}

--- a/internal/tray-agent/agent/client/notifyChannels.go
+++ b/internal/tray-agent/agent/client/notifyChannels.go
@@ -16,6 +16,12 @@ const (
 	ChanAdvDeleted
 	//Notification channel id for the revocation of the 'ACCEPTED' status of an Advertisement
 	ChanAdvRevoked
+	//Notification channel id for the addition of a new peer discovered.
+	ChanPeerAdded
+	//Notification channel id for the removal of an available peer.
+	ChanPeerDeleted
+	//Notification channel id for an update of an available peer.
+	ChanPeerUpdated
 )
 
 //notifyChannelNames contains all the registered NotifyChannel managed by the AgentController.
@@ -25,4 +31,7 @@ var notifyChannelNames = []NotifyChannel{
 	ChanAdvAccepted,
 	ChanAdvDeleted,
 	ChanAdvRevoked,
+	ChanPeerAdded,
+	ChanPeerDeleted,
+	ChanPeerUpdated,
 }

--- a/internal/tray-agent/agent/logic/logic_test.go
+++ b/internal/tray-agent/agent/logic/logic_test.go
@@ -3,9 +3,9 @@ package logic
 import (
 	"github.com/liqotech/liqo/internal/tray-agent/agent/client"
 	app "github.com/liqotech/liqo/internal/tray-agent/app-indicator"
+	"github.com/liqotech/liqo/internal/tray-agent/test"
 	"github.com/stretchr/testify/assert"
 	"testing"
-	"time"
 )
 
 //test the routines OnReady that is called in the app-indicator/Run() loop and manages the Liqo Agent logic.
@@ -34,6 +34,8 @@ func TestOnReady(t *testing.T) {
 	assert.Truef(t, exist, "QUICK %s not registered", qDash)
 	_, exist = i.Quick(qNotify)
 	assert.Truef(t, exist, "QUICK %s not registered", qNotify)
+	_, exist = i.Quick(qPeers)
+	assert.Truef(t, exist, "QUICK %s not registered", qPeers)
 
 	// test Listeners registrations
 	_, exist = i.Listener(client.ChanAdvNew)
@@ -53,6 +55,8 @@ func TestAdvertisementNotify(t *testing.T) {
 	client.UseMockedAgentController()
 	app.DestroyMockedIndicator()
 	client.DestroyMockedAgentController()
+	eventTester := app.GetGuiProvider().NewEventTester()
+	eventTester.Test()
 	i := app.GetIndicator()
 	startListenerAdvertisements(i)
 	assert.Equal(t, app.IconLiqoMain, i.Icon(), "startup Indicator icon is not IconLiqoMain")
@@ -62,24 +66,99 @@ func TestAdvertisementNotify(t *testing.T) {
 	}
 	testAdvName := "test"
 	//
+	eventTester.Add(1)
 	ctrl.NotifyChannel(client.ChanAdvNew) <- testAdvName
-	time.Sleep(time.Second * 4)
+	eventTester.Wait()
 	assert.Equal(t, app.IconLiqoOrange, i.Icon(), "Icon not correctly set on New Advertisement")
 	i.SetIcon(app.IconLiqoMain)
 	//
+	eventTester.Add(1)
 	ctrl.NotifyChannel(client.ChanAdvAccepted) <- testAdvName
-	time.Sleep(time.Second * 4)
+	eventTester.Wait()
 	assert.Equal(t, app.IconLiqoGreen, i.Icon(), "Icon not correctly set on Accepted Advertisement")
 	i.SetIcon(app.IconLiqoMain)
 	//
+	eventTester.Add(1)
 	ctrl.NotifyChannel(client.ChanAdvRevoked) <- testAdvName
-	time.Sleep(time.Second * 4)
+	eventTester.Wait()
 	assert.Equal(t, app.IconLiqoOrange, i.Icon(), "Icon not correctly set on Revoked Advertisement")
 	i.SetIcon(app.IconLiqoMain)
 	//
+	eventTester.Add(1)
 	ctrl.NotifyChannel(client.ChanAdvDeleted) <- testAdvName
-	time.Sleep(time.Second * 4)
+	eventTester.Wait()
 	assert.Equal(t, app.IconLiqoOrange, i.Icon(), "Icon not correctly set on Deleted Advertisement")
 	i.SetIcon(app.IconLiqoMain)
+	i.Quit()
+}
+
+func TestPeersListeners(t *testing.T) {
+	app.UseMockedGuiProvider()
+	client.UseMockedAgentController()
+	app.DestroyMockedIndicator()
+	client.DestroyMockedAgentController()
+	app.DestroyStatus()
+	eventTester := app.GetGuiProvider().NewEventTester()
+	eventTester.Test()
+	OnReady()
+	i := app.GetIndicator()
+	//test peers list when no ForeignCluster is present
+	quickNode, present := i.Quick(qPeers)
+	if !present {
+		t.Fatal("Show Peers QUICK not registered")
+	}
+	assert.Equal(t, 0, quickNode.ListChildrenLen(), "peers list is not empty when 0 ForeignCluster(s) exist [init phase]")
+	assert.False(t, quickNode.IsEnabled(), "peers menu entry should be disabled when 0 ForeignCluster(s) exist [init phase]")
+
+	//test addition of ForeignClusters
+	clusterID1 := "cl1"
+	clusterName1 := "test1"
+	clusterName2 := "test2"
+	fc1 := test.CreateForeignCluster(clusterID1, clusterName1)
+	fcCtrl := i.AgentCtrl().Controller(client.CRForeignCluster)
+	//peerAddChan := i.AgentCtrl().NotifyChannel(client.ChanPeerAdded)
+	//peerUpdateChan := i.AgentCtrl().NotifyChannel(client.ChanPeerUpdated)
+	//peerDeleteChan := i.AgentCtrl().NotifyChannel(client.ChanPeerDeleted)
+	eventTester.Add(1)
+	err := fcCtrl.Store.Add(fc1)
+	eventTester.Wait()
+	//time.Sleep(time.Second * 3)
+	//peerAddChan <- clusterID1
+	assert.NoError(t, err, "ForeignCluster addition failed")
+
+	assert.True(t, quickNode.IsEnabled(), "peers menu entry should be enabled when 1+ ForeignCluster(s) exist [init phase]")
+	assert.Equal(t, 1, quickNode.ListChildrenLen(), "peers list is empty when 1+ ForeignCluster(s) exist")
+
+	//check if inserted element is present
+	var fc1Node *app.MenuNode
+	fc1Node, present = quickNode.ListChild(clusterID1)
+	assert.Truef(t, present, "LIST MenuNode for ForeignCluster %v not present", clusterID1)
+	assert.Equal(t, clusterName1, fc1Node.Title(), "peers menu entry displays wrong content")
+	fc2 := fc1.DeepCopy()
+	fc2.Spec.ClusterIdentity.ClusterName = clusterName2
+	eventTester.Add(1)
+	err = fcCtrl.Store.Update(fc2)
+	eventTester.Wait()
+	//time.Sleep(time.Second * 3)
+	assert.NoError(t, err, "ForeignCluster update failed")
+	//peerUpdateChan <- clusterID1
+
+	//check update of the text content
+	fc1Node, present = quickNode.ListChild(clusterID1)
+	assert.Truef(t, present, "LIST MenuNode for ForeignCluster %v not present", clusterID1)
+	assert.Equal(t, clusterName2, fc1Node.Title(), "peers menu entry displays wrong content after update")
+
+	//delete element
+	eventTester.Add(1)
+	err = fcCtrl.Store.Delete(fc2)
+	eventTester.Wait()
+	//time.Sleep(time.Second * 3)
+	assert.NoError(t, err, "ForeignCluster deletion failed")
+	//peerDeleteChan <- clusterID1
+
+	//check peers list back at initial condition
+	endCount := quickNode.ListChildrenLen()
+	assert.Equal(t, 0, endCount, "peers list is not empty when 0 ForeignCluster(s) exist [init phase]")
+	assert.False(t, quickNode.IsEnabled(), "peers menu entry should be disabled when 0 ForeignCluster(s) exist")
 	i.Quit()
 }

--- a/internal/tray-agent/agent/logic/managers.go
+++ b/internal/tray-agent/agent/logic/managers.go
@@ -1,6 +1,7 @@
 package logic
 
 import (
+	"github.com/liqotech/liqo/apis/discovery/v1alpha1"
 	"github.com/liqotech/liqo/internal/tray-agent/agent/client"
 	app "github.com/liqotech/liqo/internal/tray-agent/app-indicator"
 	"github.com/skratchdot/open-golang/open"
@@ -12,11 +13,13 @@ func OnReady() {
 	i := app.GetIndicator()
 	i.RefreshStatus()
 	startListenerAdvertisements(i)
+	startListenerPeersList(i)
 	startQuickOnOff(i)
 	startQuickChangeMode(i)
 	startQuickDashboard(i)
 	startQuickSetNotifications(i)
 	startQuickLiqoWebsite(i)
+	startQuickShowPeers(i)
 	startQuickQuit(i)
 	//try to start Liqo and main ACTION
 	quickTurnOnOff(i)
@@ -74,6 +77,11 @@ func startQuickQuit(i *app.Indicator) {
 	}, i)
 }
 
+//startQuickShowPeers is the wrapper function to register QUICK "PEERS".
+func startQuickShowPeers(i *app.Indicator) {
+	i.AddQuick("AVAILABLE PEERS", qPeers, nil)
+}
+
 //LISTENERS
 
 // wrapper that starts the Listeners for the events regarding the Advertisement CRD
@@ -128,5 +136,65 @@ func startListenerAdvertisements(i *app.Indicator) {
 	i.Listen(client.ChanAdvDeleted, i.AgentCtrl().NotifyChannel(client.ChanAdvDeleted), func(objName string, args ...interface{}) {
 		i.NotifyDeletedAdv(objName)
 		i.Status().DecConsumePeerings()
+	})
+}
+
+/*startListenerPeersList is a wrapper that starts the listeners regarding the dynamic listing of Liqo discovered Liqo peers.
+  Since these listeners work on a specific QUICK MenuNode, the associated handlers works only if that QUICK
+  is registered in the Indicator.*/
+func startListenerPeersList(i *app.Indicator) {
+	i.Listen(client.ChanPeerAdded, i.AgentCtrl().NotifyChannel(client.ChanPeerAdded), func(objName string, args ...interface{}) {
+		//retrieve Peer information
+		quickNode, present := i.Quick(qPeers)
+		if !present {
+			return
+		}
+		fcCtrl := i.AgentCtrl().Controller(client.CRForeignCluster)
+		obj, exist, err := fcCtrl.Store.GetByKey(objName)
+		if err == nil && exist {
+			fCluster := obj.(*v1alpha1.ForeignCluster)
+			clusterID := fCluster.Spec.ClusterIdentity.ClusterID
+			clusterName := fCluster.Spec.ClusterIdentity.ClusterName
+			//avoid potential duplicate
+			_, present = quickNode.ListChild(clusterID)
+			if present {
+				return
+			}
+			//show cluster name as main information. The clusterID is inserted inside a status sub-element for consultation.
+			peerNode := quickNode.UseListChild(clusterName, clusterID)
+			statusNode := peerNode.UseListChild(clusterID, tagStatus)
+			statusNode.SetIsEnabled(false)
+		}
+	})
+	i.Listen(client.ChanPeerDeleted, i.AgentCtrl().NotifyChannel(client.ChanPeerDeleted), func(objName string, args ...interface{}) {
+		//retrieve Peer information
+		quickNode, present := i.Quick(qPeers)
+		if !present {
+			return
+		}
+		//in this case it is not necessary to get the ClusterID information (which is the required key to access the
+		//dynamic list), since the ForeignCluster 'Name' metadata coincides with it.
+		quickNode.FreeListChild(objName)
+	})
+	i.Listen(client.ChanPeerUpdated, i.AgentCtrl().NotifyChannel(client.ChanPeerUpdated), func(objName string, args ...interface{}) {
+		//retrieve Peer information
+		quickNode, present := i.Quick(qPeers)
+		if !present {
+			return
+		}
+		fcCtrl := i.AgentCtrl().Controller(client.CRForeignCluster)
+		obj, exist, err := fcCtrl.Store.GetByKey(objName)
+		if err == nil && exist {
+			fCluster := obj.(*v1alpha1.ForeignCluster)
+			clusterID := fCluster.Spec.ClusterIdentity.ClusterID
+			clusterName := fCluster.Spec.ClusterIdentity.ClusterName
+			var peerNode *app.MenuNode
+			peerNode, present = quickNode.ListChild(clusterID)
+			if !present {
+				return
+			}
+			//show cluster name as main information. The clusterID is inserted inside a status sub-element for consultation.
+			peerNode.SetTitle(clusterName)
+		}
 	})
 }

--- a/internal/tray-agent/agent/logic/managers.go
+++ b/internal/tray-agent/agent/logic/managers.go
@@ -79,7 +79,8 @@ func startQuickQuit(i *app.Indicator) {
 
 //startQuickShowPeers is the wrapper function to register QUICK "PEERS".
 func startQuickShowPeers(i *app.Indicator) {
-	i.AddQuick(titlePeers, qPeers, nil)
+	node := i.AddQuick(titlePeers, qPeers, nil)
+	refreshPeerCount(node)
 }
 
 //LISTENERS

--- a/internal/tray-agent/agent/logic/managers.go
+++ b/internal/tray-agent/agent/logic/managers.go
@@ -79,7 +79,7 @@ func startQuickQuit(i *app.Indicator) {
 
 //startQuickShowPeers is the wrapper function to register QUICK "PEERS".
 func startQuickShowPeers(i *app.Indicator) {
-	i.AddQuick("AVAILABLE PEERS", qPeers, nil)
+	i.AddQuick(titlePeers, qPeers, nil)
 }
 
 //LISTENERS
@@ -164,6 +164,8 @@ func startListenerPeersList(i *app.Indicator) {
 			peerNode := quickNode.UseListChild(clusterName, clusterID)
 			statusNode := peerNode.UseListChild(clusterID, tagStatus)
 			statusNode.SetIsEnabled(false)
+			//update the counter in the menu entry
+			refreshPeerCount(quickNode)
 		}
 	})
 	i.Listen(client.ChanPeerDeleted, i.AgentCtrl().NotifyChannel(client.ChanPeerDeleted), func(objName string, args ...interface{}) {
@@ -175,6 +177,8 @@ func startListenerPeersList(i *app.Indicator) {
 		//in this case it is not necessary to get the ClusterID information (which is the required key to access the
 		//dynamic list), since the ForeignCluster 'Name' metadata coincides with it.
 		quickNode.FreeListChild(objName)
+		//update the counter in the menu entry
+		refreshPeerCount(quickNode)
 	})
 	i.Listen(client.ChanPeerUpdated, i.AgentCtrl().NotifyChannel(client.ChanPeerUpdated), func(objName string, args ...interface{}) {
 		//retrieve Peer information

--- a/internal/tray-agent/agent/logic/quickPeerHelpers.go
+++ b/internal/tray-agent/agent/logic/quickPeerHelpers.go
@@ -1,0 +1,32 @@
+package logic
+
+import (
+	app "github.com/liqotech/liqo/internal/tray-agent/app-indicator"
+	"strconv"
+	"strings"
+)
+
+/*This file contains internal variables and helper functions for the QUICK qPeers in charge of displaying
+discovered peers.*/
+
+// set of frequently used tags inside application logic
+const (
+	tagStatus  = "status"
+	titlePeers = "PEERS"
+)
+
+//refreshPeerCount updates the visual counter of the discovered peers (even not peered).
+//Currently the number if retrieved directly from the MenuNode. In a future update the Indicator.Status component
+//will provide it.
+func refreshPeerCount(quick *app.MenuNode) {
+	peerCount := quick.ListChildrenLen()
+	str := strings.Join([]string{"(", strconv.Itoa(peerCount), ")"}, "")
+	quick.SetTitle(strings.Join([]string{titlePeers, str}, " "))
+	//the menu entry is disabled when the counter reaches 0 to avoid useless clicks
+	if peerCount > 0 {
+		quick.SetIsEnabled(true)
+	} else {
+		quick.SetIsEnabled(false)
+	}
+
+}

--- a/internal/tray-agent/agent/logic/quicks.go
+++ b/internal/tray-agent/agent/logic/quicks.go
@@ -19,6 +19,12 @@ const (
 	qWeb    = "Q_WEBSITE"
 	qNotify = "Q_NOTIFY"
 	qQuit   = "Q_QUIT"
+	qPeers  = "Q_PEERS"
+)
+
+// set of frequently used tags inside application logic
+const (
+	tagStatus = "status"
 )
 
 //quickTurnOnOff is the callback for the QUICK "START/STOP LIQO".

--- a/internal/tray-agent/agent/logic/quicks.go
+++ b/internal/tray-agent/agent/logic/quicks.go
@@ -22,11 +22,6 @@ const (
 	qPeers  = "Q_PEERS"
 )
 
-// set of frequently used tags inside application logic
-const (
-	tagStatus = "status"
-)
-
 //quickTurnOnOff is the callback for the QUICK "START/STOP LIQO".
 func quickTurnOnOff(i *app.Indicator) {
 	runSt := i.Status().Running()

--- a/internal/tray-agent/app-indicator/dynlist.go
+++ b/internal/tray-agent/app-indicator/dynlist.go
@@ -71,6 +71,7 @@ func (nl *nodeList) freeNode(tag string) {
 		node.SetTitle("")
 		node.SetTag("")
 		node.SetIsVisible(false)
+		node.SetIsEnabled(true)
 		node.Disconnect()
 		delete(nl.usedNodes, tag)
 		nl.freeNodes.Enqueue(node)

--- a/internal/tray-agent/app-indicator/dynlist.go
+++ b/internal/tray-agent/app-indicator/dynlist.go
@@ -97,6 +97,6 @@ func (nl *nodeList) freeAllNodes() {
 //usedNodeLen returns the number of LIST MenuNode currently in use.
 func (nl *nodeList) usedNodeLen() int {
 	nl.RLock()
-	defer nl.RLock()
+	defer nl.RUnlock()
 	return len(nl.usedNodes)
 }

--- a/internal/tray-agent/app-indicator/dynlist.go
+++ b/internal/tray-agent/app-indicator/dynlist.go
@@ -93,3 +93,10 @@ func (nl *nodeList) freeAllNodes() {
 		}(node, tag)
 	}
 }
+
+//usedNodeLen returns the number of LIST MenuNode currently in use.
+func (nl *nodeList) usedNodeLen() int {
+	nl.RLock()
+	defer nl.RLock()
+	return len(nl.usedNodes)
+}

--- a/internal/tray-agent/app-indicator/listener.go
+++ b/internal/tray-agent/app-indicator/listener.go
@@ -1,6 +1,8 @@
 package app_indicator
 
-import "github.com/liqotech/liqo/internal/tray-agent/agent/client"
+import (
+	"github.com/liqotech/liqo/internal/tray-agent/agent/client"
+)
 
 //Listener is an event listener that can react calling a specific callback.
 type Listener struct {
@@ -36,6 +38,12 @@ func (i *Indicator) Listen(tag client.NotifyChannel, notifyChan chan string, cal
 			case name, open := <-l.NotifyChan:
 				if open {
 					callback(name, args...)
+					//signal callback execution in test mode
+					if GetGuiProvider().Mocked() {
+						if et, testing := GetGuiProvider().GetEventTester(); testing {
+							et.Done()
+						}
+					}
 				}
 				//closing application
 			case <-i.quitChan:

--- a/internal/tray-agent/app-indicator/menu-node.go
+++ b/internal/tray-agent/app-indicator/menu-node.go
@@ -219,7 +219,7 @@ func (n *MenuNode) ListChild(tag string) (child *MenuNode, present bool) {
 	return
 }
 
-//UseListChild returns a child LIST MenuNode ready to use.
+//UseListChild returns a child LIST MenuNode ready to use and visible to users.
 //The node can use them to dynamically display to the user the output of application functions.
 func (n *MenuNode) UseListChild(title string, tag string) *MenuNode {
 	if n.nodeList == nil {
@@ -254,6 +254,14 @@ func (n *MenuNode) FreeListChildren() {
 		return
 	}
 	n.nodeList.freeAllNodes()
+}
+
+//ListChildrenLen returns the number of LIST MenuNode currently in use.
+func (n *MenuNode) ListChildrenLen() int {
+	if n.nodeList == nil {
+		return 0
+	}
+	return n.nodeList.usedNodeLen()
 }
 
 //------ OPTION ------

--- a/internal/tray-agent/app-indicator/menu-node.go
+++ b/internal/tray-agent/app-indicator/menu-node.go
@@ -310,6 +310,11 @@ func (n *MenuNode) SetTitle(title string) {
 	n.title = title
 }
 
+//Title returns the text content of the menu entry. Eventual check tick for checked MenuNode is not included.
+func (n *MenuNode) Title() string {
+	return n.title
+}
+
 //Tag returns the MenuNode tag.
 func (n *MenuNode) Tag() string {
 	return n.tag

--- a/internal/tray-agent/test/doc.go
+++ b/internal/tray-agent/test/doc.go
@@ -1,0 +1,4 @@
+/*
+Package test contains useful functions to test code in github.com/liqotech/liqo/internal/tray-agent/... packages.
+*/
+package test

--- a/internal/tray-agent/test/testHelpers.go
+++ b/internal/tray-agent/test/testHelpers.go
@@ -1,0 +1,36 @@
+package test
+
+import (
+	"github.com/liqotech/liqo/apis/discovery/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func CreatePeeringRequest(clusterID string, clusterName string) *v1alpha1.PeeringRequest {
+	return &v1alpha1.PeeringRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: clusterID,
+		},
+		Spec: v1alpha1.PeeringRequestSpec{
+			ClusterIdentity: v1alpha1.ClusterIdentity{
+				ClusterID:   clusterID,
+				ClusterName: clusterName,
+			},
+		},
+	}
+}
+
+func CreateForeignCluster(clusterID string, clusterName string) *v1alpha1.ForeignCluster {
+	pr := CreatePeeringRequest(clusterID, clusterName)
+
+	fc := &v1alpha1.ForeignCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: pr.Spec.ClusterIdentity.ClusterID,
+		},
+		Spec: v1alpha1.ForeignClusterSpec{
+			ClusterIdentity: pr.Spec.ClusterIdentity,
+			Namespace:       pr.Spec.Namespace,
+			Join:            false,
+		},
+	}
+	return fc
+}


### PR DESCRIPTION
# Description

This PR provides the *Liqo Agent* the ability to show a dynamic list of the available peers known by the home cluster.

* Each entry currently shows 
  * the **ClusterName** of the *peer* cluster, i.e. a user-defined parameter to characterize its own Liqo instance. It changes accordingly to variations to this info made by the peer.
  * a nested "status" element showing the *peer* **ClusterID** which is the unique identifier, useful to avoid impersonation. 

# Test

In the *Indicator* package the **EventTester** component of the *GuiProvider* has been added in order to better test the changes performed by single callbacks of the Listeners.