### PR TITLE
Virtual kubelet logs and exec fix

### DIFF
--- a/internal/utils/errdefs/invalid.go
+++ b/internal/utils/errdefs/invalid.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 )
 
-// InvalidInput is an error interface which denotes whether the opration failed due
+// ErrInvalidInput is an error interface which denotes whether the opration failed due
 // to a the resource not being found.
 type ErrInvalidInput interface {
 	InvalidInput() bool

--- a/internal/virtualKubelet/node/api/exec.go
+++ b/internal/virtualKubelet/node/api/exec.go
@@ -49,13 +49,53 @@ type TermSize struct {
 	Height uint16
 }
 
+// ContainerExecHandlerConfig is used to pass options to options to the container exec handler.
+type ContainerExecHandlerConfig struct {
+	// StreamIdleTimeout is the maximum time a streaming connection
+	// can be idle before the connection is automatically closed.
+	StreamIdleTimeout time.Duration
+	// StreamCreationTimeout is the maximum time for streaming connection
+	StreamCreationTimeout time.Duration
+}
+
+// ContainerExecHandlerOption configures a ContainerExecHandlerConfig
+// It is used as functional options passed to `HandleContainerExec`
+type ContainerExecHandlerOption func(*ContainerExecHandlerConfig)
+
+// WithExecStreamIdleTimeout sets the idle timeout for a container exec stream
+func WithExecStreamIdleTimeout(dur time.Duration) ContainerExecHandlerOption {
+	return func(cfg *ContainerExecHandlerConfig) {
+		cfg.StreamIdleTimeout = dur
+	}
+}
+
+// WithExecStreamCreationTimeout sets the creation timeout for a container exec stream
+func WithExecStreamCreationTimeout(dur time.Duration) ContainerExecHandlerOption {
+	return func(cfg *ContainerExecHandlerConfig) {
+		cfg.StreamCreationTimeout = dur
+	}
+}
+
 // HandleContainerExec makes an http handler func from a Provider which execs a command in a pod's container
 // Note that this handler currently depends on gorrilla/mux to get url parts as variables.
 // TODO(@cpuguy83): don't force gorilla/mux on consumers of this function
-func HandleContainerExec(h ContainerExecHandlerFunc) http.HandlerFunc {
+func HandleContainerExec(h ContainerExecHandlerFunc, opts ...ContainerExecHandlerOption) http.HandlerFunc {
 	if h == nil {
 		return NotImplemented
 	}
+
+	var cfg ContainerExecHandlerConfig
+	for _, o := range opts {
+		o(&cfg)
+	}
+
+	if cfg.StreamIdleTimeout == 0 {
+		cfg.StreamIdleTimeout = 30 * time.Second
+	}
+	if cfg.StreamCreationTimeout == 0 {
+		cfg.StreamCreationTimeout = 30 * time.Second
+	}
+
 	return handleError(func(w http.ResponseWriter, req *http.Request) error {
 		vars := mux.Vars(req)
 
@@ -73,14 +113,24 @@ func HandleContainerExec(h ContainerExecHandlerFunc) http.HandlerFunc {
 			return errdefs.AsInvalidInput(err)
 		}
 
-		idleTimeout := time.Second * 30
-		streamCreationTimeout := time.Second * 30
-
+		// TODO: Why aren't we using req.Context() here?
 		ctx, cancel := context.WithCancel(context.TODO())
 		defer cancel()
 
 		exec := &containerExecContext{ctx: ctx, h: h, pod: pod, namespace: namespace, container: container}
-		remotecommand.ServeExec(w, req, exec, "", "", container, command, streamOpts, idleTimeout, streamCreationTimeout, supportedStreamProtocols)
+		remotecommand.ServeExec(
+			w,
+			req,
+			exec,
+			"",
+			"",
+			container,
+			command,
+			streamOpts,
+			cfg.StreamIdleTimeout,
+			cfg.StreamCreationTimeout,
+			supportedStreamProtocols,
+		)
 
 		return nil
 	})

--- a/internal/virtualKubelet/node/api/logs.go
+++ b/internal/virtualKubelet/node/api/logs.go
@@ -17,13 +17,15 @@ package api
 import (
 	"context"
 	"io"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog"
 	"net/http"
+	"net/url"
 	"strconv"
 	"time"
 
 	"github.com/gorilla/mux"
 	"github.com/liqotech/liqo/internal/utils/errdefs"
-	"github.com/liqotech/liqo/internal/utils/log"
 	"github.com/pkg/errors"
 )
 
@@ -33,10 +35,73 @@ type ContainerLogsHandlerFunc func(ctx context.Context, namespace, podName, cont
 // ContainerLogOpts are used to pass along options to be set on the container
 // log stream.
 type ContainerLogOpts struct {
-	Tail       int
-	Since      time.Duration
-	LimitBytes int
-	Timestamps bool
+	Tail         int64
+	LimitBytes   int64
+	Timestamps   bool
+	Follow       bool
+	Previous     bool
+	SinceSeconds int64
+	SinceTime    metav1.Time
+}
+
+func parseLogOptions(q url.Values) (opts ContainerLogOpts, err error) {
+	if tailLines := q.Get("tailLines"); tailLines != "" {
+		opts.Tail, err = strconv.ParseInt(tailLines, 10, 64)
+		if err != nil {
+			return opts, errdefs.AsInvalidInput(errors.Wrap(err, "could not parse \"tailLines\""))
+		}
+		if opts.Tail < 0 {
+			return opts, errdefs.InvalidInputf("\"tailLines\" is %d", opts.Tail)
+		}
+	}
+	if follow := q.Get("follow"); follow != "" {
+		opts.Follow, err = strconv.ParseBool(follow)
+		if err != nil {
+			return opts, errdefs.AsInvalidInput(errors.Wrap(err, "could not parse \"follow\""))
+		}
+	}
+	if limitBytes := q.Get("limitBytes"); limitBytes != "" {
+		opts.LimitBytes, err = strconv.ParseInt(limitBytes, 10, 64)
+		if err != nil {
+			return opts, errdefs.AsInvalidInput(errors.Wrap(err, "could not parse \"limitBytes\""))
+		}
+		if opts.LimitBytes < 1 {
+			return opts, errdefs.InvalidInputf("\"limitBytes\" is %d", opts.LimitBytes)
+		}
+	}
+	if previous := q.Get("previous"); previous != "" {
+		opts.Previous, err = strconv.ParseBool(previous)
+		if err != nil {
+			return opts, errdefs.AsInvalidInput(errors.Wrap(err, "could not parse \"previous\""))
+		}
+	}
+	if sinceSeconds := q.Get("sinceSeconds"); sinceSeconds != "" {
+		opts.SinceSeconds, err = strconv.ParseInt(sinceSeconds, 10, 64)
+		if err != nil {
+			return opts, errdefs.AsInvalidInput(errors.Wrap(err, "could not parse \"sinceSeconds\""))
+		}
+		if opts.SinceSeconds < 1 {
+			return opts, errdefs.InvalidInputf("\"sinceSeconds\" is %d", opts.SinceSeconds)
+		}
+	}
+	if sinceTime := q.Get("sinceTime"); sinceTime != "" {
+		var tmpSinceTime time.Time
+		tmpSinceTime, err = time.Parse(time.RFC3339, sinceTime)
+		if err != nil {
+			return opts, errdefs.AsInvalidInput(errors.Wrap(err, "could not parse \"sinceTime\""))
+		}
+		if opts.SinceSeconds > 0 {
+			return opts, errdefs.InvalidInput("both \"sinceSeconds\" and \"sinceTime\" are set")
+		}
+		opts.SinceTime = metav1.NewTime(tmpSinceTime)
+	}
+	if timestamps := q.Get("timestamps"); timestamps != "" {
+		opts.Timestamps, err = strconv.ParseBool(timestamps)
+		if err != nil {
+			return opts, errdefs.AsInvalidInput(errors.Wrap(err, "could not parse \"timestamps\""))
+		}
+	}
+	return opts, nil
 }
 
 // HandleContainerLogs creates an http handler function from a provider to serve logs from a pod
@@ -55,22 +120,11 @@ func HandleContainerLogs(h ContainerLogsHandlerFunc) http.HandlerFunc {
 		namespace := vars["namespace"]
 		pod := vars["pod"]
 		container := vars["container"]
-		tail := 10
-		q := req.URL.Query()
 
-		if queryTail := q.Get("tailLines"); queryTail != "" {
-			t, err := strconv.Atoi(queryTail)
-			if err != nil {
-				return errdefs.AsInvalidInput(errors.Wrap(err, "could not parse \"tailLines\""))
-			}
-			tail = t
-		}
-
-		// TODO(@cpuguy83): support v1.PodLogOptions
-		// The kubelet decoding here is not straight forward, so this needs to be disected
-
-		opts := ContainerLogOpts{
-			Tail: tail,
+		query := req.URL.Query()
+		opts, err := parseLogOptions(query)
+		if err != nil {
+			return err
 		}
 
 		logs, err := h(ctx, namespace, pod, container, opts)
@@ -83,7 +137,7 @@ func HandleContainerLogs(h ContainerLogsHandlerFunc) http.HandlerFunc {
 		req.Header.Set("Transfer-Encoding", "chunked")
 
 		if _, ok := w.(writeFlusher); !ok {
-			log.G(ctx).Debug("http response writer does not support flushes")
+			klog.V(3).Info("http response writer does not support flushes")
 		}
 
 		if _, err := io.Copy(flushOnWrite(w), logs); err != nil {

--- a/pkg/virtualKubelet/storage/cacheManager.go
+++ b/pkg/virtualKubelet/storage/cacheManager.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"fmt"
+	"github.com/liqotech/liqo/internal/utils/errdefs"
 	apimgmt "github.com/liqotech/liqo/pkg/virtualKubelet/apiReflection"
 	"github.com/liqotech/liqo/pkg/virtualKubelet/utils"
 	"github.com/pkg/errors"
@@ -235,7 +236,7 @@ func (cm *Manager) ResyncListForeignNamespacedObject(api apimgmt.ApiType, namesp
 	return objects, nil
 }
 
-func (cm *Manager) ListHomeApiByIndex(api apimgmt.ApiType, namespace, index string) ([]interface{}, error) {
+func (cm *Manager) GetHomeApiByIndex(api apimgmt.ApiType, namespace, index string) (interface{}, error) {
 	if cm.homeInformers == nil {
 		return nil, errors.New("home informers set to nil")
 	}
@@ -253,10 +254,17 @@ func (cm *Manager) ListHomeApiByIndex(api apimgmt.ApiType, namespace, index stri
 		return nil, err
 	}
 
-	return objects, nil
+	if len(objects) == 0 {
+		return nil, errdefs.NotFound(fmt.Sprintf("no objects indexed with key %s found", index))
+	}
+	if len(objects) > 1 {
+		return nil, errors.New("multiple objects indexed with the same index")
+	}
+
+	return objects[0], nil
 }
 
-func (cm *Manager) ListForeignApiByIndex(api apimgmt.ApiType, namespace, index string) ([]interface{}, error) {
+func (cm *Manager) GetForeignApiByIndex(api apimgmt.ApiType, namespace, index string) (interface{}, error) {
 	if cm.foreignInformers == nil {
 		return nil, errors.New("foreign informers set to nil")
 	}
@@ -274,5 +282,12 @@ func (cm *Manager) ListForeignApiByIndex(api apimgmt.ApiType, namespace, index s
 		return nil, err
 	}
 
-	return objects, nil
+	if len(objects) == 0 {
+		return nil, errdefs.NotFound(fmt.Sprintf("no objects indexed with key %s found", index))
+	}
+	if len(objects) > 1 {
+		return nil, errors.New("multiple objects indexed with the same index")
+	}
+
+	return objects[0], nil
 }

--- a/pkg/virtualKubelet/storage/interfaces.go
+++ b/pkg/virtualKubelet/storage/interfaces.go
@@ -30,8 +30,8 @@ type CacheManagerReader interface {
 	ListForeignNamespacedObject(apimgmt.ApiType, string) ([]interface{}, error)
 	ResyncListHomeNamespacedObject(apimgmt.ApiType, string) ([]interface{}, error)
 	ResyncListForeignNamespacedObject(apimgmt.ApiType, string) ([]interface{}, error)
-	ListHomeApiByIndex(apimgmt.ApiType, string, string) ([]interface{}, error)
-	ListForeignApiByIndex(apimgmt.ApiType, string, string) ([]interface{}, error)
+	GetHomeApiByIndex(apimgmt.ApiType, string, string) (interface{}, error)
+	GetForeignApiByIndex(apimgmt.ApiType, string, string) (interface{}, error)
 }
 
 type CacheManagerReaderAdder interface {

--- a/pkg/virtualKubelet/storage/test/mockCacheManager.go
+++ b/pkg/virtualKubelet/storage/test/mockCacheManager.go
@@ -110,10 +110,10 @@ func (m *MockManager) ResyncListForeignNamespacedObject(apiType apimgmt.ApiType,
 	panic("implement me")
 }
 
-func (m *MockManager) ListHomeApiByIndex(apiType apimgmt.ApiType, s string, s2 string) ([]interface{}, error) {
+func (m *MockManager) GetHomeApiByIndex(apiType apimgmt.ApiType, s string, s2 string) (interface{}, error) {
 	panic("implement me")
 }
 
-func (m *MockManager) ListForeignApiByIndex(apiType apimgmt.ApiType, s string, s2 string) ([]interface{}, error) {
+func (m *MockManager) GetForeignApiByIndex(apiType apimgmt.ApiType, s string, s2 string) (interface{}, error) {
 	panic("implement me")
 }


### PR DESCRIPTION
# Description

This PR fixes the container exec and logs in the virtual kubelet, by adapting the implementation with the current provider implementation.
In addition to this, the handlers for the exec and logs endpoints in the vk server have been updated with the latest version of the virtual kubelet, including the complete parsing of the logging and exec options. 

# Testing
The testing of logs and exec APIs has to be implemented in an e2e fashion.
