### PR TITLE
Virtual kubelet cache protection

### DIFF
--- a/internal/utils/errdefs/unavailable.go
+++ b/internal/utils/errdefs/unavailable.go
@@ -1,0 +1,65 @@
+package errdefs
+
+import (
+	"errors"
+	"fmt"
+)
+
+// ErrUnavailable is an error interface which denotes whether the operation failed due
+// to the unavailability of a resource
+type ErrUnavailable interface {
+	Unavailable() bool
+	error
+}
+
+type unavailableError struct {
+	error
+}
+
+func (e *unavailableError) Unavailable() bool {
+	return true
+}
+
+func (e *unavailableError) Cause() error {
+	return e.error
+}
+
+// AsUnavailable wraps the passed in error to make it of type ErrUnavailable
+//
+// Callers should make sure the passed in error has exactly the error message
+// it wants as this function does not decorate the message.
+func AsUnavailableError(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &unavailableError{err}
+}
+
+// InvalidInput makes an ErrInvalidInput from the provided error message
+func Unavailable(msg string) error {
+	return &unavailableError{errors.New(msg)}
+}
+
+// InvalidInputf makes an ErrInvalidInput from the provided error format and args
+func Unavailablef(format string, args ...interface{}) error {
+	return &unavailableError{fmt.Errorf(format, args...)}
+}
+
+// IsUnavailable determines if the passed in error is of type unavailableError
+//
+// This will traverse the causal chain (`Cause() error`), until it finds an error
+// which implements the `InvalidInput` interface.
+func IsUnavailable(err error) bool {
+	if err == nil {
+		return false
+	}
+	if e, ok := err.(ErrUnavailable); ok {
+		return e.Unavailable()
+	}
+
+	if e, ok := err.(causal); ok {
+		return IsUnavailable(e.Cause())
+	}
+
+	return false
+}

--- a/pkg/virtualKubelet/apiReflection/reflectors/incoming/pods.go
+++ b/pkg/virtualKubelet/apiReflection/reflectors/incoming/pods.go
@@ -141,7 +141,7 @@ func (r *PodsIncomingReflector) CleanupNamespace(namespace string) {
 		return
 	}
 
