### PR TITLE
Removing a trailing comma in slash-commands pipeline

### DIFF
--- a/.github/workflows/slash-commands.yml
+++ b/.github/workflows/slash-commands.yml
@@ -29,5 +29,5 @@ jobs:
               {
                 "command": "ok-to-test",
                 "permission": "write"
-              },
+              }
             ]


### PR DESCRIPTION
# Description

This PR fixes the slash-commands pipeline, by removing a trailing comma in the json where actions are reported.