### PR TITLE
refactoring of agentConfig section of ClusterConfig CRD

### DIFF
--- a/apis/config/v1alpha1/clusterconfig_types.go
+++ b/apis/config/v1alpha1/clusterconfig_types.go
@@ -31,7 +31,11 @@ type ClusterConfigSpec struct {
 	AuthConfig          AuthConfig          `json:"authConfig"`
 	LiqonetConfig       LiqonetConfig       `json:"liqonetConfig"`
 	DispatcherConfig    DispatcherConfig    `json:"dispatcherConfig,omitempty"`
-	//AgentConfig defines the configuration for Liqo Agent.
+	//AgentConfig defines the configuration required by the LiqoAgent app to enable some features on
+	//a Liqo cluster.
+	//
+	//LiqoAgent (https://github.com/liqotech/liqo-agent) is an external desktop application that
+	//allows the user to interact more easily with a Liqo cluster.
 	AgentConfig AgentConfig `json:"agentConfig"`
 }
 
@@ -153,20 +157,14 @@ type DispatcherConfig struct {
 type DashboardConfig struct {
 	// Namespace defines the namespace LiqoDash resources belongs to.
 	Namespace string `json:"namespace"`
-	// Service is the LiqoDash service name.
-	Service string `json:"service"`
-	// ServiceAccount is the LiqoDash serviceAccount name.
-	ServiceAccount string `json:"serviceAccount"`
 	// AppLabel defines the value of the 'app' label. All LiqoDash
 	// related resources are labelled with it.
 	AppLabel string `json:"appLabel"`
-	// Ingress is the LiqoDash ingress name.
-	Ingress string `json:"ingress"`
 }
 
 type AgentConfig struct {
-	// DashboardConfig contains the parameters required for Liqo Agent
-	//to provide access to LiqoDash
+	//DashboardConfig contains the parameters required by LiqoAgent
+	//to provide access to LiqoDash (https://github.com/liqotech/dashboard).
 	DashboardConfig DashboardConfig `json:"dashboardConfig"`
 }
 

--- a/deployments/liqo/crds/config.liqo.io_clusterconfigs.yaml
+++ b/deployments/liqo/crds/config.liqo.io_clusterconfigs.yaml
@@ -137,36 +137,27 @@ spec:
                 - outgoingConfig
                 type: object
               agentConfig:
-                description: AgentConfig defines the configuration for Liqo Agent.
+                description: "AgentConfig defines the configuration required by the
+                  LiqoAgent app to enable some features on a Liqo cluster. \n LiqoAgent
+                  (https://github.com/liqotech/liqo-agent) is an external desktop
+                  application that allows the user to interact more easily with a
+                  Liqo cluster."
                 properties:
                   dashboardConfig:
                     description: DashboardConfig contains the parameters required
-                      for Liqo Agent to provide access to LiqoDash
+                      by LiqoAgent to provide access to LiqoDash (https://github.com/liqotech/dashboard).
                     properties:
                       appLabel:
                         description: AppLabel defines the value of the 'app' label.
                           All LiqoDash related resources are labelled with it.
                         type: string
-                      ingress:
-                        description: Ingress is the LiqoDash ingress name.
-                        type: string
                       namespace:
                         description: Namespace defines the namespace LiqoDash resources
                           belongs to.
                         type: string
-                      service:
-                        description: Service is the LiqoDash service name.
-                        type: string
-                      serviceAccount:
-                        description: ServiceAccount is the LiqoDash serviceAccount
-                          name.
-                        type: string
                     required:
                     - appLabel
-                    - ingress
                     - namespace
-                    - service
-                    - serviceAccount
                     type: object
                 required:
                 - dashboardConfig

--- a/deployments/liqo/templates/clusterconfig.yaml
+++ b/deployments/liqo/templates/clusterconfig.yaml
@@ -17,10 +17,7 @@ spec:
   agentConfig:
     dashboardConfig:
       namespace: {{ .Release.Namespace }}
-      service: {{ .Values.liqodash.agentConfig.service }}
-      serviceAccount: {{ .Values.liqodash.agentConfig.serviceAccount }}
-      ingress: {{ .Values.liqodash.agentConfig.ingress }}
-      appLabel: {{ .Values.liqodash.agentConfig.appLabel }}
+      appLabel: "liqo-dashboard"
   discoveryConfig:
     clusterName: {{ .Values.clusterName}}
     autojoin: true

--- a/deployments/liqo/values.yaml
+++ b/deployments/liqo/values.yaml
@@ -9,8 +9,6 @@ pullPolicy: "IfNotPresent"
 podCIDR: ""
 serviceCIDR: ""
 configmapName: "liqo-configmap"
-dashboard_ingress: ""
-dashboard_version: ""
 apiServer:
   ip: ""
   port: ""
@@ -87,18 +85,6 @@ peeringRequestOperator:
       repository: "liqo/peering-request-operator"
       pullPolicy: "IfNotPresent"
   enabled: true
-
-liqodash:
-  image:
-    repository: "liqo/dashboard"
-    pullPolicy: "IfNotPresent"
-  enabled: true
-  agentConfig:
-    service: "liqo-dashboard"
-    serviceAccount: "liqodash-admin-sa"
-    ingress: "liqo-dashboard-ingress"
-    appLabel: "liqo-dashboard"
-  version: "1.0"
 
 crdReplicator:
   image:


### PR DESCRIPTION
This PR performs a refactoring on the **AgentConfig** section of the *Liqo* *ClusterConfig* CRD.

- removal of unused fields
- removal of default parameters for the AgentConfig from the Liqo Helm chart *.Values* file.
- removal of default parameters for the LiqoDash subchart (already removed).