### PR TITLE
Fixed changePodIp func

### DIFF
--- a/pkg/virtualKubelet/apiReflection/reflectors/outgoing/endpointSlices.go
+++ b/pkg/virtualKubelet/apiReflection/reflectors/outgoing/endpointSlices.go
@@ -2,6 +2,7 @@ package outgoing
 
 import (
 	"context"
+
 	apimgmt "github.com/liqotech/liqo/pkg/virtualKubelet/apiReflection"
 	"github.com/liqotech/liqo/pkg/virtualKubelet/apiReflection/reflectors"
 	ri "github.com/liqotech/liqo/pkg/virtualKubelet/apiReflection/reflectors/reflectorsInterfaces"
@@ -180,8 +181,12 @@ func filterEndpoints(slice *discoveryv1beta1.EndpointSlice, podCidr string, node
 	for _, v := range slice.Endpoints {
 		t := v.Topology["kubernetes.io/hostname"]
 		if t != nodeName {
+			ip, err := forge.ChangePodIp(podCidr, v.Addresses[0])
+			if err != nil {
+				klog.Error(err)
+			}
 			newEp := discoveryv1beta1.Endpoint{
-				Addresses:  []string{forge.ChangePodIp(podCidr, v.Addresses[0])},
+				Addresses:  []string{ip},
 				Conditions: v.Conditions,
 				Hostname:   nil,
 				TargetRef:  nil,

--- a/pkg/virtualKubelet/forge/forge_suite_test.go
+++ b/pkg/virtualKubelet/forge/forge_suite_test.go
@@ -1,0 +1,13 @@
+package forge_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestForge(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Forge Suite")
+}

--- a/pkg/virtualKubelet/forge/pods_test.go
+++ b/pkg/virtualKubelet/forge/pods_test.go
@@ -1,0 +1,31 @@
+package forge_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	"github.com/onsi/gomega"
+
+	"github.com/liqotech/liqo/pkg/virtualKubelet/forge"
+)
+
+var _ = Describe("Pods", func() {
+	DescribeTable("ChangePodIp",
+		func(oldIp, newPodCidr, expectedIP string, expectedErr string) {
+			ip, err := forge.ChangePodIp(oldIp, newPodCidr)
+			if expectedErr != "" {
+				gomega.Expect(err.Error()).To(gomega.Equal(expectedErr))
+			} else {
+				gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			}
+			gomega.Expect(ip).To(gomega.Equal(expectedIP))
+		},
+		Entry("Mapping 10.2.1.3 to 10.0.4.0/24", "10.0.4.0/24", "10.2.1.3", "10.0.4.3", ""),
+		Entry("Mapping 10.2.1.128 to 10.0.4.0/24", "10.0.4.0/24", "10.2.1.128", "10.0.4.128", ""),
+		Entry("Mapping 10.2.1.1 to 10.0.4.0/24", "10.0.4.0/24", "10.2.1.1", "10.0.4.1", ""),
+		Entry("Mapping 10.2.127.128 to 10.0.128.0/23", "10.0.128.0/23", "10.2.127.128", "10.0.129.128", ""),
+		Entry("Mapping 10.2.128.128 to 10.0.126.0/23", "10.0.127.0/23", "10.2.128.128", "10.0.127.128", ""),
+		Entry("Mapping 10.2.128.128 to 10.0.126.0/25", "10.0.126.0/25", "10.2.128.128", "10.0.126.0", ""),
+		Entry("Using an invalid newPodCidr", "10.0..0/25", "10.2.128.128", "", "invalid CIDR address: 10.0..0/25"),
+		Entry("Using an invalid oldIp", "10.0.0.0/25", "10.2...128", "", "cannot parse oldIp"),
+	)
+})


### PR DESCRIPTION
# Description

Function changePodIp forges a new IP taking the first 2 octets from the newPodCidr and the last 2 from the original Pod Ip. Since Liqo does support networks with random masks, this function needs to be modified: thanks to this PR, the function now takes a number of bits equal to the mask length from the newPodCidr and 32-mask bits from the old Pod IP.