### PR TITLE
ClusterIdentity defaulting

### DIFF
--- a/apis/discovery/v1alpha1/foreigncluster_types.go
+++ b/apis/discovery/v1alpha1/foreigncluster_types.go
@@ -35,13 +35,16 @@ type ForeignClusterSpec struct {
 	// Important: Run "make" to regenerate code after modifying this file
 
 	// Foreign Cluster Identity
-	ClusterIdentity ClusterIdentity `json:"clusterIdentity"`
+	ClusterIdentity ClusterIdentity `json:"clusterIdentity,omitempty"`
 	// Namespace where Liqo is deployed
-	Namespace string `json:"namespace"`
+	Namespace string `json:"namespace,omitempty"`
 	// Enable join process to foreign cluster
-	Join bool `json:"join"`
+	// +kubebuilder:default=false
+	Join bool `json:"join,omitempty"`
+	// +kubebuilder:validation:Enum="LAN";"WAN";"Manual";"IncomingPeering"
+	// +kubebuilder:default="Manual"
 	// How this ForeignCluster has been discovered
-	DiscoveryType discovery.DiscoveryType `json:"discoveryType"`
+	DiscoveryType discovery.DiscoveryType `json:"discoveryType,omitempty"`
 	// URL where to contact foreign Auth service
 	AuthUrl string `json:"authUrl"`
 	// +kubebuilder:validation:Enum="Unknown";"Trusted";"Untrusted"

--- a/deployments/liqo/crds/discovery.liqo.io_foreignclusters.yaml
+++ b/deployments/liqo/crds/discovery.liqo.io_foreignclusters.yaml
@@ -53,9 +53,16 @@ spec:
                 - clusterID
                 type: object
               discoveryType:
+                default: Manual
                 description: How this ForeignCluster has been discovered
+                enum:
+                - LAN
+                - WAN
+                - Manual
+                - IncomingPeering
                 type: string
               join:
+                default: false
                 description: Enable join process to foreign cluster
                 type: boolean
               namespace:
@@ -71,10 +78,6 @@ spec:
                 type: string
             required:
             - authUrl
-            - clusterIdentity
-            - discoveryType
-            - join
-            - namespace
             type: object
           status:
             description: ForeignClusterStatus defines the observed state of ForeignCluster

--- a/internal/discovery/foreign-cluster-operator/clusterIdentityDefaulting.go
+++ b/internal/discovery/foreign-cluster-operator/clusterIdentityDefaulting.go
@@ -1,0 +1,48 @@
+package foreign_cluster_operator
+
+import (
+	"github.com/liqotech/liqo/apis/discovery/v1alpha1"
+	"github.com/liqotech/liqo/internal/discovery/utils"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog"
+)
+
+// check if the ForeignCluster CR does not have a value in one of the required fields (Namespace and ClusterID)
+// and needs a value defaulting
+func (r *ForeignClusterReconciler) needsClusterIdentityDefaulting(fc *v1alpha1.ForeignCluster) bool {
+	return fc.Spec.Namespace == "" || fc.Spec.ClusterIdentity.ClusterID == ""
+}
+
+// load the default values for that ForeignCluster basing on the AuthUrl value, an HTTP request is sent and the retrieved
+// values are applied for the following fields (if they are empty): Namespace, ClusterIdentity.ClusterID, ClusterIdentity.Namespace
+// and the TrustMode
+// if it returns no error, the ForeignCluster CR has been updated
+func (r *ForeignClusterReconciler) clusterIdentityDefaulting(fc *v1alpha1.ForeignCluster) error {
+	klog.V(4).Infof("Defaulting ClusterIdentity values for ForeignCluster %v", fc.Name)
+	ids, trustMode, err := utils.GetClusterInfo(fc.Spec.AuthUrl)
+	if err != nil {
+		klog.Error(err)
+		return err
+	}
+
+	if fc.Spec.Namespace == "" {
+		fc.Spec.Namespace = ids.GuestNamespace
+	}
+	if fc.Spec.ClusterIdentity.ClusterID == "" {
+		fc.Spec.ClusterIdentity.ClusterID = ids.ClusterID
+	}
+	if fc.Spec.ClusterIdentity.ClusterName == "" {
+		fc.Spec.ClusterIdentity.ClusterName = ids.ClusterName
+	}
+
+	fc.Spec.TrustMode = trustMode
+
+	klog.V(4).Infof("New values:\n\tNamespace:\t%v\n\tClusterId:\t%v\n\tClusterName:\t%v\n\tTrustMode:\t%v", fc.Spec.Namespace, fc.Spec.ClusterIdentity.ClusterID, fc.Spec.ClusterIdentity.ClusterName, fc.Spec.TrustMode)
+
+	// update the ForeignCluster
+	if _, err = r.crdClient.Resource("foreignclusters").Update(fc.Name, fc, metav1.UpdateOptions{}); err != nil {
+		klog.Error(err)
+		return err
+	}
+	return nil
+}

--- a/internal/discovery/foreign-cluster-operator/foreign-cluster-controller.go
+++ b/internal/discovery/foreign-cluster-operator/foreign-cluster-controller.go
@@ -88,6 +88,20 @@ func (r *ForeignClusterReconciler) Reconcile(req ctrl.Request) (ctrl.Result, err
 
 	requireUpdate := false
 
+	if r.needsClusterIdentityDefaulting(fc) {
+		// this ForeignCluster has not all the required fields, probably it has been added manually, so default to exposed values
+		if err = r.clusterIdentityDefaulting(fc); err != nil {
+			klog.Error(err)
+			return ctrl.Result{
+				Requeue:      true,
+				RequeueAfter: r.RequeueAfter,
+			}, err
+		} else {
+			// the resource has been updated, no need to requeue
+			return ctrl.Result{}, nil
+		}
+	}
+
 	// set trust property
 	// This will only be executed in the ForeignCluster CR has been added in a manual way,
 	// if it was discovered this field is set by the discovery process.

--- a/internal/discovery/resolve.go
+++ b/internal/discovery/resolve.go
@@ -2,12 +2,10 @@ package discovery
 
 import (
 	"context"
-	"encoding/json"
 	"github.com/grandcat/zeroconf"
 	"github.com/liqotech/liqo/internal/discovery/utils"
 	"github.com/liqotech/liqo/pkg/auth"
 	discoveryPkg "github.com/liqotech/liqo/pkg/discovery"
-	"io/ioutil"
 	"k8s.io/klog"
 	"net"
 	"os"
@@ -87,25 +85,13 @@ func (discovery *DiscoveryCtrl) Resolve(ctx context.Context, service string, dom
 }
 
 func (discovery *DiscoveryCtrl) getClusterInfo(authData *AuthData) (*auth.ClusterInfo, discoveryPkg.TrustMode, error) {
-	resp, trustMode, err := utils.GetClusterInfo(authData.GetUrl())
+	ids, trustMode, err := utils.GetClusterInfo(authData.GetUrl())
 	if err != nil {
 		klog.Error(err)
 		return nil, "", err
 	}
 
-	respBytes, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		klog.Error(err)
-		return nil, "", err
-	}
-
-	var ids auth.ClusterInfo
-	if err = json.Unmarshal(respBytes, &ids); err != nil {
-		klog.Error(err)
-		return nil, "", err
-	}
-
-	return &ids, trustMode, nil
+	return ids, trustMode, nil
 }
 
 func (discovery *DiscoveryCtrl) getIPs() map[string]bool {


### PR DESCRIPTION
# Description

This PR adds a defaulting mechanism to get the clusterIdentity info from the foreign cluster. This can be helpful when we add a foreign cluster manually, we have not to retrieve all this info manually (clusterId, clusterName, liqoNamespace) but we can only provide the Auth Url

The old minimal ForeignCluster resource:
```yaml
apiVersion: discovery.liqo.io/v1alpha1
kind: ForeignCluster
metadata:
  name: my-cluster
spec:
  authUrl: https://172.18.0.5:32088
  clusterIdentity:
    clusterID: f039243d-7cc1-49c9-8d9a-50e0bcce4134
    clusterName: LiqoCluster8588
  discoveryType: Manual
  join: false
  namespace: liqo
```

The new minimal ForeingCluster resource:
```yaml
apiVersion: discovery.liqo.io/v1alpha1
kind: ForeignCluster
metadata:
  name: my-cluster
spec:
  authUrl: https://172.18.0.5:32088
```