### PR TITLE
Release pipeline: update changelog generation 

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -154,18 +154,36 @@ jobs:
           repository: ${{ github.repository }}
 
       - name: Generate the CHANGELOG
-        uses: RiskLedger/generate-changelog@v1.2
+        uses: heinrichreimer/github-changelog-generator-action@v2.2
         id: changelog
         with:
-          from: ${{ steps.last-release.outputs.release }}
-          to: ${{ needs.configure.outputs.commit_ref }}
-        env:
-          GITHUB_AUTH: ${{ secrets.CI_TOKEN }}
-
-      - name: Save the CHANGELOG as a file
-        run: |
-          echo "${{ steps.changelog.outputs.changelog }}" > ./CHANGELOG.md
-          sed -i "1s/.*/## Changes since ${{ needs.configure.outputs.commit_ref }}/" ./CHANGELOG.md
+          token: ${{ secrets.GITHUB_TOKEN }}
+          # Changelog will start from this tag.
+          sinceTag: ${{ steps.last-release.outputs.release }}
+          # Include pull-requests in changelog.
+          pullRequests: true
+          # Include pull requests without labels in changelog.
+          prWoLabels: true
+          # Add author of pull request at the end.
+          author: true
+          # Use GitHub tags instead of Markdown links for the author of an issue or pull-request.
+          usernamesAsGithubLogins: true
+          # Do not include compare link (Full Changelog) between older version and newer version.
+          compareLink: false
+          # Issues with the specified labels will be excluded from changelog.
+          excludeLabels: kind/no-changelog
+          # Define your own set of sections which overrides all default sections.
+          configureSections: '{
+              "breaking": {"labels": ["kind/breaking"], "prefix": "### :boom: Breaking Change"},
+              "feature": {"labels": ["kind/feature","kind/epic"], "prefix": "### :rocket: New Features"},
+              "bug": {"labels": ["kind/bug"], "prefix": "### :bug: Bug Fixes"},
+              "cleanup": {"labels": ["kind/cleanup"], "prefix": "### :broom: Code Refactoring"},
+              "docs": {"labels": ["kind/docs"], "prefix": "### :memo: Documentation"}
+            }'
+          # Do not include issues in the changelog
+          issues: false
+          # Run verbosely
+          verbose: true
 
       - name: Create release
         id: create_release


### PR DESCRIPTION
# Description

This PR updates the GitHub action used to generate the changelog for the release, as the previous one did not work correctly.
Let me know if you like the outcome, otherwise most parameters can be customized. For instance, it is possible to decide not to include all PRs in the changelog but only the ones with specific labels, as well as to include also the issues in the changelog

Here it is an excerpt of the generated changelog with the current settings:

---
# Changelog

## [v0.2alpha1](https://github.com/liqotech/liqo/tree/v0.2alpha1) (2021-02-05)

### :rocket: New Features

- \[Feature\] Pod resiliency [\#380](https://github.com/liqotech/liqo/issues/380)
- \[Feature\] Pod initContainers support [\#335](https://github.com/liqotech/liqo/issues/335)
- \[Feature\] Use custom resources and labels on virtual node [\#334](https://github.com/liqotech/liqo/issues/334)
- \[Feature\] Reflection Improvement [\#299](https://github.com/liqotech/liqo/issues/299)
- \[Feature\] Improve Advertisement Generation [\#245](https://github.com/liqotech/liqo/issues/245)
- \[Epic\] Virtual Kubelet Enhancements [\#170](https://github.com/liqotech/liqo/issues/170)
- Improve pod translation in Liqo virtual kubelet [\#330](https://github.com/liqotech/liqo/pull/330) (@aleoli)

### :bug: Bug Fixes

- \[Bug\] Inter-cluster networking stops working if TEP is manually deleted [\#446](https://github.com/liqotech/liqo/issues/446)
- Github Actions: remove legacy step from integration pipeline [\#472](https://github.com/liqotech/liqo/pull/472) (@giorio94)
-  BUGFIX - fix inconsistency between the in memory cache and existing vpn connection  [\#447](https://github.com/liqotech/liqo/pull/447) (@alacuku)
- Bugfix: crdReplicator now handles correctly namespaced resources [\#389](https://github.com/liqotech/liqo/pull/389) (@alacuku)

### :memo: Documentation

- Aligning the liqo demo namespace with the one used in the documentation [\#410](https://github.com/liqotech/liqo/pull/410) (@frisso)
- kind.sh: use posix comparaison in order to be compatible with zsh [\#403](https://github.com/liqotech/liqo/pull/403) (@vgramer)
- Small docs improvement. [\#400](https://github.com/liqotech/liqo/pull/400) (@frisso)
- Add kubectl installation to sample infrastructure script [\#399](https://github.com/liqotech/liqo/pull/399) (@palexster)
- demo: support other architecture that linux-amd64 [\#390](https://github.com/liqotech/liqo/pull/390) (@vgramer)
- Update new version of the Liqo Logo [\#387](https://github.com/liqotech/liqo/pull/387) (@palexster)
- Southbound driver for vpn backends [\#374](https://github.com/liqotech/liqo/pull/374) (@alacuku)
- change section's title [\#372](https://github.com/liqotech/liqo/pull/372) (@filippoprojetto)
- Documentation Refactoring [\#354](https://github.com/liqotech/liqo/pull/354) (@palexster)
- Add changelog generation for Liqo Releases [\#346](https://github.com/liqotech/liqo/pull/346) (@palexster)
- naming changed in kind.sh [\#345](https://github.com/liqotech/liqo/pull/345) (@mlavacca)
- Cluster creation script [\#343](https://github.com/liqotech/liqo/pull/343) (@mlavacca)
- Add Kind installation to infrastructure script [\#342](https://github.com/liqotech/liqo/pull/342) (@palexster)

**Merged pull requests:**

- Webhook resources update [\#471](https://github.com/liqotech/liqo/pull/471) (@mlavacca)
- refactoring of agentConfig section of ClusterConfig CRD [\#464](https://github.com/liqotech/liqo/pull/464) (@AbakusW)
- fix linter after agent migration [\#463](https://github.com/liqotech/liqo/pull/463) (@AbakusW)
- removal of Liqo Agent components and dependencies for migration [\#462](https://github.com/liqotech/liqo/pull/462) (@AbakusW)
- Adding unit test for utils function in wireguard package [\#461](https://github.com/liqotech/liqo/pull/461) (@alacuku)
- ...

 \* *This Changelog was automatically generated by [github_changelog_generator](https://github.com/github-changelog-generator/github-changelog-generator)*
