### PR TITLE
Virtual kubelet throttling mitigation

### DIFF
--- a/apis/config/v1alpha1/clusterConfigClient.go
+++ b/apis/config/v1alpha1/clusterConfigClient.go
@@ -21,7 +21,7 @@ func CreateClusterConfigClient(kubeconfig string, watchResources bool) (*crdClie
 
 	crdClient.AddToRegistry("clusterconfigs", &ClusterConfig{}, &ClusterConfigList{}, Keyer, GroupResource)
 
-	config, err = crdClient.NewKubeconfig(kubeconfig, &GroupVersion)
+	config, err = crdClient.NewKubeconfig(kubeconfig, &GroupVersion, nil)
 	if err != nil {
 		panic(err)
 	}

--- a/apis/discovery/v1alpha1/foreignClusterClient.go
+++ b/apis/discovery/v1alpha1/foreignClusterClient.go
@@ -16,7 +16,7 @@ func CreateForeignClusterClient(kubeconfig string) (*crdClient.CRDClient, error)
 		panic(err)
 	}
 	crdClient.AddToRegistry("foreignclusters", &ForeignCluster{}, &ForeignClusterList{}, ForeignClusterKeyer, ForeignClusterGroupResource)
-	config, err = crdClient.NewKubeconfig(kubeconfig, &GroupVersion)
+	config, err = crdClient.NewKubeconfig(kubeconfig, &GroupVersion, nil)
 	if err != nil {
 		panic(err)
 	}

--- a/apis/discovery/v1alpha1/peeringRequestClient.go
+++ b/apis/discovery/v1alpha1/peeringRequestClient.go
@@ -24,7 +24,7 @@ func CreatePeeringRequestClient(kubeconfig string) (*crdClient.CRDClient, error)
 
 	crdClient.AddToRegistry("peeringrequests", &PeeringRequest{}, &PeeringRequestList{}, Keyer, GroupResource)
 
-	config, err = crdClient.NewKubeconfig(kubeconfig, &GroupVersion)
+	config, err = crdClient.NewKubeconfig(kubeconfig, &GroupVersion, nil)
 	if err != nil {
 		panic(err)
 	}

--- a/apis/net/v1alpha1/tunnelEndpointClient.go
+++ b/apis/net/v1alpha1/tunnelEndpointClient.go
@@ -21,7 +21,7 @@ func CreateTunnelEndpointClient(kubeconfig string) (*crdClient.CRDClient, error)
 
 	crdClient.AddToRegistry("tunnelendpoints", &TunnelEndpoint{}, &TunnelEndpointList{}, Keyer, TunnelEndpointGroupResource)
 
-	config, err = crdClient.NewKubeconfig(kubeconfig, &GroupVersion)
+	config, err = crdClient.NewKubeconfig(kubeconfig, &GroupVersion, nil)
 	if err != nil {
 		panic(err)
 	}

