### PR TITLE
Avoid Start-Time Throttling

### DIFF
--- a/apis/discovery/v1alpha1/groupversion_info.go
+++ b/apis/discovery/v1alpha1/groupversion_info.go
@@ -21,7 +21,6 @@ package v1alpha1
 
 import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	k8sScheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/scheme"
 )
 
@@ -40,7 +39,3 @@ var (
 	//ForeignClusterGroupResource is the group resource used to register ForeignCluster CRD.
 	ForeignClusterGroupResource = schema.GroupResource{Group: GroupVersion.Group, Resource: "foreignclusters"}
 )
-
-func init() {
-	_ = AddToScheme(k8sScheme.Scheme)
-}

--- a/apis/discovery/v1alpha1/peeringrequest_types.go
+++ b/apis/discovery/v1alpha1/peeringrequest_types.go
@@ -78,7 +78,7 @@ func init() {
 		panic(err)
 	}
 	crdClient.AddToRegistry("peeringrequests", &PeeringRequest{}, &PeeringRequestList{}, nil, schema.GroupResource{
-		Group:    v1.SchemeGroupVersion.Group,
+		Group:    GroupVersion.Group,
 		Resource: "peeringrequests",
 	})
 }

--- a/apis/discovery/v1alpha1/searchdomain_types.go
+++ b/apis/discovery/v1alpha1/searchdomain_types.go
@@ -18,7 +18,6 @@ package v1alpha1
 
 import (
 	"github.com/liqotech/liqo/pkg/crdClient"
-	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -73,7 +72,7 @@ func init() {
 		panic(err)
 	}
 	crdClient.AddToRegistry("searchdomains", &SearchDomain{}, &SearchDomainList{}, nil, schema.GroupResource{
-		Group:    v1.SchemeGroupVersion.Group,
+		Group:    GroupVersion.Group,
 		Resource: "searchdomains",
 	})
 }

