### PR TITLE
generic NotifyChannel for events about peers

### DIFF
--- a/internal/tray-agent/agent/client/advertisementController.go
+++ b/internal/tray-agent/agent/client/advertisementController.go
@@ -1,9 +1,7 @@
 package client
 
 import (
-	"fmt"
 	advertisementApi "github.com/liqotech/liqo/apis/sharing/v1alpha1"
-	"strings"
 )
 
 //createAdvertisementController creates a new CRDController for the Liqo Advertisement CRD.
@@ -17,26 +15,4 @@ func createAdvertisementController(kubeconfig string) (*CRDController, error) {
 	controller.CRDClient = newClient
 	controller.resource = string(CRAdvertisement)
 	return controller, nil
-}
-
-//DescribeAdvertisement provides a textual representation of an Advertisement CR
-//that can be displayed in a MenuNode.
-func DescribeAdvertisement(adv *advertisementApi.Advertisement) string {
-	str := strings.Builder{}
-	prices := adv.Spec.Prices
-	str.WriteString(fmt.Sprintf("• ClusterID: %v\n", adv.Spec.ClusterId))
-	str.WriteString(fmt.Sprintf("\t• STATUS: %v\n", adv.Status.AdvertisementStatus))
-	str.WriteString("\t• Available Resources:\n")
-	str.WriteString(fmt.Sprintf("\t\t- shared cpu = %v ", adv.Spec.ResourceQuota.Hard.Cpu()))
-	if CpuPrice, cFound := prices["cpu"]; cFound {
-		str.WriteString(fmt.Sprintf("[price %v]", CpuPrice.String()))
-	}
-	str.WriteString("\n")
-	str.WriteString(fmt.Sprintf("\t\t-shared memory = %v ", adv.Spec.ResourceQuota.Hard.Memory()))
-	if MemPrice, mFound := prices["memory"]; mFound {
-		str.WriteString(fmt.Sprintf("[price %v]", MemPrice.String()))
-	}
-	str.WriteString("\n")
-	str.WriteString(fmt.Sprintf("\t\t-available pods = %v ", adv.Spec.ResourceQuota.Hard.Pods()))
-	return str.String()
 }

--- a/internal/tray-agent/agent/client/foreignClusterController.go
+++ b/internal/tray-agent/agent/client/foreignClusterController.go
@@ -2,6 +2,8 @@ package client
 
 import (
 	discovery "github.com/liqotech/liqo/apis/discovery/v1alpha1"
+	sharing "github.com/liqotech/liqo/apis/sharing/v1alpha1"
+	discovery2 "github.com/liqotech/liqo/pkg/discovery"
 )
 
 //createForeignClusterController creates a new CRDController for the Liqo ForeignCluster CRD.
@@ -20,55 +22,121 @@ func createForeignClusterController(kubeconfig string) (*CRDController, error) {
 	return controller, nil
 }
 
