### PR TITLE
FIX: liqo-gateway race condition

### DIFF
--- a/internal/liqonet/tunnel-operator/tunnel-operator.go
+++ b/internal/liqonet/tunnel-operator/tunnel-operator.go
@@ -158,6 +158,8 @@ func (tc *TunnelController) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 			}
 			return result, nil
 		}
+		//if object is being deleted and does not have a finalizer we just return
+		return result, nil
 	}
 	con, err := tc.connectToPeer(&endpoint)
 	if err != nil {


### PR DESCRIPTION
# Description
This PR fixes a race condition causing liqo-gateway operator to process a _tunnelendpoints.net.liqo.io_ resource even if it is marked to be deleted.
