### PR TITLE
Github Actions: remove legacy step from integration pipeline

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -147,10 +147,6 @@ jobs:
           repository: "${{ needs.configure.outputs.repo-name }}"
           persist-credentials: false
 
-      - name: Get the Liqo version to be released
-        id: version
-        run: echo "version::${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
-
       - name: Get the latest Liqo release
         uses: pozetroninc/github-action-get-latest-release@v0.5.0
         id: last-release


### PR DESCRIPTION
# Description

This PR removes a legacy step from the integration pipeline, which is no longer needed 