### PR TITLE
Namespace-controller

### DIFF
--- a/cmd/advertisement-operator/main.go
+++ b/cmd/advertisement-operator/main.go
@@ -1,11 +1,8 @@
 /*
-
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-
     http://www.apache.org/licenses/LICENSE-2.0
-
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,7 +15,9 @@ package main
 import (
 	"flag"
 	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
+	mapsv1alpha1 "github.com/liqotech/liqo/apis/virtualKubelet/v1alpha1"
 	"github.com/liqotech/liqo/pkg/crdClient"
+	namectrl "github.com/liqotech/liqo/pkg/liqo-controller-manager/namespace-controller"
 	"github.com/liqotech/liqo/pkg/mapperUtils"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -55,6 +54,8 @@ func init() {
 	_ = advtypes.AddToScheme(scheme)
 
 	_ = netv1alpha1.AddToScheme(scheme)
+
+	_ = mapsv1alpha1.AddToScheme(scheme)
 	// +kubebuilder:scaffold:scheme
 }
 
@@ -150,6 +151,15 @@ func main() {
 	if err = r.SetupWithManager(mgr); err != nil {
 		klog.Error(err)
 		os.Exit(1)
+	}
+
+	r2 := &namectrl.NamespaceReconciler{
+		Client: mgr.GetClient(),
+		Scheme: mgr.GetScheme(),
+	}
+
+	if err = r2.SetupWithManager(mgr); err != nil {
+		klog.Fatal(err)
 	}
 	// +kubebuilder:scaffold:builder
 

--- a/pkg/liqo-controller-manager/const.go
+++ b/pkg/liqo-controller-manager/const.go
@@ -1,0 +1,8 @@
+package liqo_controller_manager
+
+const (
+	VirtualNodeClusterId = "remote.liqo.io/clusterId"
+	MapNamespaceName     = "default"
+	TypeLabel            = "liqo.io/type"
+	TypeNode             = "virtual-node"
+)

--- a/pkg/liqo-controller-manager/namespace-controller/manage_namespace_labels.go
+++ b/pkg/liqo-controller-manager/namespace-controller/manage_namespace_labels.go
@@ -1,0 +1,67 @@
+package namespace_controller
+
+import (
+	const_ctrl "github.com/liqotech/liqo/pkg/liqo-controller-manager"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/klog"
+	"k8s.io/kubernetes/pkg/util/slice"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"strings"
+)
+
+// Checks if Namespace has all offloading Labels of a specific node
+func checkOffloadingLabels(na *corev1.Namespace, n *corev1.Node) bool {
+	for key := range n.GetLabels() {
+		if strings.HasPrefix(key, offloadingPrefixLabel) {
+			if _, ok := na.GetLabels()[key]; !ok {
+				klog.Infof(" Namespace '%s' cannot be offloaded on remote cluster: %s", na.GetName(), n.Annotations[const_ctrl.VirtualNodeClusterId])
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// Checks if mappingLabel value is changed from the previous one
+func mappingLabelUpdate(oldLabels map[string]string, newLabels map[string]string) bool {
+	ret := false
+	if val1, ok := oldLabels[mappingLabel]; ok {
+		ret = val1 != newLabels[mappingLabel]
+	}
+	return ret
+}
+
+// Checks if the Namespace which triggers an Event, contains mappingLabel
+func mappingLabelPresence(labels map[string]string) bool {
+	_, ok := labels[mappingLabel]
+	return ok
+}
+
+// Events not filtered:
+// 1 -- deletion timestamp is updated on a relevant namespace (only that ones with my finalizer)
+// 2 -- add/delete labels, and mappingLabel is present before or after the update
+// 3 -- update the value of mappingLabel label only
+// 4 -- add namespace with at least mappingLabel
+func manageLabelPredicate() predicate.Predicate {
+	return predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			// if a namespace with namespaceFinalizer is deleted, trigger Reconcile
+			if !(e.MetaNew.GetDeletionTimestamp().IsZero()) && slice.ContainsString(e.MetaNew.GetFinalizers(), namespaceFinalizer, nil) {
+				return true
+			}
+
+			// if the number of labels is changed after the event, and before or after the event there was mappingLabel, maybe controller has to do something, so trigger it
+			// ||
+			// if mappingLabel value is changed while the namespace is offloaded, controller has to force mappingLabel to its old value (see createRemoteNamespace function)
+			return ((len(e.MetaOld.GetLabels()) != len(e.MetaNew.GetLabels())) && (mappingLabelPresence(e.MetaOld.GetLabels()) ||
+				mappingLabelPresence(e.MetaNew.GetLabels()))) || mappingLabelUpdate(e.MetaOld.GetLabels(), e.MetaNew.GetLabels())
+		},
+		CreateFunc: func(e event.CreateEvent) bool {
+			return mappingLabelPresence(e.Meta.GetLabels())
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return false
+		},
+	}
+}

--- a/pkg/liqo-controller-manager/namespace-controller/manage_remote_namespaces.go
+++ b/pkg/liqo-controller-manager/namespace-controller/manage_remote_namespaces.go
@@ -1,0 +1,73 @@
+package namespace_controller
+
+import (
+	"context"
+	mapsv1alpha1 "github.com/liqotech/liqo/apis/virtualKubelet/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/klog"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Removes right entry from one NamespaceMap
+func (r *NamespaceReconciler) removeRemoteNamespace(localName string, nm mapsv1alpha1.NamespaceMap) error {
+
+	if _, ok := nm.Status.NattingTable[localName]; ok {
+		delete(nm.Status.NattingTable, localName)
+		if err := r.Update(context.TODO(), &nm); err != nil {
+			klog.Error(err, " --> Unable to update NamespaceMap")
+			return err
+		}
+		klog.Info(" Entries deleted correctly")
+	}
+
+	return nil
+}
+
+// Removes right entries from more than one NamespaceMap (it depends on len(nms))
+func (r *NamespaceReconciler) removeRemoteNamespaces(localName string, nms map[string]mapsv1alpha1.NamespaceMap) error {
+
+	for _, nm := range nms {
+		if err := r.removeRemoteNamespace(localName, nm); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Adds right entry on one NamespaceMap, if it isn't already there
+func (r *NamespaceReconciler) createRemoteNamespace(n *corev1.Namespace, remoteName string, nm mapsv1alpha1.NamespaceMap) error {
+
+	if nm.Status.NattingTable == nil {
+		nm.Status.NattingTable = map[string]string{}
+	}
+
+	if oldValue, ok := nm.Status.NattingTable[n.GetName()]; ok {
+		// if entries are already here, but mappingLabel has a different value from the previous one, we force again the old value.
+		// Common user cannot change remote namespace name while the namespace is offloaded onto remote clusters
+		if oldValue != remoteName {
+			n.GetLabels()[mappingLabel] = oldValue
+			if err := r.Update(context.TODO(), n); err != nil {
+				klog.Error(err, " --> Unable to update mapping label")
+				return err
+			}
+		}
+	} else {
+		nm.Status.NattingTable[n.GetName()] = remoteName
+		if err := r.Patch(context.TODO(), &nm, client.Merge); err != nil {
+			klog.Error(err, " --> Unable to add entries in NamespaceMap")
+			return err
+		}
+	}
+	return nil
+}
+
+// Adds right entries on more than one NamespaceMap (it depends on len(nms)), if they aren't already there
+func (r *NamespaceReconciler) createRemoteNamespaces(n *corev1.Namespace, remoteName string, nms map[string]mapsv1alpha1.NamespaceMap) error {
+
+	for _, nm := range nms {
+		if err := r.createRemoteNamespace(n, remoteName, nm); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/liqo-controller-manager/namespace-controller/namespace_controller.go
+++ b/pkg/liqo-controller-manager/namespace-controller/namespace_controller.go
@@ -1,0 +1,152 @@
+/*
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package namespace_controller
+
+import (
+	"context"
+	mapsv1alpha1 "github.com/liqotech/liqo/apis/virtualKubelet/v1alpha1"
+	const_ctrl "github.com/liqotech/liqo/pkg/liqo-controller-manager"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/klog"
+	"k8s.io/kubernetes/pkg/util/slice"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type NamespaceReconciler struct {
+	client.Client
+	Scheme *runtime.Scheme
+}
+
+const (
+	mappingLabel          = "mapping.liqo.io"
+	offloadingLabel       = "offloading.liqo.io"
+	offloadingPrefixLabel = "offloading.liqo.io/"
+	namespaceFinalizer    = "namespace-controller.liqo.io/finalizer"
+)
+
+func (r *NamespaceReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
+
+	namespace := &corev1.Namespace{}
+	if err := r.Get(context.TODO(), req.NamespacedName, namespace); err != nil {
+		klog.Error(err, " --> Unable to get namespace")
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	namespaceMaps := &mapsv1alpha1.NamespaceMapList{}
+	if err := r.List(context.TODO(), namespaceMaps); err != nil {
+		klog.Error(err, " --> Unable to List NamespaceMaps")
+		return ctrl.Result{}, err
+	}
+
+	if len(namespaceMaps.Items) == 0 {
+		klog.Info(" No namespaceMaps at the moment")
+		return ctrl.Result{}, nil
+	}
+
+	removeMappings := make(map[string]mapsv1alpha1.NamespaceMap)
+	for _, namespaceMap := range namespaceMaps.Items {
+		removeMappings[namespaceMap.GetLabels()[const_ctrl.VirtualNodeClusterId]] = namespaceMap
+	}
+
+	if namespace.GetDeletionTimestamp().IsZero() {
+		if !slice.ContainsString(namespace.GetFinalizers(), namespaceFinalizer, nil) {
+			namespace.SetFinalizers(append(namespace.GetFinalizers(), namespaceFinalizer))
+			if err := r.Patch(context.TODO(), namespace, client.Merge); err != nil {
+				klog.Error(err, " --> Unable to add finalizer")
+				return ctrl.Result{}, err
+			}
+		}
+	} else {
+		if slice.ContainsString(namespace.GetFinalizers(), namespaceFinalizer, nil) {
+
+			if err := r.removeRemoteNamespaces(namespace.GetName(), removeMappings); err != nil {
+				return ctrl.Result{}, err
+			}
+
+			klog.Info(" Someone try to delete namespace, ok delete!!")
+
+			namespace.SetFinalizers(slice.RemoveString(namespace.GetFinalizers(), namespaceFinalizer, nil))
+			if err := r.Update(context.TODO(), namespace); err != nil {
+				klog.Error(err, " --> Unable to remove finalizer")
+				return ctrl.Result{}, err
+			}
+		}
+
+		return ctrl.Result{}, nil
+	}
+
+	// 1. If mapping.liqo.io label is not present there are no remote namespaces associated with this namespace, removeMappings is full
+	if remoteNamespaceName, ok := namespace.GetLabels()[mappingLabel]; ok {
+
+		// 2.a If offloading.liqo.io is present there are remote namespaces on all virtual nodes
+		if _, ok = namespace.GetLabels()[offloadingLabel]; ok {
+			klog.Infof(" Offload namespace '%s' on all remote clusters", namespace.GetName())
+			if err := r.createRemoteNamespaces(namespace, remoteNamespaceName, removeMappings); err != nil {
+				return ctrl.Result{}, err
+			}
+
+			for k := range removeMappings {
+				delete(removeMappings, k)
+			}
+
+		} else {
+
+			// 2.b Iterate on all virtual nodes' labels, if the namespace has all the requested labels, is necessary to
+			// offload it onto remote cluster associated with the virtual node
+			nodes := &corev1.NodeList{}
+			if err := r.List(context.TODO(), nodes, client.MatchingLabels{const_ctrl.TypeLabel: const_ctrl.TypeNode}); err != nil {
+				klog.Error(err, " --> Unable to List all virtual nodes")
+				return ctrl.Result{}, err
+			}
+
+			if len(nodes.Items) == 0 {
+				klog.Info(" No VirtualNode at the moment")
+				return ctrl.Result{}, nil
+			}
+
+			for _, node := range nodes.Items {
+				if checkOffloadingLabels(namespace, &node) {
+					if err := r.createRemoteNamespace(namespace, remoteNamespaceName, removeMappings[node.Annotations[const_ctrl.VirtualNodeClusterId]]); err != nil {
+						return ctrl.Result{}, err
+					}
+					delete(removeMappings, node.Annotations[const_ctrl.VirtualNodeClusterId])
+					klog.Infof(" Offload namespace '%s' on remote cluster: %s", namespace.GetName(), node.Annotations[const_ctrl.VirtualNodeClusterId])
+				}
+
+			}
+		}
+
+	}
+
+	if len(removeMappings) > 0 {
+		klog.Info(" Delete all unnecessary mapping in NamespaceMaps")
+		if err := r.removeRemoteNamespaces(namespace.GetName(), removeMappings); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func (r *NamespaceReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&corev1.Namespace{}).
+		WithEventFilter(manageLabelPredicate()).
+		Complete(r)
+}

--- a/pkg/liqo-controller-manager/namespace-controller/namespace_controller_test.go
+++ b/pkg/liqo-controller-manager/namespace-controller/namespace_controller_test.go
@@ -1,0 +1,485 @@
+package namespace_controller
+
+import (
+	"context"
+	"fmt"
+	mapsv1alpha1 "github.com/liqotech/liqo/apis/virtualKubelet/v1alpha1"
+	const_ctrl "github.com/liqotech/liqo/pkg/liqo-controller-manager"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/kubernetes/pkg/util/slice"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"time"
+)
+
+var _ = Describe("Namespace controller", func() {
+
+	const (
+		timeout         = time.Second * 10
+		interval        = time.Millisecond * 250
+		mappingLabel    = "mapping.liqo.io"
+		offloadingLabel = "offloading.liqo.io"
+	)
+
+	ctx = context.TODO()
+	nms = &mapsv1alpha1.NamespaceMapList{}
+
+	Context("Adding some labels and checking state of NamespaceMaps", func() {
+
+		BeforeEach(func() {
+
+			By(fmt.Sprintf("Try to cleaning %s labels", nameNamespaceTest))
+			Eventually(func() bool {
+				if err := k8sClient.Get(ctx, types.NamespacedName{Name: nameNamespaceTest}, namespace); err != nil {
+					return false
+				}
+				delete(namespace.GetLabels(), mappingLabel)
+				delete(namespace.GetLabels(), offloadingLabel)
+				delete(namespace.GetLabels(), offloadingCluster1Label1)
+				delete(namespace.GetLabels(), offloadingCluster1Label2)
+				delete(namespace.GetLabels(), offloadingCluster2Label1)
+				delete(namespace.GetLabels(), offloadingCluster2Label2)
+				namespace.GetLabels()[randomLabel] = ""
+
+				if err := k8sClient.Update(ctx, namespace); err != nil {
+					return false
+				}
+				return true
+			}, timeout, interval).Should(BeTrue())
+
+			By(fmt.Sprintf("Check if NamespaceMap associated to %s is cleaned by the controller", remoteClusterId1))
+			Eventually(func() bool {
+				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(const_ctrl.MapNamespaceName), client.MatchingLabels{const_ctrl.VirtualNodeClusterId: remoteClusterId1}); err != nil {
+					return false
+				}
+				if len(nms.Items) != 1 {
+					return false
+				}
+				By("Check status of NattingTable")
+				if _, ok := nms.Items[0].Status.NattingTable[nameNamespaceTest]; !ok {
+					return true
+				}
+				return false
+			}, timeout, interval).Should(BeTrue())
+
+			By(fmt.Sprintf("Check if NamespaceMap associated to %s is cleaned by the controller ", remoteClusterId2))
+			Eventually(func() bool {
+				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(const_ctrl.MapNamespaceName), client.MatchingLabels{const_ctrl.VirtualNodeClusterId: remoteClusterId2}); err != nil {
+					return false
+				}
+				if len(nms.Items) != 1 {
+					return false
+				}
+				By("Check status of NattingTable")
+				if _, ok := nms.Items[0].Status.NattingTable[nameNamespaceTest]; !ok {
+					return true
+				}
+				return false
+			}, timeout, interval).Should(BeTrue())
+
+		})
+
+		It(fmt.Sprintf("Adding %s and %s , check presence of finalizer: %s", mappingLabel, offloadingLabel, namespaceFinalizer), func() {
+
+			By(fmt.Sprintf("Try to get Namespace: %s", nameNamespaceTest))
+			Eventually(func() bool {
+				if err := k8sClient.Get(ctx, types.NamespacedName{Name: nameNamespaceTest}, namespace); err != nil {
+					return false
+				}
+				namespace.GetLabels()[mappingLabel] = nameRemoteNamespace
+				namespace.GetLabels()[offloadingLabel] = ""
+
+				By(fmt.Sprintf("Adding labels to: %s", nameNamespaceTest))
+				if err := k8sClient.Patch(ctx, namespace, client.Merge); err != nil {
+					return false
+				}
+				return true
+			}, timeout, interval).Should(BeTrue())
+
+			By(fmt.Sprintf("Try to get again: %s", nameNamespaceTest))
+			Eventually(func() bool {
+				if err := k8sClient.Get(ctx, types.NamespacedName{Name: nameNamespaceTest}, namespace); err != nil {
+					return false
+				}
+				return slice.ContainsString(namespace.GetFinalizers(), namespaceFinalizer, nil)
+			}, timeout, interval).Should(BeTrue())
+
+		})
+
+		It(fmt.Sprintf("Adding %s and %s , check NamespaceMaps status", mappingLabel, offloadingLabel), func() {
+
+			By(fmt.Sprintf("Try to get Namespace: %s", nameNamespaceTest))
+			Eventually(func() bool {
+				if err := k8sClient.Get(ctx, types.NamespacedName{Name: nameNamespaceTest}, namespace); err != nil {
+					return false
+				}
+				namespace.GetLabels()[mappingLabel] = nameRemoteNamespace
+				namespace.GetLabels()[offloadingLabel] = ""
+
+				By(fmt.Sprintf("Adding labels to: %s", nameNamespaceTest))
+				if err := k8sClient.Patch(ctx, namespace, client.Merge); err != nil {
+					return false
+				}
+				return true
+			}, timeout, interval).Should(BeTrue())
+
+			By(fmt.Sprintf("Try to get NamespaceMap associated to: %s", remoteClusterId1))
+			Eventually(func() bool {
+				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(const_ctrl.MapNamespaceName), client.MatchingLabels{const_ctrl.VirtualNodeClusterId: remoteClusterId1}); err != nil {
+					return false
+				}
+				if len(nms.Items) != 1 {
+					return false
+				}
+				By("Check status of NattingTable")
+				if value, ok := nms.Items[0].Status.NattingTable[nameNamespaceTest]; ok && value == nameRemoteNamespace {
+					return true
+				}
+				return false
+			}, timeout, interval).Should(BeTrue())
+
+			By(fmt.Sprintf("Try to get NamespaceMap: associated to %s", remoteClusterId2))
+			Eventually(func() bool {
+				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(const_ctrl.MapNamespaceName), client.MatchingLabels{const_ctrl.VirtualNodeClusterId: remoteClusterId2}); err != nil {
+					return false
+				}
+				if len(nms.Items) != 1 {
+					return false
+				}
+				By("Check status of NattingTable")
+				if value, ok := nms.Items[0].Status.NattingTable[nameNamespaceTest]; ok && value == nameRemoteNamespace {
+					return true
+				}
+				return false
+			}, timeout, interval).Should(BeTrue())
+
+		})
+
+		It(fmt.Sprintf("Adding %s, %s and all labels for %s, check NamespaceMaps status", mappingLabel, offloadingLabel, nameVirtualNode1), func() {
+
+			By(fmt.Sprintf("Try to get Namespace: %s", nameNamespaceTest))
+			Eventually(func() bool {
+				if err := k8sClient.Get(ctx, types.NamespacedName{Name: nameNamespaceTest}, namespace); err != nil {
+					return false
+				}
+				namespace.GetLabels()[mappingLabel] = nameRemoteNamespace
+				namespace.GetLabels()[offloadingLabel] = ""
+				namespace.GetLabels()[offloadingCluster1Label1] = ""
+				namespace.GetLabels()[offloadingCluster1Label2] = ""
+
+				By(fmt.Sprintf("Adding labels to: %s", nameNamespaceTest))
+				if err := k8sClient.Patch(ctx, namespace, client.Merge); err != nil {
+					return false
+				}
+				return true
+			}, timeout, interval).Should(BeTrue())
+
+			By(fmt.Sprintf("Check if entry is also on NamespaceMap associated to: %s", remoteClusterId2))
+			Eventually(func() bool {
+				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(const_ctrl.MapNamespaceName), client.MatchingLabels{const_ctrl.VirtualNodeClusterId: remoteClusterId2}); err != nil {
+					return false
+				}
+				if len(nms.Items) != 1 {
+					return false
+				}
+				By("Check status of NattingTable")
+				if value, ok := nms.Items[0].Status.NattingTable[nameNamespaceTest]; ok && value == nameRemoteNamespace {
+					return true
+				}
+				return false
+
+			}, timeout, interval).Should(BeTrue())
+
+		})
+
+		It(fmt.Sprintf("Adding %s and all labels for %s, check NamespaceMaps status", mappingLabel, nameVirtualNode1), func() {
+
+			By(fmt.Sprintf("Try to get Namespace: %s", nameNamespaceTest))
+			Eventually(func() bool {
+				if err := k8sClient.Get(ctx, types.NamespacedName{Name: nameNamespaceTest}, namespace); err != nil {
+					return false
+				}
+				namespace.GetLabels()[mappingLabel] = nameRemoteNamespace
+				namespace.GetLabels()[offloadingCluster1Label1] = ""
+				namespace.GetLabels()[offloadingCluster1Label2] = ""
+
+				By(fmt.Sprintf("Adding labels to: %s", nameNamespaceTest))
+				if err := k8sClient.Patch(ctx, namespace, client.Merge); err != nil {
+					return false
+				}
+				return true
+			}, timeout, interval).Should(BeTrue())
+
+			By(fmt.Sprintf("Try to get NamespaceMap associated to %s", remoteClusterId1))
+			Eventually(func() bool {
+				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(const_ctrl.MapNamespaceName), client.MatchingLabels{const_ctrl.VirtualNodeClusterId: remoteClusterId1}); err != nil {
+					return false
+				}
+				if len(nms.Items) != 1 {
+					return false
+				}
+
+				By("Check status of NattingTable")
+				if value, ok := nms.Items[0].Status.NattingTable[nameNamespaceTest]; ok && value == nameRemoteNamespace {
+					return true
+				}
+				return false
+
+			}, timeout, interval).Should(BeTrue())
+
+			By(fmt.Sprintf("Try to get NamespaceMap associated to %s", remoteClusterId2))
+			Consistently(func() bool {
+				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(const_ctrl.MapNamespaceName), client.MatchingLabels{const_ctrl.VirtualNodeClusterId: remoteClusterId2}); err != nil {
+					return true
+				}
+				if len(nms.Items) != 1 {
+					return true
+				}
+
+				By("Check status of NattingTable")
+				if value, ok := nms.Items[0].Status.NattingTable[nameNamespaceTest]; ok && value == nameRemoteNamespace {
+					return true
+				}
+				return false
+			}, timeout/5, interval).ShouldNot(BeTrue())
+
+		})
+
+		It(fmt.Sprintf("Update %s  value and check if the namespace's label is automatically patched to old value", mappingLabel), func() {
+
+			By(fmt.Sprintf("Try to get Namespace: %s", nameNamespaceTest))
+			Eventually(func() bool {
+				if err := k8sClient.Get(ctx, types.NamespacedName{Name: nameNamespaceTest}, namespace); err != nil {
+					return false
+				}
+				namespace.GetLabels()[mappingLabel] = nameRemoteNamespace
+				namespace.GetLabels()[offloadingLabel] = ""
+
+				By(fmt.Sprintf("Adding labels to: %s", nameNamespaceTest))
+				if err := k8sClient.Patch(ctx, namespace, client.Merge); err != nil {
+					return false
+				}
+				return true
+			}, timeout, interval).Should(BeTrue())
+
+			By(fmt.Sprintf("Try to get NamespaceMap associated to: %s", remoteClusterId1))
+			Eventually(func() bool {
+				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(const_ctrl.MapNamespaceName), client.MatchingLabels{const_ctrl.VirtualNodeClusterId: remoteClusterId1}); err != nil {
+					return false
+				}
+				if len(nms.Items) != 1 {
+					return false
+				}
+
+				By("Check status of NattingTable")
+				if value, ok := nms.Items[0].Status.NattingTable[nameNamespaceTest]; ok && value == nameRemoteNamespace {
+					return true
+				}
+				return false
+			}, timeout, interval).Should(BeTrue())
+
+			By(fmt.Sprintf("Try to get NamespaceMap associated to: %s", remoteClusterId2))
+			Eventually(func() bool {
+				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(const_ctrl.MapNamespaceName), client.MatchingLabels{const_ctrl.VirtualNodeClusterId: remoteClusterId2}); err != nil {
+					return false
+				}
+				if len(nms.Items) != 1 {
+					return false
+				}
+
+				By("Check status of NattingTable")
+				if value, ok := nms.Items[0].Status.NattingTable[nameNamespaceTest]; ok && value == nameRemoteNamespace {
+					return true
+				}
+				return false
+			}, timeout, interval).Should(BeTrue())
+
+			By(fmt.Sprintf("Try to get again %s", nameNamespaceTest))
+			Eventually(func() bool {
+				if err := k8sClient.Get(ctx, types.NamespacedName{Name: nameNamespaceTest}, namespace); err != nil {
+					return false
+				}
+				namespace.GetLabels()[mappingLabel] = "new-value-remote-namespace-test"
+
+				By(fmt.Sprintf("Update %s", mappingLabel))
+				if err := k8sClient.Update(ctx, namespace); err != nil {
+					return false
+				}
+				return true
+			}, timeout, interval).Should(BeTrue())
+
+			By(fmt.Sprintf("Try to get %s and check if label %s value is the old one", nameNamespaceTest, mappingLabel))
+			Eventually(func() bool {
+				if err := k8sClient.Get(ctx, types.NamespacedName{Name: nameNamespaceTest}, namespace); err != nil {
+					return false
+				}
+				value, ok := namespace.GetLabels()[mappingLabel]
+				return ok && value == nameRemoteNamespace
+			}, timeout, interval).Should(BeTrue())
+
+		})
+
+	})
+
+	Context("Check deletion of entries in NamespaceMaps", func() {
+
+		BeforeEach(func() {
+
+			By(fmt.Sprintf("Add labels to %s", nameNamespaceTest))
+			Eventually(func() bool {
+				if err := k8sClient.Get(ctx, types.NamespacedName{Name: nameNamespaceTest}, namespace); err != nil {
+					return false
+				}
+				namespace.GetLabels()[mappingLabel] = nameRemoteNamespace
+				namespace.GetLabels()[offloadingLabel] = ""
+				delete(namespace.GetLabels(), offloadingCluster1Label1)
+				delete(namespace.GetLabels(), offloadingCluster1Label2)
+				delete(namespace.GetLabels(), offloadingCluster2Label1)
+				delete(namespace.GetLabels(), offloadingCluster2Label2)
+				namespace.GetLabels()[randomLabel] = ""
+
+				if err := k8sClient.Update(ctx, namespace); err != nil {
+					return false
+				}
+				return true
+			}, timeout, interval).Should(BeTrue())
+
+			By(fmt.Sprintf("Try to get NamespaceMap associated to: %s", remoteClusterId1))
+			Eventually(func() bool {
+				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(const_ctrl.MapNamespaceName), client.MatchingLabels{const_ctrl.VirtualNodeClusterId: remoteClusterId1}); err != nil {
+					return false
+				}
+				if len(nms.Items) != 1 {
+					return false
+				}
+
+				By("Check status of NattingTable")
+				if value, ok := nms.Items[0].Status.NattingTable[nameNamespaceTest]; ok && value == nameRemoteNamespace {
+					return true
+				}
+				return false
+			}, timeout, interval).Should(BeTrue())
+
+			By(fmt.Sprintf("Try to get NamespaceMap associated to: %s", remoteClusterId2))
+			Eventually(func() bool {
+				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(const_ctrl.MapNamespaceName), client.MatchingLabels{const_ctrl.VirtualNodeClusterId: remoteClusterId2}); err != nil {
+					return false
+				}
+				if len(nms.Items) != 1 {
+					return false
+				}
+
+				By("Check status of NattingTable")
+				if value, ok := nms.Items[0].Status.NattingTable[nameNamespaceTest]; ok && value == nameRemoteNamespace {
+					return true
+				}
+				return false
+			}, timeout, interval).Should(BeTrue())
+
+		})
+
+		It(fmt.Sprintf("Remove %s label and check if NamespaceMaps are cleared", mappingLabel), func() {
+
+			By(fmt.Sprintf("Try to remove %s label", mappingLabel))
+			Eventually(func() bool {
+				if err := k8sClient.Get(ctx, types.NamespacedName{Name: nameNamespaceTest}, namespace); err != nil {
+					return false
+				}
+
+				delete(namespace.GetLabels(), mappingLabel)
+				if err := k8sClient.Update(ctx, namespace); err != nil {
+					return false
+				}
+				return true
+			}, timeout, interval).Should(BeTrue())
+
+			By(fmt.Sprintf("Check if NamespaceMap associated to %s is cleaned by the controller", remoteClusterId1))
+			Eventually(func() bool {
+				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(const_ctrl.MapNamespaceName), client.MatchingLabels{const_ctrl.VirtualNodeClusterId: remoteClusterId1}); err != nil {
+					return false
+				}
+				if len(nms.Items) != 1 {
+					return false
+				}
+
+				By("Check status of NattingTable")
+				if _, ok := nms.Items[0].Status.NattingTable[nameNamespaceTest]; !ok {
+					return true
+				}
+				return false
+
+			}, timeout, interval).Should(BeTrue())
+
+			By(fmt.Sprintf("Check if NamespaceMap associated to %s is cleaned by the controller", remoteClusterId2))
+			Eventually(func() bool {
+				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(const_ctrl.MapNamespaceName), client.MatchingLabels{const_ctrl.VirtualNodeClusterId: remoteClusterId2}); err != nil {
+					return false
+				}
+				if len(nms.Items) != 1 {
+					return false
+				}
+
+				By("Check status of NattingTable")
+				if _, ok := nms.Items[0].Status.NattingTable[nameNamespaceTest]; !ok {
+					return true
+				}
+				return false
+
+			}, timeout, interval).Should(BeTrue())
+
+		})
+
+		It(fmt.Sprintf("Remove %s and check if NamespaceMaps are cleared", nameNamespaceTest), func() {
+
+			By("Check if namespace is really deleted")
+			Eventually(func() bool {
+				if err := k8sClient.Get(ctx, types.NamespacedName{Name: nameNamespaceTest}, namespace); err != nil {
+					return false
+				}
+
+				if err := k8sClient.Delete(ctx, namespace); err != nil {
+					return false
+				}
+				return true
+			}, timeout, interval).Should(BeTrue())
+
+			By(fmt.Sprintf("Check if NamespaceMap associated to %s is cleaned by the controller", remoteClusterId1))
+			Eventually(func() bool {
+				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(const_ctrl.MapNamespaceName), client.MatchingLabels{const_ctrl.VirtualNodeClusterId: remoteClusterId1}); err != nil {
+					return false
+				}
+				if len(nms.Items) != 1 {
+					return false
+				}
+
+				By("Check status of NattingTable")
+				if _, ok := nms.Items[0].Status.NattingTable[nameNamespaceTest]; !ok {
+					return true
+				}
+				return false
+
+			}, timeout, interval).Should(BeTrue())
+
+			By(fmt.Sprintf("Check if NamespaceMap associated to %s is cleaned by the controller", remoteClusterId2))
+			Eventually(func() bool {
+				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(const_ctrl.MapNamespaceName), client.MatchingLabels{const_ctrl.VirtualNodeClusterId: remoteClusterId2}); err != nil {
+					return false
+				}
+				if len(nms.Items) != 1 {
+					return false
+				}
+
+				By("Check status of NattingTable")
+				if _, ok := nms.Items[0].Status.NattingTable[nameNamespaceTest]; !ok {
+					return true
+				}
+				return false
+
+			}, timeout, interval).Should(BeTrue())
+
+		})
+
+	})
+
+})

--- a/pkg/liqo-controller-manager/namespace-controller/suite_test.go
+++ b/pkg/liqo-controller-manager/namespace-controller/suite_test.go
@@ -1,0 +1,209 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+   http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package namespace_controller
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	mapsv1alpha1 "github.com/liqotech/liqo/apis/virtualKubelet/v1alpha1"
+	const_ctrl "github.com/liqotech/liqo/pkg/liqo-controller-manager"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"path/filepath"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"k8s.io/klog"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
+	// +kubebuilder:scaffold:imports
+)
+
+const (
+	nameVirtualNode1    = "virtual-node-1"
+	nameVirtualNode2    = "virtual-node-2"
+	nameNamespaceTest   = "namespace-test"
+	nameRemoteNamespace = "namespace-test-remoto"
+	mapNamespaceName    = "default"
+
+	remoteClusterId1 = "6a0e9f-b52-4ed0"
+	remoteClusterId2 = "899890-dsd-323"
+
+	randomLabel              = "random"
+	offloadingCluster1Label1 = "offloading.liqo.io/cluster-1"
+	offloadingCluster1Label2 = "offloading.liqo.io/AWS"
+	offloadingCluster2Label1 = "offloading.liqo.io/cluster-2"
+	offloadingCluster2Label2 = "offloading.liqo.io/GKE"
+)
+
+var (
+	cfg          *rest.Config
+	k8sClient    client.Client
+	testEnv      *envtest.Environment
+	ctx          context.Context
+	namespace    *corev1.Namespace
+	nms          *mapsv1alpha1.NamespaceMapList
+	nm1          *mapsv1alpha1.NamespaceMap
+	nm2          *mapsv1alpha1.NamespaceMap
+	virtualNode1 *corev1.Node
+	virtualNode2 *corev1.Node
+	flags        *flag.FlagSet
+)
+
+func TestAPIs(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecsWithDefaultAndCustomReporters(t,
+		"Controller Suite",
+		[]Reporter{printer.NewlineReporter{}})
+}
+
+var _ = BeforeSuite(func(done Done) {
+
+	By("bootstrapping test environment")
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths: []string{filepath.Join("..", "..", "..", "deployments", "liqo", "crds")},
+	}
+
+	flags = &flag.FlagSet{}
+	klog.InitFlags(flags)
+	_ = flags.Set("v", "2")
+
+	var err error
+	cfg, err = testEnv.Start()
+	Expect(err).ToNot(HaveOccurred())
+	Expect(cfg).ToNot(BeNil())
+
+	err = corev1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = mapsv1alpha1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+	// +kubebuilder:scaffold:scheme
+
+	k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme: scheme.Scheme,
+	})
+	Expect(err).ToNot(HaveOccurred())
+
+	err = (&NamespaceReconciler{
+		Client: k8sManager.GetClient(),
+		Scheme: k8sManager.GetScheme(),
+	}).SetupWithManager(k8sManager)
+	Expect(err).ToNot(HaveOccurred())
+
+	go func() {
+		err = k8sManager.Start(ctrl.SetupSignalHandler())
+		Expect(err).ToNot(HaveOccurred())
+	}()
+
+	k8sClient = k8sManager.GetClient()
+	Expect(k8sClient).ToNot(BeNil())
+
+	namespace = &corev1.Namespace{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Namespace",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: nameNamespaceTest,
+			Labels: map[string]string{
+				randomLabel: "",
+			},
+		},
+	}
+
+	virtualNode1 = &corev1.Node{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Node",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: nameVirtualNode1,
+			Annotations: map[string]string{
+				const_ctrl.VirtualNodeClusterId: remoteClusterId1,
+			},
+			Labels: map[string]string{
+				const_ctrl.TypeLabel:     const_ctrl.TypeNode,
+				offloadingCluster1Label1: "",
+				offloadingCluster1Label2: "",
+			},
+		},
+	}
+
+	virtualNode2 = &corev1.Node{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Node",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: nameVirtualNode2,
+			Annotations: map[string]string{
+				const_ctrl.VirtualNodeClusterId: remoteClusterId2,
+			},
+			Labels: map[string]string{
+				const_ctrl.TypeLabel:     const_ctrl.TypeNode,
+				offloadingCluster2Label1: "",
+				offloadingCluster2Label2: "",
+			},
+		},
+	}
+
+	nm1 = &mapsv1alpha1.NamespaceMap{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "namespaceresources.liqo.io/v1",
+			Kind:       "NamespaceMap",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: fmt.Sprintf("%s-", remoteClusterId1),
+			Namespace:    mapNamespaceName,
+			Labels: map[string]string{
+				const_ctrl.VirtualNodeClusterId: remoteClusterId1,
+			},
+		},
+	}
+
+	nm2 = &mapsv1alpha1.NamespaceMap{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "namespaceresources.liqo.io/v1",
+			Kind:       "NamespaceMap",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: fmt.Sprintf("%s-", remoteClusterId2),
+			Namespace:    mapNamespaceName,
+			Labels: map[string]string{
+				const_ctrl.VirtualNodeClusterId: remoteClusterId2,
+			},
+		},
+	}
+
+	Expect(k8sClient.Create(context.TODO(), virtualNode1)).Should(Succeed())
+	Expect(k8sClient.Create(context.TODO(), virtualNode2)).Should(Succeed())
+	Expect(k8sClient.Create(context.TODO(), nm1)).Should(Succeed())
+	Expect(k8sClient.Create(context.TODO(), nm2)).Should(Succeed())
+	Expect(k8sClient.Create(context.TODO(), namespace)).Should(Succeed())
+
+	close(done)
+}, 60)
+
+var _ = AfterSuite(func() {
+	By("tearing down the test environment")
+	err := testEnv.Stop()
+	Expect(err).ToNot(HaveOccurred())
+})


### PR DESCRIPTION
# Description

Namespace-controller watches `Namespace`'s labels, adding and removing corresponding entries in `NamespaceMap` resources. If a `Namespace`, offloaded onto a remote cluster, is deleted, the controller must also manage, in a proper way, the `Namespace`'s deletion logic. 

# Fixes 
**STEP 2** #572   

