### PR TITLE
Fix - Garbage Collection

### DIFF
--- a/deployments/liqo/files/liqo-auth-ClusterRole.yaml
+++ b/deployments/liqo/files/liqo-auth-ClusterRole.yaml
@@ -32,6 +32,8 @@ rules:
   verbs:
   - create
   - delete
+  - deletecollection
+  - list
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
@@ -39,4 +41,6 @@ rules:
   verbs:
   - create
   - delete
+  - deletecollection
+  - list
 

--- a/deployments/liqo/files/liqo-auth-Role.yaml
+++ b/deployments/liqo/files/liqo-auth-Role.yaml
@@ -30,6 +30,7 @@ rules:
   - delete
   - get
   - list
+  - patch
   - update
   - watch
 - apiGroups:

--- a/deployments/liqo/files/liqo-auth-Role.yaml
+++ b/deployments/liqo/files/liqo-auth-Role.yaml
@@ -30,6 +30,7 @@ rules:
   - delete
   - get
   - list
+  - update
   - watch
 - apiGroups:
   - rbac.authorization.k8s.io

--- a/install.sh
+++ b/install.sh
@@ -630,6 +630,17 @@ function uninstall_liqodash() {
 	set -e
 }
 
+function purge_liqo_preuninstall() {
+  [ "${PURGE_LIQO}" = true ] || return 0
+
+  # Do not fail in case of errors, to avoid exiting if Liqo had already been (partially) uninstalled
+	set +e
+
+	${KUBECTL} delete serviceaccounts -n "${LIQO_NAMESPACE}" -l "discovery.liqo.io/liqo-managed" 1>/dev/null 2>&1
+
+	set -e
+}
+
 function purge_liqo() {
 	[ "${PURGE_LIQO}" = true ] || return 0
 
@@ -685,6 +696,7 @@ function main() {
 	else
 		uninstall_liqodash
 		unjoin_clusters
+		purge_liqo_preuninstall
 		uninstall_liqo
 		purge_liqo
 		launch_agent_installer --uninstall

--- a/internal/advertisement-operator/controller.go
+++ b/internal/advertisement-operator/controller.go
@@ -18,6 +18,7 @@ package advertisementOperator
 import (
 	"context"
 	goerrors "errors"
+	"fmt"
 	configv1alpha1 "github.com/liqotech/liqo/apis/config/v1alpha1"
 	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
 	advtypes "github.com/liqotech/liqo/apis/sharing/v1alpha1"
@@ -235,7 +236,7 @@ func (r *AdvertisementReconciler) UpdateForeignCluster(adv *advtypes.Advertiseme
 		// add owner reference
 		controller := true
 		adv.OwnerReferences = append(adv.OwnerReferences, metav1.OwnerReference{
-			APIVersion: "discovery.liqo.io/v1",
+			APIVersion: fmt.Sprintf("%s/%s", discoveryv1alpha1.GroupVersion.Group, discoveryv1alpha1.GroupVersion.Version),
 			Kind:       "ForeignCluster",
 			Name:       fc.Name,
 			UID:        fc.UID,

--- a/internal/auth-service/auth-service.go
+++ b/internal/auth-service/auth-service.go
@@ -32,7 +32,7 @@ import (
 //role
 // +kubebuilder:rbac:groups=core,namespace="do-not-care",resources=secrets,verbs=create;update;get;list;watch;delete
 // +kubebuilder:rbac:groups=core,namespace="do-not-care",resources=configmaps,verbs=create;update;get;list;watch;delete
-// +kubebuilder:rbac:groups=core,namespace="do-not-care",resources=serviceaccounts,verbs=get;list;watch;create;delete;update
+// +kubebuilder:rbac:groups=core,namespace="do-not-care",resources=serviceaccounts,verbs=get;list;watch;create;delete;update;patch
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,namespace="do-not-care",resources=roles,verbs=create;delete
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,namespace="do-not-care",resources=rolebindings,verbs=create;delete
 

--- a/internal/auth-service/clusterRole.go
+++ b/internal/auth-service/clusterRole.go
@@ -3,6 +3,7 @@ package auth_service
 import (
 	"context"
 	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
+	"github.com/liqotech/liqo/pkg/discovery"
 	v1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -19,6 +20,10 @@ func (authService *AuthServiceCtrl) createClusterRole(remoteClusterId string, sa
 					Name:       sa.Name,
 					UID:        sa.UID,
 				},
+			},
+			Labels: map[string]string{
+				discovery.LiqoManagedLabel: "true",
+				discovery.ClusterIdLabel:   remoteClusterId,
 			},
 		},
 		Rules: []rbacv1.PolicyRule{

--- a/internal/auth-service/clusterRole.go
+++ b/internal/auth-service/clusterRole.go
@@ -13,14 +13,6 @@ func (authService *AuthServiceCtrl) createClusterRole(remoteClusterId string, sa
 	role := &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: sa.Name,
-			OwnerReferences: []metav1.OwnerReference{
-				{
-					APIVersion: "v1",
-					Kind:       "ServiceAccount",
-					Name:       sa.Name,
-					UID:        sa.UID,
-				},
-			},
 			Labels: map[string]string{
 				discovery.LiqoManagedLabel: "true",
 				discovery.ClusterIdLabel:   remoteClusterId,

--- a/internal/auth-service/clusterRoleBinding.go
+++ b/internal/auth-service/clusterRoleBinding.go
@@ -12,14 +12,6 @@ func (authService *AuthServiceCtrl) createClusterRoleBinding(sa *v1.ServiceAccou
 	rb := &rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: sa.Name,
-			OwnerReferences: []metav1.OwnerReference{
-				{
-					APIVersion: "v1",
-					Kind:       "ServiceAccount",
-					Name:       sa.Name,
-					UID:        sa.UID,
-				},
-			},
 			Labels: map[string]string{
 				discovery.LiqoManagedLabel: "true",
 				discovery.ClusterIdLabel:   remoteClusterId,

--- a/internal/auth-service/clusterRoleBinding.go
+++ b/internal/auth-service/clusterRoleBinding.go
@@ -2,12 +2,13 @@ package auth_service
 
 import (
 	"context"
+	"github.com/liqotech/liqo/pkg/discovery"
 	v1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func (authService *AuthServiceCtrl) createClusterRoleBinding(sa *v1.ServiceAccount, clusterRole *rbacv1.ClusterRole) (*rbacv1.ClusterRoleBinding, error) {
+func (authService *AuthServiceCtrl) createClusterRoleBinding(sa *v1.ServiceAccount, clusterRole *rbacv1.ClusterRole, remoteClusterId string) (*rbacv1.ClusterRoleBinding, error) {
 	rb := &rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: sa.Name,
@@ -18,6 +19,10 @@ func (authService *AuthServiceCtrl) createClusterRoleBinding(sa *v1.ServiceAccou
 					Name:       sa.Name,
 					UID:        sa.UID,
 				},
+			},
+			Labels: map[string]string{
+				discovery.LiqoManagedLabel: "true",
+				discovery.ClusterIdLabel:   remoteClusterId,
 			},
 		},
 		Subjects: []rbacv1.Subject{

--- a/internal/auth-service/garbage-collection/serviceAccount.go
+++ b/internal/auth-service/garbage-collection/serviceAccount.go
@@ -2,18 +2,21 @@ package garbage_collection
 
 import (
 	"context"
+	"fmt"
 	"github.com/liqotech/liqo/pkg/discovery"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/klog"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
-// delete ClusterRoles and ClusterRoleBindings related to a ServiceAccount, this garbage collection is not automatically done
-// by the default garbage collector starting from Kubernetes versions 1.20
+// delete ClusterRoles and ClusterRoleBindings related to a ServiceAccount. We cannot do it setting an OwnerReference
+// on them and let the Kubernetes garbage collector to do that, due to the fact they (cluster scoped resources) need
+// to be deleted after the deletion of a ServiceAccount (namespaced resource). See https://kubernetes.io/docs/concepts/workloads/controllers/garbage-collection/#owners-and-dependents
+// to have more details on how OwnerReferences are handled by Kubernetes >= 1.20
 func OnDeleteServiceAccount(client kubernetes.Interface, serviceAccount *v1.ServiceAccount) {
 	if liqoManaged, ok := serviceAccount.Labels[discovery.LiqoManagedLabel]; !ok || liqoManaged != "true" {
 		// it is not a Liqo Managed ServiceAccount
@@ -37,6 +40,7 @@ func OnDeleteServiceAccount(client kubernetes.Interface, serviceAccount *v1.Serv
 
 	// delete ClusterRoleBindings
 	if err := retry.OnError(retry.DefaultRetry, func(err error) bool {
+		klog.V(4).Infof("%v, retrying...", err)
 		return true
 	}, func() error {
 		return client.RbacV1().ClusterRoleBindings().DeleteCollection(context.TODO(), metav1.DeleteOptions{}, metav1.ListOptions{
@@ -49,6 +53,7 @@ func OnDeleteServiceAccount(client kubernetes.Interface, serviceAccount *v1.Serv
 
 	// delete ClusterRoles
 	if err := retry.OnError(retry.DefaultRetry, func(err error) bool {
+		klog.V(4).Infof("%v, retrying...", err)
 		return true
 	}, func() error {
 		return client.RbacV1().ClusterRoles().DeleteCollection(context.TODO(), metav1.DeleteOptions{}, metav1.ListOptions{
@@ -60,12 +65,15 @@ func OnDeleteServiceAccount(client kubernetes.Interface, serviceAccount *v1.Serv
 	}
 
 	// remove the finalizer
-	controllerutil.RemoveFinalizer(serviceAccount, discovery.GarbageCollection)
-	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		var err error
-		serviceAccount, err = client.CoreV1().ServiceAccounts(serviceAccount.Namespace).Update(context.TODO(), serviceAccount, metav1.UpdateOptions{})
-		return err
-	}); err != nil {
+	finalizerPatch := []byte(fmt.Sprintf(
+		`[{"op":"remove","path":"/metadata/finalizers","value":["%s"]}]`,
+		discovery.GarbageCollection))
+
+	if _, err := client.CoreV1().ServiceAccounts(serviceAccount.Namespace).Patch(context.TODO(),
+		serviceAccount.Name,
+		types.JSONPatchType,
+		finalizerPatch,
+		metav1.PatchOptions{}); err != nil {
 		klog.Error(err)
 		return
 	}

--- a/internal/auth-service/garbage-collection/serviceAccount.go
+++ b/internal/auth-service/garbage-collection/serviceAccount.go
@@ -1,0 +1,74 @@
+package garbage_collection
+
+import (
+	"context"
+	"github.com/liqotech/liqo/pkg/discovery"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/retry"
+	"k8s.io/klog"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+// delete ClusterRoles and ClusterRoleBindings related to a ServiceAccount, this garbage collection is not automatically done
+// by the default garbage collector starting from Kubernetes versions 1.20
+func OnDeleteServiceAccount(client kubernetes.Interface, serviceAccount *v1.ServiceAccount) {
+	if liqoManaged, ok := serviceAccount.Labels[discovery.LiqoManagedLabel]; !ok || liqoManaged != "true" {
+		// it is not a Liqo Managed ServiceAccount
+		return
+	}
+
+	remoteClusterId, ok := serviceAccount.Labels[discovery.ClusterIdLabel]
+	if !ok {
+		klog.Errorf("No %v label is set on ServiceAccount %v/%v", discovery.ClusterIdLabel, serviceAccount.Namespace, serviceAccount.Name)
+		return
+	}
+
+	klog.Infof("[%v] Purging ServiceAccount", remoteClusterId)
+
+	labelSelector := metav1.LabelSelector{
+		MatchLabels: map[string]string{
+			discovery.LiqoManagedLabel: "true",
+			discovery.ClusterIdLabel:   remoteClusterId,
+		},
+	}
+
+	// delete ClusterRoleBindings
+	if err := retry.OnError(retry.DefaultRetry, func(err error) bool {
+		return true
+	}, func() error {
+		return client.RbacV1().ClusterRoleBindings().DeleteCollection(context.TODO(), metav1.DeleteOptions{}, metav1.ListOptions{
+			LabelSelector: labels.Set(labelSelector.MatchLabels).String(),
+		})
+	}); err != nil {
+		klog.Error(err)
+		return
+	}
+
+	// delete ClusterRoles
+	if err := retry.OnError(retry.DefaultRetry, func(err error) bool {
+		return true
+	}, func() error {
+		return client.RbacV1().ClusterRoles().DeleteCollection(context.TODO(), metav1.DeleteOptions{}, metav1.ListOptions{
+			LabelSelector: labels.Set(labelSelector.MatchLabels).String(),
+		})
+	}); err != nil {
+		klog.Error(err)
+		return
+	}
+
+	// remove the finalizer
+	controllerutil.RemoveFinalizer(serviceAccount, discovery.GarbageCollection)
+	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		var err error
+		serviceAccount, err = client.CoreV1().ServiceAccounts(serviceAccount.Namespace).Update(context.TODO(), serviceAccount, metav1.UpdateOptions{})
+		return err
+	}); err != nil {
+		klog.Error(err)
+		return
+	}
+
+	klog.Infof("[%v] ServiceAccount successfully purged", remoteClusterId)
+}

--- a/internal/auth-service/httpHandler.go
+++ b/internal/auth-service/httpHandler.go
@@ -51,7 +51,7 @@ func (authService *AuthServiceCtrl) role(w http.ResponseWriter, r *http.Request,
 	}
 
 	klog.Infof("Create RoleBinding %v", sa.Name)
-	_, err = authService.createRoleBinding(sa, role)
+	_, err = authService.createRoleBinding(sa, role, roleRequest.ClusterID)
 	if err != nil {
 		klog.Error(err)
 		authService.handleError(w, err)
@@ -67,7 +67,7 @@ func (authService *AuthServiceCtrl) role(w http.ResponseWriter, r *http.Request,
 	}
 
 	klog.Infof("Create ClusterRoleBinding %v", sa.Name)
-	_, err = authService.createClusterRoleBinding(sa, clusterRole)
+	_, err = authService.createClusterRoleBinding(sa, clusterRole, roleRequest.ClusterID)
 	if err != nil {
 		klog.Error(err)
 		authService.handleError(w, err)

--- a/internal/auth-service/role.go
+++ b/internal/auth-service/role.go
@@ -2,6 +2,7 @@ package auth_service
 
 import (
 	"context"
+	"github.com/liqotech/liqo/pkg/discovery"
 	v1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -18,6 +19,10 @@ func (authService *AuthServiceCtrl) createRole(remoteClusterId string, sa *v1.Se
 					Name:       sa.Name,
 					UID:        sa.UID,
 				},
+			},
+			Labels: map[string]string{
+				discovery.LiqoManagedLabel: "true",
+				discovery.ClusterIdLabel:   remoteClusterId,
 			},
 		},
 		Rules: []rbacv1.PolicyRule{

--- a/internal/auth-service/roleBinding.go
+++ b/internal/auth-service/roleBinding.go
@@ -2,12 +2,13 @@ package auth_service
 
 import (
 	"context"
+	"github.com/liqotech/liqo/pkg/discovery"
 	v1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func (authService *AuthServiceCtrl) createRoleBinding(sa *v1.ServiceAccount, role *rbacv1.Role) (*rbacv1.RoleBinding, error) {
+func (authService *AuthServiceCtrl) createRoleBinding(sa *v1.ServiceAccount, role *rbacv1.Role, remoteClusterId string) (*rbacv1.RoleBinding, error) {
 	rb := &rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: sa.Name,
@@ -18,6 +19,10 @@ func (authService *AuthServiceCtrl) createRoleBinding(sa *v1.ServiceAccount, rol
 					Name:       sa.Name,
 					UID:        sa.UID,
 				},
+			},
+			Labels: map[string]string{
+				discovery.LiqoManagedLabel: "true",
+				discovery.ClusterIdLabel:   remoteClusterId,
 			},
 		},
 		Subjects: []rbacv1.Subject{

--- a/internal/auth-service/serviceAccount.go
+++ b/internal/auth-service/serviceAccount.go
@@ -3,6 +3,7 @@ package auth_service
 import (
 	"context"
 	"fmt"
+	"github.com/liqotech/liqo/pkg/discovery"
 	v1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -80,6 +81,14 @@ func (authService *AuthServiceCtrl) createServiceAccount(remoteClusterId string)
 	sa := &v1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: fmt.Sprintf("remote-%s", remoteClusterId),
+			Labels: map[string]string{
+				discovery.LiqoManagedLabel: "true",
+				discovery.ClusterIdLabel:   remoteClusterId,
+			},
+			// used to do garbage collection on cluster scoped resources (i.e. ClusterRole and ClusterRoleBinding)
+			Finalizers: []string{
+				discovery.GarbageCollection,
+			},
 		},
 	}
 	return authService.clientset.CoreV1().ServiceAccounts(authService.namespace).Create(context.TODO(), sa, metav1.CreateOptions{})

--- a/internal/discovery/foreign-cluster-operator/foreign-cluster-controller.go
+++ b/internal/discovery/foreign-cluster-operator/foreign-cluster-controller.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
 	nettypes "github.com/liqotech/liqo/apis/net/v1alpha1"
+	netv1alpha1 "github.com/liqotech/liqo/apis/net/v1alpha1"
 	advtypes "github.com/liqotech/liqo/apis/sharing/v1alpha1"
 	"github.com/liqotech/liqo/internal/crdReplicator"
 	"github.com/liqotech/liqo/internal/discovery"
@@ -647,7 +648,7 @@ func (r *ForeignClusterReconciler) createPeeringRequestIfNotExists(clusterID str
 				GenerateName: strings.Join([]string{"pr", r.clusterID.GetClusterID(), ""}, "-"),
 				OwnerReferences: []metav1.OwnerReference{
 					{
-						APIVersion: "discovery.liqo.io/v1alpha1",
+						APIVersion: fmt.Sprintf("%s/%s", discoveryv1alpha1.GroupVersion.Group, discoveryv1alpha1.GroupVersion.Version),
 						Kind:       "PeeringRequest",
 						Name:       pr.Name,
 						UID:        pr.UID,
@@ -723,7 +724,7 @@ func (r *ForeignClusterReconciler) getForeignConfig(clusterID string, owner *dis
 	}
 
 	// crdreplicator role binding
-	err = r.setDispatcherRole(clusterID, sa)
+	err = r.setDispatcherRole(clusterID, sa, owner)
 	if err != nil {
 		return "", err
 	}
@@ -773,7 +774,7 @@ func (r *ForeignClusterReconciler) createClusterRoleIfNotExists(clusterID string
 				Name: clusterID,
 				OwnerReferences: []metav1.OwnerReference{
 					{
-						APIVersion: "v1alpha1",
+						APIVersion: fmt.Sprintf("%s/%s", discoveryv1alpha1.GroupVersion.Group, discoveryv1alpha1.GroupVersion.Version),
 						Kind:       "ForeignCluster",
 						Name:       owner.Name,
 						UID:        owner.UID,
@@ -806,7 +807,7 @@ func (r *ForeignClusterReconciler) createRoleIfNotExists(clusterID string, owner
 				Name: clusterID,
 				OwnerReferences: []metav1.OwnerReference{
 					{
-						APIVersion: "v1alpha1",
+						APIVersion: fmt.Sprintf("%s/%s", discoveryv1alpha1.GroupVersion.Group, discoveryv1alpha1.GroupVersion.Version),
 						Kind:       "ForeignCluster",
 						Name:       owner.Name,
 						UID:        owner.UID,
@@ -839,7 +840,7 @@ func (r *ForeignClusterReconciler) createServiceAccountIfNotExists(clusterID str
 				Name: clusterID,
 				OwnerReferences: []metav1.OwnerReference{
 					{
-						APIVersion: "v1alpha1",
+						APIVersion: fmt.Sprintf("%s/%s", discoveryv1alpha1.GroupVersion.Group, discoveryv1alpha1.GroupVersion.Version),
 						Kind:       "ForeignCluster",
 						Name:       owner.Name,
 						UID:        owner.UID,
@@ -865,7 +866,7 @@ func (r *ForeignClusterReconciler) createClusterRoleBindingIfNotExists(clusterID
 				Name: clusterID,
 				OwnerReferences: []metav1.OwnerReference{
 					{
-						APIVersion: "v1alpha1",
+						APIVersion: fmt.Sprintf("%s/%s", discoveryv1alpha1.GroupVersion.Group, discoveryv1alpha1.GroupVersion.Version),
 						Kind:       "ForeignCluster",
 						Name:       owner.Name,
 						UID:        owner.UID,
@@ -903,7 +904,7 @@ func (r *ForeignClusterReconciler) createRoleBindingIfNotExists(clusterID string
 				Name: clusterID,
 				OwnerReferences: []metav1.OwnerReference{
 					{
-						APIVersion: "v1alpha1",
+						APIVersion: fmt.Sprintf("%s/%s", discoveryv1alpha1.GroupVersion.Group, discoveryv1alpha1.GroupVersion.Version),
 						Kind:       "ForeignCluster",
 						Name:       owner.Name,
 						UID:        owner.UID,
@@ -932,7 +933,7 @@ func (r *ForeignClusterReconciler) createRoleBindingIfNotExists(clusterID string
 	}
 }
 
-func (r *ForeignClusterReconciler) setDispatcherRole(clusterID string, sa *apiv1.ServiceAccount) error {
+func (r *ForeignClusterReconciler) setDispatcherRole(clusterID string, sa *apiv1.ServiceAccount, owner *discoveryv1alpha1.ForeignCluster) error {
 	_, err := r.crdClient.Client().RbacV1().ClusterRoleBindings().Get(context.TODO(), clusterID+"-crdreplicator", metav1.GetOptions{})
 	if errors.IsNotFound(err) {
 		// does not exist
@@ -941,10 +942,10 @@ func (r *ForeignClusterReconciler) setDispatcherRole(clusterID string, sa *apiv1
 				Name: clusterID + "-crdreplicator",
 				OwnerReferences: []metav1.OwnerReference{
 					{
-						APIVersion: "v1",
-						Kind:       "ServiceAccount",
-						Name:       sa.Name,
-						UID:        sa.UID,
+						APIVersion: fmt.Sprintf("%s/%s", discoveryv1alpha1.GroupVersion.Group, discoveryv1alpha1.GroupVersion.Version),
+						Kind:       "ForeignCluster",
+						Name:       owner.Name,
+						UID:        owner.UID,
 					},
 				},
 			},
@@ -1038,7 +1039,7 @@ func (r *ForeignClusterReconciler) updateNetwork(labelSelector string, resourceL
 			Kind:       "NetworkConfig",
 			Name:       ncf.Name,
 			UID:        ncf.UID,
-			APIVersion: "v1alpha1",
+			APIVersion: fmt.Sprintf("%s/%s", netv1alpha1.GroupVersion.Group, netv1alpha1.GroupVersion.Version),
 		}
 		*requireUpdate = true
 	}
@@ -1072,7 +1073,7 @@ func (r *ForeignClusterReconciler) checkTEP(fc *discoveryv1alpha1.ForeignCluster
 			Kind:       "TunnelEndpoints",
 			Name:       tep.Name,
 			UID:        tep.UID,
-			APIVersion: "v1alpha1",
+			APIVersion: fmt.Sprintf("%s/%s", netv1alpha1.GroupVersion.Group, netv1alpha1.GroupVersion.Version),
 		}
 		*requireUpdate = true
 	}

--- a/internal/liqonet/tunnelEndpointCreator/tunnelEndpointCreator-operator.go
+++ b/internal/liqonet/tunnelEndpointCreator/tunnelEndpointCreator-operator.go
@@ -237,7 +237,7 @@ func (tec *TunnelEndpointCreator) createNetConfig(fc *discoveryv1alpha1.ForeignC
 			},
 			OwnerReferences: []metav1.OwnerReference{
 				{
-					APIVersion: "v1alpha1",
+					APIVersion: fmt.Sprintf("%s/%s", discoveryv1alpha1.GroupVersion.Group, discoveryv1alpha1.GroupVersion.Version),
 					Kind:       "ForeignCluster",
 					Name:       fc.Name,
 					UID:        fc.UID,

--- a/internal/peering-request-operator/broadcaster.go
+++ b/internal/peering-request-operator/broadcaster.go
@@ -2,6 +2,7 @@ package peering_request_operator
 
 import (
 	"context"
+	"fmt"
 	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
@@ -72,7 +73,7 @@ func GetBroadcasterDeployment(request *discoveryv1alpha1.PeeringRequest, nameSA 
 			Namespace:    namespace,
 			OwnerReferences: []metav1.OwnerReference{
 				{
-					APIVersion: "v1alpha1",
+					APIVersion: fmt.Sprintf("%s/%s", discoveryv1alpha1.GroupVersion.Group, discoveryv1alpha1.GroupVersion.Version),
 					Kind:       "PeeringRequest",
 					Name:       request.Name,
 					UID:        request.UID,

--- a/pkg/discovery/const.go
+++ b/pkg/discovery/const.go
@@ -6,6 +6,8 @@ const (
 	RemoteIdentityLabel = "discovery.liqo.io/remote-identity"
 	DiscoveryTypeLabel  = "discovery.liqo.io/discovery-type"
 	SearchDomainLabel   = "discovery.liqo.io/searchdomain"
+	LiqoManagedLabel    = "discovery.liqo.io/liqo-managed"
+	GarbageCollection   = "discovery.liqo.io/garbage-collection"
 )
 
 type DiscoveryType string


### PR DESCRIPTION
# Description

This pr adds a garbage collection mechanism for ClusterRoles and ClusterRoleBindings resources, no more collected by the default GC of Kubernetes starting from version 1.20

New labels have been added on ServiceAccounts, Role, RoleBinsdings, ClusterRoles, and ClusterRolesBindings managed by Liqo

When a Liqo manged SA is deleted, thanks to a finalized we are now able to delete the related resources by label

Additionally, this pr fixes some OwnerReferences that was missing the correct API group, preventing the Kubernetes default garbage collection on versions >= 1.20

# How Has This Been Tested?

- [x] Locally on kind (k8s version 1.20.2)
