### PR TITLE
Add ClusterIdentity endpoint to authentication service

### DIFF
--- a/apis/discovery/v1alpha1/foreigncluster_types.go
+++ b/apis/discovery/v1alpha1/foreigncluster_types.go
@@ -19,6 +19,7 @@ package v1alpha1
 import (
 	advtypes "github.com/liqotech/liqo/apis/sharing/v1alpha1"
 	"github.com/liqotech/liqo/pkg/crdClient"
+	"github.com/liqotech/liqo/pkg/discovery"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -27,36 +28,6 @@ import (
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
-
-type DiscoveryType string
-
-const (
-	LanDiscovery             DiscoveryType = "LAN"
-	WanDiscovery             DiscoveryType = "WAN"
-	ManualDiscovery          DiscoveryType = "Manual"
-	IncomingPeeringDiscovery DiscoveryType = "IncomingPeering"
-)
-
-type TrustMode string
-
-const (
-	TrustModeUnknown   TrustMode = "Unknown"
-	TrustModeTrusted   TrustMode = "Trusted"
-	TrustModeUntrusted TrustMode = "Untrusted"
-)
-
-type AuthStatus string
-
-const (
-	AuthStatusPending      AuthStatus = "Pending"
-	AuthStatusAccepted     AuthStatus = "Accepted"
-	AuthStatusRefused      AuthStatus = "Refused"
-	AuthStatusEmptyRefused AuthStatus = "EmptyRefused"
-)
-
-const (
-	LastUpdateAnnotation string = "discovery.liqo.io/LastUpdate"
-)
 
 // ForeignClusterSpec defines the desired state of ForeignCluster
 type ForeignClusterSpec struct {
@@ -69,12 +40,14 @@ type ForeignClusterSpec struct {
 	Namespace string `json:"namespace"`
 	// Enable join process to foreign cluster
 	Join bool `json:"join"`
-	// URL where to contact foreign API server
-	ApiUrl string `json:"apiUrl"`
 	// How this ForeignCluster has been discovered
-	DiscoveryType DiscoveryType `json:"discoveryType"`
+	DiscoveryType discovery.DiscoveryType `json:"discoveryType"`
 	// URL where to contact foreign Auth service
 	AuthUrl string `json:"authUrl"`
+	// +kubebuilder:validation:Enum="Unknown";"Trusted";"Untrusted"
+	// +kubebuilder:default="Unknown"
+	// Indicates if this remote cluster is trusted or not
+	TrustMode discovery.TrustMode `json:"trustMode,omitempty"`
 }
 
 type ClusterIdentity struct {
@@ -93,16 +66,12 @@ type ForeignClusterStatus struct {
 	Incoming Incoming `json:"incoming,omitempty"`
 	// If discoveryType is LAN and this counter reach 0 value, this FC will be removed
 	Ttl uint32 `json:"ttl,omitempty"`
-	// +kubebuilder:validation:Enum="Unknown";"Trusted";"Untrusted"
-	// +kubebuilder:default="Unknown"
-	// Indicates if this remote cluster is trusted or not
-	TrustMode TrustMode `json:"trustMode,omitempty"`
 	// It stores most important network statuses
 	Network Network `json:"network,omitempty"`
 	// Authentication status
 	// +kubebuilder:validation:Enum="Pending";"Accepted";"Refused";"EmptyRefused"
 	// +kubebuilder:default="Pending"
-	AuthStatus AuthStatus `json:"authStatus,omitempty"`
+	AuthStatus discovery.AuthStatus `json:"authStatus,omitempty"`
 }
 
 type ResourceLink struct {

--- a/deployments/liqo/crds/discovery.liqo.io_foreignclusters.yaml
+++ b/deployments/liqo/crds/discovery.liqo.io_foreignclusters.yaml
@@ -36,9 +36,6 @@ spec:
           spec:
             description: ForeignClusterSpec defines the desired state of ForeignCluster
             properties:
-              apiUrl:
-                description: URL where to contact foreign API server
-                type: string
               authUrl:
                 description: URL where to contact foreign Auth service
                 type: string
@@ -64,8 +61,15 @@ spec:
               namespace:
                 description: Namespace where Liqo is deployed
                 type: string
+              trustMode:
+                default: Unknown
+                description: Indicates if this remote cluster is trusted or not
+                enum:
+                - Unknown
+                - Trusted
+                - Untrusted
+                type: string
             required:
-            - apiUrl
             - authUrl
             - clusterIdentity
             - discoveryType
@@ -407,14 +411,6 @@ spec:
                 required:
                 - joined
                 type: object
-              trustMode:
-                default: Unknown
-                description: Indicates if this remote cluster is trusted or not
-                enum:
-                - Unknown
-                - Trusted
-                - Untrusted
-                type: string
               ttl:
                 description: If discoveryType is LAN and this counter reach 0 value,
                   this FC will be removed

--- a/deployments/liqo/subcharts/authService/templates/auth-service-deploy.yaml
+++ b/deployments/liqo/subcharts/authService/templates/auth-service-deploy.yaml
@@ -59,12 +59,14 @@ rules:
   - apiGroups:
       - ""
     resources:
+      - configmaps
       - secrets
     verbs:
       - get
       - list
       - watch
       - create
+      - update
       - delete
   - apiGroups:
       - ""

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/apparentlymart/go-cidr v1.1.0
 	github.com/atotto/clipboard v0.1.2
 	github.com/coreos/go-iptables v0.4.5
+	github.com/cratonica/2goarray v0.0.0-20190331194516-514510793eaa // indirect
 	github.com/gen2brain/beeep v0.0.0-20200526185328-e9c15c258e28
 	github.com/gen2brain/dlgs v0.0.0-20201118155338-03fe7f81ad25
 	github.com/getlantern/systray v1.1.0
@@ -41,8 +42,10 @@ require (
 	go.opencensus.io v0.22.4
 	go.uber.org/atomic v1.5.1 // indirect
 	go.uber.org/multierr v1.4.0 // indirect
+	golang.org/x/crypto v0.0.0-20201208171446-5f87f3452ae9 // indirect
 	golang.org/x/net v0.0.0-20201110031124-69a78807bb2b // indirect
-	golang.org/x/sys v0.0.0-20201113233024-12cec1faf1ba
+	golang.org/x/sys v0.0.0-20201207223542-d4d67f95c62d
+	golang.org/x/term v0.0.0-20201207232118-ee85cb95a76b // indirect
 	golang.org/x/text v0.3.4 // indirect
 	golang.org/x/tools v0.0.0-20201116002733-ac45abd4c88c
 	gopkg.in/yaml.v2 v2.3.0

--- a/go.sum
+++ b/go.sum
@@ -199,6 +199,8 @@ github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwc
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0 h1:EoUDS0afbrsXAZ9YQ9jdu/mZ2sXgT1/2yyNng4PGlyM=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
+github.com/cratonica/2goarray v0.0.0-20190331194516-514510793eaa h1:Wg+722vs7a2zQH5lR9QWYsVbplKeffaQFIs5FTdfNNo=
+github.com/cratonica/2goarray v0.0.0-20190331194516-514510793eaa/go.mod h1:6Arca19mRx58CA7OWEd7Wu1NpC1rd3uDnNs6s1pj/DI=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/cyphar/filepath-securejoin v0.2.2 h1:jCwT2GTP+PY5nBz3c/YL5PAIbusElVrPujOBSCj8xRg=
 github.com/cyphar/filepath-securejoin v0.2.2/go.mod h1:FpkQEhXnPnOthhzymB7CGsFk2G9VLXONKD9G7QGMM+4=
@@ -986,6 +988,8 @@ golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975 h1:/Tl7pH94bvbAAHBdZJT947
 golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 h1:psW17arqaxU48Z5kZ0CQnkZWQJsqcURM6tKiBApRjXI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20201208171446-5f87f3452ae9 h1:sYNJzB4J8toYPQTM6pAkcmBRgw9SnQKP9oXCHfgy604=
+golang.org/x/crypto v0.0.0-20201208171446-5f87f3452ae9/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/exp v0.0.0-20180321215751-8460e604b9de/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20180807140117-3d87b88a115f/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -1160,6 +1164,13 @@ golang.org/x/sys v0.0.0-20201015000850-e3ed0017c211 h1:9UQO31fZ+0aKQOFldThf7BKPM
 golang.org/x/sys v0.0.0-20201015000850-e3ed0017c211/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201113233024-12cec1faf1ba h1:xmhUJGQGbxlod18iJGqVEp9cHIPLl7QiX2aA3to708s=
 golang.org/x/sys v0.0.0-20201113233024-12cec1faf1ba/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20201207223542-d4d67f95c62d h1:MiWWjyhUzZ+jvhZvloX6ZrUsdEghn8a64Upd8EMHglE=
+golang.org/x/sys v0.0.0-20201207223542-d4d67f95c62d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/term v0.0.0-20201117132131-f5c789dd3221 h1:/ZHdbVpdR/jk3g30/d4yUL0JU9kksj8+F/bnQUVLGDM=
+golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
+golang.org/x/term v0.0.0-20201207232118-ee85cb95a76b h1:a0ErnNnPKmhDyIXQvdZr+Lq8dc8xpMeqkF8y5PgQU4Q=
+golang.org/x/term v0.0.0-20201207232118-ee85cb95a76b/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.0.0-20170915090833-1cbadb444a80/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/internal/auth-service/auth-service-config.go
+++ b/internal/auth-service/auth-service-config.go
@@ -10,6 +10,7 @@ func (authService *AuthServiceCtrl) GetAuthServiceConfig(kubeconfigPath string) 
 	isFirst := true
 	go clusterConfig.WatchConfiguration(func(configuration *configv1alpha1.ClusterConfig) {
 		authService.handleConfiguration(configuration.Spec.AuthConfig)
+		authService.handleDiscoveryConfiguration(configuration.Spec.DiscoveryConfig)
 		if isFirst {
 			isFirst = false
 			close(waitFirst)
@@ -28,4 +29,16 @@ func (authService *AuthServiceCtrl) GetConfig() *configv1alpha1.AuthConfig {
 	authService.configMutex.RLock()
 	defer authService.configMutex.RUnlock()
 	return authService.config.DeepCopy()
+}
+
+func (authService *AuthServiceCtrl) handleDiscoveryConfiguration(config configv1alpha1.DiscoveryConfig) {
+	authService.configMutex.Lock()
+	defer authService.configMutex.Unlock()
+	authService.discoveryConfig = config
+}
+
+func (authService *AuthServiceCtrl) GetDiscoveryConfig() configv1alpha1.DiscoveryConfig {
+	authService.configMutex.RLock()
+	defer authService.configMutex.RUnlock()
+	return authService.discoveryConfig
 }

--- a/internal/auth-service/auth-service.go
+++ b/internal/auth-service/auth-service.go
@@ -5,6 +5,7 @@ import (
 	"github.com/julienschmidt/httprouter"
 	"github.com/liqotech/liqo/apis/config/v1alpha1"
 	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
+	"github.com/liqotech/liqo/pkg/clusterID"
 	"github.com/liqotech/liqo/pkg/crdClient"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -26,8 +27,11 @@ type AuthServiceCtrl struct {
 	nodeInformer   cache.SharedIndexInformer
 	secretInformer cache.SharedIndexInformer
 
-	config      *v1alpha1.AuthConfig
-	configMutex sync.RWMutex
+	clusterId *clusterID.ClusterID
+
+	config          *v1alpha1.AuthConfig
+	discoveryConfig v1alpha1.DiscoveryConfig
+	configMutex     sync.RWMutex
 }
 
 func NewAuthServiceCtrl(namespace string, kubeconfigPath string, resyncTime time.Duration) (*AuthServiceCtrl, error) {
@@ -51,6 +55,11 @@ func NewAuthServiceCtrl(namespace string, kubeconfigPath string, resyncTime time
 	secretInformer := informerFactory.Core().V1().Secrets().Informer()
 	secretInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{})
 
+	clusterId, err := clusterID.NewClusterID(kubeconfigPath)
+	if err != nil {
+		return nil, err
+	}
+
 	informerFactory.Start(wait.NeverStop)
 	informerFactory.WaitForCacheSync(wait.NeverStop)
 
@@ -60,6 +69,7 @@ func NewAuthServiceCtrl(namespace string, kubeconfigPath string, resyncTime time
 		saInformer:     saInformer,
 		nodeInformer:   nodeInformer,
 		secretInformer: secretInformer,
+		clusterId:      clusterId,
 	}, nil
 }
 
@@ -71,6 +81,7 @@ func (authService *AuthServiceCtrl) Start(listeningPort string, certFile string,
 	router := httprouter.New()
 
 	router.POST("/identity", authService.role)
+	router.GET("/ids", authService.ids)
 
 	err := http.ListenAndServeTLS(strings.Join([]string{":", listeningPort}, ""), certFile, keyFile, router)
 	if err != nil {

--- a/internal/auth-service/idsHttpHandler.go
+++ b/internal/auth-service/idsHttpHandler.go
@@ -1,0 +1,40 @@
+package auth_service
+
+import (
+	"encoding/json"
+	"github.com/julienschmidt/httprouter"
+	"github.com/liqotech/liqo/pkg/auth"
+	"k8s.io/klog"
+	"net/http"
+)
+
+// this HTTP handler returns home cluster information to the foreign clusters that are asking for them
+// it returns a JSON encoded ClusterInfo struct with the following fields:
+// - clusterID		-> the id of the home cluster
+// - clusterName	-> the custom name for the home cluster (to be displayed in GUIs)
+// - guestNamespace	-> the namespace where to create secrets and resources to be shared with the home cluster
+func (authService *AuthServiceCtrl) ids(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	idsResponse := authService.getIdsResponse()
+
+	res, err := json.Marshal(idsResponse)
+	if err != nil {
+		klog.Error(err)
+		authService.handleError(w, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	if _, err = w.Write(res); err != nil {
+		klog.Error(err)
+		return
+	}
+}
+
+func (authService *AuthServiceCtrl) getIdsResponse() *auth.ClusterInfo {
+	conf := authService.GetDiscoveryConfig()
+	return &auth.ClusterInfo{
+		ClusterID:      authService.clusterId.GetClusterID(),
+		ClusterName:    conf.ClusterName,
+		GuestNamespace: auth.LiqoGuestNamespace,
+	}
+}

--- a/internal/discovery/authData.go
+++ b/internal/discovery/authData.go
@@ -13,7 +13,9 @@ import (
 type AuthData struct {
 	address string
 	port    int
-	isTest  bool
+	ttl     uint32
+
+	isTest bool
 }
 
 func NewAuthDataTest(address string, port int) *AuthData {
@@ -62,6 +64,8 @@ func (authData *AuthData) Decode(entry *zeroconf.ServiceEntry, timeout time.Dura
 	// use the reachable IP
 	// this is the IP that will be contacted to get the required permissions from the remote cluster
 	authData.address = ip.String()
+
+	authData.ttl = entry.TTL
 	return nil
 }
 

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -23,7 +23,6 @@ type DiscoveryCtrl struct {
 	advClient      *crdClient.CRDClient
 	ClusterId      *clusterID.ClusterID
 
-	mdnsServer                *zeroconf.Server
 	mdnsServerAuth            *zeroconf.Server
 	serverMux                 sync.Mutex
 	resolveContextRefreshTime int

--- a/internal/discovery/discoveryCache.go
+++ b/internal/discovery/discoveryCache.go
@@ -3,12 +3,13 @@ package discovery
 import (
 	"errors"
 	"github.com/jinzhu/copier"
+	"github.com/liqotech/liqo/pkg/auth"
 	"sync"
 )
 
 type discoveryData struct {
-	TxtData  *TxtData
-	AuthData *AuthData
+	AuthData    *AuthData
+	ClusterInfo *auth.ClusterInfo
 }
 
 // cache used to match different services coming for the same Liqo instance
@@ -21,10 +22,10 @@ var resolvedData = discoveryCache{
 	discoveredServices: map[string]discoveryData{},
 }
 
-func NewDiscoveryData(txtData *TxtData, authData *AuthData) *discoveryData {
+func NewDiscoveryData(authData *AuthData, clusterInfo *auth.ClusterInfo) *discoveryData {
 	return &discoveryData{
-		TxtData:  txtData,
-		AuthData: authData,
+		AuthData:    authData,
+		ClusterInfo: clusterInfo,
 	}
 }
 
@@ -33,10 +34,6 @@ func (discoveryCache *discoveryCache) add(key string, data DiscoverableData) {
 	defer discoveryCache.lock.Unlock()
 	if _, ok := discoveryCache.discoveredServices[key]; !ok {
 		switch data := data.(type) {
-		case *TxtData:
-			discoveryCache.discoveredServices[key] = discoveryData{
-				TxtData: data,
-			}
 		case *AuthData:
 			discoveryCache.discoveredServices[key] = discoveryData{
 				AuthData: data,
@@ -45,8 +42,6 @@ func (discoveryCache *discoveryCache) add(key string, data DiscoverableData) {
 	} else {
 		oldData := discoveryCache.discoveredServices[key]
 		switch data := data.(type) {
-		case *TxtData:
-			oldData.TxtData = data
 		case *AuthData:
 			oldData.AuthData = data
 		}
@@ -87,5 +82,5 @@ func (discoveryCache *discoveryCache) isComplete(key string) bool {
 }
 
 func (discoveryData *discoveryData) isComplete() bool {
-	return discoveryData.TxtData != nil && discoveryData.AuthData != nil
+	return discoveryData.AuthData != nil
 }

--- a/internal/discovery/foreign-cluster-operator/auth.go
+++ b/internal/discovery/foreign-cluster-operator/auth.go
@@ -44,7 +44,7 @@ func (r *ForeignClusterReconciler) getRemoteClient(fc *discoveryv1alpha1.Foreign
 		config.NegotiatedSerializer = client_scheme.Codecs.WithoutConversion()
 		config.UserAgent = rest.DefaultKubernetesUserAgent()
 
-		fc.Status.AuthStatus = discoveryv1alpha1.AuthStatusAccepted
+		fc.Status.AuthStatus = discovery.AuthStatusAccepted
 
 		return crdClient.NewFromConfig(&config)
 	}
@@ -56,7 +56,7 @@ func (r *ForeignClusterReconciler) getRemoteClient(fc *discoveryv1alpha1.Foreign
 		return nil, err
 	}
 
-	if fc.Status.AuthStatus == discoveryv1alpha1.AuthStatusAccepted {
+	if fc.Status.AuthStatus == discovery.AuthStatusAccepted {
 		// TODO: handle this possibility
 		// this can happen if the role was accepted but the local secret has been removed
 		err := errors.New("auth status is accepted but there is no secret found")
@@ -65,7 +65,7 @@ func (r *ForeignClusterReconciler) getRemoteClient(fc *discoveryv1alpha1.Foreign
 	}
 
 	// not existing role
-	if fc.Status.AuthStatus == discoveryv1alpha1.AuthStatusPending || (fc.Status.AuthStatus == discoveryv1alpha1.AuthStatusEmptyRefused && r.getAuthToken(fc) != "") {
+	if fc.Status.AuthStatus == discovery.AuthStatusPending || (fc.Status.AuthStatus == discovery.AuthStatusEmptyRefused && r.getAuthToken(fc) != "") {
 		kubeconfigStr, err := r.askRemoteIdentity(fc)
 		if err != nil {
 			klog.Error(err)
@@ -123,7 +123,7 @@ func (r *ForeignClusterReconciler) getIdentity(fc *discoveryv1alpha1.ForeignClus
 	config.NegotiatedSerializer = client_scheme.Codecs.WithoutConversion()
 	config.UserAgent = rest.DefaultKubernetesUserAgent()
 
-	fc.Status.AuthStatus = discoveryv1alpha1.AuthStatusAccepted
+	fc.Status.AuthStatus = discovery.AuthStatusAccepted
 
 	return crdClient.NewFromConfig(config)
 }
@@ -178,14 +178,14 @@ func (r *ForeignClusterReconciler) askRemoteIdentity(fc *discoveryv1alpha1.Forei
 	}
 	switch resp.StatusCode {
 	case http.StatusCreated:
-		fc.Status.AuthStatus = discoveryv1alpha1.AuthStatusAccepted
+		fc.Status.AuthStatus = discovery.AuthStatusAccepted
 		klog.Info("Identity Created")
 		return string(body), nil
 	case http.StatusForbidden:
 		if token == "" {
-			fc.Status.AuthStatus = discoveryv1alpha1.AuthStatusEmptyRefused
+			fc.Status.AuthStatus = discovery.AuthStatusEmptyRefused
 		} else {
-			fc.Status.AuthStatus = discoveryv1alpha1.AuthStatusRefused
+			fc.Status.AuthStatus = discovery.AuthStatusRefused
 		}
 		klog.Info(string(body))
 		return "", nil

--- a/internal/discovery/foreignClusterGarbageCollector.go
+++ b/internal/discovery/foreignClusterGarbageCollector.go
@@ -3,6 +3,7 @@ package discovery
 import (
 	goerrors "errors"
 	"github.com/liqotech/liqo/apis/discovery/v1alpha1"
+	discoveryPkg "github.com/liqotech/liqo/pkg/discovery"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog"
 	"strings"
@@ -18,7 +19,7 @@ func (discovery *DiscoveryCtrl) StartGarbageCollector() {
 // The GarbageCollector deletes all ForeignClusters discovered with LAN that have expired TTL
 func (discovery *DiscoveryCtrl) CollectGarbage() error {
 	tmp, err := discovery.crdClient.Resource("foreignclusters").List(metav1.ListOptions{
-		LabelSelector: strings.Join([]string{"discovery-type", string(v1alpha1.LanDiscovery)}, "="),
+		LabelSelector: strings.Join([]string{"discovery-type", string(discoveryPkg.LanDiscovery)}, "="),
 	})
 	if err != nil {
 		klog.Error(err)

--- a/internal/discovery/gratuitous-answers.go
+++ b/internal/discovery/gratuitous-answers.go
@@ -13,9 +13,6 @@ func (discovery *DiscoveryCtrl) StartGratuitousAnswers() {
 func (discovery *DiscoveryCtrl) sendAnswer() {
 	discovery.serverMux.Lock()
 	defer discovery.serverMux.Unlock()
-	if discovery.mdnsServer != nil {
-		discovery.mdnsServer.SendMulticast()
-	}
 	if discovery.mdnsServerAuth != nil {
 		discovery.mdnsServerAuth.SendMulticast()
 	}

--- a/internal/discovery/register.go
+++ b/internal/discovery/register.go
@@ -17,17 +17,6 @@ const (
 
 func (discovery *DiscoveryCtrl) Register() {
 	if discovery.Config.EnableAdvertisement {
-		txtData, err := discovery.GetTxtData()
-		if err != nil {
-			klog.Error(err)
-			return
-		}
-		txt, err := txtData.Encode()
-		if err != nil {
-			klog.Error(err)
-			return
-		}
-
 		authPort, err := discovery.getAuthServicePort()
 		if err != nil {
 			klog.Error(err)
@@ -36,13 +25,7 @@ func (discovery *DiscoveryCtrl) Register() {
 
 		var ttl = discovery.Config.Ttl
 		discovery.serverMux.Lock()
-		discovery.mdnsServer, err = zeroconf.Register(fmt.Sprintf("%s_%s", discovery.Config.Name, discovery.ClusterId.GetClusterID()), discovery.Config.Service, discovery.Config.Domain, discovery.Config.Port, txt, discovery.getInterfaces(), ttl)
-		if err != nil {
-			discovery.serverMux.Unlock()
-			klog.Error(err)
-			return
-		}
-		discovery.mdnsServerAuth, err = zeroconf.Register(fmt.Sprintf("%s_%s", discovery.Config.Name, discovery.ClusterId.GetClusterID()), discovery.Config.AuthService, discovery.Config.Domain, authPort, nil, discovery.getInterfaces(), ttl)
+		discovery.mdnsServerAuth, err = zeroconf.Register(discovery.ClusterId.GetClusterID(), discovery.Config.AuthService, discovery.Config.Domain, authPort, nil, discovery.getInterfaces(), ttl)
 		discovery.serverMux.Unlock()
 		if err != nil {
 			klog.Error(err)
@@ -56,7 +39,6 @@ func (discovery *DiscoveryCtrl) Register() {
 func (discovery *DiscoveryCtrl) shutdownServer() {
 	discovery.serverMux.Lock()
 	defer discovery.serverMux.Unlock()
-	discovery.mdnsServer.Shutdown()
 	discovery.mdnsServerAuth.Shutdown()
 }
 

--- a/internal/discovery/txtData.go
+++ b/internal/discovery/txtData.go
@@ -10,6 +10,9 @@ import (
 	"strings"
 )
 
+// TODO: delete this file
+// this can be done after WAN discovery changes in a next pr
+
 type TxtData struct {
 	ID        string
 	Name      string

--- a/internal/discovery/utils/utils.go
+++ b/internal/discovery/utils/utils.go
@@ -1,0 +1,38 @@
+package utils
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	goerrors "errors"
+	"fmt"
+	"github.com/liqotech/liqo/pkg/discovery"
+	"net/http"
+)
+
+// check if the error is due to a TLS certificate signed by unknown authority
+func IsUnknownAuthority(err error) bool {
+	var err509 x509.UnknownAuthorityError
+	var err509Hostname x509.HostnameError
+	return goerrors.As(err, &err509) || goerrors.As(err, &err509Hostname)
+}
+
+// contact the remote cluster to get its info
+// it returns also if the remote cluster exposes a trusted certificate
+func GetClusterInfo(url string) (*http.Response, discovery.TrustMode, error) {
+	trustMode := discovery.TrustModeTrusted
+	tr := &http.Transport{}
+	client := &http.Client{Transport: tr}
+	resp, err := client.Get(fmt.Sprintf("%s/ids", url))
+	if IsUnknownAuthority(err) {
+		trustMode = discovery.TrustModeUntrusted
+		tr := &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		}
+		client := &http.Client{Transport: tr}
+		resp, err = client.Get(fmt.Sprintf("%s/ids", url))
+	}
+	if err != nil {
+		return nil, discovery.TrustModeUnknown, err
+	}
+	return resp, trustMode, nil
+}

--- a/internal/peering-request-operator/foreign-cluster.go
+++ b/internal/peering-request-operator/foreign-cluster.go
@@ -4,10 +4,8 @@ import (
 	"errors"
 	"github.com/liqotech/liqo/apis/discovery/v1alpha1"
 	"github.com/liqotech/liqo/pkg/discovery"
-	"github.com/liqotech/liqo/pkg/kubeconfig"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/rest"
 	"k8s.io/klog"
 	"k8s.io/utils/pointer"
 	"strings"
@@ -63,19 +61,7 @@ func (r *PeeringRequestReconciler) UpdateForeignCluster(pr *v1alpha1.PeeringRequ
 }
 
 func (r *PeeringRequestReconciler) createForeignCluster(pr *v1alpha1.PeeringRequest) (*v1alpha1.ForeignCluster, error) {
-	var cnf *rest.Config
 	var err error
-
-	cnf, err = pr.GetConfig(r.crdClient.Client())
-	if err != nil {
-		if errors.As(err, &kubeconfig.LoadConfigError{}) {
-			klog.Warning("using default ForeignConfig")
-			cnf = r.ForeignConfig
-		} else {
-			klog.Error(err, err.Error())
-			return nil, err
-		}
-	}
 
 	fc := &v1alpha1.ForeignCluster{
 		ObjectMeta: metav1.ObjectMeta{
@@ -85,8 +71,7 @@ func (r *PeeringRequestReconciler) createForeignCluster(pr *v1alpha1.PeeringRequ
 			ClusterIdentity: pr.Spec.ClusterIdentity,
 			Namespace:       pr.Spec.Namespace,
 			Join:            false,
-			ApiUrl:          cnf.Host,
-			DiscoveryType:   v1alpha1.IncomingPeeringDiscovery,
+			DiscoveryType:   discovery.IncomingPeeringDiscovery,
 			AuthUrl:         pr.Spec.AuthUrl,
 		},
 		Status: v1alpha1.ForeignClusterStatus{

--- a/pkg/auth/const.go
+++ b/pkg/auth/const.go
@@ -1,0 +1,5 @@
+package auth
+
+const (
+	LiqoGuestNamespace = "liqo" // TODO: move to "liqo-public"
+)

--- a/pkg/auth/ids.go
+++ b/pkg/auth/ids.go
@@ -1,0 +1,7 @@
+package auth
+
+type ClusterInfo struct {
+	ClusterID      string `json:"clusterId"`
+	ClusterName    string `json:"clusterName,omitempty"`
+	GuestNamespace string `json:"guestNamespace"`
+}

--- a/pkg/discovery/const.go
+++ b/pkg/discovery/const.go
@@ -5,3 +5,33 @@ const (
 	AuthTokenLabel      = "liqo.io/auth-token"
 	RemoteIdentityLabel = "liqo.io/remote-identity"
 )
+
+type DiscoveryType string
+
+const (
+	LanDiscovery             DiscoveryType = "LAN"
+	WanDiscovery             DiscoveryType = "WAN"
+	ManualDiscovery          DiscoveryType = "Manual"
+	IncomingPeeringDiscovery DiscoveryType = "IncomingPeering"
+)
+
+type TrustMode string
+
+const (
+	TrustModeUnknown   TrustMode = "Unknown"
+	TrustModeTrusted   TrustMode = "Trusted"
+	TrustModeUntrusted TrustMode = "Untrusted"
+)
+
+type AuthStatus string
+
+const (
+	AuthStatusPending      AuthStatus = "Pending"
+	AuthStatusAccepted     AuthStatus = "Accepted"
+	AuthStatusRefused      AuthStatus = "Refused"
+	AuthStatusEmptyRefused AuthStatus = "EmptyRefused"
+)
+
+const (
+	LastUpdateAnnotation string = "LastUpdate"
+)

--- a/test/unit/discovery/dns_test.go
+++ b/test/unit/discovery/dns_test.go
@@ -4,6 +4,7 @@ import (
 	"github.com/liqotech/liqo/apis/discovery/v1alpha1"
 	"github.com/liqotech/liqo/internal/discovery"
 	search_domain_operator "github.com/liqotech/liqo/internal/discovery/search-domain-operator"
+	discoveryPkg "github.com/liqotech/liqo/pkg/discovery"
 	"gotest.tools/assert"
 	v12 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -95,8 +96,7 @@ func testSDCreation(t *testing.T) {
 			},
 			Namespace:     "default",
 			Join:          false,
-			ApiUrl:        serverCluster.cfg.Host,
-			DiscoveryType: v1alpha1.IncomingPeeringDiscovery,
+			DiscoveryType: discoveryPkg.IncomingPeeringDiscovery,
 		},
 		Status: v1alpha1.ForeignClusterStatus{
 			Incoming: v1alpha1.Incoming{
@@ -134,7 +134,7 @@ func testSDCreation(t *testing.T) {
 	assert.Equal(t, len(sds.Items), 1, "SearchDomain not created")
 
 	tmp, err = clientCluster.client.Resource("foreignclusters").List(metav1.ListOptions{
-		LabelSelector: strings.Join([]string{"discovery-type", string(v1alpha1.WanDiscovery)}, "="),
+		LabelSelector: strings.Join([]string{"discovery-type", string(discoveryPkg.WanDiscovery)}, "="),
 	})
 	assert.NilError(t, err, "Error listing ForeignClusters")
 	fcs, ok := tmp.(*v1alpha1.ForeignClusterList)
@@ -146,7 +146,7 @@ func testSDCreation(t *testing.T) {
 	assert.NilError(t, err)
 	fc, ok := tmp.(*v1alpha1.ForeignCluster)
 	assert.Assert(t, ok)
-	assert.Equal(t, fc.Spec.DiscoveryType, v1alpha1.WanDiscovery, "Discovery type was not set to WAN")
+	assert.Equal(t, fc.Spec.DiscoveryType, discoveryPkg.WanDiscovery, "Discovery type was not set to WAN")
 }
 
 // ------

--- a/test/unit/liqonet/tunnelEndpointCreator_test.go
+++ b/test/unit/liqonet/tunnelEndpointCreator_test.go
@@ -328,7 +328,6 @@ func TestCreateNetConfigFromForeignClusterOutgoingJoined(t *testing.T) {
 			},
 			Namespace:     "",
 			Join:          false,
-			ApiUrl:        "",
 			DiscoveryType: "LAN",
 		},
 		Status: discoveryv1alpha1.ForeignClusterStatus{


### PR DESCRIPTION
# Description

This PR adds an HTTP endpoint where to get the foreign ClusterIdentity (ClusterID and ClusterName), in order to be removed from the mDNS/DNS TXT packets

Ref. issue #371 