### PR TITLE
Local config file for Liqo Agent

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -45,6 +45,7 @@ require (
 	golang.org/x/sys v0.0.0-20201113233024-12cec1faf1ba
 	golang.org/x/text v0.3.4 // indirect
 	golang.org/x/tools v0.0.0-20201116002733-ac45abd4c88c
+	gopkg.in/yaml.v2 v2.3.0
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 // indirect
 	gotest.tools v2.2.0+incompatible
 	k8s.io/api v0.19.4

--- a/install.sh
+++ b/install.sh
@@ -322,8 +322,14 @@ function setup_agent_environment() {
 
 	# Directory containing the Agent binary.
 	AGENT_BIN_DIR="${HOME}/.local/bin"
+	# Liqo Agent root directory containing all resources related to Liqo.
+	AGENT_LIQO_DIR="${AGENT_XDG_DATA_DIR}/liqo"
+	# Name of the Liqo Agent config file.
+	AGENT_CONFIG_FILE_NAME="agent_conf.yaml"
+	# Filepath of the Liqo Agent config file.
+	AGENT_CONF_FILE_PATH="${AGENT_LIQO_DIR}/${AGENT_CONFIG_FILE_NAME}"
 	# Liqo subdirectory containing the notifications icons.
-	AGENT_ICONS_DIR="${AGENT_XDG_DATA_DIR}/liqo/icons"
+	AGENT_ICONS_DIR="${AGENT_LIQO_DIR}/icons"
 	# Directory storing the '.desktop' file.
 	AGENT_APP_DIR="${AGENT_XDG_DATA_DIR}/applications"
 	# Directory storing the scalable icon for the desktop application.
@@ -597,8 +603,20 @@ function install_agent() {
 		gio set "${AGENT_APP_DIR}/io.liqo.Agent.desktop" "metadata::trusted" yes
 		gio set "${AGENT_AUTOSTART_DIR}/io.liqo.Agent.desktop" "metadata::trusted" yes
 	fi
+	# f) If there are specific parameters needed by the Agent, these are written to a config file.
+	write_agent_config_file
 	info "[AGENT] [INSTALL]" "Installation complete!"
 	command_exists gtk-launch && gtk-launch io.liqo.Agent.desktop
+}
+
+function write_agent_config_file() {
+	# If there are configuration parameters whose value differs from default, write them down to the agent
+	# configuration file, creating or truncating the file if already present.
+	# Currently the only considered information is the kubeconfig file path (KUBECONFIG env var).
+	if [[ "${KUBECONFIG}" != "${HOME}/.kube/config" ]]; then
+		info "[AGENT] [INSTALL]" "writing Liqo Agent configuration file"
+		echo "kubeconfig: ${KUBECONFIG}" > "${AGENT_CONF_FILE_PATH}"
+	fi
 }
 
 function all_clusters_unjoined() {

--- a/internal/tray-agent/agent/client/liqo/agent_conf.yaml
+++ b/internal/tray-agent/agent/client/liqo/agent_conf.yaml
@@ -1,0 +1,1 @@
+kubeconfig: /test/path

--- a/internal/tray-agent/agent/client/local-config.go
+++ b/internal/tray-agent/agent/client/local-config.go
@@ -1,0 +1,81 @@
+package client
+
+import (
+	"gopkg.in/yaml.v2"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+//ConfigFilename is the basename of the Agent configuration file.
+const ConfigFilename = ".agent_conf.yaml"
+
+//fileConfig contains Liqo Agent configuration parameters acquired from the cluster.
+var fileConfig *LocalConfiguration
+
+//LocalConfig maps the information of a Liqo Agent configuration file, containing persistent settings data.
+type LocalConfig struct {
+	//Kubeconfig contains the path of the kubeconfig file.
+	Kubeconfig string `yaml:"kubeconfig,omitempty"`
+}
+
+//LocalConfiguration stores the LocalConfig configuration acquired from a local config file and a validity flag.
+type LocalConfiguration struct {
+	//Content maps the content of the config file.
+	Content *LocalConfig
+	//Valid specifies whether LocalConfiguration contains a valid Content.
+	Valid bool
+	sync.RWMutex
+}
+
+func newLocalConfiguration() *LocalConfiguration {
+	return &LocalConfiguration{
+		Content: &LocalConfig{},
+	}
+}
+
+//LoadLocalConfig tries to load configuration data from a config file ConfigFilename on the local filesystem
+//(if present and valid). The config file structure is mapped on the LocalConfig type.
+func LoadLocalConfig() {
+	fileConfig := newLocalConfiguration()
+	liqoDir, present := os.LookupEnv("LIQO_PATH")
+	if !present {
+		return
+	}
+	filePath := filepath.Join(liqoDir, ConfigFilename)
+	yamlFile, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		return
+	}
+	err = yaml.Unmarshal(yamlFile, fileConfig.Content)
+	if err != nil {
+		return
+	}
+	fileConfig.Valid = true
+}
+
+//SaveLocalConfig tries to save the configuration data contained in the AgentController inner LocalConfig to a
+//config file one the local file system named after ConfigFilename.
+func SaveLocalConfig() {
+	liqoDir, present := os.LookupEnv("LIQO_PATH")
+	if !present {
+		return
+	}
+	if _, err := os.Stat(liqoDir); err != nil || fileConfig == nil {
+		return
+	}
+	data, err := yaml.Marshal(fileConfig.Content)
+	if err != nil {
+		return
+	}
+	_ = ioutil.WriteFile(filepath.Join(liqoDir, ConfigFilename), data, 0644)
+}
+
+//GetLocalConfig returns configuration data acquired from a config file on the local file system.
+func GetLocalConfig() (config *LocalConfiguration, valid bool) {
+	if fileConfig == nil {
+		return nil, false
+	}
+	return fileConfig, fileConfig.Valid
+}

--- a/internal/tray-agent/agent/client/local-config.go
+++ b/internal/tray-agent/agent/client/local-config.go
@@ -9,7 +9,7 @@ import (
 )
 
 //ConfigFilename is the basename of the Agent configuration file.
-const ConfigFilename = ".agent_conf.yaml"
+const ConfigFilename = "agent_conf.yaml"
 
 //fileConfig contains Liqo Agent configuration parameters acquired from the cluster.
 var fileConfig *LocalConfiguration

--- a/internal/tray-agent/agent/client/local-config_test.go
+++ b/internal/tray-agent/agent/client/local-config_test.go
@@ -1,0 +1,45 @@
+package client
+
+import (
+	"github.com/stretchr/testify/assert"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLocalConfiguration(t *testing.T) {
+	//set env variables
+	env, present := os.LookupEnv(EnvLiqoPath)
+	liqoPath, err := filepath.Abs("test_config/liqo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.NoError(t, os.Setenv(EnvLiqoPath, liqoPath), "PRE-TEST: envLiqoPath not set")
+	assert.NoError(t, os.MkdirAll(liqoPath, 0777), "PRE-TEST: path for Liqo directory not created")
+
+	NewLocalConfig()
+	conf, valid := GetLocalConfig()
+	assert.False(t, valid, "new configuration should not be valid")
+	assert.NotNil(t, conf.Content, "content for new configuration should not be nil")
+	setString := "/test/path"
+	//update local configuration
+	conf.SetKubeconfig(setString)
+	assert.Equal(t, setString, conf.Content.Kubeconfig, "configuration content not updated")
+	//write to file
+	assert.NoError(t, SaveLocalConfig(), "error on file writing")
+	//reset local configuration
+	NewLocalConfig()
+	//read from file
+	LoadLocalConfig()
+	conf, valid = GetLocalConfig()
+	assert.True(t, valid, "correct loaded configuration should be valid")
+	//read from local configuration
+	getString := conf.GetKubeconfig()
+	assert.Equal(t, setString, getString, "loaded configuration differs from saved one")
+	//POST TEST: delete file
+	_ = os.RemoveAll(EnvLiqoPath)
+	//POST TEST: reset env var
+	if present {
+		_ = os.Setenv(EnvLiqoPath, env)
+	}
+}

--- a/internal/tray-agent/agent/client/test_config/liqo/agent_conf.yaml
+++ b/internal/tray-agent/agent/client/test_config/liqo/agent_conf.yaml
@@ -1,0 +1,1 @@
+kubeconfig: /test/path

--- a/internal/tray-agent/app-indicator/config.go
+++ b/internal/tray-agent/app-indicator/config.go
@@ -1,6 +1,7 @@
 package app_indicator
 
 import (
+	"github.com/liqotech/liqo/internal/tray-agent/agent/client"
 	"os"
 	"path/filepath"
 )
@@ -28,7 +29,7 @@ func newConfig() *config {
 		XDGBaseDir = filepath.Join(os.Getenv("HOME"), ".local/share")
 	}
 	liqoPath := filepath.Join(XDGBaseDir, "liqo")
-	if err := os.Setenv("LIQO_PATH", liqoPath); err != nil {
+	if err := os.Setenv(client.EnvLiqoPath, liqoPath); err != nil {
 		os.Exit(1)
 	}
 	conf := &config{notifyLevel: NotifyLevelMax, notifyIconPath: filepath.Join(liqoPath, "icons")}

--- a/internal/tray-agent/app-indicator/config_test.go
+++ b/internal/tray-agent/app-indicator/config_test.go
@@ -1,6 +1,7 @@
 package app_indicator
 
 import (
+	"github.com/liqotech/liqo/internal/tray-agent/agent/client"
 	"github.com/stretchr/testify/assert"
 	"os"
 	"testing"
@@ -33,7 +34,7 @@ func TestNewConfig(t *testing.T) {
 		t.Skip("it was not possible to set OS env variable")
 	}
 	conf := newConfig()
-	assert.Equal(t, "test/liqo", os.Getenv("LIQO_PATH"))
+	assert.Equal(t, "test/liqo", os.Getenv(client.EnvLiqoPath))
 	assert.Equal(t, 3, len(conf.notifyTranslateMap))
 	assert.Equal(t, 3, len(conf.notifyTranslateReverseMap))
 	// test config startup content

--- a/internal/tray-agent/app-indicator/indicator.go
+++ b/internal/tray-agent/app-indicator/indicator.go
@@ -94,6 +94,7 @@ func GetIndicator() *Indicator {
 		root.config = newConfig()
 		root.status = GetStatus()
 		root.RefreshStatus()
+		client.LoadLocalConfig()
 		root.agentCtrl = client.GetAgentController()
 		if !root.agentCtrl.Connected() {
 			root.ShowErrorNoConnection()

--- a/internal/tray-agent/app-indicator/notify.go
+++ b/internal/tray-agent/app-indicator/notify.go
@@ -46,7 +46,7 @@ const (
 
 //Notify manages Indicator notification logic. Depending on the current NotifyLevel of the Indicator,
 //it changes the Indicator tray icon and displays a desktop banner, having title 'title' and 'message' as body.
-//If present in $LIQO_PATH, also 'notifyIcon' is shown inside the banner.
+//If present in client.EnvLiqoPath, also 'notifyIcon' is shown inside the banner.
 //
 //The "nil" values can be used for both 'notifyIcon' and 'indicatorIcon':
 //


### PR DESCRIPTION
# Description

This PR introduces for Liqo Agent to load and store some configuration data on a *.yaml* config file on the local filesystem, inside the *liqo* directory where other resources are already present (e.g. the desktop icons).

This feature brings some benefits:

- [x] The Agent can acquire some parameters that would be otherwise inaccessible, e.g. the indication of a specific kubeconfig filepath directly injected by the Liqo installer in the config file.

- [x] Persistency of the information: the config file is stille accessible after a Turn-Off of the Agent, allowing a stateful configuration

- [x] easy configuration and fields expansion thanks to yaml format

- further developments
  - Switching between clusters and ApiServers can be easier

  - users profiles

##### Note

Notifications setting will be moved in the config file in a further PR.

# Tests

unit tests and local testing