### PR TITLE
Test on Managed Kubernetes

### DIFF
--- a/cmd/auth-service/main.go
+++ b/cmd/auth-service/main.go
@@ -18,6 +18,7 @@ func main() {
 	var listeningPort string
 	var certFile string
 	var keyFile string
+	var useTls bool
 
 	flag.StringVar(&namespace, "namespace", "default", "Namespace where your configs are stored.")
 	flag.StringVar(&kubeconfigPath, "kubeconfigPath", filepath.Join(os.Getenv("HOME"), ".kube", "config"), "For debug purpose, set path to local kubeconfig")
@@ -25,11 +26,12 @@ func main() {
 	flag.StringVar(&listeningPort, "listeningPort", "5000", "Sets the port where the service will listen")
 	flag.StringVar(&certFile, "certFile", "/certs/cert.pem", "Path to cert file")
 	flag.StringVar(&keyFile, "keyFile", "/certs/key.pem", "Path to key file")
+	flag.BoolVar(&useTls, "useTls", false, "Enable HTTPS server")
 	flag.Parse()
 
 	klog.Info("Namespace: ", namespace)
 
-	authService, err := auth_service.NewAuthServiceCtrl(namespace, kubeconfigPath, time.Duration(resyncSeconds)*time.Second)
+	authService, err := auth_service.NewAuthServiceCtrl(namespace, kubeconfigPath, time.Duration(resyncSeconds)*time.Second, useTls)
 	if err != nil {
 		klog.Error(err)
 		os.Exit(1)

--- a/deployments/liqo/subcharts/authService/templates/auth-service-deploy.yaml
+++ b/deployments/liqo/subcharts/authService/templates/auth-service-deploy.yaml
@@ -140,14 +140,16 @@ spec:
         run: auth-service
     spec:
       serviceAccountName: auth-service-sa
+      {{ if not .Values.ingress.enable }}
       initContainers:
         - name: cert-creator
-          image: nginx
+          image: nginx:1.19
           volumeMounts:
             - mountPath: '/certs'
               name: certs
           command: [ "/bin/sh" ]
           args: [ "-c", 'openssl req -x509 -subj "/C=IT/ST=Turin/O=Liqo" -nodes -days 365 -newkey rsa:4096 -keyout /certs/key.pem -out /certs/cert.pem' ]
+      {{ end }}
       containers:
         - image: {{ .Values.image.repository }}{{ .Values.global.suffix | default .Values.suffix }}:{{ .Values.global.version | default .Values.version }}
           name: auth-service
@@ -159,19 +161,24 @@ spec:
           - "--resyncSeconds"
           - "30"
           - "--listeningPort"
+          {{ if .Values.ingress.enable }}
           - "5000"
+          {{ else }}
+          - "443"
+          - "--useTls"
+          {{ end }}
           env:
             - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            {{ if .Values.apiServerIp }}
+            {{ if .Values.global.apiServer.ip }}
             - name: APISERVER
-              value: {{ .Values.apiServerIp }}
+              value: "{{ .Values.global.apiServer.ip }}"
             {{ end }}
-            {{ if .Values.apiServerPort }}
+            {{ if .Values.global.apiServer.port }}
             - name: APISERVER_PORT
-              value: {{ .Values.apiServerPort }}
+              value: "{{ .Values.global.apiServer.port }}"
             {{ end }}
           resources:
             limits:
@@ -195,11 +202,56 @@ metadata:
   name: auth-service
   namespace: {{ .Release.Namespace }}
 spec:
+  {{ if .Values.ingress.enable }}
+  type: ClusterIP
+  {{ else }}
   type: NodePort
+  {{ end }}
   selector:
     run: auth-service
   ports:
     - name: https
       protocol: TCP
-      port: 443
+      {{ if .Values.ingress.enable }}
+      port: 5000
       targetPort: 5000
+      {{ else }}
+      port: 443
+      targetPort: 443
+      {{ end }}
+---
+{{ if .Values.ingress.enable }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  labels:
+    run: auth-service
+  annotations:
+    {{ if (.Values.ingress.class) }}
+    kubernetes.io/ingress.class: {{ .Values.ingress.class }}
+    {{ end }}
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+  name: auth-service
+  namespace: {{ .Release.Namespace }}
+spec:
+  rules:
+    - http:
+        paths:
+          - backend:
+              service:
+                name: auth-service
+                port:
+                  number: 5000
+            path: /
+            pathType: Prefix
+      {{ if (.Values.ingress.host) }}
+      host: {{ .Values.ingress.host }}
+      {{ end }}
+  tls:
+    {{ if (.Values.ingress.host) }}
+    - hosts:
+      - {{ .Values.ingress.host }}
+    {{ else }}
+    - hosts: []
+    {{ end }}
+{{ end }}

--- a/deployments/liqo/subcharts/authService/values.yaml
+++ b/deployments/liqo/subcharts/authService/values.yaml
@@ -10,5 +10,7 @@ image:
 suffix: ""
 version: "latest"
 
-apiServerIp: ""
-apiServerPort: ""
+ingress:
+  enable: false
+  host: ""
+  class: ""

--- a/deployments/liqo/subcharts/discoveryOperator/templates/discovery-deploy.yaml
+++ b/deployments/liqo/subcharts/discoveryOperator/templates/discovery-deploy.yaml
@@ -221,13 +221,21 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            {{ if .Values.apiServerIp }}
+            {{ if .Values.global.apiServer.ip }}
             - name: APISERVER
-              value: {{ .Values.apiServerIp }}
+              value: "{{ .Values.global.apiServer.ip }}"
             {{ end }}
-            {{ if .Values.apiServerPort }}
+            {{ if .Values.global.apiServer.port }}
             - name: APISERVER_PORT
-              value: {{ .Values.apiServerPort }}
+              value: "{{ .Values.global.apiServer.port }}"
+            {{ end }}
+            {{ if .Values.global.authServer.ip }}
+            - name: AUTH_ADDR
+              value: "{{ .Values.global.authServer.ip }}"
+            {{ end }}
+            {{ if .Values.global.authServer.port }}
+            - name: AUTH_SVC_PORT
+              value: "{{ .Values.global.authServer.port }}"
             {{ end }}
           volumeMounts:
             - mountPath: /usr/local/share/ca-certificates

--- a/deployments/liqo/subcharts/discoveryOperator/values.yaml
+++ b/deployments/liqo/subcharts/discoveryOperator/values.yaml
@@ -9,6 +9,3 @@ image:
 
 suffix: ""
 version: "latest"
-
-apiServerIp: ""
-apiServerPort: ""

--- a/deployments/liqo/subcharts/peeringRequestOperator/templates/peering-request-deploy.yaml
+++ b/deployments/liqo/subcharts/peeringRequestOperator/templates/peering-request-deploy.yaml
@@ -197,6 +197,22 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            {{ if .Values.global.apiServer.ip }}
+            - name: APISERVER
+              value: "{{ .Values.global.apiServer.ip }}"
+            {{ end }}
+            {{ if .Values.global.apiServer.port }}
+            - name: APISERVER_PORT
+              value: "{{ .Values.global.apiServer.port }}"
+            {{ end }}
+            {{ if .Values.global.authServer.ip }}
+            - name: AUTH_ADDR
+              value: "{{ .Values.global.authServer.ip }}"
+            {{ end }}
+            {{ if .Values.global.authServer.port }}
+            - name: AUTH_SVC_PORT
+              value: "{{ .Values.global.authServer.port }}"
+          {{ end }}
           resources:
             limits:
               cpu: 100m

--- a/deployments/liqo/values.yaml
+++ b/deployments/liqo/values.yaml
@@ -102,6 +102,10 @@ authService:
     repository: "liqo/auth-service"
     pullPolicy: "IfNotPresent"
   enabled: true
+  ingress:
+    enable: false
+    host: ""
+    class: ""
 
 global:
   configmapName: "liqo-configmap"
@@ -109,3 +113,9 @@ global:
   dashboard_version: ""
   suffix: ""
   version: ""
+  apiServer:
+    ip: ""
+    port: ""
+  authServer:
+    ip: ""
+    port: ""

--- a/install.sh
+++ b/install.sh
@@ -35,6 +35,17 @@ set -o pipefail  # Fail if one of the piped commands fails
 #   - DASHBOARD_HOSTNAME
 #     the hostname assigned to the Liqo dashboard (exposed through an Ingress resource).
 #
+#   - LIQO_INGRESS_CLASS
+#     the kubernetes ingress class to be used for the ingresses created by Liqo.
+#   - LIQO_APISERVER_ADDR
+#     the address where to contact the home API Server (defaults to the master node IP).
+#   - LIQO_APISERVER_PORT
+#     the address where to contact the home API Server (defaults to 6443).
+#   - LIQO_AUTHSERVER_ADDR
+#     the hostname assigned to the Liqo AuthService (exposed through an Ingress resource).
+#   - LIQO_AUTHSERVER_PORT
+#     the address where to contact the home API Server (exposed through an Ingress resource, defaults to 443).
+#
 #   - POD_CIDR
 #     the Pod CIDR of your cluster (e.g.; 10.0.0.0/16). Automatically detected if not configured.
 #   - SERVICE_CIDR
@@ -131,6 +142,12 @@ function help() {
 	  ${BOLD}LIQO_NAMESPACE${RESET}:     the Kubernetes namespace where all Liqo components are created (defaults to liqo)
 	  ${BOLD}CLUSTER_NAME${RESET}:       the mnemonic name assigned to this Liqo instance. Automatically generated if not specified.
 	  ${BOLD}DASHBOARD_HOSTNAME${RESET}: the hostname assigned to the Liqo dashboard (exposed through an Ingress resource).
+
+	  ${BOLD}LIQO_INGRESS_CLASS${RESET}:   the kubernetes ingress class to be used for the ingresses created by Liqo.
+	  ${BOLD}LIQO_APISERVER_ADDR${RESET}:  the address where to contact the home API Server (defaults to the master node IP).
+	  ${BOLD}LIQO_APISERVER_PORT${RESET}:  the address where to contact the home API Server (defaults to 6443).
+	  ${BOLD}LIQO_AUTHSERVER_ADDR${RESET}: the hostname assigned to the Liqo AuthService (exposed through an Ingress resource).
+	  ${BOLD}LIQO_AUTHSERVER_PORT${RESET}: the address where to contact the home API Server (exposed through an Ingress resource, defaults to 443).
 
 	  ${BOLD}POD_CIDR${RESET}:           the Pod CIDR of your cluster (e.g.; 10.0.0.0/16). Automatically detected if not configured.
 	  ${BOLD}SERVICE_CIDR${RESET}:       the Service CIDR of your cluster (e.g.; 10.96.0.0/12). Automatically detected if not configured.
@@ -501,6 +518,24 @@ function configure_installation_variables() {
 				"Please, manually specify it with 'export SERVICE_CIDR=...' before executing again this script"
 	fi
 	info "[INSTALL] [CONFIGURE]" "Service CIDR: ${SERVICE_CIDR}"
+
+	# Set variables for kubernetes ingress
+	if [ -z "${LIQO_AUTHSERVER_ADDR:-}" ]; then
+	  LIQO_ENABLE_INGRESS=""
+	else
+	  LIQO_ENABLE_INGRESS="true"
+	fi
+	if [ -n "${LIQO_AUTHSERVER_ADDR:-}" ]; then
+	  LIQO_AUTHSERVER_PORT="${LIQO_AUTHSERVER_PORT:-"443"}"
+	fi
+	if [ -n "${LIQO_APISERVER_ADDR:-}" ]; then
+	  LIQO_APISERVER_PORT="${LIQO_APISERVER_PORT:-"6443"}"
+	fi
+	if [ -n "${LIQO_ENABLE_INGRESS:-}" ]; then
+	  info "[INSTALL] [CONFIGURE]" "Ingress Class: ${LIQO_INGRESS_CLASS:-"default"}"
+	  info "[INSTALL] [CONFIGURE]" "AuthServer: ${LIQO_AUTHSERVER_ADDR}:${LIQO_AUTHSERVER_PORT}"
+	  info "[INSTALL] [CONFIGURE]" "APIServer: ${LIQO_APISERVER_ADDR}:${LIQO_APISERVER_PORT}"
+	fi
 }
 
 function configure_gateway_node() {
@@ -540,7 +575,14 @@ function install_liqo() {
 		--set global.version="${LIQO_IMAGE_VERSION}" --set global.suffix="${LIQO_SUFFIX:-}" --set clusterName="${CLUSTER_NAME}" \
 		--set podCIDR="${POD_CIDR}" --set serviceCIDR="${SERVICE_CIDR}" --set gatewayIP="${GATEWAY_IP}" \
 		--set global.dashboard_version="${LIQO_DASHBOARD_IMAGE_VERSION}" \
-		--set global.dashboard_ingress="${DASHBOARD_INGRESS:-}" >/dev/null ||
+		--set global.dashboard_ingress="${DASHBOARD_INGRESS:-}" \
+		--set authService.ingress.enable="${LIQO_ENABLE_INGRESS:-}" \
+		--set authService.ingress.host="${LIQO_AUTHSERVER_ADDR:-}" \
+		--set authService.ingress.class="${LIQO_INGRESS_CLASS:-}" \
+		--set global.apiServer.ip="${LIQO_APISERVER_ADDR:-}" \
+		--set global.apiServer.port="${LIQO_APISERVER_PORT:-}" \
+		--set global.authServer.ip="${LIQO_AUTHSERVER_ADDR:-}" \
+		--set global.authServer.port="${LIQO_AUTHSERVER_PORT:-}" >/dev/null ||
 			fatal "[INSTALL]" "Something went wrong while installing Liqo"
 
 	info "[INSTALL]" "Hooray! Liqo is now installed on your cluster"

--- a/internal/discovery/foreign-cluster-operator/foreign-cluster-controller.go
+++ b/internal/discovery/foreign-cluster-operator/foreign-cluster-controller.go
@@ -439,7 +439,7 @@ func (r *ForeignClusterReconciler) checkJoined(fc *discoveryv1alpha1.ForeignClus
 }
 
 func (r *ForeignClusterReconciler) getHomeAuthUrl() (string, error) {
-	address, _ := os.LookupEnv("APISERVER")
+	address, _ := os.LookupEnv("AUTH_ADDR")
 
 	if address == "" {
 		nodes, err := r.crdClient.Client().CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})

--- a/test/unit/discovery/discovery_test.go
+++ b/test/unit/discovery/discovery_test.go
@@ -58,6 +58,7 @@ func TestMain(m *testing.M) {
 	_ = os.Setenv("APISERVER", "127.0.0.1")
 	_ = os.Setenv("AUTH_SVC_PORT", "30001")
 	_ = os.Setenv("TEST", "true")
+	_ = os.Setenv("AUTH_ADDR", "fake://localhost")
 
 	setUp()
 	defer tearDown()


### PR DESCRIPTION
# Description

This PR includes some small changes needed in the Helm Chart and in the Installer to make Liqo work on managed Kubernetes clusters

Users can now set some environment variables to set the API server hostname and the AuthService hostname. If the AuthService hostname is set this service is exposed as ingress, and only as a nodeport

# How Has This Been Tested?

- [x] on AKS managed clusters with Kubernetes version 1.19.1, setting the following variables
  * POD_CIDR=10.244.0.0/16
  * SERVICE_CIDR=10.0.0.0/16
  * LIQO_INGRESS_CLASS=addon-http-application-routing
  * LIQO_APISERVER_ADDR=test-liqo-1-dns-4b5279e4.hcp.westeurope.azmk8s.io
  * LIQO_AUTHSERVER_ADDR=auth.319075fecaae46988083.westeurope.aksapp.io
- [x] locally on kind to test that the old installation was still working
