### PR TITLE
Virtual node initialized to NotReady

### DIFF
--- a/pkg/virtualKubelet/provider/node.go
+++ b/pkg/virtualKubelet/provider/node.go
@@ -34,7 +34,7 @@ func (p *LiqoProvider) nodeConditions() []v1.NodeCondition {
 	return []v1.NodeCondition{
 		{
 			Type:               "Ready",
-			Status:             v1.ConditionTrue,
+			Status:             v1.ConditionFalse,
 			LastHeartbeatTime:  metav1.Now(),
 			LastTransitionTime: metav1.Now(),
 			Reason:             "KubeletReady",
@@ -66,7 +66,7 @@ func (p *LiqoProvider) nodeConditions() []v1.NodeCondition {
 		},
 		{
 			Type:               "NetworkUnavailable",
-			Status:             v1.ConditionFalse,
+			Status:             v1.ConditionTrue,
 			LastHeartbeatTime:  metav1.Now(),
 			LastTransitionTime: metav1.Now(),
 			Reason:             "RouteCreated",


### PR DESCRIPTION
# Description

The node is created in NotReady status. Once the `tunnelEndpoint` resource is detected, then the node is set in ready status. By using this approach we fix the transitory problem in node status (ready-notReady-ready) 


