### PR TITLE
Fix Advertisements Counter

### DIFF
--- a/internal/advertisement-operator/controller.go
+++ b/internal/advertisement-operator/controller.go
@@ -95,6 +95,12 @@ func (r *AdvertisementReconciler) Reconcile(req ctrl.Request) (ctrl.Result, erro
 		}
 	}
 
+	// if the Advertisement is deleting and it was in accepted state, we have to decrease the counter
+	if r.isDeleting(&adv) && adv.Status.AdvertisementStatus == advtypes.AdvertisementAccepted {
+		r.AcceptedAdvNum--
+		klog.Infof("Currently accepted Advertisements: %v", r.AcceptedAdvNum)
+	}
+
 	// we do that on Advertisement creation
 	err, update := r.UpdateForeignCluster(&adv)
 	if err != nil {
@@ -161,6 +167,11 @@ func (r *AdvertisementReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&advtypes.Advertisement{}).
 		Complete(r)
+}
+
+// checks that the Advertisement is being deleted
+func (r *AdvertisementReconciler) isDeleting(adv *advtypes.Advertisement) bool {
+	return !adv.DeletionTimestamp.IsZero()
 }
 
 // set Advertisement reference in related ForeignCluster


### PR DESCRIPTION
# Description

This pr fixes the counter of currently accepted advertisements. Currently, this counter is increased but never decreased, with these changes the operator intercepts the delete event and, if the advertisement was in the accepted state, decreases the counter.

Fixes #459 

# How Has This Been Tested?

- [x] in a kind cluster trying to peer and unpeer for 6 times
