### PR TITLE
Introduce retry logic into "get ClusterID" function 

### DIFF
--- a/cmd/crd-replicator/main.go
+++ b/cmd/crd-replicator/main.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"flag"
+	"os"
+	"time"
+
 	configv1alpha1 "github.com/liqotech/liqo/apis/config/v1alpha1"
 	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
 	"github.com/liqotech/liqo/internal/crdReplicator"
@@ -9,12 +12,12 @@ import (
 	"github.com/liqotech/liqo/pkg/mapperUtils"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/dynamic/dynamicinformer"
 	"k8s.io/client-go/kubernetes"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/klog/v2"
-	"os"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
@@ -50,7 +53,16 @@ func main() {
 		klog.Errorf("namespace env variable not set, please set it in manifest file of the operator")
 		os.Exit(-1)
 	}
-	clusterID, err := util.GetClusterID(k8sClient, clusterIDConfMap, namespaceName)
+
+	// 7 attempts with 30 seconds sleep between one another
+	// for a total of 3 minutes
+	backoff := wait.Backoff{
+		Steps:    7,
+		Duration: 30 * time.Second,
+		Factor:   1.0,
+		Jitter:   0,
+	}
+	clusterID, err := util.GetClusterID(k8sClient, clusterIDConfMap, namespaceName, backoff)
 	if err != nil {
 		klog.Errorf("an error occurred while retrieving the clusterID: %s", err)
 		os.Exit(-1)

--- a/pkg/liqonet/utils_test.go
+++ b/pkg/liqonet/utils_test.go
@@ -1,0 +1,112 @@
+package liqonet_test
+
+import (
+	"context"
+	"time"
+
+	"github.com/liqotech/liqo/pkg/liqonet"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+var _ = Describe("Liqonet", func() {
+
+	Describe("Getting ClusterID info from ConfigMap", func() {
+
+		var (
+			ns             string
+			clusterIDKey   string
+			clusterIDValue string
+			configMapData  map[string]string
+			configMap      corev1.ConfigMap
+			backoff        wait.Backoff
+			clientset      *fake.Clientset
+		)
+
+		BeforeEach(func() {
+			ns = "default"
+			clusterIDKey = "cluster-id"
+			clusterIDValue = "fake-cluster-id"
+			configMapData = make(map[string]string, 1)
+			configMapData[clusterIDKey] = clusterIDValue
+			configMap = corev1.ConfigMap{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "ConfigMap",
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      clusterIDKey,
+					Namespace: ns,
+				},
+				Data: configMapData,
+			}
+
+			// 3 attempts with 3 seconds sleep between one another
+			// for a total of 6 seconds
+			backoff = wait.Backoff{
+				Steps:    3,
+				Duration: 3 * time.Second,
+				Factor:   1.0,
+				Jitter:   0,
+			}
+
+			clientset = fake.NewSimpleClientset()
+		})
+
+		Context("When it has not been created yet", func() {
+			It("should retry more times and eventually fail", func() {
+				start := time.Now()
+				_, err := liqonet.GetClusterID(clientset, clusterIDKey, ns, backoff)
+				end := time.Now()
+				Expect(err).To(HaveOccurred())
+
+				timeout := backoff.Duration * time.Duration(backoff.Factor-1)
+				Expect(end).Should(BeTemporally(">=", start.Add(timeout)))
+			})
+		})
+		Context("When it has been already created", func() {
+			It("should return immediately the clusterID value", func() {
+				_, err := clientset.CoreV1().ConfigMaps(ns).Create(
+					context.TODO(),
+					&configMap,
+					metav1.CreateOptions{},
+				)
+				Expect(err).NotTo(HaveOccurred())
+				start := time.Now()
+				clusterID, err := liqonet.GetClusterID(clientset, clusterIDKey, "default", backoff)
+				end := time.Now()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(clusterID).To(Equal(clusterIDValue))
+
+				Expect(end).Should(BeTemporally("<", start.Add(backoff.Duration)))
+			})
+		})
+		Context("When it has been created during backoff", func() {
+			It("should detect the configmap and return the ClusterID value", func() {
+
+				go func() {
+					time.Sleep(4 * time.Second)
+					_, err := clientset.CoreV1().ConfigMaps(ns).Create(
+						context.TODO(),
+						&configMap,
+						metav1.CreateOptions{},
+					)
+					Expect(err).NotTo(HaveOccurred())
+				}()
+				start := time.Now()
+				clusterID, err := liqonet.GetClusterID(clientset, clusterIDKey, "default", backoff)
+				end := time.Now()
+				Expect(err).NotTo(HaveOccurred())
+
+				minimum_sleep := 2 * backoff.Duration
+				Expect(end).Should(BeTemporally(">=", start.Add(minimum_sleep)))
+				Expect(clusterID).To(Equal(clusterIDValue))
+			})
+		})
+	})
+
+})


### PR DESCRIPTION
# Description

This PR make the `GetClusterID` more reliable in the situation when the ConfigMap it tries to read from has not been created yet.

I reused the retry primitive included in the k8s `client-go` library, in order to be more consistent with the rest of the project. The function wait 30 seconds for 10 times. We could hard-code an opinionated configuration (current implementation) or make configurable by the caller (if useful, maybe not). 

Fixes #521 

## Plan

- [x] Implementation
- [x] Local build
- [x] Preliminary tests on development k8s cluster
- [x] Write test cases
