### PR TITLE
crdReplicator finalizer on foreigncluster resources

### DIFF
--- a/cmd/crd-replicator/main.go
+++ b/cmd/crd-replicator/main.go
@@ -57,7 +57,7 @@ func main() {
 	}
 	dynClient := dynamic.NewForConfigOrDie(cfg)
 	dynFac := dynamicinformer.NewFilteredDynamicSharedInformerFactory(dynClient, crdReplicator.ResyncPeriod, metav1.NamespaceAll, crdReplicator.SetLabelsForLocalResources)
-	d := &crdReplicator.CRDReplicatorReconciler{
+	d := &crdReplicator.Controller{
 		Scheme:                         mgr.GetScheme(),
 		Client:                         mgr.GetClient(),
 		ClientSet:                      k8sClient,
@@ -67,7 +67,7 @@ func main() {
 		LocalDynSharedInformerFactory:  dynFac,
 		RegisteredResources:            nil,
 		UnregisteredResources:          nil,
-		LocalWatchers:                  make(map[string]map[string]chan struct{}),
+		LocalWatchers:                  make(map[string]chan struct{}),
 		RemoteWatchers:                 make(map[string]map[string]chan struct{}),
 		RemoteDynSharedInformerFactory: make(map[string]dynamicinformer.DynamicSharedInformerFactory),
 	}

--- a/deployments/liqo/subcharts/crdReplicator/templates/crdReplicator.yaml
+++ b/deployments/liqo/subcharts/crdReplicator/templates/crdReplicator.yaml
@@ -39,7 +39,6 @@ rules:
       - get
       - patch
       - update
-
   - apiGroups:
     - discovery.liqo.io
     resources:
@@ -48,6 +47,7 @@ rules:
       - get
       - list
       - watch
+      - update
   - apiGroups:
       - discovery.liqo.io
     resources:
@@ -56,7 +56,6 @@ rules:
       - get
       - patch
       - update
-
   - apiGroups:
       - config.liqo.io
     resources:

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/apparentlymart/go-cidr v1.1.0
 	github.com/atotto/clipboard v0.1.2
 	github.com/coreos/go-iptables v0.4.5
+	github.com/cratonica/2goarray v0.0.0-20190331194516-514510793eaa // indirect
 	github.com/gen2brain/beeep v0.0.0-20200526185328-e9c15c258e28
 	github.com/gen2brain/dlgs v0.0.0-20201118155338-03fe7f81ad25
 	github.com/getlantern/systray v1.1.0
@@ -42,10 +43,10 @@ require (
 	go.opencensus.io v0.22.4
 	go.uber.org/atomic v1.5.1 // indirect
 	go.uber.org/multierr v1.4.0 // indirect
-	golang.org/x/crypto v0.0.0-20201208171446-5f87f3452ae9 // indirect
+	golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad // indirect
 	golang.org/x/net v0.0.0-20201110031124-69a78807bb2b // indirect
-	golang.org/x/sys v0.0.0-20201207223542-d4d67f95c62d
-	golang.org/x/term v0.0.0-20201207232118-ee85cb95a76b // indirect
+	golang.org/x/sys v0.0.0-20201223074533-0d417f636930
+	golang.org/x/term v0.0.0-20201210144234-2321bbc49cbf // indirect
 	golang.org/x/text v0.3.4 // indirect
 	golang.org/x/tools v0.0.0-20201116002733-ac45abd4c88c
 	golang.zx2c4.com/wireguard/wgctrl v0.0.0-20200609130330-bd2cb7843e1b

--- a/go.sum
+++ b/go.sum
@@ -199,6 +199,8 @@ github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwc
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0 h1:EoUDS0afbrsXAZ9YQ9jdu/mZ2sXgT1/2yyNng4PGlyM=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
+github.com/cratonica/2goarray v0.0.0-20190331194516-514510793eaa h1:Wg+722vs7a2zQH5lR9QWYsVbplKeffaQFIs5FTdfNNo=
+github.com/cratonica/2goarray v0.0.0-20190331194516-514510793eaa/go.mod h1:6Arca19mRx58CA7OWEd7Wu1NpC1rd3uDnNs6s1pj/DI=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/cyphar/filepath-securejoin v0.2.2 h1:jCwT2GTP+PY5nBz3c/YL5PAIbusElVrPujOBSCj8xRg=
 github.com/cyphar/filepath-securejoin v0.2.2/go.mod h1:FpkQEhXnPnOthhzymB7CGsFk2G9VLXONKD9G7QGMM+4=
@@ -1001,6 +1003,8 @@ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 h1:psW17arqaxU48Z5kZ0CQnk
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201208171446-5f87f3452ae9 h1:sYNJzB4J8toYPQTM6pAkcmBRgw9SnQKP9oXCHfgy604=
 golang.org/x/crypto v0.0.0-20201208171446-5f87f3452ae9/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
+golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad h1:DN0cp81fZ3njFcrLCytUHRSUkqBjfTo4Tx9RJTWs0EY=
+golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/exp v0.0.0-20180321215751-8460e604b9de/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20180807140117-3d87b88a115f/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -1182,10 +1186,14 @@ golang.org/x/sys v0.0.0-20201015000850-e3ed0017c211/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201207223542-d4d67f95c62d h1:MiWWjyhUzZ+jvhZvloX6ZrUsdEghn8a64Upd8EMHglE=
 golang.org/x/sys v0.0.0-20201207223542-d4d67f95c62d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20201223074533-0d417f636930 h1:vRgIt+nup/B/BwIS0g2oC0haq0iqbV3ZA+u6+0TlNCo=
+golang.org/x/sys v0.0.0-20201223074533-0d417f636930/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221 h1:/ZHdbVpdR/jk3g30/d4yUL0JU9kksj8+F/bnQUVLGDM=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201207232118-ee85cb95a76b h1:a0ErnNnPKmhDyIXQvdZr+Lq8dc8xpMeqkF8y5PgQU4Q=
 golang.org/x/term v0.0.0-20201207232118-ee85cb95a76b/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+golang.org/x/term v0.0.0-20201210144234-2321bbc49cbf h1:MZ2shdL+ZM/XzY3ZGOnh4Nlpnxz5GSOhOmtHo3iPU6M=
+golang.org/x/term v0.0.0-20201210144234-2321bbc49cbf/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.0.0-20170915090833-1cbadb444a80/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/internal/crdReplicator/crdReplicator-config_test.go
+++ b/internal/crdReplicator/crdReplicator-config_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestDispatcherReconciler_GetConfig(t *testing.T) {
-	dispatcher := CRDReplicatorReconciler{}
+	dispatcher := Controller{}
 	//test 1
 	//the list of the resources to be replicated is 0, so we expect a 0 length list to be returned by the function
 	t1 := configv1alpha1.DispatcherConfig{ResourcesToReplicate: nil}
@@ -47,7 +47,7 @@ func TestDispatcherReconciler_GetConfig(t *testing.T) {
 }
 
 func TestDispatcherReconciler_GetRemovedResources(t *testing.T) {
-	dispatcher := CRDReplicatorReconciler{
+	dispatcher := Controller{
 		RegisteredResources: []schema.GroupVersionResource{
 			{
 				Group:    netv1alpha1.GroupVersion.Group,
@@ -105,7 +105,7 @@ func TestDispatcherReconciler_GetRemovedResources(t *testing.T) {
 }
 
 func TestDispatcherReconciler_UpdateConfig(t *testing.T) {
-	dispatcher := CRDReplicatorReconciler{}
+	dispatcher := Controller{}
 	//test 1
 	//the list of the resources to be replicated is 0, so we expect a 0 length list to be returned by the function
 	//and 0 elements removed
@@ -164,7 +164,7 @@ func TestDispatcherReconciler_UpdateConfig(t *testing.T) {
 
 //we test that if the *rest.config of the custer is not correct the function return the error
 func TestDispatcherReconciler_WatchConfiguration(t *testing.T) {
-	dispatcher := CRDReplicatorReconciler{}
+	dispatcher := Controller{}
 	//test1
 	//the group version is not correct and we expect an error
 	config := k8sManagerLocal.GetConfig()

--- a/internal/crdReplicator/crdReplicator-operator_test.go
+++ b/internal/crdReplicator/crdReplicator-operator_test.go
@@ -48,8 +48,8 @@ func getLabels() map[string]string {
 	}
 }
 
-func getCRDReplicator() CRDReplicatorReconciler {
-	return CRDReplicatorReconciler{
+func getCRDReplicator() Controller {
+	return Controller{
 		Scheme:                         nil,
 		ClusterID:                      localClusterID,
 		RemoteDynClients:               map[string]dynamic.Interface{remoteClusterID: dynClient},
@@ -59,7 +59,7 @@ func getCRDReplicator() CRDReplicatorReconciler {
 		RemoteWatchers:                 map[string]map[string]chan struct{}{},
 		LocalDynClient:                 dynClient,
 		LocalDynSharedInformerFactory:  localDynFac,
-		LocalWatchers:                  map[string]map[string]chan struct{}{},
+		LocalWatchers:                  map[string]chan struct{}{},
 	}
 }
 
@@ -180,13 +180,12 @@ func TestCRDReplicatorReconciler_StartAndStopWatchers(t *testing.T) {
 	d.RegisteredResources = test1
 	d.StartWatchers()
 	assert.Equal(t, 2, len(d.RemoteWatchers[remoteClusterID]), "it should be 2")
-	assert.Equal(t, 2, len(d.LocalWatchers[remoteClusterID]), "it should be 2")
+	assert.Equal(t, 2, len(d.LocalWatchers), "it should be 2")
 	for _, r := range test1 {
 		d.UnregisteredResources = append(d.UnregisteredResources, r.String())
 	}
 	d.StopWatchers()
 	assert.Equal(t, 0, len(d.RemoteWatchers[remoteClusterID]), "it should be 0")
-	assert.Equal(t, 0, len(d.LocalWatchers[remoteClusterID]), "it should be 0")
 	d.UnregisteredResources = []string{}
 
 }

--- a/test/unit/crdReplicator/crdReplicator-operator_test.go
+++ b/test/unit/crdReplicator/crdReplicator-operator_test.go
@@ -35,7 +35,7 @@ func setupDispatcherOperator() error {
 	var err error
 	localDynClient := dynamic.NewForConfigOrDie(k8sManagerLocal.GetConfig())
 	localDynFac := dynamicinformer.NewFilteredDynamicSharedInformerFactory(localDynClient, crdReplicator.ResyncPeriod, metav1.NamespaceAll, crdReplicator.SetLabelsForLocalResources)
-	dOperator = &crdReplicator.CRDReplicatorReconciler{
+	dOperator = &crdReplicator.Controller{
 		Scheme:                         k8sManagerLocal.GetScheme(),
 		Client:                         k8sManagerLocal.GetClient(),
 		ClientSet:                      nil,
@@ -46,7 +46,7 @@ func setupDispatcherOperator() error {
 		RemoteDynSharedInformerFactory: peeringClustersDynFactories,
 		RegisteredResources:            nil,
 		UnregisteredResources:          nil,
-		LocalWatchers:                  make(map[string]map[string]chan struct{}),
+		LocalWatchers:                  make(map[string]chan struct{}),
 		RemoteWatchers:                 make(map[string]map[string]chan struct{}),
 	}
 	err = dOperator.SetupWithManager(k8sManagerLocal)

--- a/test/unit/crdReplicator/env_test.go
+++ b/test/unit/crdReplicator/env_test.go
@@ -35,7 +35,7 @@ var (
 	configClusterClient         *crdClient.CRDClient
 	k8sManagerLocal             ctrl.Manager
 	testEnvLocal                *envtest.Environment
-	dOperator                   *crdReplicator.CRDReplicatorReconciler
+	dOperator                   *crdReplicator.Controller
 )
 
 func TestMain(m *testing.M) {


### PR DESCRIPTION
# Description

Each time a `foreigncluster.discovery.liqo.io` resource is created the **crdReplicator** creates a dynamic client to the remote api-server. A finalizer is added to the `foreigncluster` resources in order to close the connection to the remote api-servers when the resource is deleted.

Using two kind clusters:

1. peering then unpeering and then peering again the cluster.
2. deleting the foreigcluster resource and checking that the crdReplicator removes the connection and then recreates the client to the remote api-server once the foreigncluster resource is recreated.
