### PR TITLE
Add labels with IncomingPeering discovery

### DIFF
--- a/internal/peering-request-operator/foreign-cluster.go
+++ b/internal/peering-request-operator/foreign-cluster.go
@@ -66,6 +66,10 @@ func (r *PeeringRequestReconciler) createForeignCluster(pr *v1alpha1.PeeringRequ
 	fc := &v1alpha1.ForeignCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: pr.Spec.ClusterIdentity.ClusterID,
+			Labels: map[string]string{
+				discovery.DiscoveryTypeLabel: string(discovery.IncomingPeeringDiscovery),
+				discovery.ClusterIdLabel:     pr.Spec.ClusterIdentity.ClusterID,
+			},
 		},
 		Spec: v1alpha1.ForeignClusterSpec{
 			ClusterIdentity: pr.Spec.ClusterIdentity,


### PR DESCRIPTION
# Description

This pr fixes an issue that can cause a long update time for ForeignCluster CR previously discovered with IncomingPeering discovery time.

When these labels were not inserted, the CR was not found listing it by the cluster id.