### PR TITLE
Add label to exclude virtual-node from load-balancers

### DIFF
--- a/pkg/virtualKubelet/provider/node.go
+++ b/pkg/virtualKubelet/provider/node.go
@@ -23,6 +23,7 @@ func (p *LiqoProvider) ConfigureNode(ctx context.Context, n *v1.Node) {
 	n.Status.NodeInfo.OperatingSystem = os
 	n.Status.NodeInfo.Architecture = "amd64"
 	n.ObjectMeta.Labels["alpha.service-controller.kubernetes.io/exclude-balancer"] = "true"
+	n.ObjectMeta.Labels["node.kubernetes.io/exclude-from-external-load-balancers"] = "true"
 	n.Labels["type"] = "virtual-node"
 }
 


### PR DESCRIPTION
# Description

The virtual node should be excluded from LB backend pool. Label "node.kubernetes.io/exclude-from-external-load-balancers" is required to do so for k8s>=1.19 while Liqo virtual-kubelet is still using "alpha.service-controller.kubernetes.io/exclude-balancer". This PR adds the new version of this label.