+//NotifyDataForeignCluster is a NotifyDataGeneric sub-type used to exchange data concerning ForeignClusters events.
+type NotifyDataForeignCluster struct {
+	//Name of the ForeignCluster CR (to enable further its further retrieval).
+	Name        string
+	ClusterID   string
+	ClusterName string
+	//LocalDiscovered identifies whether the peer has been discovered inside the home cluster LAN.
+	LocalDiscovered bool
+	//Trusted identifies whether the ForeignCluster has a valid certificate.
+	Trusted discovery2.TrustMode
+	//AuthStatus determines if the home cluster has been correctly authenticated on the foreign cluster.
+	//This property determines the possibility to perform an outgoing peering.
+	AuthStatus discovery2.AuthStatus
+	//OutPeering contains information about the current status of the outgoing peering towards this foreign cluster.
+	OutPeering struct {
+		//Connected  determines whether the outgoing peering is established and running.
+		Connected bool
+		//CpuQuota is the literal representation of the CPU quota shared by the foreign cluster in the currently
+		//active outgoing peering.
+		CpuQuota string
+		//MemQuota is the literal representation of the CPU quota shared by the foreign cluster in the currently
+		//active outgoing peering.
+		MemQuota string
+	}
+	//InPeering contains information about the current status of the incoming peering from this foreign cluster.
+	InPeering struct {
+		//Connected determines whether the incoming peering is established and running.
+		Connected bool
+	}
+}
+
+//			**** HELPERS ****
+//	The following functions are helpers used to simplify the loading and sharing of information.
+
+//loadPeerInfo loads useful data about the peer represented by a ForeignCluster.
+func (d *NotifyDataForeignCluster) loadPeerInfo(fc *discovery.ForeignCluster) {
+	d.Name = fc.Name
+	d.ClusterID = fc.Spec.ClusterIdentity.ClusterID
+	d.ClusterName = fc.Spec.ClusterIdentity.ClusterName
+	//only distinguish local discovery which may represent useful information
+	if fc.Spec.DiscoveryType == discovery2.LanDiscovery {
+		d.LocalDiscovered = true
+	}
+	d.Trusted = fc.Spec.TrustMode
+	d.AuthStatus = fc.Status.AuthStatus
+}
+
+//loadPeeringInfo loads useful data about peerings established with a ForeignCluster.
+func (d *NotifyDataForeignCluster) loadPeeringInfo(fc *discovery.ForeignCluster) {
+	//OUTGOING PEERING
+	if fc.Status.Outgoing.Joined && fc.Status.Outgoing.AdvertisementStatus == sharing.AdvertisementAccepted {
+		d.OutPeering.Connected = true
+		//try to recover details on shared resources
+		if advCtl := GetAgentController().Controller(CRAdvertisement); advCtl.Running() {
+			if obj, exist, err := advCtl.Store.GetByKey(fc.Status.Outgoing.Advertisement.Name); exist && err == nil {
+				if foreignAdv, ok := obj.(*sharing.Advertisement); ok {
+					quotas := foreignAdv.Spec.ResourceQuota.Hard
+					d.OutPeering.CpuQuota = quotas.Cpu().String()
+					d.OutPeering.MemQuota = quotas.Memory().String()
+				}
+			}
+		}
+	}
+	//INCOMING PEERING
+	if fc.Status.Incoming.Joined && fc.Status.Incoming.AdvertisementStatus == sharing.AdvertisementAccepted {
+		d.InPeering.Connected = true
+	}
+}
+
+//			**** EVENT FUNCTIONS ****
+//	The following functions are the callbacks the ForeignCluster Controller uses to handle the events
+//	of the correspondent cache.
+
 //foreignclusterAddFunc is the ADD event handler for the ForeignCluster CRDController.
 func foreignclusterAddFunc(obj interface{}) {
 	fc := obj.(*discovery.ForeignCluster)
-	agentCtrl.NotifyChannel(ChanPeerAdded) <- fc.Name
-	if outPeeringNew := fc.Status.Outgoing.Joined; outPeeringNew {
-		agentCtrl.NotifyChannel(ChanPeeringOutgoingNew) <- fc.Name
+	/*There are some cases when a just created ForeignCluster already contains information about a peering
+	(pending or accepted), e.g. for a FC discovered due to an incoming peering request or with a peering
+	established before the Agent start.*/
+
+	/*If the ClusterID is not provided, it means that the FC cluster identity is yet to be retrieved
+	from the authN endpoint of the foreign cluster. In this case the "new peer" event is handled when this kind
+	of information is provided.*/
+	if fc.Spec.ClusterIdentity.ClusterID == "" {
+		return
 	}
-	if inPeeringNew := fc.Status.Outgoing.Joined; inPeeringNew {
-		agentCtrl.NotifyChannel(ChanPeeringIncomingNew) <- fc.Name
-	}
+	data := &NotifyDataForeignCluster{}
+	data.loadPeerInfo(fc)
+	data.loadPeeringInfo(fc)
+	agentCtrl.NotifyChannel(ChanPeerAdded) <- data
 }
 
 //foreignclusterUpdateFunc is the UPDATE event handler for the ForeignCluster CRDController.
 func foreignclusterUpdateFunc(oldObj interface{}, newObj interface{}) {
 	fcOld := oldObj.(*discovery.ForeignCluster)
 	fcNew := newObj.(*discovery.ForeignCluster)
-	//currently the handler only monitors updates on cluster information, not
-	//a peering workflow
-	//updates on foreign cluster data
-	if fcNew.Spec.ClusterIdentity.ClusterName != fcOld.Spec.ClusterIdentity.ClusterName {
-		agentCtrl.NotifyChannel(ChanPeerUpdated) <- fcNew.Name
+	if fcNew.Spec.ClusterIdentity.ClusterID == "" {
+		return
 	}
-	//monitor changes os peering operations
-	//outgoing
-	if outPeeringNew, outPeeringOld := fcNew.Status.Outgoing.Joined, fcOld.Status.Outgoing.Joined; outPeeringNew && outPeeringOld != outPeeringNew {
-		//new outgoing peering active
-		agentCtrl.NotifyChannel(ChanPeeringOutgoingNew) <- fcNew.Name
-	} else if outPeeringOld && outPeeringNew != outPeeringOld {
-		//outgoing peering torn down
-		agentCtrl.NotifyChannel(ChanPeeringOutgoingDelete) <- fcNew.Name
+	data := &NotifyDataForeignCluster{}
+	data.loadPeerInfo(fcNew)
+	data.loadPeeringInfo(fcNew)
+	//recover CREATE case when there was no cluster identity available yet and
+	//treat it as a 'peer added' event
+	if fcOld.Spec.ClusterIdentity.ClusterID == "" && fcNew.Spec.ClusterIdentity.ClusterID != "" {
+		agentCtrl.NotifyChannel(ChanPeerAdded) <- data
 	}
-	if inPeeringNew, inPeeringOld := fcNew.Status.Incoming.Joined, fcOld.Status.Incoming.Joined; inPeeringNew && inPeeringOld != inPeeringNew {
-		//new incoming peering active
-		agentCtrl.NotifyChannel(ChanPeeringIncomingNew) <- fcNew.Name
-	} else if inPeeringOld && inPeeringNew != inPeeringOld {
-		//incoming peering torn down
-		agentCtrl.NotifyChannel(ChanPeeringIncomingDelete) <- fcNew.Name
-	}
-
+	agentCtrl.NotifyChannel(ChanPeerUpdated) <- data
 }
 
 //foreignclusterDeleteFunc is the DELETE event handler for the ForeignCluster CRDController.
 func foreignclusterDeleteFunc(obj interface{}) {
 	fc := obj.(*discovery.ForeignCluster)
-	if fc.Status.Outgoing.Joined {
-		agentCtrl.NotifyChannel(ChanPeeringOutgoingDelete) <- fc.Name
-	}
-	if fc.Status.Incoming.Joined {
-		agentCtrl.NotifyChannel(ChanPeeringIncomingDelete) <- fc.Name
-	}
-	agentCtrl.NotifyChannel(ChanPeerDeleted) <- fc.Name
+	data := &NotifyDataForeignCluster{}
+	data.loadPeerInfo(fc)
+	data.loadPeeringInfo(fc)
+	agentCtrl.NotifyChannel(ChanPeerDeleted) <- data
 }

--- a/internal/tray-agent/agent/client/notifyChannels.go
+++ b/internal/tray-agent/agent/client/notifyChannels.go
@@ -14,11 +14,6 @@ const (
 	ChanPeerDeleted
 	//Notification channel id for an update of an available peer.
 	ChanPeerUpdated
-	//todo the following channels will be merged into a single ChanPeering after changing the chan type of NotifyChannels from string to interface{}
-	ChanPeeringOutgoingNew
-	ChanPeeringOutgoingDelete
-	ChanPeeringIncomingNew
-	ChanPeeringIncomingDelete
 )
 
 //notifyChannelNames contains all the registered NotifyChannel managed by the AgentController.
@@ -27,8 +22,4 @@ var notifyChannelNames = []NotifyChannel{
 	ChanPeerAdded,
 	ChanPeerDeleted,
 	ChanPeerUpdated,
-	ChanPeeringOutgoingNew,
-	ChanPeeringOutgoingDelete,
-	ChanPeeringIncomingNew,
-	ChanPeeringIncomingDelete,
 }

--- a/internal/tray-agent/agent/logic/logic_test.go
+++ b/internal/tray-agent/agent/logic/logic_test.go
@@ -46,16 +46,6 @@ func TestOnReady(t *testing.T) {
 	assert.True(t, exist, "Listener for NotifyChanType ChanPeerUpdated not registered")
 	_, exist = i.Listener(client.ChanPeerDeleted)
 	assert.True(t, exist, "Listener for NotifyChanType ChanPeerDeleted not registered")
-
-	// test peerings Listeners
-	_, exist = i.Listener(client.ChanPeeringIncomingNew)
-	assert.True(t, exist, "Listener for NotifyChanType ChanPeeringIncomingNew not registered")
-	_, exist = i.Listener(client.ChanPeeringOutgoingNew)
-	assert.True(t, exist, "Listener for NotifyChanType ChanPeeringOutgoingNew not registered")
-	_, exist = i.Listener(client.ChanPeeringIncomingDelete)
-	assert.True(t, exist, "Listener for NotifyChanType ChanPeeringIncomingDelete not registered")
-	_, exist = i.Listener(client.ChanPeeringOutgoingDelete)
-	assert.True(t, exist, "Listener for NotifyChanType ChanPeeringOutgoingDelete not registered")
 }
 
 func TestPeersListeners(t *testing.T) {
@@ -82,14 +72,9 @@ func TestPeersListeners(t *testing.T) {
 	clusterName2 := "test2"
 	fc1 := test.CreateForeignCluster(clusterID1, clusterName1)
 	fcCtrl := i.AgentCtrl().Controller(client.CRForeignCluster)
-	//peerAddChan := i.AgentCtrl().NotifyChannel(client.ChanPeerAdded)
-	//peerUpdateChan := i.AgentCtrl().NotifyChannel(client.ChanPeerUpdated)
-	//peerDeleteChan := i.AgentCtrl().NotifyChannel(client.ChanPeerDeleted)
 	eventTester.Add(1)
 	err := fcCtrl.Store.Add(fc1)
 	eventTester.Wait()
-	//time.Sleep(time.Second * 3)
-	//peerAddChan <- clusterID1
 	assert.NoError(t, err, "ForeignCluster addition failed")
 
 	assert.True(t, quickNode.IsEnabled(), "peers menu entry should be enabled when 1+ ForeignCluster(s) exist [init phase]")

--- a/internal/tray-agent/agent/logic/managers.go
+++ b/internal/tray-agent/agent/logic/managers.go
@@ -12,7 +12,6 @@ func OnReady() {
 	i := app.GetIndicator()
 	i.RefreshStatus()
 	startListenerPeersList(i)
-	startListenerPeerings(i)
 	startQuickOnOff(i)
 	startQuickChangeMode(i)
 	startQuickDashboard(i)
@@ -88,14 +87,7 @@ func startQuickShowPeers(i *app.Indicator) {
   Since these listeners work on a specific QUICK MenuNode, the associated handlers works only if that QUICK
   is registered in the Indicator.*/
 func startListenerPeersList(i *app.Indicator) {
-	i.Listen(client.ChanPeerAdded, i.AgentCtrl().NotifyChannel(client.ChanPeerAdded), listenNewPeer)
-	i.Listen(client.ChanPeerDeleted, i.AgentCtrl().NotifyChannel(client.ChanPeerDeleted), listenUpdatedPeer)
-	i.Listen(client.ChanPeerUpdated, i.AgentCtrl().NotifyChannel(client.ChanPeerUpdated), listenDeletedPeer)
-}
-
-func startListenerPeerings(i *app.Indicator) {
-	i.Listen(client.ChanPeeringIncomingNew, i.AgentCtrl().NotifyChannel(client.ChanPeeringIncomingNew), listenNewIncomingPeering)
-	i.Listen(client.ChanPeeringIncomingDelete, i.AgentCtrl().NotifyChannel(client.ChanPeeringIncomingDelete), listenDeleteIncomingPeering)
-	i.Listen(client.ChanPeeringOutgoingNew, i.AgentCtrl().NotifyChannel(client.ChanPeeringOutgoingNew), listenNewOutgoingPeering)
-	i.Listen(client.ChanPeeringOutgoingDelete, i.AgentCtrl().NotifyChannel(client.ChanPeeringOutgoingDelete), listenDeleteOutgoingPeering)
+	i.Listen(client.ChanPeerAdded, listenNewPeer)
+	i.Listen(client.ChanPeerUpdated, listenUpdatedPeer)
+	i.Listen(client.ChanPeerDeleted, listenDeletedPeer)
 }

--- a/internal/tray-agent/agent/logic/quickPeerHelpers.go
+++ b/internal/tray-agent/agent/logic/quickPeerHelpers.go
@@ -1,20 +1,57 @@
 package logic
 
 import (
+	"fmt"
+	"github.com/liqotech/liqo/internal/tray-agent/agent/client"
 	app "github.com/liqotech/liqo/internal/tray-agent/app-indicator"
+	discovery2 "github.com/liqotech/liqo/pkg/discovery"
 	"strconv"
 	"strings"
+	"sync"
 )
 
 /*This file contains internal variables and helper functions for the QUICK qPeers in charge of displaying
 discovered peers.*/
 
-// set of frequently used tags inside application logic
+// set of frequently used tags for menu entries regarding peers management
 const (
-	tagStatus   = "status"
-	titlePeers  = "PEERS"
-	tagIncoming = "INCOMING PEERING"
-	tagOutgoing = "OUTGOING PEERING"
+	tagStatus          = "status"
+	tagPeerAuthToken   = "auth"
+	tagPeeringIncoming = "inPeering"
+	tagPeeringOutgoing = "outPeering"
+	tagPeeringCmd      = "cmd"
+)
+
+// set of frequently used title strings for menu entries regarding peers management
+const (
+	titlePeers           = "PEERS"
+	titlePeerAuthToken   = "Insert auth token manually "
+	titlePeeringOutgoing = "OUTGOING PEERING"
+	titlePeeringIncoming = "INCOMING PEERING"
+	titlePeeringCmdStart = "Request peering"
+	titlePeeringCmdStop  = "Stop peering"
+)
+
+// set of frequently used text strings for menu entries regarding peers management
+const (
+	//labelPeerUntrusted is the label used to describe a peer whose certificate for the authn endpoint is trusted
+	//(e.g. self-signed)
+	labelPeerUntrusted = "NO"
+	//labelPeerLAN is the label used in the peers list to indicate a peer has been discovered inside user's LAN.
+	labelPeerLAN = "[LAN]"
+	//labelPeerUnknown is the replacement label used in the peers list when any ClusterName is provided for a peer.
+	labelPeerUnknown = "UNKNOWN"
+	//labelPeerTrusted is the label used to describe a peer whose certificate for the authn endpoint can be trusted
+	labelPeerTrusted = "YES"
+	//labelAuthTokenAccepted is the label used when the Authn Token to perform Peering towards a peer has been accepted.
+	labelAuthTokenAccepted = "ACCEPTED"
+	//labelAuthTokenRefused is the label used when the Authn Token to perform Peering towards a peer has been refused
+	//(wrong or empty token).
+	labelAuthTokenRefused = "REFUSED"
+	//labelAuthTokenPending is the label used when the validation process of the Authn Token towards a peer is still pending.
+	labelAuthTokenPending = "PENDING"
+	//labelResourceQuotaUnavailable is a placeholder text for a shared resource quota.
+	labelResourceQuotaUnavailable = "unavailable"
 )
 
 //refreshPeerCount updates the visual counter of the discovered peers (even not peered).
@@ -30,4 +67,184 @@ func refreshPeerCount(quick *app.MenuNode) {
 	} else {
 		quick.SetIsEnabled(false)
 	}
+}
+
+/*createPeerNode creates an entry in the tray menu peers list for a newly discovered peer.
+Each peer entry has the following structure:
+	- 	peer name
+	1-		STATUS: peer information
+	2-		AUTHN TOKEN MANUAL INSERTION: button to enable manual insertion of the auth token for the foreign cluster if the
+			AuthN request has been refused
+	3-		OUTGOING PEERING: display information and commands for an outgoing peering towards this peer
+	3.1-	START/STOP peering
+	3.2-	PEERING STATUS: details on the active peering (e.g. consumed resources)
+	4-		INCOMING PEERING: display information and commands for an incoming peering from this peer
+	4.1-	STOP PEERING
+*/
+func createPeerNode(peerList *app.MenuNode, data *client.NotifyDataForeignCluster) *app.MenuNode {
+	//create the structure for a single peer
+	peerNode := peerList.UseListChild("", data.ClusterID)
+	//1- STATUS
+	statusNode := peerNode.UseListChild("", tagStatus)
+	statusNode.SetIsEnabled(false)
+	//2- AUTHN TOKEN MANUAL INSERTION
+	insertAuthToken := peerNode.UseListChild(titlePeerAuthToken, tagPeerAuthToken)
+	insertAuthToken.SetIsEnabled(false)
+	//todo further connection of the "insert auth token" entry with a callback
+	//3- OUTGOING PEERING
+	outgoingNode := peerNode.UseListChild(titlePeeringOutgoing, tagPeeringOutgoing)
+	//3.1- START/STOP PEERING
+	outgoingNode.UseListChild(titlePeeringCmdStart, tagPeeringCmd)
+	//todo further connection of the "start/stop peering" entry with a callback
+	//3.2- STATUS
+	outgoingStatus := outgoingNode.UseListChild("", tagStatus)
+	outgoingStatus.SetIsVisible(false)
+	outgoingStatus.SetIsEnabled(false)
+	//4- INCOMING PEERING
+	incomingNode := peerNode.UseListChild(titlePeeringIncoming, tagPeeringIncoming)
+	//4.1- STOP PEERING
+	incomingCmd := incomingNode.UseListChild(titlePeeringCmdStop, tagPeeringCmd)
+	//todo further connection of the "stop peering" entry with a callback
+	//the "stop peering" entry is by default disabled since its callback can be executed only in presence
+	//of an active incoming peering
+	incomingCmd.SetIsEnabled(false)
+	return peerNode
+}
+
+//refreshPeerName refreshes the content of the main menu entry of a peer, displaying:
+//
+//1- The ClusterName of the correspondent ForeignCluster (or a text replacement labelPeerUnknown indicating its name is unknown
+//
+//2- A tag labelPeerLAN indicating whether the peer is located in the same LAN of the home cluster
+func refreshPeerName(peerNode *app.MenuNode, peer *app.PeerInfo, data *client.NotifyDataForeignCluster, wg *sync.WaitGroup) {
+	defer wg.Done()
+	var title []string
+	//- check unknown identity
+	if peer.Unknown {
+		title = append(title, labelPeerUnknown, strconv.Itoa(peer.UnknownId))
+	} else {
+		title = append(title, data.ClusterName)
+	}
+	//check if the cluster is located inside the LAN
+	if data.LocalDiscovered {
+		title = append(title, labelPeerLAN)
+	}
+	peerNode.SetTitle(strings.Join(title, " "))
+}
+
+//refreshPeerStatus refreshes the content of the peer status entry.
+func refreshPeerStatus(peerNode *app.MenuNode, data *client.NotifyDataForeignCluster, wg *sync.WaitGroup) {
+	defer wg.Done()
+	statusNode, present := peerNode.ListChild(tagStatus)
+	content := strings.Builder{}
+	if present {
+		//a) ClusterID
+		content.WriteString(fmt.Sprintf("%s\n", data.ClusterID))
+		//b) TrustMode: identify whether the foreign cluster has a trusted signed certificate
+		var trustMode string
+		switch data.Trusted {
+		case discovery2.TrustModeTrusted:
+			trustMode = labelPeerTrusted
+		case discovery2.TrustModeUntrusted:
+			trustMode = labelPeerUntrusted
+		default:
+			trustMode = labelPeerUnknown
+		}
+		//c) Status of the Authentication process of the Home cluster on the Foreign cluster.
+		content.WriteString(fmt.Sprintf("Trusted: %s\n", trustMode))
+		var authStat string
+		switch data.AuthStatus {
+		case discovery2.AuthStatusAccepted:
+			authStat = labelAuthTokenAccepted
+		case discovery2.AuthStatusEmptyRefused:
+			authStat = labelAuthTokenRefused
+		case discovery2.AuthStatusRefused:
+			authStat = labelAuthTokenRefused
+		default:
+			authStat = labelAuthTokenPending
+		}
+		content.WriteString(fmt.Sprintf("Auth token: %s", authStat))
+	}
+	statusNode.SetTitle(content.String())
+}
+
+//refreshPeerInfo reloads into the tray menu details on identity and status of a specific peer.
+func refreshPeerInfo(peerNode *app.MenuNode, peer *app.PeerInfo, data *client.NotifyDataForeignCluster, wg *sync.WaitGroup) {
+	peerWg := &sync.WaitGroup{}
+	peerWg.Add(2)
+	defer wg.Done()
+	//set content of the NAME entry
+	go refreshPeerName(peerNode, peer, data, peerWg)
+	//set content of the STATUS entry
+	go refreshPeerStatus(peerNode, data, peerWg)
+	peerWg.Wait()
+}
+
+//refreshPeerInfo reloads into the tray menu details on peering status of a specific peer.
+func refreshPeeringInfo(peerNode *app.MenuNode, peer *app.PeerInfo, data *client.NotifyDataForeignCluster, wg *sync.WaitGroup) {
+	defer wg.Done()
+	//outgoing peering
+	outgoingEntry, outPresent := peerNode.ListChild(tagPeeringOutgoing)
+	if outPresent {
+		cmdNode, ok1 := outgoingEntry.ListChild(tagPeeringCmd)
+		statusNode, ok2 := outgoingEntry.ListChild(tagStatus)
+		if peer.OutPeeringConnected {
+			outgoingEntry.SetIsChecked(true)
+			if ok1 {
+				//handle start/stop peering button
+				cmdNode.SetTitle(titlePeeringCmdStop)
+			}
+			if ok2 {
+				//show shared resources in active peering
+				statusNode.SetTitle(describeOutResources(data))
+				statusNode.SetIsVisible(true)
+			}
+		} else {
+			outgoingEntry.SetIsChecked(false)
+			if ok1 {
+				//handle start/stop peering button
+				cmdNode.SetTitle(titlePeeringCmdStart)
+			}
+			if ok2 {
+				//no resource is being shared
+				statusNode.SetIsVisible(false)
+				statusNode.SetTitle("")
+			}
+		}
+	}
+	//incoming peering
+	incomingEntry, inPresent := peerNode.ListChild(tagPeeringIncoming)
+	if inPresent {
+		cmdNode, present := incomingEntry.ListChild(tagPeeringCmd)
+		if peer.InPeeringConnected {
+			incomingEntry.SetIsChecked(true)
+			if present {
+				cmdNode.SetIsEnabled(true)
+			}
+		} else {
+			incomingEntry.SetIsChecked(false)
+			if present {
+				cmdNode.SetIsEnabled(false)
+			}
+		}
+	}
+}
+
+//describeOutResources returns the formatted content of an outgoing peering status,
+//describing the amount of shared resources.
+func describeOutResources(data *client.NotifyDataForeignCluster) string {
+	content := strings.Builder{}
+	content.WriteString("CPU: ")
+	if data.OutPeering.CpuQuota != "" {
+		content.WriteString(data.OutPeering.CpuQuota)
+	} else {
+		content.WriteString(labelResourceQuotaUnavailable)
+	}
+	content.WriteString("\nRAM: ")
+	if data.OutPeering.MemQuota != "" {
+		content.WriteString(data.OutPeering.MemQuota)
+	} else {
+		content.WriteString(labelResourceQuotaUnavailable)
+	}
+	return content.String()
 }

--- a/internal/tray-agent/app-indicator/notify_test.go
+++ b/internal/tray-agent/app-indicator/notify_test.go
@@ -64,10 +64,4 @@ func TestIndicator_NotifyFunctions(t *testing.T) {
 	//test if Indicator icon correctly changes accordingly to each default Notify*() internal config
 	i.NotifyNoConnection()
 	assert.Equal(t, IconLiqoNoConn, i.icon, "NotifyNoConnection: indicator icon not correctly set")
-	i.NotifyNewAdv("")
-	assert.Equal(t, IconLiqoOrange, i.icon, "NotifyNewAdv: indicator icon not correctly set")
-	i.NotifyAcceptedAdv("")
-	assert.Equal(t, IconLiqoGreen, i.icon, "NotifyAcceptedAdv: indicator icon not correctly set")
-	i.NotifyRevokedAdv("")
-	assert.Equal(t, IconLiqoOrange, i.icon, "NotifyRevokedAdv: indicator icon not correctly set")
 }

--- a/internal/tray-agent/app-indicator/status_test.go
+++ b/internal/tray-agent/app-indicator/status_test.go
@@ -24,26 +24,4 @@ func TestStatus(t *testing.T) {
 	assert.Equal(t, StatRunOn, stat.Running(), "running status should be ON")
 	assert.Equal(t, 0, stat.Peerings(PeeringOutgoing))
 	assert.Equal(t, 0, stat.Peerings(PeeringIncoming))
-	//addition of consuming and offering peerings are allowed while
-	//in AUTONOMOUS mode.
-	stat.IncDecPeerings(PeeringOutgoing, true)
-	stat.IncDecPeerings(PeeringIncoming, true)
-	assert.Equal(t, 1, stat.Peerings(PeeringOutgoing), "addition of consuming peer in"+
-		"AUTONOMOUS mode is not allowed")
-	assert.Equal(t, 1, stat.Peerings(PeeringIncoming), "addition of offering peer in"+
-		"AUTONOMOUS mode is not allowed")
-	//test transition to TETHERED mode
-	assert.Errorf(t, stat.SetMode(StatModeTethered), "TETHERED mode should not be allowed with active consuming peerings.")
-	stat.IncDecPeerings(PeeringOutgoing, false)
-	//without active consuming peerings, TETHERED mode is allowed
-	_ = stat.SetMode(StatModeTethered)
-	assert.Equal(t, StatModeTethered, stat.Mode(), "transition to TETHERED should be"+
-		"allowed with matching requirements")
-	assert.True(t, stat.IsTetheredCompliant(), "TETHERED mode requirements not matching")
-	//turning the system off should shut down all active peerings
-	stat.SetRunning(StatRunOff)
-	assert.Equal(t, 0, stat.Peerings(PeeringOutgoing), "there should be no active consuming peerings"+
-		"after turning off the system")
-	assert.Equal(t, 0, stat.Peerings(PeeringIncoming), "there should be no active offering peerings"+
-		"after turning off the system")
 }


### PR DESCRIPTION
# Description

This PR:

- introduces a new level of abstraction to the **NotifyChannel** elements that the *AgentController* (k8s client) uses to send event notifications to the event *Listener*s. The type has been changed from ~~string~~ to *NotifyDataGeneric*, allowing more customization for different kinds of events and CRD handled.
- applies this change to the management of events related to peers and peerings
  1. the *Listeners* receive data about the peers of type **NotifyDataForeignCluster**
  2. the Listener logic uses received data to update the information on discovered peers stored in the **Indicator.Status** component
  3. the Listener logic uses received data and peers data to 
    - refresh the view of the *peers menu* in the tray menu
    - notify the user events related to peerings (de)activation

### improvements

- each peer entry in the tray menu displays:
  - peer name (clusterName if defined, an "UNKNOWN-n" label to distinguish between clusters with not announced clusterName)
  - status box
    - clusterID
    - status of authN procedure
    - trust status of the foreign cluster certificate
  - outgoing peering control panel
    - check if peering active
    - turn on/off peering
    - have a look to the quotas of shared resources
  - incoming peering control panel
    - check if peering active
    - turn off peering (if active)
- customized Notify functions for events related to peerings

# Testing

- update of existing tests
- a new and more complete test suite will be created in a forthcoming PR