### PR TITLE
rs cleanup in virtual kubelet unjoin

### DIFF
--- a/pkg/virtualKubelet/apiReflection/controller/reflectorsController.go
+++ b/pkg/virtualKubelet/apiReflection/controller/reflectorsController.go
@@ -96,8 +96,6 @@ func (c *ReflectorsController) startNamespaceReflection(namespace string) {
 		for _, reflector := range c.apiReflectors {
 			reflector.(ri.SpecializedAPIReflector).CleanupNamespace(namespace)
 		}
-
-		c.cacheManager.RemoveNamespace(namespace)
 		c.reflectionGroup.Done()
 	}()
 }


### PR DESCRIPTION
# Description

Upon node unjoin, the Liqo VK ensures that all remote objects are deleted. Due to a bug, ReplicaSets created on the remote were not correctly removed and continued to run indefinitely. This PR fixes this behavior by enforcing the correct RS deletion.
