### PR TITLE
Added Advertisement print columns

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Coding guidelines
 
-When creating PRs and issues follow the repo's guidelines presented in our [documentation website](https://doc.liqo.io/contributing/guidelines/).
+When creating PRs and issues follow the repo's guidelines presented in our [documentation website](https://doc.liqo.io/contributing/).
 
 
 

--- a/apis/sharing/v1alpha1/advertisement_types.go
+++ b/apis/sharing/v1alpha1/advertisement_types.go
@@ -77,6 +77,9 @@ type AdvertisementStatus struct {
 // +kubebuilder:resource:scope=Cluster
 
 // Advertisement is the Schema for the advertisements API
+// +kubebuilder:printcolumn:name="Status",type=string,JSONPath=`.status.advertisementStatus`
+// +kubebuilder:printcolumn:name="Expiration",type=string,JSONPath=`.spec.timeToLive`
+// +kubebuilder:printcolumn:name="VkCreated",type=boolean,JSONPath=`.status.vkCreated`
 type Advertisement struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/deployments/liqo/crds/sharing.liqo.io_advertisements.yaml
+++ b/deployments/liqo/crds/sharing.liqo.io_advertisements.yaml
@@ -14,9 +14,21 @@ spec:
     listKind: AdvertisementList
     plural: advertisements
     singular: advertisement
+    shortNames:
+      - adv
   scope: Cluster
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.advertisementStatus
+      name: Status
+      type: string
+    - jsonPath: .spec.timeToLive
+      name: Expiration
+      type: string
+    - jsonPath: .status.vkCreated
+      name: VkCreated
+      type: boolean
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: Advertisement is the Schema for the advertisements API


### PR DESCRIPTION
# Hi guys!! 🎆 🎆 
A very small PR after a lot of time 😄 

# Description
Kubebuilder allows to specify additional print columns when you perform `kubectl get <crd>`( [link](https://book.kubebuilder.io/reference/markers/crd.html) )
In this PR some additional columns have been added to the Advertisement to easily find its status (Accepted/Refused), expiration date and if the VirtualKubelet has been created. Different/other fields can be easily added.
A dead link to Contributing page has been updated too.

# How Has This Been Tested?

Tested with our beloved KinD