### PR TITLE
Tenant Control Namespace Manager

### DIFF
--- a/pkg/discovery/const.go
+++ b/pkg/discovery/const.go
@@ -1,6 +1,9 @@
 package discovery
 
 const (
+	TenantControlNamespaceLabel = "discovery.liqo.io/tenant-control-namespace"
+	ClusterRoleLabel            = "discovery.liqo.io/cluster-role"
+
 	ClusterIdLabel      = "discovery.liqo.io/cluster-id"
 	AuthTokenLabel      = "discovery.liqo.io/auth-token"
 	RemoteIdentityLabel = "discovery.liqo.io/remote-identity"

--- a/pkg/tenantControlNamespace/bindings.go
+++ b/pkg/tenantControlNamespace/bindings.go
@@ -1,0 +1,101 @@
+package tenantControlNamespace
+
+import (
+	"context"
+	"strings"
+
+	"github.com/liqotech/liqo/pkg/discovery"
+	v1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/klog/v2"
+)
+
+// add the bindings for the remote clusterID for the given ClusterRoles
+// This method creates RoleBindings in the Tenant Control Namespace for a remote identity
+func (nm *tenantControlNamespaceManager) BindClusterRoles(clusterID string, clusterRoles ...*rbacv1.ClusterRole) ([]*rbacv1.RoleBinding, error) {
+	namespace, err := nm.GetNamespace(clusterID)
+	if err != nil {
+		klog.Error(err)
+		return nil, err
+	}
+
+	bindings := make([]*rbacv1.RoleBinding, len(clusterRoles))
+	for i, clusterRole := range clusterRoles {
+		bindings[i], err = nm.bindClusterRole(clusterID, namespace, clusterRole)
+		if err != nil {
+			klog.Error(err)
+			return nil, err
+		}
+	}
+	return bindings, nil
+}
+
+// remove the bindings for the remote clusterID for the given ClusterRoles
+// This method deletes RoleBindings in the Tenant Control Namespace for a remote identity
+func (nm *tenantControlNamespaceManager) UnbindClusterRoles(clusterID string, clusterRoles ...string) error {
+	namespace, err := nm.GetNamespace(clusterID)
+	if err != nil {
+		klog.Error(err)
+		return err
+	}
+
+	for _, clusterRole := range clusterRoles {
+		if err = nm.unbindClusterRole(namespace, clusterRole); err != nil {
+			klog.Error(err)
+			return err
+		}
+	}
+	return nil
+}
+
+// create a RoleBinding for the given clusterID in the given Namespace
+func (nm *tenantControlNamespaceManager) bindClusterRole(clusterID string, namespace *v1.Namespace, clusterRole *rbacv1.ClusterRole) (*rbacv1.RoleBinding, error) {
+	ownerRef := metav1.OwnerReference{
+		APIVersion: rbacv1.SchemeGroupVersion.String(),
+		Kind:       "ClusterRole",
+		Name:       clusterRole.Name,
+		UID:        clusterRole.UID,
+	}
+
+	rb := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: strings.Join([]string{roleBindingRoot, clusterRole.Name, ""}, "-"),
+			Namespace:    namespace.Name,
+			Labels: map[string]string{
+				discovery.ClusterRoleLabel: clusterRole.Name,
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				ownerRef,
+			},
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:     rbacv1.UserKind,
+				APIGroup: rbacv1.GroupName,
+				Name:     clusterID,
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: rbacv1.GroupName,
+			Kind:     "ClusterRole",
+			Name:     clusterRole.Name,
+		},
+	}
+
+	return nm.client.RbacV1().RoleBindings(namespace.Name).Create(context.TODO(), rb, metav1.CreateOptions{})
+}
+
+// delete a RoleBinding in the given Namespace
+func (nm *tenantControlNamespaceManager) unbindClusterRole(namespace *v1.Namespace, clusterRole string) error {
+	labelSelector := metav1.LabelSelector{
+		MatchLabels: map[string]string{
+			discovery.ClusterRoleLabel: clusterRole,
+		},
+	}
+
+	return nm.client.RbacV1().RoleBindings(namespace.Name).DeleteCollection(context.TODO(), metav1.DeleteOptions{}, metav1.ListOptions{
+		LabelSelector: labels.Set(labelSelector.MatchLabels).String(),
+	})
+}

