### PR TITLE
install.sh: [darwin] fix package installation when script is piped

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -190,8 +190,11 @@ function darwin_install_gnu_tool(){
 									info "[PRE-FLIGHT][${OS}]" "package '${PACKAGE}' installed";
 									break;;
 						No ) fatal "[PRE-FLIGHT][${OS}] package '${PACKAGE}' is required. Abort";;
+						* ) warn "[PRE-FLIGHT][${OS}]" "Invalid selected option '${REPLY}'";;
 				esac
-		done
+		# select read input from stdin, if the script is piped (like in demo), the stdin is the pipe. Consequenty the select not works.
+		# To avoid this problem we read input from tty
+		done < /dev/tty
 	fi
 	info "[PRE-FLIGHT][${OS}]" "Add gnu tool provided by '${PACKAGE}' package to the PATH"
 	export PATH="${BINARY_PATH}:$PATH"


### PR DESCRIPTION
# Description

On `darwin` when a required, package is not installed, we propose to the user to install it. If the script is piped this proposal does not work and the script fails because some command does not exist or does not have the right options.


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] running `./install.sh`
- [X] running `cat install.sh | bash -s`
