### PR TITLE
 BUGFIX - fix inconsistency between the in memory cache and existing vpn connection 

### DIFF
--- a/pkg/liqonet/tunnel/wireguard/driver.go
+++ b/pkg/liqonet/tunnel/wireguard/driver.go
@@ -228,6 +228,7 @@ func (w *wireguard) DisconnectFromEndpoint(tep *netv1alpha1.TunnelEndpoint) erro
 	}
 
 	klog.Infof("Done removing WireGuard peer with clusterID %s", tep.Spec.ClusterID)
+	delete(w.connections, tep.Spec.ClusterID)
 
 	return nil
 }


### PR DESCRIPTION

# Description

For each _tunnelendpoint.net.liqo.io_ (TEP) instance a VPN connection is configured to a remote cluster. **Liqo-gateway operator** caches this connections in memory in order to not fetch this information from the kernel each time it has to process a TEP instance. The _WireGuard driver_ implementation did not remove the cache entry when a TEP instance is deleted causing the operator to not configure the VPN connection once the TEP is recreated.

Fixes #(issue)
#446 
# How Has This Been Tested?

1. Deploy two k8s clusters with kind;
2. Let them peer with each other;
3. Check that a TEP instance has been created on both the clusters;
4. Make sure that TEP instances' status is updated and that the VPN connection has been configured;
5. Try to contact a service from cluster 1 to cluster 2 verifying the network connection between the clusters;
6. Choose one of the two clusters and delete the TEP instance;
7. After the TEP instance is created perform steps: 4 and 5;
8. The network connection between the clusters is correctly configured.

