### PR TITLE
Wireguard package unit tests

### DIFF
--- a/cmd/liqonet/main.go
+++ b/cmd/liqonet/main.go
@@ -23,6 +23,7 @@ import (
 	tunnel_operator "github.com/liqotech/liqo/internal/liqonet/tunnel-operator"
 	"github.com/liqotech/liqo/internal/liqonet/tunnelEndpointCreator"
 	"github.com/liqotech/liqo/pkg/liqonet"
+	"github.com/liqotech/liqo/pkg/liqonet/wireguard"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
@@ -70,7 +71,12 @@ func main() {
 	clientset := kubernetes.NewForConfigOrDie(mgr.GetConfig())
 	switch runAs {
 	case route_operator.OperatorName:
-		r, err := route_operator.NewRouteController(mgr)
+		wgc, err := wireguard.NewWgClient()
+		if err != nil {
+			klog.Errorf("an error occurred while creating wireguard client: %v", err)
+			os.Exit(1)
+		}
+		r, err := route_operator.NewRouteController(mgr, wgc, wireguard.NewNetLinker())
 		if err != nil {
 			klog.Errorf("an error occurred while creating the route operator -> %v", err)
 			os.Exit(1)
@@ -86,7 +92,12 @@ func main() {
 			os.Exit(1)
 		}
 	case tunnel_operator.OperatorName:
-		tc, err := tunnel_operator.NewTunnelController(mgr)
+		wgc, err := wireguard.NewWgClient()
+		if err != nil {
+			klog.Errorf("an error occurred while creating wireguard client: %v", err)
+			os.Exit(1)
+		}
+		tc, err := tunnel_operator.NewTunnelController(mgr, wgc, wireguard.NewNetLinker())
 		if err != nil {
 			klog.Errorf("an error occurred while creating the tunnel controller: %v", err)
 			os.Exit(1)

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/apparentlymart/go-cidr v1.1.0
 	github.com/atotto/clipboard v0.1.2
 	github.com/coreos/go-iptables v0.4.5
-	github.com/cratonica/2goarray v0.0.0-20190331194516-514510793eaa // indirect
 	github.com/gen2brain/beeep v0.0.0-20200526185328-e9c15c258e28
 	github.com/gen2brain/dlgs v0.0.0-20201118155338-03fe7f81ad25
 	github.com/getlantern/systray v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -199,8 +199,6 @@ github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwc
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0 h1:EoUDS0afbrsXAZ9YQ9jdu/mZ2sXgT1/2yyNng4PGlyM=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
-github.com/cratonica/2goarray v0.0.0-20190331194516-514510793eaa h1:Wg+722vs7a2zQH5lR9QWYsVbplKeffaQFIs5FTdfNNo=
-github.com/cratonica/2goarray v0.0.0-20190331194516-514510793eaa/go.mod h1:6Arca19mRx58CA7OWEd7Wu1NpC1rd3uDnNs6s1pj/DI=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/cyphar/filepath-securejoin v0.2.2 h1:jCwT2GTP+PY5nBz3c/YL5PAIbusElVrPujOBSCj8xRg=
 github.com/cyphar/filepath-securejoin v0.2.2/go.mod h1:FpkQEhXnPnOthhzymB7CGsFk2G9VLXONKD9G7QGMM+4=
@@ -1001,8 +999,6 @@ golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975 h1:/Tl7pH94bvbAAHBdZJT947
 golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 h1:psW17arqaxU48Z5kZ0CQnkZWQJsqcURM6tKiBApRjXI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/crypto v0.0.0-20201208171446-5f87f3452ae9 h1:sYNJzB4J8toYPQTM6pAkcmBRgw9SnQKP9oXCHfgy604=
-golang.org/x/crypto v0.0.0-20201208171446-5f87f3452ae9/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad h1:DN0cp81fZ3njFcrLCytUHRSUkqBjfTo4Tx9RJTWs0EY=
 golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/exp v0.0.0-20180321215751-8460e604b9de/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -1090,7 +1086,6 @@ golang.org/x/net v0.0.0-20200520182314-0ba52f642ac2 h1:eDrdRpKgkcCqKZQwyZRyeFZgf
 golang.org/x/net v0.0.0-20200520182314-0ba52f642ac2/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200625001655-4c5254603344 h1:vGXIOMxbNfDTk/aXCmfdLgkrSV+Z2tcbze+pEc3v5W4=
 golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
-golang.org/x/net v0.0.0-20200707034311-ab3426394381/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20201006153459-a7d1128ccaa0 h1:wBouT66WTYFXdxfVdz9sVWARVd/2vfGcmI45D2gj45M=
 golang.org/x/net v0.0.0-20201006153459-a7d1128ccaa0/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
@@ -1184,14 +1179,10 @@ golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201015000850-e3ed0017c211 h1:9UQO31fZ+0aKQOFldThf7BKPMJTiBfWycGh/u3UoO88=
 golang.org/x/sys v0.0.0-20201015000850-e3ed0017c211/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20201207223542-d4d67f95c62d h1:MiWWjyhUzZ+jvhZvloX6ZrUsdEghn8a64Upd8EMHglE=
-golang.org/x/sys v0.0.0-20201207223542-d4d67f95c62d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201223074533-0d417f636930 h1:vRgIt+nup/B/BwIS0g2oC0haq0iqbV3ZA+u6+0TlNCo=
 golang.org/x/sys v0.0.0-20201223074533-0d417f636930/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221 h1:/ZHdbVpdR/jk3g30/d4yUL0JU9kksj8+F/bnQUVLGDM=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
-golang.org/x/term v0.0.0-20201207232118-ee85cb95a76b h1:a0ErnNnPKmhDyIXQvdZr+Lq8dc8xpMeqkF8y5PgQU4Q=
-golang.org/x/term v0.0.0-20201207232118-ee85cb95a76b/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20201210144234-2321bbc49cbf h1:MZ2shdL+ZM/XzY3ZGOnh4Nlpnxz5GSOhOmtHo3iPU6M=
 golang.org/x/term v0.0.0-20201210144234-2321bbc49cbf/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -1462,7 +1453,6 @@ k8s.io/kube-scheduler v0.18.6/go.mod h1:J+GApeR/QkU6eYonXir0i7+rcUVWzZPZbNHqjq4F
 k8s.io/kubectl v0.18.6 h1:IFPNuLPkZ59vSGQzynXY8XGz9yuOSRpkJupnobdYvO4=
 k8s.io/kubectl v0.18.6/go.mod h1:3TLzFOrF9h4mlRPAvdNkDbs5NWspN4e0EnPnEB41CGo=
 k8s.io/kubelet v0.18.6/go.mod h1:5e0PJYialWMWZgsYWJqI6zVW58y+MaQvmOQwEGFF4Xc=
-k8s.io/kubelet v0.19.1/go.mod h1:FJBxOTBiFjE3KM+0gdPpZeiaKX8lrsb6fTlyBGqPWgs=
 k8s.io/kubernetes v1.18.6 h1:2rkR3ffvd5YVyPYU4LAUDCKoKQZtjuuj8ga15mbv96o=
 k8s.io/kubernetes v1.18.6/go.mod h1:Efg82S+Ti02A/Mww53bxroc7IgzX2bgPsf6hT8gAs3M=
 k8s.io/legacy-cloud-providers v0.18.6/go.mod h1:0bU6t0dTOd0YkcByIdjx7WD4ihApa+aUrTgVJpqciZU=

--- a/internal/liqonet/route-operator/route-operator.go
+++ b/internal/liqonet/route-operator/route-operator.go
@@ -57,7 +57,7 @@ type RouteController struct {
 	DynClient dynamic.Interface
 }
 
-func NewRouteController(mgr ctrl.Manager) (*RouteController, error) {
+func NewRouteController(mgr ctrl.Manager, wgc wireguard.Client, nl wireguard.Netlinker) (*RouteController, error) {
 	dynClient := dynamic.NewForConfigOrDie(mgr.GetConfig())
 	clientSet := kubernetes.NewForConfigOrDie(mgr.GetConfig())
 	//get node name
@@ -77,7 +77,7 @@ func NewRouteController(mgr ctrl.Manager) (*RouteController, error) {
 		return nil, err
 	}
 	overlayIP := strings.Join([]string{overlay.GetOverlayIP(podIP.String()), "4"}, "/")
-	wg, err := overlay.CreateInterface(nodeName, namespace, overlayIP, clientSet)
+	wg, err := overlay.CreateInterface(nodeName, namespace, overlayIP, clientSet, wgc, nl)
 	if err != nil {
 		klog.Errorf("unable to create the controller: %v", err)
 		return nil, err

--- a/internal/liqonet/tunnel-operator/tunnel-operator.go
+++ b/internal/liqonet/tunnel-operator/tunnel-operator.go
@@ -69,7 +69,7 @@ type TunnelController struct {
 // +kubebuilder:rbac:groups=net.liqo.io,resources=tunnelendpoints/status,verbs=get;update;patch
 
 //Instantiates and initializes the tunnel controller
-func NewTunnelController(mgr ctrl.Manager) (*TunnelController, error) {
+func NewTunnelController(mgr ctrl.Manager, wgc wireguard.Client, nl wireguard.Netlinker) (*TunnelController, error) {
 	clientSet := k8s.NewForConfigOrDie(mgr.GetConfig())
 	namespace, err := utils.GetPodNamespace()
 	if err != nil {
@@ -81,7 +81,7 @@ func NewTunnelController(mgr ctrl.Manager) (*TunnelController, error) {
 	}
 	overlayIP := strings.Join([]string{overlay.GetOverlayIP(podIP.String()), "4"}, "/")
 	//create overlay network interface
-	wg, err := overlay.CreateInterface(gatewayPodName, namespace, overlayIP, clientSet)
+	wg, err := overlay.CreateInterface(gatewayPodName, namespace, overlayIP, clientSet, wgc, nl)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/liqonet/overlay/overlay.go
+++ b/pkg/liqonet/overlay/overlay.go
@@ -19,7 +19,7 @@ var (
 	wgMtu  = 1300
 )
 
-func CreateInterface(nodeName, namespace, ipAddr string, c *k8s.Clientset) (*wireguard.Wireguard, error) {
+func CreateInterface(nodeName, namespace, ipAddr string, c *k8s.Clientset, wgc wireguard.Client, nl wireguard.Netlinker) (*wireguard.Wireguard, error) {
 	secretName := strings.Join([]string{secretPrefix, nodeName}, "")
 	priv, pub, err := wireguard.GetKeys(secretName, namespace, c)
 	if err != nil {
@@ -33,7 +33,7 @@ func CreateInterface(nodeName, namespace, ipAddr string, c *k8s.Clientset) (*wir
 		PriKey:    &priv,
 		PubKey:    &pub,
 	}
-	wg, err := wireguard.NewWireguard(wgConfig)
+	wg, err := wireguard.NewWireguard(wgConfig, wgc, nl)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/liqonet/wireguard/netlinkClient.go
+++ b/pkg/liqonet/wireguard/netlinkClient.go
@@ -1,0 +1,102 @@
+package wireguard
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
+	"k8s.io/klog/v2"
+	"os/exec"
+)
+
+const (
+	wgLinkType = "wireguard"
+)
+
+type Netlinker interface {
+	getLinkIndex() int
+	createLink(linkName string) error
+	getLinkName() string
+	addIP(ipAddr string) error
+	setMTU(mtu int) error
+}
+
+type netlinkDevice struct {
+	link netlink.Link
+}
+
+func NewNetLinker() Netlinker {
+	return &netlinkDevice{link: nil}
+}
+
+func (nld *netlinkDevice) createLink(linkName string) error {
+	var err error
+	if link, err := netlink.LinkByName(linkName); err == nil {
+		// delete existing device
+		if err := netlink.LinkDel(link); err != nil {
+			return fmt.Errorf("failed to delete existing wireguard device '%s': %v", linkName, err)
+		}
+	}
+	// create the wg device (ip link add dev $DefaultlinkName type wireguard)
+	la := netlink.NewLinkAttrs()
+	la.Name = linkName
+	link := &netlink.GenericLink{
+		LinkAttrs: la,
+		LinkType:  wgLinkType,
+	}
+	if err = netlink.LinkAdd(link); err != nil && err != unix.EOPNOTSUPP {
+		return fmt.Errorf("failed to add wireguard device '%s': %v", linkName, err)
+	}
+	if err == unix.EOPNOTSUPP {
+		klog.Warningf("wireguard kernel module not present, falling back to the userspace implementation")
+		cmd := exec.Command("/usr/bin/boringtun", linkName, "--disable-drop-privileges", "true")
+		var stdout, stderr bytes.Buffer
+		cmd.Stdout = &stdout
+		cmd.Stderr = &stderr
+		err = cmd.Run()
+		if err != nil {
+			outStr, errStr := stdout.String(), stderr.String()
+			fmt.Printf("out:\n%s\nerr:\n%s\n", outStr, errStr)
+			return fmt.Errorf("failed to add wireguard devices '%s': %v", linkName, err)
+		}
+		if nld.link, err = netlink.LinkByName(linkName); err != nil {
+			return fmt.Errorf("failed to get wireguard device '%s': %v", linkName, err)
+		}
+	}
+	nld.link = link
+	// ip link set $w.getName up
+	if err := netlink.LinkSetUp(nld.link); err != nil {
+		return fmt.Errorf("failed to bring up wireguard device '%s': %v", linkName, err)
+	}
+	return nil
+}
+
+//adds the ip address to the interface
+//ip address in cidr notation: x.x.x.x/x
+func (nld *netlinkDevice) addIP(ipAddr string) error {
+	ipNet, err := netlink.ParseIPNet(ipAddr)
+	if err != nil {
+		return err
+	}
+	err = netlink.AddrAdd(nld.link, &netlink.Addr{IPNet: ipNet})
+	if err != nil {
+		return fmt.Errorf("failed to add ip address %s to interface %s: %v", ipAddr, nld.link.Attrs().Name, err)
+	}
+	return nil
+}
+
+func (nld *netlinkDevice) setMTU(mtu int) error {
+	if err := netlink.LinkSetMTU(nld.link, mtu); err != nil {
+		return fmt.Errorf("failed to set mtu on interface %s: %v", nld.link.Attrs().Name, err)
+	}
+	return nil
+}
+
+// get link index of the wireguard device
+func (nld *netlinkDevice) getLinkIndex() int {
+	return nld.link.Attrs().Index
+}
+
+func (nld *netlinkDevice) getLinkName() string {
+	return nld.link.Attrs().Name
+}

--- a/pkg/liqonet/wireguard/netlinkClient_fake.go
+++ b/pkg/liqonet/wireguard/netlinkClient_fake.go
@@ -1,0 +1,70 @@
+package wireguard
+
+import (
+	"fmt"
+	"github.com/vishvananda/netlink"
+	"net"
+)
+
+type netlinkDeviceFake struct {
+	link          netlink.Link
+	ip            net.IPNet
+	mtu           int
+	errorOnCreate bool
+	errorOnAddIP  bool
+	errorOnSetMTU bool
+}
+
+func NewNetLinkerFake(errOnCreate, errOnAddIP, errOnSetMtu bool) Netlinker {
+	return &netlinkDeviceFake{link: nil,
+		errorOnCreate: errOnCreate,
+		errorOnAddIP:  errOnAddIP,
+		errorOnSetMTU: errOnSetMtu,
+	}
+}
+
+func (nld *netlinkDeviceFake) createLink(linkName string) error {
+	// create the wg device (ip link add dev $DefaultlinkName type wireguard)
+	la := netlink.NewLinkAttrs()
+	la.Name = linkName
+	la.Index = 123
+	nld.link = &netlink.GenericLink{
+		LinkAttrs: la,
+		LinkType:  wgLinkType,
+	}
+	if nld.errorOnCreate {
+		return fmt.Errorf("error generated for testing purpose")
+	}
+	return nil
+}
+
+//adds the ip address to the interface
+//ip address in cidr notation: x.x.x.x/x
+func (nld *netlinkDeviceFake) addIP(ipAddr string) error {
+	ip, err := netlink.ParseIPNet(ipAddr)
+	nld.ip = *ip
+	if err != nil {
+		return err
+	}
+	if nld.errorOnAddIP {
+		return fmt.Errorf("error generated for testing purposes")
+	}
+	return nil
+}
+
+func (nld *netlinkDeviceFake) setMTU(mtu int) error {
+	nld.mtu = mtu
+	if nld.errorOnSetMTU {
+		return fmt.Errorf("error generated for testing purposes")
+	}
+	return nil
+}
+
+// get link index of the wireguard device
+func (nld *netlinkDeviceFake) getLinkIndex() int {
+	return nld.link.Attrs().Index
+}
+
+func (nld *netlinkDeviceFake) getLinkName() string {
+	return nld.link.Attrs().Name
+}

--- a/pkg/liqonet/wireguard/utils.go
+++ b/pkg/liqonet/wireguard/utils.go
@@ -11,7 +11,7 @@ import (
 	k8s "k8s.io/client-go/kubernetes"
 )
 
-func GetKeys(secretName, namespace string, c *k8s.Clientset) (priv, pub wgtypes.Key, err error) {
+func GetKeys(secretName, namespace string, c k8s.Interface) (priv, pub wgtypes.Key, err error) {
 	//first we check if a secret containing valid keys already exists
 	s, err := c.CoreV1().Secrets(namespace).Get(context.Background(), secretName, metav1.GetOptions{})
 	if err != nil && !apierrors.IsNotFound(err) {

--- a/pkg/liqonet/wireguard/wireguardClient.go
+++ b/pkg/liqonet/wireguard/wireguardClient.go
@@ -1,0 +1,40 @@
+package wireguard
+
+import (
+	"fmt"
+	"golang.zx2c4.com/wireguard/wgctrl"
+	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
+)
+
+//a simple interface that implements some of the methods of wgctrl.Client interface.
+//a fake implementation is used for the unit tests
+type Client interface {
+	configureDevice(name string, cfg wgtypes.Config) error
+	device(name string) (*wgtypes.Device, error)
+	close() error
+}
+
+type wgClient struct {
+	c *wgctrl.Client
+}
+
+func NewWgClient() (*wgClient, error) {
+	var c *wgctrl.Client
+	var err error
+	if c, err = wgctrl.New(); err != nil {
+		return nil, fmt.Errorf("unable to create wireguard client: %v", err)
+	}
+	return &wgClient{c}, nil
+}
+
+func (wgc *wgClient) configureDevice(name string, cfg wgtypes.Config) error {
+	return wgc.c.ConfigureDevice(name, cfg)
+}
+
+func (wgc *wgClient) device(name string) (*wgtypes.Device, error) {
+	return wgc.c.Device(name)
+}
+
+func (wgc *wgClient) close() error {
+	return wgc.c.Close()
+}

--- a/pkg/liqonet/wireguard/wireguardClient_fake.go
+++ b/pkg/liqonet/wireguard/wireguardClient_fake.go
@@ -1,0 +1,55 @@
+package wireguard
+
+import (
+	"github.com/liqotech/liqo/internal/utils/errdefs"
+	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
+	"time"
+)
+
+type wgClientFake struct {
+	dev wgtypes.Device
+}
+
+func NewWgClientFake(deviceName string) (*wgClientFake, error) {
+	return &wgClientFake{wgtypes.Device{Name: deviceName}}, nil
+}
+
+func (wgc *wgClientFake) configureDevice(name string, cfg wgtypes.Config) error {
+	if wgc.dev.Name != name {
+		return errdefs.NotFoundf("device named %s not found", name)
+	}
+	for _, peer := range cfg.Peers {
+		if !peer.Remove {
+			wgc.dev.Peers = append(wgc.dev.Peers, wgtypes.Peer{
+				PublicKey:                   peer.PublicKey,
+				Endpoint:                    peer.Endpoint,
+				PersistentKeepaliveInterval: *peer.PersistentKeepaliveInterval,
+				LastHandshakeTime:           time.Time{},
+				ReceiveBytes:                0,
+				TransmitBytes:               0,
+				AllowedIPs:                  peer.AllowedIPs,
+				ProtocolVersion:             0,
+			})
+			return nil
+		}
+		for i, p := range wgc.dev.Peers {
+			if peer.PublicKey == p.PublicKey {
+				wgc.dev.Peers[i] = wgc.dev.Peers[len(wgc.dev.Peers)-1]
+				wgc.dev.Peers = wgc.dev.Peers[:len(wgc.dev.Peers)-1]
+			}
+		}
+	}
+	return nil
+}
+
+func (wgc *wgClientFake) device(name string) (*wgtypes.Device, error) {
+
+	if wgc.dev.Name != name {
+		return nil, errdefs.NotFoundf("device named %s not found", name)
+	}
+	return &wgc.dev, nil
+}
+
+func (wgc *wgClientFake) close() error {
+	return nil
+}

--- a/pkg/liqonet/wireguard/wireguard_suite_test.go
+++ b/pkg/liqonet/wireguard/wireguard_suite_test.go
@@ -1,0 +1,41 @@
+package wireguard_test
+
+import (
+	"github.com/liqotech/liqo/pkg/liqonet/wireguard"
+	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var (
+	ka     = 1 * time.Second
+	mtu    = 1350
+	port   = 51194
+	ipAddr = "10.1.1.1/24"
+
+	pubKey   wgtypes.Key
+	devName  = "test-device"
+	wgConfig wireguard.WgConfig
+)
+
+func TestWireguard(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Wireguard Suite")
+}
+
+var _ = BeforeSuite(func() {
+	priKey, err := wgtypes.GeneratePrivateKey()
+	Expect(err).NotTo(HaveOccurred())
+	pubKey = priKey.PublicKey()
+	wgConfig = wireguard.WgConfig{
+		Name:      devName,
+		IPAddress: ipAddr,
+		Mtu:       mtu,
+		Port:      &port,
+		PriKey:    &priKey,
+		PubKey:    &pubKey,
+	}
+})

--- a/pkg/liqonet/wireguard/wireguard_test.go
+++ b/pkg/liqonet/wireguard/wireguard_test.go
@@ -1,0 +1,135 @@
+package wireguard_test
+
+import (
+	"github.com/liqotech/liqo/pkg/liqonet/wireguard"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	"time"
+)
+
+var _ = Describe("Wireguard", func() {
+	type peerConfig struct {
+		pubKey        string
+		endpointIP    string
+		listeningPort string
+		allowedIPs    []string
+		keepAlive     *time.Duration
+	}
+	var (
+		wg            *wireguard.Wireguard
+		errorVerified bool
+		correctConfig = peerConfig{
+			pubKey:        pubKey.String(),
+			endpointIP:    "10.0.0.0",
+			listeningPort: "12345",
+			allowedIPs:    []string{"10.1.0.0/24", "10.2.0.0/24"},
+			keepAlive:     &ka,
+		}
+	)
+	BeforeEach(func() {
+		var err error
+		c, _ := wireguard.NewWgClientFake(devName)
+		n := wireguard.NewNetLinkerFake(false, false, false)
+		wg, err = wireguard.NewWireguard(wgConfig, c, n)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	DescribeTable("Adding wireguard peer", func(configFunc func() peerConfig, expectedBool bool) {
+		c := configFunc()
+		err := wg.AddPeer(c.pubKey, c.endpointIP, c.listeningPort, c.allowedIPs, c.keepAlive)
+		if err != nil {
+			errorVerified = true
+		} else {
+			errorVerified = false
+		}
+
+		Expect(errorVerified).Should(Equal(expectedBool))
+	},
+		Entry("wrong endpoint IP format", func() peerConfig { c := correctConfig; c.endpointIP = "192.168.1.555"; return c }, true),
+		Entry("wrong public key", func() peerConfig { c := correctConfig; c.pubKey = "s"; return c }, true),
+		Entry("wrong port number", func() peerConfig { c := correctConfig; c.listeningPort = "L3333"; return c }, true),
+		Entry("wrong allowed IPs format", func() peerConfig { c := correctConfig; c.allowedIPs = append(c.allowedIPs, "10.1.1.1"); return c }, true),
+		Entry("right configuration for peer", func() peerConfig { return correctConfig }, false),
+		Entry("peer exists but with different configuration", func() peerConfig {
+			c := correctConfig
+			err := wg.AddPeer(c.pubKey, c.endpointIP, c.listeningPort, c.allowedIPs, c.keepAlive)
+			Expect(err).NotTo(HaveOccurred())
+			c.listeningPort = "1111"
+			return c
+		}, false),
+	)
+
+	DescribeTable("Removing wireguard peer", func(pubKey string, expectedBool bool) {
+		err := wg.AddPeer(correctConfig.pubKey, correctConfig.endpointIP, correctConfig.listeningPort, correctConfig.allowedIPs, correctConfig.keepAlive)
+		Expect(err).NotTo(HaveOccurred())
+		err = wg.RemovePeer(pubKey)
+		if err != nil {
+			errorVerified = true
+		} else {
+			errorVerified = false
+		}
+
+		Expect(errorVerified).Should(Equal(expectedBool))
+	},
+		Entry("peer exists", pubKey.String(), false),
+		//if the peer does not exist wgctrl.client does not return an error
+		Entry("peer does not exist", "14TNJjZxo6MM1RiAxA93BYljs46orAjxhXCzlLIZkU8=", false),
+		Entry("wrong public key format", "94TNJjZxo6MM1RiAx", true),
+	)
+
+	It("Getting device name", func() {
+		dn := wg.GetDeviceName()
+		Expect(dn).Should(Equal(devName))
+	})
+
+	It("Getting link index", func() {
+		li := wg.GetLinkIndex()
+		Expect(li).Should(Equal(123))
+	})
+
+	It("Getting device public key", func() {
+		pbk := wg.GetPubKey()
+		Expect(pbk).Should(Equal(pubKey.String()))
+	})
+})
+
+var _ = Describe("Wireguard newWireguard functions", func() {
+
+	var wgClient wireguard.Client
+
+	BeforeEach(func() {
+		wgClient, _ = wireguard.NewWgClientFake(devName)
+	})
+
+	DescribeTable("Creating new wireguard device", func(testFunc func() bool, expectedBool bool) {
+		outcome := testFunc()
+		Expect(outcome).Should(Equal(expectedBool))
+	},
+		Entry("Correctly creating a wireguard instance", func() bool {
+			n := wireguard.NewNetLinkerFake(false, false, false)
+			_, err := wireguard.NewWireguard(wgConfig, wgClient, n)
+			Expect(err).NotTo(HaveOccurred())
+			return false
+		}, false),
+		Entry("Error while creating wireguard instance", func() bool {
+			n := wireguard.NewNetLinkerFake(true, false, false)
+			_, err := wireguard.NewWireguard(wgConfig, wgClient, n)
+			Expect(err).To(HaveOccurred())
+			return true
+		}, true),
+		Entry("Error while adding IP address to wireguard device", func() bool {
+			n := wireguard.NewNetLinkerFake(false, true, false)
+			_, err := wireguard.NewWireguard(wgConfig, wgClient, n)
+			Expect(err).To(HaveOccurred())
+			return true
+		}, true),
+		Entry("Error while setting mtu to wireguard device", func() bool {
+			n := wireguard.NewNetLinkerFake(false, false, true)
+			_, err := wireguard.NewWireguard(wgConfig, wgClient, n)
+			Expect(err).To(HaveOccurred())
+			return true
+		}, true),
+	)
+
+})


### PR DESCRIPTION
# Description

The wireguard package exports a set of functions that allows to create and configure network interfaces of type wireguard.
This PR adds wrapper interfaces  for _wgctrl.Client interface_ and _netlink package_ in order to easily mock them. And it implements a mock version of these interfaces along the unit tests for the wireguard package.


# How Has This Been Tested?
Unit tests for the wireguard package.
