### PR TITLE
Foreign replicaset deletion

### DIFF
--- a/pkg/virtualKubelet/forge/apiForger.go
+++ b/pkg/virtualKubelet/forge/apiForger.go
@@ -49,6 +49,10 @@ func ReplicasetFromPod(pod *corev1.Pod) *appsv1.ReplicaSet {
 	return forger.replicasetFromPod(pod)
 }
 
+func ForeignReplicasetDeleted(pod *corev1.Pod) *corev1.Pod {
+	return forger.setPodToBeDeleted(pod)
+}
+
 type apiForger struct {
 	nattingTable namespacesMapping.NamespaceNatter
 

--- a/pkg/virtualKubelet/forge/pods.go
+++ b/pkg/virtualKubelet/forge/pods.go
@@ -66,6 +66,22 @@ func (f *apiForger) podStatusForeignToHome(foreignObj, homeObj runtime.Object) *
 	return homePod
 }
 
+// setPodToBeDeleted set the pod status such that it can be collected by the replicasetController,
+// setting the pod status to PodUnknwon and all the containers in terminated status.
+func (f *apiForger) setPodToBeDeleted(pod *corev1.Pod) *corev1.Pod {
+	now := metav1.Now()
+
+	pod.Status.Phase = corev1.PodUnknown
+	for i := range pod.Status.ContainerStatuses {
+		pod.Status.ContainerStatuses[i].State = corev1.ContainerState{
+			Terminated: &corev1.ContainerStateTerminated{},
+		}
+	}
+	pod.DeletionTimestamp = &now
+
+	return pod
+}
+
 func (f *apiForger) podHomeToForeign(homeObj, foreignObj runtime.Object, reflectionType string) (*corev1.Pod, error) {
 	var isNewObject bool
 	var homePod, foreignPod *corev1.Pod

--- a/pkg/virtualKubelet/kubeletInterface/node.go
+++ b/pkg/virtualKubelet/kubeletInterface/node.go
@@ -1,0 +1,1 @@
+package kubeletInterface

--- a/pkg/virtualKubelet/kubeletInterface/provider.go
+++ b/pkg/virtualKubelet/kubeletInterface/provider.go
@@ -1,0 +1,80 @@
+package kubeletInterface
+
+import (
+	"context"
+	"io"
+
+	"github.com/liqotech/liqo/internal/virtualKubelet/node"
+	"github.com/liqotech/liqo/internal/virtualKubelet/node/api"
+	corev1 "k8s.io/api/core/v1"
+	stats "k8s.io/kubernetes/pkg/kubelet/apis/stats/v1alpha1"
+)
+
+// PodLifecycleHandler defines the interface used by the PodController to react
+// to new and changed pods scheduled to the node that is being managed.
+type PodLifecycleHandler interface {
+	// CreatePod takes a Kubernetes Pod and deploys it within the provider.
+	CreatePod(ctx context.Context, pod *corev1.Pod) error
+
+	// UpdatePod takes a Kubernetes Pod and updates it within the provider.
+	UpdatePod(ctx context.Context, pod *corev1.Pod) error
+
+	// DeletePod takes a Kubernetes Pod and deletes it from the provider. Once a pod is deleted, the provider is
+	// expected to call the NotifyPods callback with a terminal pod status where all the containers are in a terminal
+	// state, as well as the pod. DeletePod may be called multiple times for the same pod.
+	DeletePod(ctx context.Context, pod *corev1.Pod) error
+
+	// GetPod retrieves a pod by name from the provider (can be cached).
+	// The Pod returned is expected to be immutable, and may be accessed
+	// concurrently outside of the calling goroutine. Therefore it is recommended
+	// to return a version after DeepCopy.
+	GetPod(ctx context.Context, namespace, name string) (*corev1.Pod, error)
+
+	// GetPodStatus retrieves the status of a pod by name from the provider.
+	// The PodStatus returned is expected to be immutable, and may be accessed
+	// concurrently outside of the calling goroutine. Therefore it is recommended
+	// to return a version after DeepCopy.
+	GetPodStatus(ctx context.Context, namespace, name string) (*corev1.PodStatus, error)
+
+	// GetPods retrieves a list of all pods running on the provider (can be cached).
+	// The Pods returned are expected to be immutable, and may be accessed
+	// concurrently outside of the calling goroutine. Therefore it is recommended
+	// to return a version after DeepCopy.
+	GetPods(context.Context) ([]*corev1.Pod, error)
+}
+
+// PodNotifier is used as an extension to PodLifecycleHandler to support async updates of pod statuses.
+type PodNotifier interface {
+	// NotifyPods instructs the notifier to call the passed in function when
+	// the pod status changes. It should be called when a pod's status changes.
+	//
+	// The provided pointer to a Pod is guaranteed to be used in a read-only
+	// fashion. The provided pod's PodStatus should be up to date when
+	// this function is called.
+	//
+	// NotifyPods will not block callers.
+	NotifyPods(context.Context, func(interface{}))
+}
+
+// Provider contains the methods required to implement a virtual-kubelet provider
+type Provider interface {
+	PodLifecycleHandler
+
+	// GetContainerLogs retrieves the logs of a container by name from the provider.
+	GetContainerLogs(ctx context.Context, namespace, podName, containerName string, opts api.ContainerLogOpts) (io.ReadCloser, error)
+
+	// RunInContainer executes a command in a container in the pod, copying data
+	// between in/out/err and the container's stdin/stdout/stderr.
+	RunInContainer(ctx context.Context, namespace, podName, containerName string, cmd []string, attach api.AttachIO) error
+
+	// ConfigureNode enables a provider to configure the node object that
+	// will be used for Kubernetes.
+	ConfigureNode(context.Context, *corev1.Node)
+
+	StartNodeUpdater(nodeRunner *node.NodeController) (chan struct{}, chan struct{}, error)
+}
+
+// PodMetricsProvider is an optional interface that providers can implement to expose pod stats
+type PodMetricsProvider interface {
+	GetStatsSummary(context.Context) (*stats.Summary, error)
+}

--- a/pkg/virtualKubelet/provider/pods.go
+++ b/pkg/virtualKubelet/provider/pods.go
@@ -100,6 +100,10 @@ func (p *LiqoProvider) DeletePod(ctx context.Context, pod *corev1.Pod) (err erro
 	}
 
 	err = p.foreignClient.AppsV1().ReplicaSets(foreignNamespace).Delete(context.TODO(), replicasetName, metav1.DeleteOptions{})
+	if kerror.IsNotFound(err) {
+		klog.V(5).Infof("replicaset %v/%v not deleted because not existing", foreignNamespace, replicasetName)
+		return nil
+	}
 	if err != nil {
 		return errors.Wrap(err, "Unable to delete foreign replicaset")
 	}
@@ -347,5 +351,5 @@ func (p *LiqoProvider) GetStatsSummary(ctx context.Context) (*stats.Summary, err
 // within the provider.
 func (p *LiqoProvider) NotifyPods(_ context.Context, notifier func(interface{})) {
 	p.apiController.SetInformingFunc(apimgmgt.Pods, notifier)
-	p.notifier = notifier
+	p.apiController.SetInformingFunc(apimgmgt.ReplicaSets, notifier)
 }


### PR DESCRIPTION
# Description

This commit introduces the support for the deletion of a foreign replicaset, which is reflected as an incoming event for a pod deletion.

The main issue was to trigger two different events:
* delete event for a specific home pod
* setting all the containers of the home deleted pod to terminated status, in order to allow the replicasetController to collect the deleted home pod.

address #380 