### PR TITLE
VirtualNode-controller

### DIFF
--- a/pkg/liqo-controller-manager/virtualNode-controller/namespaceMap_lifecycle.go
+++ b/pkg/liqo-controller-manager/virtualNode-controller/namespaceMap_lifecycle.go
@@ -1,0 +1,128 @@
+package virtualNode_controller
+
+import (
+	"context"
+	"fmt"
+	mapsv1alpha1 "github.com/liqotech/liqo/apis/virtualKubelet/v1alpha1"
+	constctrl "github.com/liqotech/liqo/pkg/liqo-controller-manager"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog"
+	ctrlutils "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"time"
+)
+
+// remove Finalizer and Update the NamespaceMap
+func (r *VirtualNodeReconciler) removeNamespaceMapFinalizer(nm mapsv1alpha1.NamespaceMap) error {
+	ctrlutils.RemoveFinalizer(&nm, namespaceMapFinalizer)
+	klog.Infof("The NamespaceMap '%s' is requested to be deleted", nm.GetName())
+
+	if err := r.Update(context.TODO(), &nm); err != nil {
+		// WARNING: Is possible that this Update is called on a resource that is no more here
+		// it doesn't return "NotFound" but "Conflict"
+		klog.Errorf(" %s --> Problems while removing finalizer from '%s'", err, nm.GetName())
+		return err
+	}
+	klog.Infof("Finalizer is correctly removed from the NamespaceMap '%s'", nm.GetName())
+
+	return nil
+}
+
+// create a new NamespaceMap with Finalizer and OwnerReference
+func (r *VirtualNodeReconciler) createNamespaceMap(n corev1.Node, s mapsv1alpha1.NamespaceMapStatus) error {
+	nm := &mapsv1alpha1.NamespaceMap{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "namespaceresources.liqo.io/v1",
+			Kind:       "NamespaceMap",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: fmt.Sprintf("%s-", n.GetAnnotations()[constctrl.VirtualNodeClusterId]),
+			Namespace:    constctrl.MapNamespaceName,
+			Labels: map[string]string{
+				constctrl.VirtualNodeClusterId: n.GetAnnotations()[constctrl.VirtualNodeClusterId],
+			},
+		},
+		Status: s,
+	}
+
+	ctrlutils.AddFinalizer(nm, namespaceMapFinalizer)
+	if err := ctrlutils.SetControllerReference(&n, nm, r.Scheme); err != nil {
+		return err
+	}
+
+	if err := r.Create(context.TODO(), nm); err != nil {
+		klog.Errorf("%s --> Problems in NamespaceMap creation for the virtual node '%s'", err, n.GetName())
+		return err
+	}
+	klog.Infof(" Create NamespaceMap '%s' for the virtual node '%s'", nm.GetName(), n.GetName())
+	return nil
+}
+
+// first create a new NamespaceMap which preserves the Status and then delete the other
+func (r *VirtualNodeReconciler) regenerateNamespaceMap(nm mapsv1alpha1.NamespaceMap, n corev1.Node) error {
+
+	// create a new namespaceMap with same Status but with different Name
+	if err := r.createNamespaceMap(n, nm.Status); err != nil {
+		return err
+	}
+
+	if err := r.removeNamespaceMapFinalizer(nm); err != nil {
+		return err
+	}
+	return nil
+}
+
+// This function manages NamespaceMaps Lifecycle on the basis of NamespaceMaps' number
+func (r *VirtualNodeReconciler) namespaceMapLifecycle(n corev1.Node) error {
+
+	nms := &mapsv1alpha1.NamespaceMapList{}
+	if err := r.List(context.TODO(), nms, client.InNamespace(constctrl.MapNamespaceName),
+		client.MatchingLabels{constctrl.VirtualNodeClusterId: n.GetAnnotations()[constctrl.VirtualNodeClusterId]}); err != nil {
+		klog.Errorf("%s --> Unable to List NamespaceMaps of virtual node '%s'", err, n.GetName())
+		return err
+	}
+
+	if len(nms.Items) == 0 {
+		return r.createNamespaceMap(n, mapsv1alpha1.NamespaceMapStatus{})
+	}
+
+	if len(nms.Items) == 1 {
+		if !nms.Items[0].GetDeletionTimestamp().IsZero() {
+			return r.regenerateNamespaceMap(nms.Items[0], n)
+		}
+		return nil
+	}
+
+	if len(nms.Items) > 1 {
+
+		oldestCreation := metav1.Time{Time: time.Now()}
+		var oldestMap int
+
+		for i, nm := range nms.Items {
+			if nm.CreationTimestamp.Before(&oldestCreation) && nm.DeletionTimestamp.IsZero() {
+				oldestCreation = nm.CreationTimestamp
+				oldestMap = i
+			}
+		}
+
+		for i, nm := range nms.Items {
+			if i != oldestMap {
+				if nm.GetDeletionTimestamp().IsZero() {
+					if err := r.Delete(context.TODO(), &nm); err != nil {
+						klog.Errorf(" %s --> Unable to remove NamespaceMap '%s'", err, nm.GetName())
+						return err
+					}
+					continue
+				}
+				if err := r.removeNamespaceMapFinalizer(nm); err != nil {
+					return err
+				}
+			}
+		}
+
+	}
+
+	return nil
+}

