### PR TITLE
Setting default value for the service type used to expose liqo-gateway to "NodePort"

### DIFF
--- a/deployments/liqo/subcharts/networkModule/templates/tunnelEndpoint-operator.yaml
+++ b/deployments/liqo/subcharts/networkModule/templates/tunnelEndpoint-operator.yaml
@@ -123,11 +123,11 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: wireguard-endpoint
+  name: liqo-gateway-endpoint
   labels:
     net.liqo.io/gateway: "true"
 spec:
-  type: NodePort
+  type: {{ .Values.tunnelEndpointOperator.vpnEndpoint }}
   ports:
     - name: wireguard
       port: 5871

--- a/deployments/liqo/subcharts/networkModule/values.yaml
+++ b/deployments/liqo/subcharts/networkModule/values.yaml
@@ -10,6 +10,7 @@ tunnelEndpointOperator:
   image:
     repository: "liqo/liqonet"
     pullPolicy: "IfNotPresent"
+  vpnEndpoint: "NodePort"
 
 suffix: ""
 version: "latest"

--- a/deployments/liqo/values.yaml
+++ b/deployments/liqo/values.yaml
@@ -28,6 +28,7 @@ networkModule:
     image:
       repository: "liqo/liqonet"
       pullPolicy: "IfNotPresent"
+    vpnEndpoint: "NodePort"
   enabled: true
 
 #configuration values for the tunnelendpointCreator subchart


### PR DESCRIPTION
# Description

The k8s service associated to the liqo-gateway component is now by default of type _NodePort_.

This PR partially address the following feature request: #427.