-	objects, err := r.GetCacheManager().ResyncListForeignNamespacedObject(apimgmt.Pods, foreignNamespace)
+	objects, err := r.GetCacheManager().ListForeignNamespacedObject(apimgmt.Pods, foreignNamespace)
 	if err != nil {
 		klog.Errorf("error while listing remote objects in namespace %v", namespace)
 		return

--- a/pkg/virtualKubelet/apiReflection/reflectors/outgoing/configmaps.go
+++ b/pkg/virtualKubelet/apiReflection/reflectors/outgoing/configmaps.go
@@ -40,11 +40,10 @@ func (r *ConfigmapsReflector) HandleEvent(e interface{}) {
 	case watch.Added:
 		_, err := r.GetForeignClient().CoreV1().ConfigMaps(cm.Namespace).Create(context.TODO(), cm, metav1.CreateOptions{})
 		if kerrors.IsAlreadyExists(err) {
-			klog.V(3).Infof("OUTGOING REFLECTION: The remote configmap %v/%v has not been created: %v", cm.Namespace, cm.Name, err)
+			klog.V(3).Infof("OUTGOING REFLECTION: The remote configmap %v/%v has not been created because already existing", cm.Namespace, cm.Name)
 			break
 		}
-
-		if err != nil && !kerrors.IsAlreadyExists(err) {
+		if err != nil {
 			klog.Errorf("OUTGOING REFLECTION: Error while updating the remote configmap %v/%v - ERR: %v", cm.Namespace, cm.Name, err)
 		} else {
 			klog.V(3).Infof("OUTGOING REFLECTION: remote configMap %v/%v correctly created", cm.Namespace, cm.Name)
@@ -160,7 +159,7 @@ func (r *ConfigmapsReflector) CleanupNamespace(localNamespace string) {
 		return
 	}
 
-	objects, err := r.GetCacheManager().ResyncListForeignNamespacedObject(apimgmt.Configmaps, foreignNamespace)
+	objects, err := r.GetCacheManager().ListForeignNamespacedObject(apimgmt.Configmaps, foreignNamespace)
 	if err != nil {
 		klog.Error(err)
 		return

--- a/pkg/virtualKubelet/storage/cache.go
+++ b/pkg/virtualKubelet/storage/cache.go
@@ -18,11 +18,11 @@ var (
 )
 
 type NamespacedAPICaches struct {
+	sync.RWMutex
+
 	apiInformers      map[string]*APICaches
 	informerFactories map[string]informers.SharedInformerFactory
 	client            kubernetes.Interface
-
-	mutex sync.RWMutex
 }
 
 func (ac *NamespacedAPICaches) Namespace(namespace string) *APICaches {
@@ -30,8 +30,8 @@ func (ac *NamespacedAPICaches) Namespace(namespace string) *APICaches {
 }
 
 func (ac *NamespacedAPICaches) AddNamespace(namespace string) error {
-	ac.mutex.Lock()
-	defer ac.mutex.Unlock()
+	ac.Lock()
+	defer ac.Unlock()
 
 	if ac.apiInformers == nil {
 		return errors.New("informers map set to nil")

--- a/pkg/virtualKubelet/storage/cacheManager_test.go
+++ b/pkg/virtualKubelet/storage/cacheManager_test.go
@@ -129,12 +129,12 @@ var _ = Describe("CacheManager", func() {
 
 						It("resync list objects", func() {
 							By("home pods")
-							objs, err := manager.ResyncListHomeNamespacedObject(apimgmt.Pods, test.HomeNamespace)
+							objs, err := manager.ListHomeNamespacedObject(apimgmt.Pods, test.HomeNamespace)
 							Expect(err).NotTo(HaveOccurred())
 							Expect(len(objs)).To(Equal(2))
 
 							By("foreign pod")
-							objs, err = manager.ResyncListForeignNamespacedObject(apimgmt.Pods, test.ForeignNamespace)
+							objs, err = manager.ListForeignNamespacedObject(apimgmt.Pods, test.ForeignNamespace)
 							Expect(err).NotTo(HaveOccurred())
 							Expect(len(objs)).To(Equal(2))
 						})
@@ -176,11 +176,11 @@ var _ = Describe("CacheManager", func() {
 
 				It("resync list objects", func() {
 					By("home pods")
-					_, err := manager.ResyncListHomeNamespacedObject(apimgmt.Pods, test.HomeNamespace)
+					_, err := manager.ListHomeNamespacedObject(apimgmt.Pods, test.HomeNamespace)
 					Expect(err).To(HaveOccurred())
 
 					By("foreign pod")
-					_, err = manager.ResyncListForeignNamespacedObject(apimgmt.Pods, test.ForeignNamespace)
+					_, err = manager.ListForeignNamespacedObject(apimgmt.Pods, test.ForeignNamespace)
 					Expect(err).To(HaveOccurred())
 				})
 			})

--- a/pkg/virtualKubelet/storage/interfaces.go
+++ b/pkg/virtualKubelet/storage/interfaces.go
@@ -28,8 +28,6 @@ type CacheManagerReader interface {
 	GetForeignNamespacedObject(apimgmt.ApiType, string, string) (interface{}, error)
 	ListHomeNamespacedObject(apimgmt.ApiType, string) ([]interface{}, error)
 	ListForeignNamespacedObject(apimgmt.ApiType, string) ([]interface{}, error)
-	ResyncListHomeNamespacedObject(apimgmt.ApiType, string) ([]interface{}, error)
-	ResyncListForeignNamespacedObject(apimgmt.ApiType, string) ([]interface{}, error)
 	GetHomeApiByIndex(apimgmt.ApiType, string, string) (interface{}, error)
 	GetForeignApiByIndex(apimgmt.ApiType, string, string) (interface{}, error)
 }

--- a/pkg/virtualKubelet/storage/test/mockCacheManager.go
+++ b/pkg/virtualKubelet/storage/test/mockCacheManager.go
@@ -4,12 +4,17 @@ import (
 	apimgmt "github.com/liqotech/liqo/pkg/virtualKubelet/apiReflection"
 	"github.com/pkg/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
 )
 
 type MockManager struct {
 	HomeCache    map[string]map[apimgmt.ApiType]map[string]v1.Object
 	ForeignCache map[string]map[apimgmt.ApiType]map[string]v1.Object
+}
+
+func (m *MockManager) CheckNamespaceCaching(_ *wait.Backoff, _ string, _ string, _ apimgmt.ApiType) error {
+	return nil
 }
 
 func (m *MockManager) AddHomeEntry(namespace string, api apimgmt.ApiType, obj v1.Object) {

--- a/pkg/virtualKubelet/translation/serviceEnv/serviceEnv.go
+++ b/pkg/virtualKubelet/translation/serviceEnv/serviceEnv.go
@@ -3,6 +3,7 @@ package serviceEnv
 import (
 	apimgmgt "github.com/liqotech/liqo/pkg/virtualKubelet/apiReflection"
 	"github.com/liqotech/liqo/pkg/virtualKubelet/storage"
+	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/klog"
 	v1helper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
@@ -76,7 +77,8 @@ func getServiceEnvVarMap(ns string, enableServiceLinks bool, remoteNs string, ca
 
 		if service.Namespace == ns && enableServiceLinks {
 			if err = addService(&serviceMap, cacheManager, remoteNs, serviceName, true); err != nil {
-				klog.Error(err)
+				err := errors.Wrapf(err, "cannot add remote service")
+				klog.V(4).Info(err)
 				continue
 			}
 		}

--- a/pkg/virtualKubelet/utils/storage.go
+++ b/pkg/virtualKubelet/utils/storage.go
@@ -15,10 +15,6 @@ func Keyer(namespace, name string) string {
 }
 
 func GetObject(informer cache.SharedIndexInformer, key string, backoff wait.Backoff) (interface{}, error) {
-	if informer == nil {
-		return nil, errors.New("informer not instantiated")
-	}
-
 	var object interface{}
 
 	fn := func() error {


### PR DESCRIPTION
# Description

This commit adds a protection layer to the cache access, preventing the log of several log messages communicating the caches have not been instantiated. Those errors cannot be avoided since they make part of the transitory state of a new mapping operation between two namespaces.