--- a/pkg/tenantControlNamespace/const.go
+++ b/pkg/tenantControlNamespace/const.go
@@ -1,0 +1,6 @@
+package tenantControlNamespace
+
+const (
+	tenantControlNamespaceRoot = "liqo-tenant-control"
+	roleBindingRoot            = "liqo-binding"
+)

--- a/pkg/tenantControlNamespace/interface.go
+++ b/pkg/tenantControlNamespace/interface.go
@@ -1,0 +1,13 @@
+package tenantControlNamespace
+
+import (
+	v1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+)
+
+type TenantControlNamespaceManager interface {
+	CreateNamespace(clusterID string) (*v1.Namespace, error)
+	GetNamespace(clusterID string) (*v1.Namespace, error)
+	BindClusterRoles(clusterID string, clusterRoles ...*rbacv1.ClusterRole) ([]*rbacv1.RoleBinding, error)
+	UnbindClusterRoles(clusterID string, clusterRoles ...string) error
+}

--- a/pkg/tenantControlNamespace/namespaceManager.go
+++ b/pkg/tenantControlNamespace/namespaceManager.go
@@ -1,0 +1,81 @@
+package tenantControlNamespace
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/liqotech/liqo/pkg/discovery"
+	v1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+)
+
+type tenantControlNamespaceManager struct {
+	client kubernetes.Interface
+}
+
+// create a new TenantControlNamespaceManager object
+func NewTenantControlNamespaceManager(client kubernetes.Interface) TenantControlNamespaceManager {
+	return &tenantControlNamespaceManager{
+		client: client,
+	}
+}
+
+// create a new Tenant Control Namespace given the clusterID
+// This method is idempotent, multiple calls of it will not lead to multiple namespace creations
+func (nm *tenantControlNamespaceManager) CreateNamespace(clusterID string) (*v1.Namespace, error) {
+	// first check that it does not exist yet
+	ns, err := nm.GetNamespace(clusterID)
+	if err == nil {
+		return ns, nil
+	} else if !kerrors.IsNotFound(err) {
+		// an error occurred, but it is not a not found error
+		klog.Error(err)
+		return nil, err
+	}
+	// a not found error occurred, create the namespace
+
+	ns = &v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: strings.Join([]string{tenantControlNamespaceRoot, ""}, "-"),
+			Labels: map[string]string{
+				discovery.ClusterIdLabel:              clusterID,
+				discovery.TenantControlNamespaceLabel: "true",
+			},
+		},
+	}
+	return nm.client.CoreV1().Namespaces().Create(context.TODO(), ns, metav1.CreateOptions{})
+}
+
+// get a Tenant Control Namespace given the clusterID
+func (nm *tenantControlNamespaceManager) GetNamespace(clusterID string) (*v1.Namespace, error) {
+	labelSelector := metav1.LabelSelector{
+		MatchLabels: map[string]string{
+			discovery.ClusterIdLabel:              clusterID,
+			discovery.TenantControlNamespaceLabel: "true",
+		},
+	}
+
+	namespaces, err := nm.client.CoreV1().Namespaces().List(context.TODO(), metav1.ListOptions{
+		LabelSelector: labels.Set(labelSelector.MatchLabels).String(),
+	})
+	if err != nil {
+		klog.Error(err)
+		return nil, err
+	}
+
+	if nItems := len(namespaces.Items); nItems == 0 {
+		err = kerrors.NewNotFound(v1.Resource("Namespace"), clusterID)
+		klog.Error(err)
+		return nil, err
+	} else if nItems > 1 {
+		err = fmt.Errorf("multiple tenant control namespaces found for clusterID %v", clusterID)
+		klog.Error(err)
+		return nil, err
+	}
+	return &namespaces.Items[0], nil
+}

