### PR TITLE
print columns for crds

### DIFF
--- a/apis/discovery/v1alpha1/foreigncluster_types.go
+++ b/apis/discovery/v1alpha1/foreigncluster_types.go
@@ -125,6 +125,9 @@ type Incoming struct {
 // +kubebuilder:resource:scope=Cluster
 
 // ForeignCluster is the Schema for the foreignclusters API
+// +kubebuilder:printcolumn:name="Outgoing joined",type=string,JSONPath=`.status.outgoing.joined`
+// +kubebuilder:printcolumn:name="Incoming joined",type=string,JSONPath=`.status.incoming.joined`
+// +kubebuilder:printcolumn:name="Authentication status",type=string,JSONPath=`.status.authStatus`
 type ForeignCluster struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/apis/net/v1alpha1/tunnel_endpoint_types.go
+++ b/apis/net/v1alpha1/tunnel_endpoint_types.go
@@ -74,6 +74,9 @@ const (
 // +kubebuilder:resource:scope=Cluster
 
 // TunnelEndpoint is the Schema for the endpoints API
+// +kubebuilder:printcolumn:name="Endpoint IP",type=string,JSONPath=`.spec.endpointIP`
+// +kubebuilder:printcolumn:name="Backend type",type=string,JSONPath=`.spec.backendType`
+// +kubebuilder:printcolumn:name="Connection status",type=string,JSONPath=`.status.connection.status`
 type TunnelEndpoint struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/deployments/liqo/crds/discovery.liqo.io_foreignclusters.yaml
+++ b/deployments/liqo/crds/discovery.liqo.io_foreignclusters.yaml
@@ -16,7 +16,17 @@ spec:
     singular: foreigncluster
   scope: Cluster
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.outgoing.joined
+      name: Outgoing joined
+      type: string
+    - jsonPath: .status.incoming.joined
+      name: Incoming joined
+      type: string
+    - jsonPath: .status.authStatus
+      name: Authentication status
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: ForeignCluster is the Schema for the foreignclusters API
@@ -423,6 +433,7 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}
 status:
   acceptedNames:
     kind: ""

--- a/deployments/liqo/crds/net.liqo.io_tunnelendpoints.yaml
+++ b/deployments/liqo/crds/net.liqo.io_tunnelendpoints.yaml
@@ -16,7 +16,17 @@ spec:
     singular: tunnelendpoint
   scope: Cluster
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.endpointIP
+      name: Endpoint IP
+      type: string
+    - jsonPath: .spec.backendType
+      name: Backend type
+      type: string
+    - jsonPath: .status.connection.status
+      name: Connection status
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: TunnelEndpoint is the Schema for the endpoints API


### PR DESCRIPTION
# Description
	
I added kubebuilder markers to add more info columns when performing `kubectl get` on `foreignclusters` and `tunnelendpoints`.
Specifically, I added the following columns:
	
### ForeignCluster
- **INJOINED** reflects `status.incoming.joined`
- **OUTJOINED** reflects `status.outgoing.joined`
- **STATUS** reflects `status.authStatus`
	
### TunnelEndpoint
- **ENDPOINTIP** reflects `spec.endpointIP`
- **BACKENDTYPE** reflects `spec.backendType`
- **STATUS** reflects `status.connection.status`
	
Fixes #520 
Fixes #519 
	
# How Has This Been Tested?
	
Being a manifest update only, I did not performed tests in strict sense. I performed `make gen` in order to have the updated manifests inside the `deployment/liqo/crd` folder and then installed the chart. 
