### PR TITLE
Move VK certificate generation to K8s CSR API v1

### DIFF
--- a/pkg/advertisement-operator/creation.go
+++ b/pkg/advertisement-operator/creation.go
@@ -121,6 +121,10 @@ func CreateVkDeployment(adv *advtypes.Advertisement, vkName, vkNamespace, vkImag
 									Name:      "POD_NAME",
 									ValueFrom: &v1.EnvVarSource{FieldRef: &v1.ObjectFieldSelector{FieldPath: "metadata.name", APIVersion: "v1"}},
 								},
+								{
+									Name:  "NODE_NAME",
+									Value: nodeName,
+								},
 							},
 							Args: []string{
 								"/etc/virtual-kubelet/certs",

--- a/scripts/virtual-kubelet/script.sh
+++ b/scripts/virtual-kubelet/script.sh
@@ -14,20 +14,17 @@ cat <<EOF | cfssl genkey - | cfssljson -bare server
   "hosts": [
     "${POD_IP}"
   ],
-  "CN": "${POD_NAME}",
+  "CN": "system:node:${NODE_NAME}",
   "names": [
       {
-	"C": "IT",
-  "O": "system:nodes",
-	"L": "Turin",
-	"OU": "Virtual Kubelet",
-  "ST": "Italy"
+  "O": "system:nodes"
       }
     ],
   "key": {
     "algo": "ecdsa",
     "size": 256
   }
+
 }
 EOF
 cat <<EOF | kubectl apply -f -
@@ -39,6 +36,7 @@ metadata:
      "liqo.io/csr": "true"
 spec:
   request: $(< server.csr base64 | tr -d '\n')
+  signerName: kubernetes.io/kubelet-serving
   usages:
   - digital signature
   - key encipherment


### PR DESCRIPTION
# Description

This PR updates the virtual-kubelet CRT generation mechanism for the virtual-kubelet. In particular, it creates a CSR compatible with the signer "kubernetes.io/kubelet-serving"

# How Has This Been Tested?