### PR TITLE
kind.sh: use posix comparaison in order to be compatible with zsh

### DIFF
--- a/docs/examples/kind.sh
+++ b/docs/examples/kind.sh
@@ -103,8 +103,8 @@ echo "- NAMESPACE=liqo"
 echo "If you want to select $CLUSTER_NAME_1, you should simply type:" 'export KUBECONFIG=$KUBECONFIG_1'
 # shellcheck disable=SC2016
 echo "If you want to select $CLUSTER_NAME_2, you should simply type:" 'export KUBECONFIG=$KUBECONFIG_2'
-if [ "$KUBECTL_DOWNLOAD" == "true" ]; then
-	echo "kubectl is now installed in ${BINDIR}/kubectl and has been added to your PATH. To make it available without explicitly setting the PATH variable"
+if [ "$KUBECTL_DOWNLOAD" = "true" ]; then
+	echo -e "\nkubectl is now installed in ${BINDIR}/kubectl and has been added to your PATH. To make it available without explicitly setting the PATH variable"
 	echo "You can copy it to a system-wide location such as /usr/local/bin by typing:"
 	echo "sudo cp ${BINDIR}/kubectl /usr/local/bin"
 fi


### PR DESCRIPTION
# Description

The following test `if [ "$KUBECTL_DOWNLOAD" == "true" ]` is not compliant with POSIX.  Consequently, the script shows the following error on zsh

```
If you want to select cluster2, you should simply type: export KUBECONFIG=$KUBECONFIG_2
/dev/fd/11:106: = not found
```

`==` is not valid with the test operator `[`. it should be `=`.  Or we should use the `[[` instead of `[`operator.

more info at http://mywiki.wooledge.org/BashFAQ/031
# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] on bash: source docs/example/kind.sh  (with and without kubectl in path)
- [X] zsh: source docs/example/kind.sh  (with and without kubectl in path)
