### PR TITLE
Auth values refactoring

### DIFF
--- a/deployments/liqo/templates/liqo-auth-deployment.yaml
+++ b/deployments/liqo/templates/liqo-auth-deployment.yaml
@@ -48,7 +48,7 @@ spec:
           - "--resyncSeconds"
           - "30"
           - "--listeningPort"
-          {{- if .Values.auth.ingress.enable }}
+          {{- if not .Values.auth.tls}}
           - "5000"
           {{- else }}
           - "443"
@@ -59,9 +59,9 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            {{- if .Values.apiServer.ip }}
+            {{- if .Values.apiServer.address }}
             - name: APISERVER
-              value: "{{ .Values.apiServer.ip }}"
+              value: "{{ .Values.apiServer.address }}"
             {{- end }}
             {{- if .Values.apiServer.port  }}
             - name: APISERVER_PORT

--- a/deployments/liqo/templates/liqo-auth-ingress.yaml
+++ b/deployments/liqo/templates/liqo-auth-ingress.yaml
@@ -24,7 +24,11 @@ spec:
               service:
                 name: {{ include "liqo.prefixedName" $authConfig }}
                 port:
+                {{- if not .Values.auth.tls}}
                   number: 5000
+                {{- else }}
+                  number: 443
+                {{- end }}
             path: /
             pathType: Prefix
       {{- if .Values.auth.ingress.host }}

--- a/deployments/liqo/templates/liqo-auth-service.yaml
+++ b/deployments/liqo/templates/liqo-auth-service.yaml
@@ -20,7 +20,7 @@ spec:
   ports:
     - name: https
       protocol: TCP
-      {{- if .Values.auth.ingress.enable }}
+      {{- if not .Values.auth.tls }}
       port: 5000
       targetPort: 5000
       {{- else }}

--- a/deployments/liqo/templates/liqo-discovery-deployment.yaml
+++ b/deployments/liqo/templates/liqo-discovery-deployment.yaml
@@ -39,21 +39,21 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            {{- if .Values.apiServer.ip }}
+            {{- if .Values.apiServer.address }}
             - name: APISERVER
-              value: "{{ .Values.apiServer.ip }}"
+              value: "{{ .Values.apiServer.address }}"
             {{- end }}
             {{- if .Values.apiServer.port }}
             - name: APISERVER_PORT
               value: "{{ .Values.apiServer.port }}"
             {{- end }}
-            {{- if .Values.authServer.ip }}
+            {{- if .Values.auth.ingress.host}}
             - name: AUTH_ADDR
-              value: "{{ .Values.authServer.ip }}"
+              value: "{{ .Values.auth.ingress.host }}"
             {{- end }}
-            {{- if .Values.authServer.port }}
+            {{- if .Values.auth.ingress.port }}
             - name: AUTH_SVC_PORT
-              value: "{{ .Values.authServer.port }}"
+              value: "{{ .Values.auth.ingress.port }}"
             {{- end }}
           resources:
             limits:

--- a/deployments/liqo/templates/liqo-peering-request-deployment.yaml
+++ b/deployments/liqo/templates/liqo-peering-request-deployment.yaml
@@ -38,21 +38,21 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            {{- if .Values.apiServer.ip }}
+            {{- if .Values.apiServer.address }}
             - name: APISERVER
-              value: "{{ .Values.apiServer.ip }}"
+              value: "{{ .Values.apiServer.address }}"
             {{- end }}
             {{- if .Values.apiServer.port }}
             - name: APISERVER_PORT
               value: "{{ .Values.apiServer.port }}"
             {{- end }}
-            {{- if .Values.authServer.ip }}
+            {{- if .Values.auth.ingress.host}}
             - name: AUTH_ADDR
-              value: "{{ .Values.authServer.ip }}"
+              value: "{{ .Values.auth.ingress.host }}"
             {{- end }}
-            {{- if .Values.authServer.port }}
+            {{- if .Values.auth.ingress.port }}
             - name: AUTH_SVC_PORT
-              value: "{{ .Values.authServer.port }}"
+              value: "{{ .Values.auth.ingress.port }}"
             {{- end }}
           resources:
             limits:

--- a/deployments/liqo/values.yaml
+++ b/deployments/liqo/values.yaml
@@ -10,13 +10,8 @@ tag: ""
 pullPolicy: "IfNotPresent"
 apiServer:
   # -- remote API server IP address
-  ip: ""
+  address: ""
   # -- remote API server port
-  port: ""
-authServer:
-  # -- remote auth server IP address
-  ip: ""
-  # -- remote auth server port
   port: ""
 
 # -- liqo name override
@@ -74,8 +69,8 @@ networkManager:
   # -- networkManager image repository
   imageName: "liqo/liqonet"
   config:
-    podCIDR: "10.244.0.0/16"
-    serviceCIDR: "10.0.0.0/16"
+    podCIDR: ""
+    serviceCIDR: ""
     reservedSubnets: []
 
 crdReplicator:
@@ -128,11 +123,13 @@ auth:
     type: "NodePort"
     # -- auth service annotations
     annotations: {}
+  tls: true
   ingress:
     # -- auth ingress annotations
     annotations: {}
     enable: false
     host: ""
+    port: ""
     class: ""
   config:
     allowEmptyToken: true


### PR DESCRIPTION
# Description

In this PR, the backend configuration of the authorization server has been moved under the auth module. Besides, a new module regarding the TLS configuration of the auth server has been added, alongside the deletion of the `podCIDR` and `serviceCIDR` default values in the `networkManager` configuration module.