--- a/apis/sharing/v1alpha1/advertisementClient.go
+++ b/apis/sharing/v1alpha1/advertisementClient.go
@@ -15,7 +15,7 @@ import (
 // - secret != nil                     : the kubeconfig is extracted from the secret
 // - secret == nil && kubeconfig == "" : use an in-cluster configuration
 // - secret == nil && kubeconfig != "" : read the kubeconfig from the provided filepath
-func CreateAdvertisementClient(kubeconfig string, secret *v1.Secret, watchResources bool) (*crdClient.CRDClient, error) {
+func CreateAdvertisementClient(kubeconfig string, secret *v1.Secret, watchResources bool, configOptions func(config *rest.Config)) (*crdClient.CRDClient, error) {
 	var config *rest.Config
 	var err error
 
@@ -26,7 +26,7 @@ func CreateAdvertisementClient(kubeconfig string, secret *v1.Secret, watchResour
 	crdClient.AddToRegistry("advertisements", &Advertisement{}, &AdvertisementList{}, Keyer, GroupResource)
 
 	if secret == nil {
-		config, err = crdClient.NewKubeconfig(kubeconfig, &GroupVersion)
+		config, err = crdClient.NewKubeconfig(kubeconfig, &GroupVersion, configOptions)
 		if err != nil {
 			panic(err)
 		}

--- a/apis/virtualKubelet/v1alpha1/namespaceNattingTableClient.go
+++ b/apis/virtualKubelet/v1alpha1/namespaceNattingTableClient.go
@@ -8,7 +8,7 @@ import (
 	"k8s.io/client-go/rest"
 )
 
-func CreateClient(kubeconfig string) (*crdClient.CRDClient, error) {
+func CreateClient(kubeconfig string, configOptions func(config *rest.Config)) (*crdClient.CRDClient, error) {
 	var config *rest.Config
 	var err error
 
@@ -16,7 +16,7 @@ func CreateClient(kubeconfig string) (*crdClient.CRDClient, error) {
 		panic(err)
 	}
 
-	config, err = crdClient.NewKubeconfig(kubeconfig, &GroupVersion)
+	config, err = crdClient.NewKubeconfig(kubeconfig, &GroupVersion, configOptions)
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/advertisement-operator/main.go
+++ b/cmd/advertisement-operator/main.go
@@ -106,7 +106,7 @@ func main() {
 	go csrApprover.WatchCSR(clientset, "liqo.io/csr=true", 5*time.Second)
 
 	// get the number of already accepted advertisements
-	advClient, err := advtypes.CreateAdvertisementClient(localKubeconfig, nil, true)
+	advClient, err := advtypes.CreateAdvertisementClient(localKubeconfig, nil, true, nil)
 	if err != nil {
 		klog.Errorln(err, "unable to create local client for Advertisement")
 		os.Exit(1)
@@ -123,7 +123,7 @@ func main() {
 		}
 	}
 
-	discoveryConfig, err := crdClient.NewKubeconfig(localKubeconfig, &discoveryv1alpha1.GroupVersion)
+	discoveryConfig, err := crdClient.NewKubeconfig(localKubeconfig, &discoveryv1alpha1.GroupVersion, nil)
 	if err != nil {
 		klog.Error(err, "unable to get kube config")
 		os.Exit(1)

--- a/cmd/virtual-kubelet/internal/commands/root/root.go
+++ b/cmd/virtual-kubelet/internal/commands/root/root.go
@@ -33,6 +33,7 @@ import (
 	kubeinformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/kubernetes/typed/coordination/v1beta1"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog"
 	"os"
@@ -81,7 +82,10 @@ func runRootCommand(ctx context.Context, s *provider.Store, c *Opts) error {
 		}
 	}
 
-	client, err := v1alpha1.CreateAdvertisementClient(c.HomeKubeconfig, nil, false)
+	client, err := v1alpha1.CreateAdvertisementClient(c.HomeKubeconfig, nil, false, func(config *rest.Config) {
+		config.QPS = virtualKubelet.HOME_CLIENT_QPS
+		config.Burst = virtualKubelet.HOME_CLIENTS_BURST
+	})
 	if err != nil {
 		return err
 	}

--- a/internal/advertisement-operator/broadcaster.go
+++ b/internal/advertisement-operator/broadcaster.go
@@ -61,14 +61,14 @@ func StartBroadcaster(homeClusterId, localKubeconfigPath, peeringRequestName, sa
 	klog.V(6).Info("starting broadcaster")
 
 	// create the Advertisement client to the local cluster
-	localClient, err := advtypes.CreateAdvertisementClient(localKubeconfigPath, nil, true)
+	localClient, err := advtypes.CreateAdvertisementClient(localKubeconfigPath, nil, true, nil)
 	if err != nil {
 		klog.Errorln(err, "Unable to create client to local cluster")
 		return err
 	}
 
 	// create the discovery client
-	config, err := crdClient.NewKubeconfig(localKubeconfigPath, &discoveryv1alpha1.GroupVersion)
+	config, err := crdClient.NewKubeconfig(localKubeconfigPath, &discoveryv1alpha1.GroupVersion, nil)
 	if err != nil {
 		klog.Error(err, err.Error())
 		return err
@@ -105,7 +105,7 @@ func StartBroadcaster(homeClusterId, localKubeconfigPath, peeringRequestName, sa
 
 	// create a CRD-client to the foreign cluster
 	for retry = 0; retry < 3; retry++ {
-		remoteClient, err = advtypes.CreateAdvertisementClient("", secretForAdvertisementCreation, true)
+		remoteClient, err = advtypes.CreateAdvertisementClient("", secretForAdvertisementCreation, true, nil)
 		if err != nil {
 			klog.Errorln(err, "Unable to create client to remote cluster "+foreignClusterId+". Retry in 1 minute")
 			time.Sleep(1 * time.Minute)

--- a/internal/advertisement-operator/controller.go
+++ b/internal/advertisement-operator/controller.go
@@ -383,7 +383,7 @@ func (r *AdvertisementReconciler) checkClusterStatus(adv advtypes.Advertisement)
 		return err
 	}
 
-	remoteClient, err := advtypes.CreateAdvertisementClient("", remoteKubeconfig, true)
+	remoteClient, err := advtypes.CreateAdvertisementClient("", remoteKubeconfig, true, nil)
 	if err != nil {
 		return err
 	}

--- a/internal/auth-service/auth-service.go
+++ b/internal/auth-service/auth-service.go
@@ -53,7 +53,7 @@ type AuthServiceCtrl struct {
 }
 
 func NewAuthServiceCtrl(namespace string, kubeconfigPath string, resyncTime time.Duration, useTls bool) (*AuthServiceCtrl, error) {
-	config, err := crdClient.NewKubeconfig(kubeconfigPath, &discoveryv1alpha1.GroupVersion)
+	config, err := crdClient.NewKubeconfig(kubeconfigPath, &discoveryv1alpha1.GroupVersion, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -32,7 +32,7 @@ type DiscoveryCtrl struct {
 }
 
 func NewDiscoveryCtrl(namespace string, clusterId clusterID.ClusterID, kubeconfigPath string, resolveContextRefreshTime int, dialTcpTimeout time.Duration) (*DiscoveryCtrl, error) {
-	config, err := crdClient.NewKubeconfig(kubeconfigPath, &discoveryv1alpha1.GroupVersion)
+	config, err := crdClient.NewKubeconfig(kubeconfigPath, &discoveryv1alpha1.GroupVersion, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -41,7 +41,7 @@ func NewDiscoveryCtrl(namespace string, clusterId clusterID.ClusterID, kubeconfi
 		return nil, err
 	}
 
-	advClient, err := advtypes.CreateAdvertisementClient(kubeconfigPath, nil, true)
+	advClient, err := advtypes.CreateAdvertisementClient(kubeconfigPath, nil, true, nil)
 	if err != nil {
 		klog.Error(err, "unable to create local client for Advertisement")
 		os.Exit(1)

--- a/internal/discovery/foreign-cluster-operator/setup.go
+++ b/internal/discovery/foreign-cluster-operator/setup.go
@@ -27,7 +27,7 @@ func init() {
 }
 
 func StartOperator(mgr *manager.Manager, namespace string, requeueAfter time.Duration, discoveryCtrl *discovery.DiscoveryCtrl, kubeconfigPath string) {
-	config, err := crdClient.NewKubeconfig(kubeconfigPath, &discoveryv1alpha1.GroupVersion)
+	config, err := crdClient.NewKubeconfig(kubeconfigPath, &discoveryv1alpha1.GroupVersion, nil)
 	if err != nil {
 		klog.Error(err, "unable to get kube config")
 		os.Exit(1)
@@ -43,7 +43,7 @@ func StartOperator(mgr *manager.Manager, namespace string, requeueAfter time.Dur
 		os.Exit(1)
 	}
 
-	advClient, err := advtypes.CreateAdvertisementClient(kubeconfigPath, nil, true)
+	advClient, err := advtypes.CreateAdvertisementClient(kubeconfigPath, nil, true, nil)
 	if err != nil {
 		klog.Error(err, "unable to create local client for Advertisement")
 		os.Exit(1)

--- a/internal/discovery/search-domain-operator/setup.go
+++ b/internal/discovery/search-domain-operator/setup.go
@@ -24,7 +24,7 @@ func init() {
 }
 
 func StartOperator(mgr *manager.Manager, requeueAfter time.Duration, discoveryCtrl *discovery.DiscoveryCtrl, kubeconfigPath string) {
-	config, err := crdClient.NewKubeconfig(kubeconfigPath, &discoveryv1alpha1.GroupVersion)
+	config, err := crdClient.NewKubeconfig(kubeconfigPath, &discoveryv1alpha1.GroupVersion, nil)
 	if err != nil {
 		klog.Error(err, "unable to get kube config")
 		os.Exit(1)

--- a/internal/peering-request-operator/setup.go
+++ b/internal/peering-request-operator/setup.go
@@ -36,7 +36,7 @@ func StartOperator(namespace string, broadcasterImage string, broadcasterService
 		os.Exit(1)
 	}
 
-	config, err := crdClient.NewKubeconfig(kubeconfigPath, &discoveryv1alpha1.GroupVersion)
+	config, err := crdClient.NewKubeconfig(kubeconfigPath, &discoveryv1alpha1.GroupVersion, nil)
 	if err != nil {
 		klog.Error(err, "unable to get kube config")
 		os.Exit(1)

--- a/pkg/clusterConfig/watchConfig.go
+++ b/pkg/clusterConfig/watchConfig.go
@@ -14,7 +14,7 @@ import (
 func WatchConfiguration(handler func(*configv1alpha1.ClusterConfig), client *crdClient.CRDClient, kubeconfigPath string) {
 	var rsyncPeriod = 5 * time.Minute
 	if client == nil {
-		config, err := crdClient.NewKubeconfig(kubeconfigPath, &configv1alpha1.GroupVersion)
+		config, err := crdClient.NewKubeconfig(kubeconfigPath, &configv1alpha1.GroupVersion, nil)
 		if err != nil {
 			klog.Error(err, err.Error())
 			os.Exit(1)
@@ -65,5 +65,4 @@ func WatchConfiguration(handler func(*configv1alpha1.ClusterConfig), client *crd
 		os.Exit(1)
 	}
 	klog.Info("Cluster Config Informer initialized")
-
 }

--- a/pkg/clusterID/clusterID.go
+++ b/pkg/clusterID/clusterID.go
@@ -41,7 +41,7 @@ func GetNewClusterID(id string, client kubernetes.Interface) ClusterID {
 }
 
 func NewClusterID(kubeconfigPath string) (ClusterID, error) {
-	config, err := crdClient.NewKubeconfig(kubeconfigPath, &discoveryv1alpha1.GroupVersion)
+	config, err := crdClient.NewKubeconfig(kubeconfigPath, &discoveryv1alpha1.GroupVersion, nil)
 	if err != nil {
 		klog.Error(err, "unable to get kube config")
 		os.Exit(1)

--- a/pkg/crdClient/client.go
+++ b/pkg/crdClient/client.go
@@ -30,7 +30,7 @@ type CRDClient struct {
 	Stop   chan struct{}
 }
 
-func NewKubeconfig(configPath string, gv *schema.GroupVersion) (*rest.Config, error) {
+func NewKubeconfig(configPath string, gv *schema.GroupVersion, configOptions func(config *rest.Config)) (*rest.Config, error) {
 	config := &rest.Config{}
 
 	if !Fake {
@@ -56,6 +56,10 @@ func NewKubeconfig(configPath string, gv *schema.GroupVersion) (*rest.Config, er
 	config.APIPath = "/apis"
 	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
 	config.UserAgent = rest.DefaultKubernetesUserAgent()
+
+	if configOptions != nil {
+		configOptions(config)
+	}
 
 	return config, nil
 }

--- a/pkg/virtualKubelet/const.go
+++ b/pkg/virtualKubelet/const.go
@@ -9,4 +9,10 @@ const (
 	AdvertisementPrefix     = "advertisement-"
 	ReflectedpodKey         = "virtualkubelet.liqo.io/source-pod"
 	HomePodFinalizer        = "virtual-kubelet.liqo.io/provider"
+
+	// Clients configuration
+	HOME_CLIENT_QPS      = 1000
+	HOME_CLIENTS_BURST   = 5000
+	FOREIGN_CLIENT_QPS   = 1000
+	FOREIGN_CLIENT_BURST = 5000
 )

--- a/test/unit/advertisement-operator/broadcaster_test.go
+++ b/test/unit/advertisement-operator/broadcaster_test.go
@@ -25,13 +25,13 @@ func createBroadcaster(configv1alpha1 configv1alpha1.ClusterConfigSpec) advop.Ad
 	// set the client in fake mode
 	crdClient.Fake = true
 	// create fake client for the home cluster
-	homeClient, err := advtypes.CreateAdvertisementClient("", nil, true)
+	homeClient, err := advtypes.CreateAdvertisementClient("", nil, true, nil)
 	if err != nil {
 		panic(err)
 	}
 
 	// create the fake client for the foreign cluster
-	foreignClient, err := advtypes.CreateAdvertisementClient("", nil, true)
+	foreignClient, err := advtypes.CreateAdvertisementClient("", nil, true, nil)
 	if err != nil {
 		panic(err)
 	}

--- a/test/unit/advertisement-operator/controller_test.go
+++ b/test/unit/advertisement-operator/controller_test.go
@@ -17,7 +17,7 @@ func createReconciler(acceptedAdv, maxAcceptableAdv int32, acceptPolicy configv1
 	// set the client in fake mode
 	crdClient.Fake = true
 	// create fake client for the home cluster
-	advClient, err := advtypes.CreateAdvertisementClient("", nil, true)
+	advClient, err := advtypes.CreateAdvertisementClient("", nil, true, nil)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
# Description

This PR aims at mitigating the throttling caused by the go-client package.
Now the CRDClient accepts a handler that allows customizing the `rest.Config` object. This handler is exploited by the callers in the Virtual kubelet to set QPS and Burst of the clients to 1000 and 5000 respectively.