--- a/pkg/tenantControlNamespace/tenantControlNamespaceManager_test.go
+++ b/pkg/tenantControlNamespace/tenantControlNamespaceManager_test.go
@@ -1,0 +1,200 @@
+package tenantControlNamespace
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/liqotech/liqo/pkg/discovery"
+	"github.com/liqotech/liqo/pkg/testUtils"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+func TestTenantControlNamespace(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "TenantControlNamespace Suite")
+}
+
+var _ = Describe("TenantControlNamespace", func() {
+
+	var (
+		cluster   testUtils.Cluster
+		clusterID string
+
+		namespaceManager TenantControlNamespaceManager
+	)
+
+	BeforeSuite(func() {
+		clusterID = "testCreation"
+
+		var err error
+		cluster, _, err = testUtils.NewTestCluster([]string{filepath.Join("..", "..", "deployments", "liqo", "crds")})
+		if err != nil {
+			By(err.Error())
+			os.Exit(1)
+		}
+
+		namespaceManager = NewTenantControlNamespaceManager(cluster.GetClient().Client())
+	})
+
+	AfterSuite(func() {
+		err := cluster.GetEnv().Stop()
+		if err != nil {
+			By(err.Error())
+			os.Exit(1)
+		}
+	})
+
+	It("Create Namespace", func() {
+		ns, err := namespaceManager.CreateNamespace(clusterID)
+		Expect(err).To(BeNil())
+		Expect(ns).NotTo(BeNil())
+		Expect(strings.HasPrefix(ns.Name, "liqo-tenant-control-")).To(BeTrue())
+		Expect(ns.Labels).NotTo(BeNil())
+
+		_, ok := ns.Labels[discovery.TenantControlNamespaceLabel]
+		Expect(ok).To(BeTrue())
+	})
+
+	It("Create Namespace Twice", func() {
+		ns, err := namespaceManager.CreateNamespace(clusterID)
+		Expect(err).To(BeNil())
+		Expect(ns).NotTo(BeNil())
+		Expect(strings.HasPrefix(ns.Name, "liqo-tenant-control-")).To(BeTrue())
+		Expect(ns.Labels).NotTo(BeNil())
+
+		_, ok := ns.Labels[discovery.TenantControlNamespaceLabel]
+		Expect(ok).To(BeTrue())
+	})
+
+	It("Get Namespace", func() {
+		ns, err := namespaceManager.GetNamespace(clusterID)
+		Expect(err).To(BeNil())
+		Expect(ns).NotTo(BeNil())
+		Expect(strings.HasPrefix(ns.Name, "liqo-tenant-control-")).To(BeTrue())
+		Expect(ns.Labels).NotTo(BeNil())
+
+		_, ok := ns.Labels[discovery.TenantControlNamespaceLabel]
+		Expect(ok).To(BeTrue())
+
+		ns, err = namespaceManager.GetNamespace("unknownId")
+		Expect(err).NotTo(BeNil())
+		Expect(ns).To(BeNil())
+	})
+
+	Context("Permission Management", func() {
+
+		var client kubernetes.Interface
+		var namespace *v1.Namespace
+		var clusterRoles []*rbacv1.ClusterRole
+		var cnt int = 0
+
+		BeforeEach(func() {
+			cnt += 1
+			clusterID = fmt.Sprintf("testPermission%v", cnt)
+			client = cluster.GetClient().Client()
+
+			cr := &rbacv1.ClusterRole{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "role1",
+				},
+			}
+			cr, err := client.RbacV1().ClusterRoles().Create(context.TODO(), cr, metav1.CreateOptions{})
+			Expect(err).To(BeNil())
+			Expect(cr).NotTo(BeNil())
+			clusterRoles = append(clusterRoles, cr)
+
+			cr = &rbacv1.ClusterRole{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "role2",
+				},
+			}
+			cr, err = client.RbacV1().ClusterRoles().Create(context.TODO(), cr, metav1.CreateOptions{})
+			Expect(err).To(BeNil())
+			Expect(cr).NotTo(BeNil())
+			clusterRoles = append(clusterRoles, cr)
+
+			namespace, err = namespaceManager.CreateNamespace(clusterID)
+			Expect(err).To(BeNil())
+			Expect(namespace).NotTo(BeNil())
+		})
+
+		AfterEach(func() {
+			for _, cr := range clusterRoles {
+				err := client.RbacV1().ClusterRoles().Delete(context.TODO(), cr.Name, metav1.DeleteOptions{})
+				Expect(err).To(BeNil())
+			}
+			clusterRoles = []*rbacv1.ClusterRole{}
+
+			err := client.CoreV1().Namespaces().Delete(context.TODO(), namespace.Name, metav1.DeleteOptions{})
+			Expect(err).To(BeNil())
+		})
+
+		Context("Single ClusterRole", func() {
+
+			var rb []*rbacv1.RoleBinding
+
+			It("Bind ClusterRole", func() {
+				var err error
+				rb, err = namespaceManager.BindClusterRoles(clusterID, clusterRoles[0])
+				Expect(err).To(BeNil())
+				Expect(rb).NotTo(BeNil())
+				Expect(len(rb)).To(Equal(1))
+				checkRoleBinding(rb[0], namespace.Name, clusterID, clusterRoles[0].Name)
+
+				err = namespaceManager.UnbindClusterRoles(clusterID, clusterRoles[0].Name)
+				Expect(err).To(BeNil())
+
+				_, err = client.RbacV1().RoleBindings(namespace.Name).Get(context.TODO(), rb[0].Name, metav1.GetOptions{})
+				Expect(err).NotTo(BeNil())
+				Expect(kerrors.IsNotFound(err)).To(BeTrue())
+			})
+
+			It("Bind Multiple ClusterRoles", func() {
+				var err error
+				rb, err = namespaceManager.BindClusterRoles(clusterID, clusterRoles...)
+				Expect(err).To(BeNil())
+				Expect(rb).NotTo(BeNil())
+				Expect(len(rb)).To(Equal(len(clusterRoles)))
+
+				checkRoleBinding(rb[0], namespace.Name, clusterID, clusterRoles[0].Name)
+				checkRoleBinding(rb[1], namespace.Name, clusterID, clusterRoles[1].Name)
+
+				err = namespaceManager.UnbindClusterRoles(clusterID, clusterRoles[0].Name)
+				Expect(err).To(BeNil())
+
+				_, err = client.RbacV1().RoleBindings(namespace.Name).Get(context.TODO(), rb[0].Name, metav1.GetOptions{})
+				Expect(err).NotTo(BeNil())
+				Expect(kerrors.IsNotFound(err)).To(BeTrue())
+
+				_, err = client.RbacV1().RoleBindings(namespace.Name).Get(context.TODO(), rb[1].Name, metav1.GetOptions{})
+				Expect(err).To(BeNil())
+				Expect(kerrors.IsNotFound(err)).NotTo(BeTrue())
+
+				err = namespaceManager.UnbindClusterRoles(clusterID, clusterRoles[1].Name)
+				Expect(err).To(BeNil())
+			})
+
+		})
+
+	})
+
+})
+
+func checkRoleBinding(rb *rbacv1.RoleBinding, namespace string, clusterID string, clusterRoleName string) {
+	Expect(rb.Namespace).To(Equal(namespace))
+	Expect(len(rb.Subjects)).To(Equal(1))
+	Expect(rb.Subjects[0].Kind).To(Equal(rbacv1.UserKind))
+	Expect(rb.Subjects[0].Name).To(Equal(clusterID))
+	Expect(rb.RoleRef.Kind).To(Equal("ClusterRole"))
+	Expect(rb.RoleRef.Name).To(Equal(clusterRoleName))
+}


### PR DESCRIPTION
# Description

This pr adds a new interface that will be used for the Tenant Control Namespaces management

The Tenant Control Namespace will be used to store the resources linked to the peering with a remote cluster

The implementation of this interface allows the idempotent creation of Tenant Control Namespaces, and the possibility to bind and unbind CluterRoles for a remote identity

Ref #573 

# How Has This Been Tested?

- [x] Add new unit tests
