### PR TITLE
Fixing liqo-gateway permissions for the clusterconfigs

### DIFF
--- a/apis/config/v1alpha1/clusterconfig_types.go
+++ b/apis/config/v1alpha1/clusterconfig_types.go
@@ -139,10 +139,14 @@ type LiqonetConfig struct {
 	//Add here the subnets already used in your environment as a list in CIDR notation (e.g. [10.1.0.0/16, 10.200.1.0/24]).
 	ReservedSubnets []string `json:"reservedSubnets"`
 	//the subnet used by the cluster for the pods, in CIDR notation
+	//at this moment only /16 subnets are supported
+	// +kubebuilder:validation:Pattern="^([0-9]{1,3}.){3}[0-9]{1,3}(/(16))"
 	PodCIDR string `json:"podCIDR"`
 	//the subnet used by the cluster for the services, in CIDR notation
+	// +kubebuilder:validation:Pattern="^([0-9]{1,3}.){3}[0-9]{1,3}(/([0-9]|[1-2][0-9]|3[0-2]))$"
 	ServiceCIDR string `json:"serviceCIDR"`
-	//set this flag to true if you are using GKE with kubenet CNI
+	//set this flag to true if you are using GKE, default value is "false"
+	// +kubebuilder:default=false
 	GKEProvider bool `json:"GKEProvider"`
 }
 

--- a/deployments/liqo/README.md
+++ b/deployments/liqo/README.md
@@ -51,7 +51,7 @@
 | gateway.service.type | string | `"NodePort"` | If you plan to use liqo over the Internet consider to change this field to "LoadBalancer". More generally, if your cluster nodes are not directly reachable by the cluster to whom you are peering then change it to "LoadBalancer" |
 | nameOverride | string | `""` | liqo name override |
 | networkManager.config.GKEProvider | bool | `false` | set this field to true if you are deploying liqo in GKE cluster |
-| networkManager.config.podCIDR | string | `""` | the subnet used by the cluster for the pods, in CIDR notation |
+| networkManager.config.podCIDR | string | `""` | The subnet used by the cluster for the pods, in CIDR notation. At the moment the internal IPAM used by liqo only supports podCIDRs with netmask /16 (255.255.0.0). |
 | networkManager.config.reservedSubnets | list | `[]` | Usually the IPs used for the pods in k8s clusters belong to private subnets. In order to prevent IP conflicting between locally used private subnets in your infrastructure and private subnets belonging to remote clusters you need tell liqo the subnets used in your cluster. E.g if your cluster nodes belong to the 192.168.2.0/24 subnet then you should add that subnet to the reservedSubnets. PodCIDR and serviceCIDR used in the local cluster are automatically added to the reserved list. |
 | networkManager.config.serviceCIDR | string | `""` | the subnet used by the cluster for the services, in CIDR notation |
 | networkManager.imageName | string | `"liqo/liqonet"` | networkManager image repository |

--- a/deployments/liqo/crds/config.liqo.io_clusterconfigs.yaml
+++ b/deployments/liqo/crds/config.liqo.io_clusterconfigs.yaml
@@ -235,12 +235,14 @@ spec:
               liqonetConfig:
                 properties:
                   GKEProvider:
-                    description: set this flag to true if you are using GKE with kubenet
-                      CNI
+                    default: false
+                    description: set this flag to true if you are using GKE, default
+                      value is "false"
                     type: boolean
                   podCIDR:
                     description: the subnet used by the cluster for the pods, in CIDR
-                      notation
+                      notation at this moment only /16 subnets are supported
+                    pattern: ^([0-9]{1,3}.){3}[0-9]{1,3}(/(16))
                     type: string
                   reservedSubnets:
                     description: This field is used by the IPAM embedded in the tunnelEndpointCreator.
@@ -254,6 +256,7 @@ spec:
                   serviceCIDR:
                     description: the subnet used by the cluster for the services,
                       in CIDR notation
+                    pattern: ^([0-9]{1,3}.){3}[0-9]{1,3}(/([0-9]|[1-2][0-9]|3[0-2]))$
                     type: string
                 required:
                 - GKEProvider

--- a/deployments/liqo/files/liqo-gateway-ClusterRole.yaml
+++ b/deployments/liqo/files/liqo-gateway-ClusterRole.yaml
@@ -4,7 +4,11 @@ rules:
   resources:
   - clusterconfigs
   verbs:
+  - create
+  - get
   - list
+  - update
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/deployments/liqo/values.yaml
+++ b/deployments/liqo/values.yaml
@@ -71,7 +71,8 @@ networkManager:
   # -- networkManager image repository
   imageName: "liqo/liqonet"
   config:
-    # -- the subnet used by the cluster for the pods, in CIDR notation
+    # -- The subnet used by the cluster for the pods, in CIDR notation.
+    # At the moment the internal IPAM used by liqo only supports podCIDRs with netmask /16 (255.255.0.0).
     podCIDR: ""
     # -- the subnet used by the cluster for the services, in CIDR notation
     serviceCIDR: ""

--- a/internal/liqonet/tunnel-operator/tunnel-operator.go
+++ b/internal/liqonet/tunnel-operator/tunnel-operator.go
@@ -72,7 +72,7 @@ type TunnelController struct {
 // +kubebuilder:rbac:groups=net.liqo.io,resources=tunnelendpoints,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=net.liqo.io,resources=tunnelendpoints/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=core,resources=events,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=config.liqo.io,resources=clusterconfigs,verbs=list
+// +kubebuilder:rbac:groups=config.liqo.io,resources=clusterconfigs,verbs=get;list;watch;create;update
 //role
 // +kubebuilder:rbac:groups=core,namespace="do-not-care",resources=secrets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,namespace="do-not-care",resources=services,verbs=get;list;watch;update

--- a/test/unit/crdReplicator/env_test.go
+++ b/test/unit/crdReplicator/env_test.go
@@ -211,6 +211,8 @@ func getClusterConfig() *configv1alpha1.ClusterConfig {
 				Ttl:                 30,
 			},
 			LiqonetConfig: configv1alpha1.LiqonetConfig{
+				PodCIDR:         "10.0.0.0/16",
+				ServiceCIDR:     "10.96.0.0/12",
 				ReservedSubnets: []string{"10.0.0.0/16"},
 			},
 			DispatcherConfig: configv1alpha1.DispatcherConfig{ResourcesToReplicate: []configv1alpha1.Resource{{


### PR DESCRIPTION


# Description
This PR adds:

- ` get, watch, create, update` permissions for the `clusterconfigs` resources on the liqo-gateway component;
- regular expressions patterns for the values that can be set for the `podCIDR` and `serviceCIDR` configuration fields in the `clusterconfig` instance