### PR TITLE
docs target added in makefile

### DIFF
--- a/.github/workflows/check-generated-helm-documentation.yml
+++ b/.github/workflows/check-generated-helm-documentation.yml
@@ -64,10 +64,9 @@ jobs:
           body: |
             The Helm README.md appears to be out-of-date.
 
-            Please, fetch the latest version of [helm-docs](https://github.com/norwoodj/helm-docs) and run
+            Please, run
             ```
-            cd deployments/liqo
-            helm-docs -t README.gotmpl
+            make docs
             ```
 
             <details>

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,10 @@ else
 GOBIN=$(shell go env GOBIN)
 endif
 
+#generate helm documentation
+docs: helm-docs
+	$(HELM_DOCS) -t deployments/liqo/README.gotmpl deployments/liqo
+
 gen: generate fmt vet manifests
 
 #run all tests
@@ -78,4 +82,24 @@ ifeq (, $(shell which controller-gen))
 CONTROLLER_GEN=$(GOBIN)/controller-gen
 else
 CONTROLLER_GEN=$(shell which controller-gen)
+endif
+
+helm-docs:
+ifeq (, $(shell which helm-docs))
+	@{ \
+	set -e ;\
+	HELM_DOCS_TMP_DIR=$$(mktemp -d) ;\
+	cd $$HELM_DOCS_TMP_DIR ;\
+	version=1.5.0 ;\
+    arch=x86_64 ;\
+    echo  $$HELM_DOCS_PATH ;\
+    echo https://github.com/norwoodj/helm-docs/releases/download/v$${version}/helm-docs_$${version}_linux_$${arch}.tar.gz ;\
+    curl -LO https://github.com/norwoodj/helm-docs/releases/download/v$${version}/helm-docs_$${version}_linux_$${arch}.tar.gz ;\
+    tar -zxvf helm-docs_$${version}_linux_$${arch}.tar.gz ;\
+    mv helm-docs $(GOBIN)/helm-docs ;\
+	rm -rf $$HELM_DOCS_TMP_DIR ;\
+	}
+HELM_DOCS=$(GOBIN)/helm-docs
+else
+HELM_DOCS=$(shell which helm-docs)
 endif


### PR DESCRIPTION
# Description

This PR adds a documentation target in the makefile that introduces a way to generate the helm documentation through helm-docs.