--- a/cmd/advertisement-operator/main.go
+++ b/cmd/advertisement-operator/main.go
@@ -19,6 +19,7 @@ import (
 	"flag"
 	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
 	"github.com/liqotech/liqo/pkg/crdClient"
+	"github.com/liqotech/liqo/pkg/mapperUtils"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
@@ -84,6 +85,7 @@ func main() {
 	}
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+		MapperProvider:     mapperUtils.LiqoMapperProvider(scheme),
 		Scheme:             scheme,
 		MetricsBindAddress: "0",
 		LeaderElection:     enableLeaderElection,

--- a/cmd/crd-replicator/main.go
+++ b/cmd/crd-replicator/main.go
@@ -6,6 +6,7 @@ import (
 	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
 	"github.com/liqotech/liqo/internal/crdReplicator"
 	util "github.com/liqotech/liqo/pkg/liqonet"
+	"github.com/liqotech/liqo/pkg/mapperUtils"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/dynamic"
@@ -32,6 +33,7 @@ func main() {
 	flag.Parse()
 	cfg := ctrl.GetConfigOrDie()
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+		MapperProvider: mapperUtils.LiqoMapperProvider(scheme),
 		Scheme:         scheme,
 		Port:           9443,
 		LeaderElection: false,

--- a/cmd/discovery/main.go
+++ b/cmd/discovery/main.go
@@ -9,6 +9,7 @@ import (
 	foreign_cluster_operator "github.com/liqotech/liqo/internal/discovery/foreign-cluster-operator"
 	search_domain_operator "github.com/liqotech/liqo/internal/discovery/search-domain-operator"
 	"github.com/liqotech/liqo/pkg/clusterID"
+	"github.com/liqotech/liqo/pkg/mapperUtils"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/klog"
@@ -71,6 +72,7 @@ func main() {
 	discoveryCtl.StartDiscovery()
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+		MapperProvider:   mapperUtils.LiqoMapperProvider(scheme),
 		Scheme:           scheme,
 		Port:             9443,
 		LeaderElection:   false,

--- a/cmd/liqonet/main.go
+++ b/cmd/liqonet/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/liqotech/liqo/internal/liqonet/tunnelEndpointCreator"
 	liqonetOperator "github.com/liqotech/liqo/pkg/liqonet"
 	"github.com/liqotech/liqo/pkg/liqonet/wireguard"
+	"github.com/liqotech/liqo/pkg/mapperUtils"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
@@ -58,6 +59,7 @@ func main() {
 	flag.StringVar(&runAs, "run-as", "tunnel-operator", "The accepted values are: liqo-gateway, liqo-route, tunnelEndpointCreator-operator. The default value is \"tunnel-operator\"")
 	flag.Parse()
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+		MapperProvider:     mapperUtils.LiqoMapperProvider(scheme),
 		Scheme:             scheme,
 		MetricsBindAddress: metricsAddr,
 		LeaderElection:     enableLeaderElection,

--- a/cmd/schedulingNodeOperator/main.go
+++ b/cmd/schedulingNodeOperator/main.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"flag"
+	"github.com/liqotech/liqo/pkg/mapperUtils"
 	"os"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -56,6 +57,7 @@ func main() {
 	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+		MapperProvider:     mapperUtils.LiqoMapperProvider(scheme),
 		Scheme:             scheme,
 		MetricsBindAddress: metricsAddr,
 		Port:               9443,

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -16,12 +16,13 @@ import (
 type DiscoveryCtrl struct {
 	Namespace string
 
-	Config         *configv1alpha1.DiscoveryConfig
-	stopMDNS       chan bool
-	stopMDNSClient chan bool
-	crdClient      *crdClient.CRDClient
-	advClient      *crdClient.CRDClient
-	ClusterId      clusterID.ClusterID
+	Config              *configv1alpha1.DiscoveryConfig
+	crdReplicatorConfig *configv1alpha1.DispatcherConfig
+	stopMDNS            chan bool
+	stopMDNSClient      chan bool
+	crdClient           *crdClient.CRDClient
+	advClient           *crdClient.CRDClient
+	ClusterId           clusterID.ClusterID
 
 	mdnsServerAuth            *zeroconf.Server
 	serverMux                 sync.Mutex

--- a/internal/peering-request-operator/setup.go
+++ b/internal/peering-request-operator/setup.go
@@ -4,6 +4,7 @@ import (
 	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
 	"github.com/liqotech/liqo/pkg/clusterID"
 	"github.com/liqotech/liqo/pkg/crdClient"
+	"github.com/liqotech/liqo/pkg/mapperUtils"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/klog"
@@ -24,6 +25,7 @@ func init() {
 
 func StartOperator(namespace string, broadcasterImage string, broadcasterServiceAccount string, vkServiceAccount string, kubeconfigPath string) {
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+		MapperProvider:   mapperUtils.LiqoMapperProvider(scheme),
 		Scheme:           scheme,
 		Port:             9443,
 		LeaderElection:   false,

--- a/pkg/clusterConfig/watchConfig.go
+++ b/pkg/clusterConfig/watchConfig.go
@@ -12,7 +12,7 @@ import (
 )
 
 func WatchConfiguration(handler func(*configv1alpha1.ClusterConfig), client *crdClient.CRDClient, kubeconfigPath string) {
-	var rsyncPeriod = 1 * time.Second
+	var rsyncPeriod = 5 * time.Minute
 	if client == nil {
 		config, err := crdClient.NewKubeconfig(kubeconfigPath, &configv1alpha1.GroupVersion)
 		if err != nil {

--- a/pkg/mapperUtils/mapper.go
+++ b/pkg/mapperUtils/mapper.go
@@ -1,0 +1,107 @@
+package mapperUtils
+
+import (
+	configv1alpha1 "github.com/liqotech/liqo/apis/config/v1alpha1"
+	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
+	netv1alpha1 "github.com/liqotech/liqo/apis/net/v1alpha1"
+	schedulingv1alpha1 "github.com/liqotech/liqo/apis/scheduling/v1alpha1"
+	sharingv1alpha1 "github.com/liqotech/liqo/apis/sharing/v1alpha1"
+	virtualKubeletv1alpha1 "github.com/liqotech/liqo/apis/virtualKubelet/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
+	"k8s.io/klog"
+)
+
+type LiqoMapper func(c *rest.Config) (meta.RESTMapper, error)
+
+// get the default liqo mapper
+func LiqoMapperProvider(scheme *runtime.Scheme, additionalGroupVersions ...schema.GroupVersion) LiqoMapper {
+	mapper := meta.NewDefaultRESTMapper(scheme.PrioritizedVersionsAllGroups())
+
+	return func(c *rest.Config) (meta.RESTMapper, error) {
+		dClient, err := discovery.NewDiscoveryClientForConfig(c)
+		if err != nil {
+			klog.Error(err)
+			return nil, err
+		}
+		if err = addDefaults(dClient, mapper); err != nil {
+			klog.Error(err)
+			return nil, err
+		}
+
+		for _, gv := range additionalGroupVersions {
+			if err = addGroup(dClient, gv, mapper); err != nil {
+				klog.Error(err)
+				return nil, err
+			}
+		}
+
+		return mapper, nil
+	}
+}
+
+// add most used groups to the mapper, this includes all Liqo groups with core/v1, apps/v1 and rbac/v1
+func addDefaults(dClient *discovery.DiscoveryClient, mapper *meta.DefaultRESTMapper) error {
+	var err error
+
+	// Liqo groups
+	if err = addGroup(dClient, configv1alpha1.GroupVersion, mapper); err != nil {
+		return err
+	}
+	if err = addGroup(dClient, discoveryv1alpha1.GroupVersion, mapper); err != nil {
+		return err
+	}
+	if err = addGroup(dClient, netv1alpha1.GroupVersion, mapper); err != nil {
+		return err
+	}
+	if err = addGroup(dClient, schedulingv1alpha1.GroupVersion, mapper); err != nil {
+		return err
+	}
+	if err = addGroup(dClient, sharingv1alpha1.GroupVersion, mapper); err != nil {
+		return err
+	}
+	if err = addGroup(dClient, virtualKubeletv1alpha1.GroupVersion, mapper); err != nil {
+		return err
+	}
+
+	// Kubernetes groups
+	if err = addGroup(dClient, corev1.SchemeGroupVersion, mapper); err != nil {
+		return err
+	}
+	if err = addGroup(dClient, appsv1.SchemeGroupVersion, mapper); err != nil {
+		return err
+	}
+	if err = addGroup(dClient, rbacv1.SchemeGroupVersion, mapper); err != nil {
+		return err
+	}
+	return nil
+}
+
+// add all the resources in the specified groupVersion to the mapper
+func addGroup(dClient *discovery.DiscoveryClient, groupVersion schema.GroupVersion, mapper *meta.DefaultRESTMapper) error {
+	res, err := dClient.ServerResourcesForGroupVersion(groupVersion.String())
+	if err != nil {
+		klog.Error(err)
+		return err
+	}
+	for _, apiRes := range res.APIResources {
+		var scope meta.RESTScope
+		if apiRes.Namespaced {
+			scope = meta.RESTScopeNamespace
+		} else {
+			scope = meta.RESTScopeRoot
+		}
+		mapper.Add(schema.GroupVersionKind{
+			Group:   groupVersion.Group,
+			Version: groupVersion.Version,
+			Kind:    apiRes.Kind,
+		}, scope)
+	}
+	return nil
+}


### PR DESCRIPTION
# Description

This pr adds a different Mapper implementation to reduce the number of calls during components startup

A helper function has been added to add the resources belonging to the Liqo groups and the core/v1, apps/v1, and rbac/v1 groups into the new Mapper