### PR TITLE
Multiple tolerations in mutatingWebhook

### DIFF
--- a/pkg/mutate/mutate.go
+++ b/pkg/mutate/mutate.go
@@ -52,17 +52,17 @@ func (s *MutationServer) Mutate(body []byte, verbose bool) ([]byte, error) {
 			Value []corev1.Toleration `json:"value"`
 		}
 
+		tolerations := append(pod.Spec.Tolerations, corev1.Toleration{
+			Key:      "virtual-node.liqo.io/not-allowed",
+			Operator: "Exists",
+			Effect:   "NoExecute",
+		})
+
 		patch := []patchType{
 			{
-				Op:   "add",
-				Path: "/spec/tolerations",
-				Value: []corev1.Toleration{
-					{
-						Key:      "virtual-node.liqo.io/not-allowed",
-						Operator: "Exists",
-						Effect:   "NoExecute",
-					},
-				},
+				Op:    "add",
+				Path:  "/spec/tolerations",
+				Value: tolerations,
 			},
 		}
 		if resp.Patch, err = json.Marshal(patch); err != nil {


### PR DESCRIPTION
# Description

This commit supports multiple tolerations to the pods handled by the
mutating webhook.
