### PR TITLE
fix agent logic test

### DIFF
--- a/internal/tray-agent/agent/logic/logic_test.go
+++ b/internal/tray-agent/agent/logic/logic_test.go
@@ -56,8 +56,6 @@ func TestOnReady(t *testing.T) {
 	assert.True(t, exist, "Listener for NotifyChanType ChanPeeringIncomingDelete not registered")
 	_, exist = i.Listener(client.ChanPeeringOutgoingDelete)
 	assert.True(t, exist, "Listener for NotifyChanType ChanPeeringOutgoingDelete not registered")
-
-	i.Quit()
 }
 
 func TestPeersListeners(t *testing.T) {
@@ -122,11 +120,9 @@ func TestPeersListeners(t *testing.T) {
 	eventTester.Wait()
 	//time.Sleep(time.Second * 3)
 	assert.NoError(t, err, "ForeignCluster deletion failed")
-	//peerDeleteChan <- clusterID1
 
 	//check peers list back at initial condition
 	endCount := quickNode.ListChildrenLen()
 	assert.Equal(t, 0, endCount, "peers list is not empty when 0 ForeignCluster(s) exist [init phase]")
 	assert.False(t, quickNode.IsEnabled(), "peers menu entry should be disabled when 0 ForeignCluster(s) exist")
-	i.Quit()
 }


### PR DESCRIPTION
# Description

This PR fixes a race condition error that may happen during the test of the Tray Agent **logic**. This is due to the potential destruction of the *Indicator* object by the *DestroyIndicator* function in other tests (and its internal chan) before a Listener goroutine reacts to a correct close of that chan.