### PR TITLE
Status Menunode synchronization with peerings information

### DIFF
--- a/internal/tray-agent/agent/client/advertisementController.go
+++ b/internal/tray-agent/agent/client/advertisementController.go
@@ -19,33 +19,6 @@ func createAdvertisementController(kubeconfig string) (*CRDController, error) {
 	return controller, nil
 }
 
-//advertisementAddFunc is the ADD event handler for the Advertisement CRDController.
-func advertisementAddFunc(obj interface{}) {
-	newAdv := obj.(*advertisementApi.Advertisement)
-	if newAdv.Status.AdvertisementStatus == advertisementApi.AdvertisementAccepted {
-		agentCtrl.NotifyChannel(ChanAdvAccepted) <- newAdv.Name
-	} else {
-		agentCtrl.NotifyChannel(ChanAdvNew) <- newAdv.Name
-	}
-}
-
-//advertisementUpdateFunc is the UPDATE event handler for the Advertisement CRDController.
-func advertisementUpdateFunc(oldObj interface{}, newObj interface{}) {
-	oldAdv := oldObj.(*advertisementApi.Advertisement)
-	newAdv := newObj.(*advertisementApi.Advertisement)
-	if oldAdv.Status.AdvertisementStatus != advertisementApi.AdvertisementAccepted && newAdv.Status.AdvertisementStatus == advertisementApi.AdvertisementAccepted {
-		agentCtrl.NotifyChannel(ChanAdvAccepted) <- newAdv.Name
-	} else if oldAdv.Status.AdvertisementStatus == advertisementApi.AdvertisementAccepted && newAdv.Status.AdvertisementStatus != advertisementApi.AdvertisementAccepted {
-		agentCtrl.NotifyChannel(ChanAdvRevoked) <- newAdv.Name
-	}
-}
-
-//advertisementDeleteFunc is the DELETE event handler for the Advertisement CRDController.
-func advertisementDeleteFunc(obj interface{}) {
-	adv := obj.(*advertisementApi.Advertisement)
-	agentCtrl.NotifyChannel(ChanAdvDeleted) <- adv.Name
-}
-
 //DescribeAdvertisement provides a textual representation of an Advertisement CR
 //that can be displayed in a MenuNode.
 func DescribeAdvertisement(adv *advertisementApi.Advertisement) string {

--- a/internal/tray-agent/agent/client/advertisementController.go
+++ b/internal/tray-agent/agent/client/advertisementController.go
@@ -8,11 +8,7 @@ import (
 
 //createAdvertisementController creates a new CRDController for the Liqo Advertisement CRD.
 func createAdvertisementController(kubeconfig string) (*CRDController, error) {
-	controller := &CRDController{
-		addFunc:    advertisementAddFunc,
-		updateFunc: advertisementUpdateFunc,
-		deleteFunc: advertisementDeleteFunc,
-	}
+	controller := &CRDController{}
 	//init client
 	newClient, err := advertisementApi.CreateAdvertisementClient(kubeconfig, nil, false)
 	if err != nil {

--- a/internal/tray-agent/agent/client/notifyChannels.go
+++ b/internal/tray-agent/agent/client/notifyChannels.go
@@ -22,6 +22,11 @@ const (
 	ChanPeerDeleted
 	//Notification channel id for an update of an available peer.
 	ChanPeerUpdated
+	//todo the following channels will be merged into a single ChanPeering after changing the chan type of NotifyChannels from string to interface{}
+	ChanPeeringOutgoingNew
+	ChanPeeringOutgoingDelete
+	ChanPeeringIncomingNew
+	ChanPeeringIncomingDelete
 )
 
 //notifyChannelNames contains all the registered NotifyChannel managed by the AgentController.
@@ -34,4 +39,8 @@ var notifyChannelNames = []NotifyChannel{
 	ChanPeerAdded,
 	ChanPeerDeleted,
 	ChanPeerUpdated,
+	ChanPeeringOutgoingNew,
+	ChanPeeringOutgoingDelete,
+	ChanPeeringIncomingNew,
+	ChanPeeringIncomingDelete,
 }

--- a/internal/tray-agent/agent/client/notifyChannels.go
+++ b/internal/tray-agent/agent/client/notifyChannels.go
@@ -8,16 +8,8 @@ type NotifyChannel int
 
 //NotifyChannel identifiers.
 const (
-	//Notification channel id for the creation of an Advertisement
-	ChanAdvNew NotifyChannel = iota
-	//Notification channel id for the acceptance of an Advertisement
-	ChanAdvAccepted
-	//Notification channel id for the deletion of an Advertisement
-	ChanAdvDeleted
-	//Notification channel id for the revocation of the 'ACCEPTED' status of an Advertisement
-	ChanAdvRevoked
 	//Notification channel id for the addition of a new peer discovered.
-	ChanPeerAdded
+	ChanPeerAdded NotifyChannel = iota
 	//Notification channel id for the removal of an available peer.
 	ChanPeerDeleted
 	//Notification channel id for an update of an available peer.
@@ -32,10 +24,6 @@ const (
 //notifyChannelNames contains all the registered NotifyChannel managed by the AgentController.
 //It is used for init and testing purposes.
 var notifyChannelNames = []NotifyChannel{
-	ChanAdvNew,
-	ChanAdvAccepted,
-	ChanAdvDeleted,
-	ChanAdvRevoked,
 	ChanPeerAdded,
 	ChanPeerDeleted,
 	ChanPeerUpdated,

--- a/internal/tray-agent/agent/logic/listeners.go
+++ b/internal/tray-agent/agent/logic/listeners.go
@@ -1,0 +1,120 @@
+package logic
+
+import (
+	"fmt"
+	app "github.com/liqotech/liqo/internal/tray-agent/app-indicator"
+)
+
+//this file contains the callback functions for the Indicator listeners
+
+func listenNewIncomingPeering(obj string, args ...interface{}) {
+	i := app.GetIndicator()
+	st := i.Status()
+	//update Status model
+	st.IncDecPeerings(app.PeeringIncoming, true)
+	i.RefreshStatus()
+	//retrieve peering info
+	//retrieve Peer information
+	quickNode, present := i.Quick(qPeers)
+	if !present {
+		return
+	}
+	//update peer information in the list on the Incoming entry (peers -> this peer -> incoming peering)
+	var peerNode, iPeeringNode *app.MenuNode
+	peerNode, present = quickNode.ListChild(obj)
+	if !present {
+		return
+	}
+	iPeeringNode, present = peerNode.ListChild(tagIncoming)
+	if !present {
+		panic("no incoming MenuNode for a Peer element")
+	}
+	iPeeringNode.SetIsChecked(true)
+	//todo next version of this feature will display a subelement containing shared resources
+	//notify new peering
+	i.Notify("INCOMING PEERING ACCEPTED", fmt.Sprintf("You are offering resources to %s", obj), app.NotifyIconDefault, app.IconLiqoPurple)
+}
+
+func listenDeleteIncomingPeering(obj string, args ...interface{}) {
+	i := app.GetIndicator()
+	st := i.Status()
+	//update Status model
+	st.IncDecPeerings(app.PeeringIncoming, false)
+	i.RefreshStatus()
+	//retrieve peering info
+	//retrieve Peer information
+	quickNode, present := i.Quick(qPeers)
+	if !present {
+		return
+	}
+	//update peer information in the list on the Incoming entry (peers -> this peer -> incoming peering)
+	var peerNode, iPeeringNode *app.MenuNode
+	peerNode, present = quickNode.ListChild(obj)
+	if !present {
+		return
+	}
+	iPeeringNode, present = peerNode.ListChild(tagIncoming)
+	if !present {
+		panic("no incoming MenuNode for a Peer element")
+	}
+	iPeeringNode.SetIsChecked(false)
+	//todo next version of this feature will display a subelement containing shared resources
+	//notify peering disconnected
+	i.Notify("INCOMING PEERING CLOSED", fmt.Sprintf("Stopped sharing resources to %s", obj), app.NotifyIconDefault, app.IconLiqoRed)
+}
+
+func listenNewOutgoingPeering(obj string, args ...interface{}) {
+	i := app.GetIndicator()
+	st := i.Status()
+	//update Status model
+	st.IncDecPeerings(app.PeeringOutgoing, true)
+	i.RefreshStatus()
+	//retrieve peering info
+	//retrieve Peer information
+	quickNode, present := i.Quick(qPeers)
+	if !present {
+		return
+	}
+	//update peer information in the list on the Outgoing entry (peers -> this peer -> outgoing peering)
+	var peerNode, oPeeringNode *app.MenuNode
+	peerNode, present = quickNode.ListChild(obj)
+	if !present {
+		return
+	}
+	oPeeringNode, present = peerNode.ListChild(tagOutgoing)
+	if !present {
+		panic("no outgoing MenuNode for a Peer element")
+	}
+	oPeeringNode.SetIsChecked(true)
+	//todo next version of this feature will display a subelement containing shared resources
+	//notify new peering
+	i.Notify("OUTGOING PEERING ACCEPTED", fmt.Sprintf("You are receiving resources from %s", obj), app.NotifyIconDefault, app.IconLiqoPurple)
+}
+
+func listenDeleteOutgoingPeering(obj string, args ...interface{}) {
+	i := app.GetIndicator()
+	st := i.Status()
+	//update Status model
+	st.IncDecPeerings(app.PeeringOutgoing, false)
+	i.RefreshStatus()
+	//retrieve peering info
+	//retrieve Peer information
+	quickNode, present := i.Quick(qPeers)
+	if !present {
+		return
+	}
+	//update peer information in the list on the Incoming entry (peers -> this peer -> incoming peering)
+	var peerNode, oPeeringNode *app.MenuNode
+	peerNode, present = quickNode.ListChild(obj)
+	if !present {
+		return
+	}
+	oPeeringNode, present = peerNode.ListChild(tagOutgoing)
+	if !present {
+		panic("no outgoing MenuNode for a Peer element")
+	}
+	oPeeringNode.SetIsChecked(false)
+	//todo next version of this feature will display a subelement containing shared resources
+	//notify peering disconnected
+	i.Notify("OUTGOING PEERING CLOSED", fmt.Sprintf("Stopped receiving resources from %s", obj), app.NotifyIconDefault, app.IconLiqoRed)
+}

--- a/internal/tray-agent/agent/logic/logic_test.go
+++ b/internal/tray-agent/agent/logic/logic_test.go
@@ -38,57 +38,25 @@ func TestOnReady(t *testing.T) {
 	assert.Truef(t, exist, "QUICK %s not registered", qPeers)
 
 	// test Listeners registrations
-	_, exist = i.Listener(client.ChanAdvNew)
-	assert.True(t, exist, "Listener for NotifyChanType ChanAdvNew not registered")
-	_, exist = i.Listener(client.ChanAdvAccepted)
-	assert.True(t, exist, "Listener for NotifyChanType ChanAdvAccepted not registered")
-	_, exist = i.Listener(client.ChanAdvRevoked)
-	assert.True(t, exist, "Listener for NotifyChanType ChanAdvRevoked not registered")
-	_, exist = i.Listener(client.ChanAdvDeleted)
-	assert.True(t, exist, "Listener for NotifyChanType ChanAdvDeleted not registered")
-	i.Quit()
-}
 
-//test notification system for the Advertisements-related events, monitoring icon changes
-func TestAdvertisementNotify(t *testing.T) {
-	app.UseMockedGuiProvider()
-	client.UseMockedAgentController()
-	app.DestroyMockedIndicator()
-	client.DestroyMockedAgentController()
-	eventTester := app.GetGuiProvider().NewEventTester()
-	eventTester.Test()
-	i := app.GetIndicator()
-	startListenerAdvertisements(i)
-	assert.Equal(t, app.IconLiqoMain, i.Icon(), "startup Indicator icon is not IconLiqoMain")
-	ctrl := i.AgentCtrl()
-	if err := ctrl.StartCaches(); err != nil {
-		t.Fatal("caches not started")
-	}
-	testAdvName := "test"
-	//
-	eventTester.Add(1)
-	ctrl.NotifyChannel(client.ChanAdvNew) <- testAdvName
-	eventTester.Wait()
-	assert.Equal(t, app.IconLiqoOrange, i.Icon(), "Icon not correctly set on New Advertisement")
-	i.SetIcon(app.IconLiqoMain)
-	//
-	eventTester.Add(1)
-	ctrl.NotifyChannel(client.ChanAdvAccepted) <- testAdvName
-	eventTester.Wait()
-	assert.Equal(t, app.IconLiqoGreen, i.Icon(), "Icon not correctly set on Accepted Advertisement")
-	i.SetIcon(app.IconLiqoMain)
-	//
-	eventTester.Add(1)
-	ctrl.NotifyChannel(client.ChanAdvRevoked) <- testAdvName
-	eventTester.Wait()
-	assert.Equal(t, app.IconLiqoOrange, i.Icon(), "Icon not correctly set on Revoked Advertisement")
-	i.SetIcon(app.IconLiqoMain)
-	//
-	eventTester.Add(1)
-	ctrl.NotifyChannel(client.ChanAdvDeleted) <- testAdvName
-	eventTester.Wait()
-	assert.Equal(t, app.IconLiqoOrange, i.Icon(), "Icon not correctly set on Deleted Advertisement")
-	i.SetIcon(app.IconLiqoMain)
+	// test peers Listeners
+	_, exist = i.Listener(client.ChanPeerAdded)
+	assert.True(t, exist, "Listener for NotifyChanType ChanPeerAdded not registered")
+	_, exist = i.Listener(client.ChanPeerUpdated)
+	assert.True(t, exist, "Listener for NotifyChanType ChanPeerUpdated not registered")
+	_, exist = i.Listener(client.ChanPeerDeleted)
+	assert.True(t, exist, "Listener for NotifyChanType ChanPeerDeleted not registered")
+
+	// test peerings Listeners
+	_, exist = i.Listener(client.ChanPeeringIncomingNew)
+	assert.True(t, exist, "Listener for NotifyChanType ChanPeeringIncomingNew not registered")
+	_, exist = i.Listener(client.ChanPeeringOutgoingNew)
+	assert.True(t, exist, "Listener for NotifyChanType ChanPeeringOutgoingNew not registered")
+	_, exist = i.Listener(client.ChanPeeringIncomingDelete)
+	assert.True(t, exist, "Listener for NotifyChanType ChanPeeringIncomingDelete not registered")
+	_, exist = i.Listener(client.ChanPeeringOutgoingDelete)
+	assert.True(t, exist, "Listener for NotifyChanType ChanPeeringOutgoingDelete not registered")
+
 	i.Quit()
 }
 

--- a/internal/tray-agent/agent/logic/quickPeerHelpers.go
+++ b/internal/tray-agent/agent/logic/quickPeerHelpers.go
@@ -11,15 +11,17 @@ discovered peers.*/
 
 // set of frequently used tags inside application logic
 const (
-	tagStatus  = "status"
-	titlePeers = "PEERS"
+	tagStatus   = "status"
+	titlePeers  = "PEERS"
+	tagIncoming = "INCOMING PEERING"
+	tagOutgoing = "OUTGOING PEERING"
 )
 
 //refreshPeerCount updates the visual counter of the discovered peers (even not peered).
 //Currently the number if retrieved directly from the MenuNode. In a future update the Indicator.Status component
 //will provide it.
 func refreshPeerCount(quick *app.MenuNode) {
-	peerCount := quick.ListChildrenLen()
+	peerCount := app.GetIndicator().Status().Peers()
 	str := strings.Join([]string{"(", strconv.Itoa(peerCount), ")"}, "")
 	quick.SetTitle(strings.Join([]string{titlePeers, str}, " "))
 	//the menu entry is disabled when the counter reaches 0 to avoid useless clicks
@@ -28,5 +30,4 @@ func refreshPeerCount(quick *app.MenuNode) {
 	} else {
 		quick.SetIsEnabled(false)
 	}
-
 }

--- a/internal/tray-agent/app-indicator/dynlist.go
+++ b/internal/tray-agent/app-indicator/dynlist.go
@@ -72,6 +72,7 @@ func (nl *nodeList) freeNode(tag string) {
 		node.SetTag("")
 		node.SetIsVisible(false)
 		node.SetIsEnabled(true)
+		node.SetIsChecked(false)
 		node.Disconnect()
 		delete(nl.usedNodes, tag)
 		nl.freeNodes.Enqueue(node)

--- a/internal/tray-agent/app-indicator/indicator.go
+++ b/internal/tray-agent/app-indicator/indicator.go
@@ -332,8 +332,8 @@ func (i *Indicator) RefreshLabel() {
 	out := st.Peerings(PeeringOutgoing)
 	//since the label is graphically invasive, its content is displayed only when
 	//there is at least one active peering
-	if st.Running() && (in >= 0 || out >= 0) {
-		i.SetLabel(fmt.Sprintf("(I:%d/O:%d)", in, out))
+	if st.Running() && (in > 0 || out > 0) {
+		i.SetLabel(fmt.Sprintf("(IN:%d/OUT:%d)", in, out))
 		return
 	}
 	i.SetLabel("")

--- a/internal/tray-agent/app-indicator/indicator.go
+++ b/internal/tray-agent/app-indicator/indicator.go
@@ -325,14 +325,18 @@ func (i *Indicator) SetLabel(label string) {
 }
 
 //RefreshLabel updates the content of the Indicator label
-//with the total number of actual peerings.
+//with the total number of both incoming and outgoing peerings currently active.
 func (i *Indicator) RefreshLabel() {
-	n := i.status.ActivePeerings()
-	if n <= 0 {
-		i.SetLabel("")
-	} else {
-		i.SetLabel(fmt.Sprintf("(%v)", n))
+	st := i.Status()
+	in := st.Peerings(PeeringIncoming)
+	out := st.Peerings(PeeringOutgoing)
+	//since the label is graphically invasive, its content is displayed only when
+	//there is at least one active peering
+	if st.Running() && (in >= 0 || out >= 0) {
+		i.SetLabel(fmt.Sprintf("(I:%d/O:%d)", in, out))
+		return
 	}
+	i.SetLabel("")
 }
 
 //--------------

--- a/internal/tray-agent/app-indicator/status_test.go
+++ b/internal/tray-agent/app-indicator/status_test.go
@@ -17,24 +17,24 @@ func TestStatus(t *testing.T) {
 		"default running state should be OFF")
 	assert.Equal(t, StatModeAutonomous, stat.Mode(),
 		"default working mode should be AUTONOMOUS")
-	assert.Equal(t, 0, stat.ConsumePeerings())
-	assert.Equal(t, 0, stat.OfferPeerings())
+	assert.Equal(t, 0, stat.Peerings(PeeringOutgoing))
+	assert.Equal(t, 0, stat.Peerings(PeeringIncoming))
 	//test status operations
 	stat.SetRunning(StatRunOn)
 	assert.Equal(t, StatRunOn, stat.Running(), "running status should be ON")
-	assert.Equal(t, 0, stat.ConsumePeerings())
-	assert.Equal(t, 0, stat.OfferPeerings())
+	assert.Equal(t, 0, stat.Peerings(PeeringOutgoing))
+	assert.Equal(t, 0, stat.Peerings(PeeringIncoming))
 	//addition of consuming and offering peerings are allowed while
 	//in AUTONOMOUS mode.
-	stat.IncConsumePeerings()
-	stat.IncOfferPeerings()
-	assert.Equal(t, 1, stat.ConsumePeerings(), "addition of consuming peer in"+
+	stat.IncDecPeerings(PeeringOutgoing, true)
+	stat.IncDecPeerings(PeeringIncoming, true)
+	assert.Equal(t, 1, stat.Peerings(PeeringOutgoing), "addition of consuming peer in"+
 		"AUTONOMOUS mode is not allowed")
-	assert.Equal(t, 1, stat.OfferPeerings(), "addition of offering peer in"+
+	assert.Equal(t, 1, stat.Peerings(PeeringIncoming), "addition of offering peer in"+
 		"AUTONOMOUS mode is not allowed")
 	//test transition to TETHERED mode
 	assert.Errorf(t, stat.SetMode(StatModeTethered), "TETHERED mode should not be allowed with active consuming peerings.")
-	stat.DecConsumePeerings()
+	stat.IncDecPeerings(PeeringOutgoing, false)
 	//without active consuming peerings, TETHERED mode is allowed
 	_ = stat.SetMode(StatModeTethered)
 	assert.Equal(t, StatModeTethered, stat.Mode(), "transition to TETHERED should be"+
@@ -42,8 +42,8 @@ func TestStatus(t *testing.T) {
 	assert.True(t, stat.IsTetheredCompliant(), "TETHERED mode requirements not matching")
 	//turning the system off should shut down all active peerings
 	stat.SetRunning(StatRunOff)
-	assert.Equal(t, 0, stat.ConsumePeerings(), "there should be no active consuming peerings"+
+	assert.Equal(t, 0, stat.Peerings(PeeringOutgoing), "there should be no active consuming peerings"+
 		"after turning off the system")
-	assert.Equal(t, 0, stat.OfferPeerings(), "there should be no active offering peerings"+
+	assert.Equal(t, 0, stat.Peerings(PeeringIncoming), "there should be no active offering peerings"+
 		"after turning off the system")
 }


### PR DESCRIPTION
# Description

This PR operates a refactoring on the *Status* MenuNode (which shows some metrics on the tray menu) and introduces the possibility for the Agent to manage the status of active peerings (read only).

* STATUS MenuNode
  * code refactoring for a cleaner and more efficient workflow
  * added an explicit *peers* counter to aggregate all data inside the Status
  * the tray agent *label* (small text beside the tray icon) is now used to dynamically display the number of active peerings (with a distinction between **incoming** and **outgoing** ones)

* Peerings management (read only)
  * The AgentController now handles also events on the *ForeignCluster* CRD regarding the establishment and disconnection of peerings
  * The Indicator listens to these two kinds of events and reacts by:
    * notifying the event (acording to current notification settings)
    * updating STATUS data
    * signalling the event inside the "*peers* list" for the corresponding peer; currently a ✔️ is used to indicate whether a peering in a given direction is active
    * the function handlers regarding the Advertisements have been removed, since the updates about peerings are now acquired from the ForeignCluster

### NOTE: 

The peerings feature implemented in this PR is an early version. In a very next PR there will be a code refactoring for the **NotifyChannel**s and Indicator **Listener**s, thus enabling a more efficient and compact handling of these events.

# How Has This Been Tested?

Since this is not a definitive version and a relevant portion of code will be soon updated, the tests only cover the STATUS refactoring. New tests will be added in the updating PR. Some live tests have been conducted locally.