--- a/pkg/liqo-controller-manager/virtualNode-controller/node_controller.go
+++ b/pkg/liqo-controller-manager/virtualNode-controller/node_controller.go
@@ -1,0 +1,144 @@
+/*
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package virtualNode_controller
+
+import (
+	"context"
+	mapsv1alpha1 "github.com/liqotech/liqo/apis/virtualKubelet/v1alpha1"
+	constctrl "github.com/liqotech/liqo/pkg/liqo-controller-manager"
+	ctrlutils "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/klog"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+const (
+	namespaceMapFinalizer = "namespacemap.liqo.io/finalizer"
+	virtualNodeFinalizer  = "virtualnode-controller.liqo.io/finalizer"
+)
+
+type VirtualNodeReconciler struct {
+	client.Client
+	Scheme *runtime.Scheme
+}
+
+// +kubebuilder:rbac:groups=core,resources=nodes,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=core,resources=nodes/status,verbs=get;update;patch
+
+func (r *VirtualNodeReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
+
+	node := &corev1.Node{}
+	if err := r.Get(context.TODO(), req.NamespacedName, node); err != nil {
+		klog.Errorf(" %s --> Unable to get virtual-node '%s'", err, req.Name)
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	if !ctrlutils.ContainsFinalizer(node, virtualNodeFinalizer) {
+		ctrlutils.AddFinalizer(node, virtualNodeFinalizer)
+		if err := r.Patch(context.TODO(), node, client.Merge); err != nil {
+			klog.Errorf("%s --> Unable to add '%s' to the virtual node '%s'", err, virtualNodeFinalizer, node.GetName())
+			return ctrl.Result{}, err
+		}
+	}
+
+	if !node.GetDeletionTimestamp().IsZero() {
+
+		klog.Infof("The virtual node '%s' is requested to be deleted", node.GetName())
+
+		nms := &mapsv1alpha1.NamespaceMapList{}
+		if err := r.List(context.TODO(), nms, client.InNamespace(constctrl.MapNamespaceName),
+			client.MatchingLabels{constctrl.VirtualNodeClusterId: node.GetAnnotations()[constctrl.VirtualNodeClusterId]}); err != nil {
+			klog.Errorf("%s --> Unable to List NamespaceMaps of virtual node '%s'", err, node.GetName())
+			return ctrl.Result{}, err
+		}
+
+		// delete all NamespaceMaps associated with this node, in normal conditions only one
+		for _, nm := range nms.Items {
+			if err := r.removeNamespaceMapFinalizer(nm); err != nil {
+				return ctrl.Result{}, err
+			}
+		}
+
+		ctrlutils.RemoveFinalizer(node, virtualNodeFinalizer)
+		if err := r.Update(context.TODO(), node); err != nil {
+			klog.Errorf(" %s --> Unable to remove %s from the virtual node '%s'", err, virtualNodeFinalizer, node.GetName())
+			return ctrl.Result{}, err
+		}
+		klog.Infof("Finalizer is correctly removed from the virtual node '%s'", node.GetName())
+		return ctrl.Result{}, nil
+	}
+
+	if err := r.namespaceMapLifecycle(*node); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// Events not filtered:
+// 1 -- creation of a new Virtual-node
+// 2 -- creation of a new NamespaceMap
+// 3 -- update deletionTimestamp on NamespaceMap or on Virtual-node, due to deletion request
+func filterVirtualNodes() predicate.Predicate {
+	return predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			// if the resource has no namespace, it surely a node, so we have to check if it is virtual or not, we are
+			// interested only in virtual-nodes' deletion, not common nodes' deletion.
+			if e.MetaNew.GetNamespace() == "" {
+				if value, ok := (e.MetaNew.GetLabels())[constctrl.TypeLabel]; !ok || value != constctrl.TypeNode {
+					return false
+				}
+			}
+			// so here we monitor only NamespaceMaps' and virtual-nodes' deletion
+			return !(e.MetaNew.GetDeletionTimestamp().IsZero())
+		},
+		CreateFunc: func(e event.CreateEvent) bool {
+			// listen only virtual-node creation, not simple node
+			if e.Meta.GetNamespace() == "" {
+				if value, ok := (e.Meta.GetLabels())[constctrl.TypeLabel]; !ok || value != constctrl.TypeNode {
+					return false
+				}
+			}
+			// so here we monitor only NamespaceMaps' and virtual-nodes' creation
+			return true
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return false
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			if e.Meta.GetNamespace() == "" {
+				if value, ok := (e.Meta.GetLabels())[constctrl.TypeLabel]; !ok || value != constctrl.TypeNode {
+					return false
+				}
+			}
+			return !(e.Meta.GetDeletionTimestamp().IsZero())
+		},
+	}
+}
+
+func (r *VirtualNodeReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&corev1.Node{}).
+		Owns(&mapsv1alpha1.NamespaceMap{}).
+		WithEventFilter(filterVirtualNodes()).
+		Complete(r)
+}

--- a/pkg/liqo-controller-manager/virtualNode-controller/node_controller_test.go
+++ b/pkg/liqo-controller-manager/virtualNode-controller/node_controller_test.go
@@ -1,0 +1,365 @@
+package virtualNode_controller
+
+import (
+	mapsv1alpha1 "github.com/liqotech/liqo/apis/virtualKubelet/v1alpha1"
+	const_ctrl "github.com/liqotech/liqo/pkg/liqo-controller-manager"
+
+	"context"
+	"fmt"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/kubernetes/pkg/util/slice"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"strings"
+)
+
+const (
+	testLabel = "test/key"
+	testValue = "test-value"
+)
+
+var _ = Describe("VirtualNode controller", func() {
+
+	ctx = context.TODO()
+	nms = &mapsv1alpha1.NamespaceMapList{}
+
+	Context("Check if resources VirtualNodes and NamespaceMaps are correctly initialized", func() {
+
+		It("Check presence of NamespaceMaps and virtual nodes", func() {
+
+			By(fmt.Sprintf("Try to get NamespaceMap associated to: %s", remoteClusterId1))
+			Eventually(func() bool {
+				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(const_ctrl.MapNamespaceName), client.MatchingLabels{const_ctrl.VirtualNodeClusterId: remoteClusterId1}); err != nil {
+					return false
+				}
+				if len(nms.Items) != 1 {
+					return false
+				}
+				return true
+			}, timeout, interval).Should(BeTrue())
+
+			By(fmt.Sprintf("Try to get virtual-node: %s", nameVirtualNode1))
+			Eventually(func() bool {
+				if err := k8sClient.Get(ctx, types.NamespacedName{Name: nameVirtualNode1}, virtualNode1); err != nil {
+					return false
+				}
+				return true
+			}, timeout, interval).Should(BeTrue())
+
+			By(fmt.Sprintf("Try to get NamespaceMap associated to: %s", remoteClusterId2))
+			Eventually(func() bool {
+				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(const_ctrl.MapNamespaceName), client.MatchingLabels{const_ctrl.VirtualNodeClusterId: remoteClusterId2}); err != nil {
+					return false
+				}
+				if len(nms.Items) != 1 {
+					return false
+				}
+				return true
+			}, timeout, interval).Should(BeTrue())
+
+			By(fmt.Sprintf("Try to get virtual-node: %s", nameVirtualNode2))
+			Eventually(func() bool {
+				if err := k8sClient.Get(ctx, types.NamespacedName{Name: nameVirtualNode2}, virtualNode2); err != nil {
+					return false
+				}
+				return true
+			}, timeout, interval).Should(BeTrue())
+
+		})
+
+		It(fmt.Sprintf("Check if finalizers and ownerReference are correctly created for %s", nameVirtualNode1), func() {
+
+			By(fmt.Sprintf("Try to get virtual-node: %s", nameVirtualNode1))
+			Eventually(func() bool {
+				if err := k8sClient.Get(ctx, types.NamespacedName{Name: nameVirtualNode1}, virtualNode1); err != nil {
+					return false
+				}
+				return true
+			}, timeout, interval).Should(BeTrue())
+
+			By(fmt.Sprintf("Try to get NamespaceMap associated to: %s", remoteClusterId1))
+			Eventually(func() bool {
+				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(const_ctrl.MapNamespaceName), client.MatchingLabels{const_ctrl.VirtualNodeClusterId: remoteClusterId1}); err != nil {
+					return false
+				}
+				if len(nms.Items) != 1 {
+					return false
+				}
+				return true
+			}, timeout, interval).Should(BeTrue())
+
+			expectedOwnerReference := v1.OwnerReference{
+				APIVersion:         "v1",
+				BlockOwnerDeletion: pointer.BoolPtr(true),
+				Kind:               "Node",
+				Name:               virtualNode1.GetName(),
+				UID:                virtualNode1.GetUID(),
+				Controller:         pointer.BoolPtr(true),
+			}
+
+			By(fmt.Sprintf("Try to check ownership of NamespaceMap: %s", nms.Items[0].GetName()))
+			Expect(nms.Items[0].GetOwnerReferences()).To(ContainElement(expectedOwnerReference))
+
+			By(fmt.Sprintf("Try to check presence of finalizer in NamespaceMap: %s", nms.Items[0].GetName()))
+			Expect(nms.Items[0].GetFinalizers()).To(ContainElement(namespaceMapFinalizer))
+
+			By(fmt.Sprintf("Try to check presence of finalizer in VirtualNode: %s", virtualNode1.GetName()))
+			// i have to update my node instance, because finalizer could be updated after my first get
+			Eventually(func() bool {
+				if err := k8sClient.Get(ctx, types.NamespacedName{Name: nameVirtualNode1}, virtualNode1); err != nil {
+					return false
+				}
+				return slice.ContainsString(virtualNode1.GetFinalizers(), virtualNodeFinalizer, nil)
+			}, timeout, interval).Should(BeTrue())
+
+		})
+
+		It(fmt.Sprintf("Check if finalizers and ownerReference are correctly created for %s", nameVirtualNode2), func() {
+
+			By(fmt.Sprintf("Try to get virtual-node: %s", nameVirtualNode2))
+			Eventually(func() bool {
+				if err := k8sClient.Get(ctx, types.NamespacedName{Name: nameVirtualNode2}, virtualNode2); err != nil {
+					return false
+				}
+				return true
+			}, timeout, interval).Should(BeTrue())
+
+			By(fmt.Sprintf("Try to get NamespaceMap associated to: %s", remoteClusterId2))
+			Eventually(func() bool {
+				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(const_ctrl.MapNamespaceName), client.MatchingLabels{const_ctrl.VirtualNodeClusterId: remoteClusterId2}); err != nil {
+					return false
+				}
+				if len(nms.Items) != 1 {
+					return false
+				}
+				return true
+			}, timeout, interval).Should(BeTrue())
+
+			expectedOwnerReference := v1.OwnerReference{
+				APIVersion:         "v1",
+				BlockOwnerDeletion: pointer.BoolPtr(true),
+				Kind:               "Node",
+				Name:               virtualNode2.GetName(),
+				UID:                virtualNode2.GetUID(),
+				Controller:         pointer.BoolPtr(true),
+			}
+
+			By(fmt.Sprintf("Try to check ownership of NamespaceMap: %s", nms.Items[0].GetName()))
+			Expect(nms.Items[0].GetOwnerReferences()).To(ContainElement(expectedOwnerReference))
+
+			By(fmt.Sprintf("Try to check presence of finalizer in NamespaceMap: %s", nms.Items[0].GetName()))
+			Expect(nms.Items[0].GetFinalizers()).To(ContainElement(namespaceMapFinalizer))
+
+			By(fmt.Sprintf("Try to check presence of finalizer in VirtualNode: %s", virtualNode2.GetName()))
+			// i have to update my node instance, because finalizer could be updated after my first get
+			Eventually(func() bool {
+				if err := k8sClient.Get(ctx, types.NamespacedName{Name: nameVirtualNode2}, virtualNode2); err != nil {
+					return false
+				}
+				return slice.ContainsString(virtualNode2.GetFinalizers(), virtualNodeFinalizer, nil)
+			}, timeout, interval).Should(BeTrue())
+
+		})
+
+	})
+
+	Context("Check if a non-virtual node is monitored", func() {
+
+		ctx = context.TODO()
+
+		It("Check absence of NamespaceMap and of finalizer", func() {
+
+			By(fmt.Sprintf("Try to get not virtual-node: %s", nameSimpleNode))
+			Eventually(func() bool {
+				if err := k8sClient.Get(ctx, types.NamespacedName{Name: nameSimpleNode}, simpleNode); err != nil {
+					return false
+				}
+				return true
+			}, timeout, interval).Should(BeTrue())
+
+			By(fmt.Sprintf("Check absence of NamespaceMap associated to %s", remoteClusterIdSimpleNode))
+			Consistently(func() bool {
+				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(const_ctrl.MapNamespaceName), client.MatchingLabels{const_ctrl.VirtualNodeClusterId: remoteClusterIdSimpleNode}); err != nil {
+					return false
+				}
+				if len(nms.Items) == 0 {
+					return true
+				}
+				return false
+			}, timeout/5, interval).Should(BeTrue())
+
+			By(fmt.Sprintf("Check absence of finalizer %s: ", virtualNodeFinalizer))
+			Consistently(func() bool {
+				if err := k8sClient.Get(ctx, types.NamespacedName{Name: nameSimpleNode}, simpleNode); err != nil {
+					return true
+				}
+				return slice.ContainsString(simpleNode.GetFinalizers(), virtualNodeFinalizer, nil)
+			}, timeout/5, interval).ShouldNot(BeTrue())
+
+		})
+
+	})
+
+	Context("Check deletion lifecycle of Namespacemaps and virtual-nodes ", func() {
+
+		ctx = context.TODO()
+
+		BeforeEach(func() {
+			buffer.Reset()
+		})
+
+		It(fmt.Sprintf("Check regeneration of NamespaceMap associated to %s", remoteClusterId1), func() {
+
+			oldName := ""
+			By(fmt.Sprintf("Try to delete NamespaceMap associated to: %s", remoteClusterId1))
+			Eventually(func() bool {
+				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(const_ctrl.MapNamespaceName), client.MatchingLabels{const_ctrl.VirtualNodeClusterId: remoteClusterId1}); err != nil {
+					return false
+				}
+				if len(nms.Items) != 1 {
+					return false
+				}
+
+				if nms.Items[0].Status.NattingTable == nil {
+					nms.Items[0].Status.NattingTable = map[string]string{}
+				}
+				nms.Items[0].Status.NattingTable[testLabel] = testValue
+				By(fmt.Sprintf("Try to update NamespaceMap: %s", nms.Items[0].GetName()))
+				if err := k8sClient.Update(ctx, &nms.Items[0]); err != nil {
+					return false
+				}
+
+				oldName = nms.Items[0].GetName()
+				By(fmt.Sprintf("Try to delete NamespaceMap: %s", nms.Items[0].GetName()))
+				if err := k8sClient.Delete(ctx, &nms.Items[0]); err != nil {
+					return false
+				}
+				return true
+			}, timeout, interval).Should(BeTrue())
+
+			By(fmt.Sprintf("Try to get new NamespaceMap associated to: %s", remoteClusterId1))
+			Eventually(func() bool {
+				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(const_ctrl.MapNamespaceName), client.MatchingLabels{const_ctrl.VirtualNodeClusterId: remoteClusterId1}); err != nil {
+					return false
+				}
+				if len(nms.Items) != 1 {
+					return false
+				}
+				if oldName != nms.Items[0].GetName() && nms.Items[0].Status.NattingTable[testLabel] == testValue {
+					return true
+				}
+				return false
+			}, timeout, interval).Should(BeTrue())
+
+		})
+
+		It(fmt.Sprintf("Check regeneration of NamespaceMap associated to %s", remoteClusterId2), func() {
+
+			oldName := ""
+			By(fmt.Sprintf("Try to delete NamespaceMap associated to: %s", remoteClusterId2))
+			Eventually(func() bool {
+				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(const_ctrl.MapNamespaceName), client.MatchingLabels{const_ctrl.VirtualNodeClusterId: remoteClusterId2}); err != nil {
+					return false
+				}
+				if len(nms.Items) != 1 {
+					return false
+				}
+
+				if nms.Items[0].Status.NattingTable == nil {
+					nms.Items[0].Status.NattingTable = map[string]string{}
+				}
+				nms.Items[0].Status.NattingTable[testLabel] = testValue
+				By(fmt.Sprintf("Try to update NamespaceMap: %s", nms.Items[0].GetName()))
+				if err := k8sClient.Update(ctx, &nms.Items[0]); err != nil {
+					return false
+				}
+
+				oldName = nms.Items[0].GetName()
+				By(fmt.Sprintf("Try to delete NamespaceMap: %s", nms.Items[0].GetName()))
+				if err := k8sClient.Delete(ctx, &nms.Items[0]); err != nil {
+					return false
+				}
+				return true
+			}, timeout, interval).Should(BeTrue())
+
+			By(fmt.Sprintf("Try to get new NamespaceMap associated to: %s", remoteClusterId2))
+			Eventually(func() bool {
+				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(const_ctrl.MapNamespaceName), client.MatchingLabels{const_ctrl.VirtualNodeClusterId: remoteClusterId2}); err != nil {
+					return false
+				}
+				if len(nms.Items) != 1 {
+					return false
+				}
+				if oldName != nms.Items[0].GetName() && nms.Items[0].Status.NattingTable[testLabel] == testValue {
+					return true
+				}
+				return false
+			}, timeout, interval).Should(BeTrue())
+
+		})
+
+		It(fmt.Sprintf("Check deletion of virtualNode: %s", nameVirtualNode1), func() {
+
+			By(fmt.Sprintf("Try to delete virtual-node: %s", nameVirtualNode1))
+			Eventually(func() bool {
+				if err := k8sClient.Get(ctx, types.NamespacedName{Name: nameVirtualNode1}, virtualNode1); err != nil {
+					return false
+				}
+				if err := k8sClient.Delete(ctx, virtualNode1); err != nil {
+					return false
+				}
+				return true
+			}, timeout, interval).Should(BeTrue())
+
+			By("Try to catch right virtual-node log: ")
+			Eventually(func() bool {
+				return strings.Contains(buffer.String(), fmt.Sprintf("The virtual node '%s' is requested to be deleted", nameVirtualNode1))
+			}, timeout, interval).Should(BeTrue())
+
+			By(fmt.Sprintf("Try to get if virtual-node %s is removed", nameVirtualNode1))
+			Eventually(func() bool {
+				if err := k8sClient.Get(ctx, types.NamespacedName{Name: nameVirtualNode1}, virtualNode1); err != nil {
+					if errors.IsNotFound(err) {
+						return true
+					}
+				}
+				return false
+			}, timeout*2, interval).Should(BeTrue())
+		})
+
+		It(fmt.Sprintf("Check deletion of virtualNode: %s", nameVirtualNode2), func() {
+
+			By(fmt.Sprintf("Try to delete virtual-node: %s", nameVirtualNode2))
+			Eventually(func() bool {
+				if err := k8sClient.Get(ctx, types.NamespacedName{Name: nameVirtualNode2}, virtualNode2); err != nil {
+					return false
+				}
+				if err := k8sClient.Delete(ctx, virtualNode2); err != nil {
+					return false
+				}
+				return true
+			}, timeout, interval).Should(BeTrue())
+
+			By("Try to catch right virtual-node log: ")
+			Eventually(func() bool {
+				return strings.Contains(buffer.String(), fmt.Sprintf("The virtual node '%s' is requested to be deleted", nameVirtualNode2))
+			}, timeout, interval).Should(BeTrue())
+
+			By(fmt.Sprintf("Try to get if virtual-node %s is removed", nameVirtualNode2))
+			Eventually(func() bool {
+				if err := k8sClient.Get(ctx, types.NamespacedName{Name: nameVirtualNode2}, virtualNode2); err != nil {
+					if errors.IsNotFound(err) {
+						return true
+					}
+				}
+				return false
+			}, timeout, interval).Should(BeTrue())
+		})
+
+	})
+
+})

--- a/pkg/liqo-controller-manager/virtualNode-controller/suite_test.go
+++ b/pkg/liqo-controller-manager/virtualNode-controller/suite_test.go
@@ -1,0 +1,206 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package virtualNode_controller
+
+import (
+	"bytes"
+	"context"
+	"flag"
+	mapsv1alpha1 "github.com/liqotech/liqo/apis/virtualKubelet/v1alpha1"
+	const_ctrl "github.com/liqotech/liqo/pkg/liqo-controller-manager"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"path/filepath"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"k8s.io/klog"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
+	// +kubebuilder:scaffold:imports
+)
+
+// These tests use Ginkgo (BDD-style Go testing framework). Refer to
+// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
+
+var cfg *rest.Config
+var k8sClient client.Client
+var testEnv *envtest.Environment
+
+const (
+	nameVirtualNode1          = "virtual-node-1"
+	nameVirtualNode2          = "virtual-node-2"
+	nameSimpleNode            = "simple-node"
+	remoteClusterId1          = "6a0e9f-b52-4ed0"
+	remoteClusterId2          = "899890-dsd-323"
+	remoteClusterIdSimpleNode = "909030-sd-3231"
+	offloadingCluster1Label1  = "offloading.liqo.io/cluster-1"
+	offloadingCluster1Label2  = "offloading.liqo.io/AWS"
+	offloadingCluster2Label1  = "offloading.liqo.io/cluster-2"
+	offloadingCluster2Label2  = "offloading.liqo.io/GKE"
+	timeout                   = time.Second * 10
+	interval                  = time.Millisecond * 250
+)
+
+var (
+	nms          *mapsv1alpha1.NamespaceMapList
+	ctx          context.Context
+	virtualNode1 *corev1.Node
+	virtualNode2 *corev1.Node
+	simpleNode   *corev1.Node
+	mapNamespace *corev1.Namespace
+	flags        *flag.FlagSet
+	buffer       *bytes.Buffer
+)
+
+func TestAPIs(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecsWithDefaultAndCustomReporters(t,
+		"Controller Suite",
+		[]Reporter{printer.NewlineReporter{}})
+}
+
+var _ = BeforeSuite(func(done Done) {
+
+	By("bootstrapping test environment")
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths: []string{filepath.Join("..", "..", "..", "deployments", "liqo", "crds")},
+	}
+
+	buffer = &bytes.Buffer{}
+	flags = &flag.FlagSet{}
+	klog.InitFlags(flags)
+	_ = flags.Set("v", "2")
+	_ = flags.Set("logtostderr", "false")
+	klog.SetOutput(buffer)
+	buffer.Reset()
+
+	var err error
+	cfg, err = testEnv.Start()
+	Expect(err).ToNot(HaveOccurred())
+	Expect(cfg).ToNot(BeNil())
+
+	err = corev1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = mapsv1alpha1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+	// +kubebuilder:scaffold:scheme
+
+	k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme: scheme.Scheme,
+	})
+	Expect(err).ToNot(HaveOccurred())
+
+	err = (&VirtualNodeReconciler{
+		Client: k8sManager.GetClient(),
+		Scheme: k8sManager.GetScheme(),
+	}).SetupWithManager(k8sManager)
+	Expect(err).ToNot(HaveOccurred())
+
+	go func() {
+		err = k8sManager.Start(ctrl.SetupSignalHandler())
+		Expect(err).ToNot(HaveOccurred())
+	}()
+
+	k8sClient = k8sManager.GetClient()
+	Expect(k8sClient).ToNot(BeNil())
+
+	virtualNode1 = &corev1.Node{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Node",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: nameVirtualNode1,
+			Annotations: map[string]string{
+				const_ctrl.VirtualNodeClusterId: remoteClusterId1,
+			},
+			Labels: map[string]string{
+				const_ctrl.TypeLabel:     const_ctrl.TypeNode,
+				offloadingCluster1Label1: "",
+				offloadingCluster1Label2: "",
+			},
+		},
+	}
+
+	virtualNode2 = &corev1.Node{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Node",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: nameVirtualNode2,
+			Annotations: map[string]string{
+				const_ctrl.VirtualNodeClusterId: remoteClusterId2,
+			},
+			Labels: map[string]string{
+				const_ctrl.TypeLabel:     const_ctrl.TypeNode,
+				offloadingCluster2Label1: "",
+				offloadingCluster2Label2: "",
+			},
+		},
+	}
+
+	simpleNode = &corev1.Node{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Node",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: nameSimpleNode,
+			Annotations: map[string]string{
+				const_ctrl.VirtualNodeClusterId: remoteClusterIdSimpleNode,
+			},
+			Labels: map[string]string{
+				offloadingCluster1Label1: "",
+				offloadingCluster1Label2: "",
+			},
+		},
+	}
+
+	mapNamespace = &corev1.Namespace{}
+	Eventually(func() bool {
+		if err = k8sClient.Get(ctx, types.NamespacedName{Name: const_ctrl.MapNamespaceName}, mapNamespace); err != nil {
+			if errors.IsNotFound(err) {
+				if err = k8sClient.Create(context.TODO(), virtualNode1); err == nil {
+					return true
+				}
+			}
+			return false
+		}
+		return true
+	}, timeout, interval).Should(BeTrue())
+
+	// create 2 virtual-nodes and 1 simple node (not virtual)
+	Expect(k8sClient.Create(context.TODO(), virtualNode1)).Should(Succeed())
+	Expect(k8sClient.Create(context.TODO(), virtualNode2)).Should(Succeed())
+	Expect(k8sClient.Create(context.TODO(), simpleNode)).Should(Succeed())
+
+	close(done)
+}, 60)
+
+var _ = AfterSuite(func() {
+	By("tearing down the test environment")
+	err := testEnv.Stop()
+	Expect(err).ToNot(HaveOccurred())
+})


### PR DESCRIPTION
# Description

Virtual-node controller spawns `NamespaceMaps` relative to cluster's virtual-nodes. This controller must ensure that virtual-nodes have their associated `NamespaceMap` during all their lifecycle, so it is also necessary to manage, in a suitable way, `NamespaceMap`'s deletion logic.

# Fixes

**STEP 2** #572 
