### PR TITLE
Certificate Identity Manager

### DIFF
--- a/pkg/clusterID/test/clusterID-mock.go
+++ b/pkg/clusterID/test/clusterID-mock.go
@@ -1,14 +1,14 @@
 package test
 
 type ClusterIDMock struct {
-	id string
+	Id string
 }
 
 func (cId *ClusterIDMock) SetupClusterID(namespace string) error {
-	cId.id = "local-cluster"
+	cId.Id = "local-cluster"
 	return nil
 }
 
 func (cId *ClusterIDMock) GetClusterID() string {
-	return cId.id
+	return cId.Id
 }

--- a/pkg/identityManager/certificate.go
+++ b/pkg/identityManager/certificate.go
@@ -1,0 +1,206 @@
+package identityManager
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"encoding/pem"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/liqotech/liqo/pkg/discovery"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/klog/v2"
+)
+
+// create a new key and a new csr to be used as an identity to authenticate with a remote cluster
+func (certManager *certificateIdentityManager) CreateIdentity(remoteClusterID string) (*v1.Secret, error) {
+	namespace, err := certManager.namespaceManager.GetNamespace(remoteClusterID)
+	if err != nil {
+		klog.Error(err)
+		return nil, err
+	}
+
+	return certManager.createIdentityInNamespace(remoteClusterID, namespace.Name)
+}
+
+// get the CertificateSigningRequest for a remote cluster
+func (certManager *certificateIdentityManager) GetSigningRequest(remoteClusterID string) ([]byte, error) {
+	secret, err := certManager.getSecret(remoteClusterID)
+	if err != nil {
+		klog.Error(err)
+		return nil, err
+	}
+
+	csrBytes, ok := secret.Data[csrSecretKey]
+	if !ok {
+		err = fmt.Errorf("csr not found in secret %v/%v for clusterID %v", secret.Namespace, secret.Name, remoteClusterID)
+		klog.Error(err)
+		return nil, err
+	}
+
+	return csrBytes, nil
+}
+
+// store the certificate issued by a remote authority for the specified remoteClusterID
+func (certManager *certificateIdentityManager) StoreCertificate(remoteClusterID string, certificate []byte) error {
+	secret, err := certManager.getSecret(remoteClusterID)
+	if err != nil {
+		klog.Error(err)
+		return err
+	}
+
+	if secret.Labels == nil {
+		secret.Labels = map[string]string{}
+	}
+	secret.Labels[certificateAvailableLabel] = "true"
+
+	secret.Data[certificateSecretKey] = certificate
+	if _, err = certManager.client.CoreV1().Secrets(secret.Namespace).Update(context.TODO(), secret, metav1.UpdateOptions{}); err != nil {
+		klog.Error(err)
+		return err
+	}
+	return nil
+}
+
+// retrieve the identity secret given the clusterID
+func (certManager *certificateIdentityManager) getSecret(remoteClusterID string) (*v1.Secret, error) {
+	namespace, err := certManager.namespaceManager.GetNamespace(remoteClusterID)
+	if err != nil {
+		klog.Error(err)
+		return nil, err
+	}
+
+	labelSelector := metav1.LabelSelector{
+		MatchLabels: map[string]string{
+			localIdentitySecretLabel: "true",
+			discovery.ClusterIdLabel: remoteClusterID,
+		},
+	}
+	secretList, err := certManager.client.CoreV1().Secrets(namespace.Name).List(context.TODO(), metav1.ListOptions{
+		LabelSelector: labels.Set(labelSelector.MatchLabels).String(),
+	})
+	if err != nil {
+		klog.Error(err)
+		return nil, err
+	}
+
+	secrets := secretList.Items
+	if nItems := len(secrets); nItems == 0 {
+		// create a new one
+		return certManager.createIdentityInNamespace(remoteClusterID, namespace.Name)
+	}
+
+	// sort by reverse certificate expire time
+	sort.Slice(secrets, func(i, j int) bool {
+		time1 := getExpireTime(&secretList.Items[i])
+		time2 := getExpireTime(&secretList.Items[j])
+		return time1 > time2
+	})
+
+	// if there are multiple secrets, get the one with the certificate that will expire last
+	return &secrets[0], nil
+}
+
+// generate a key and a certificate signing request
+func (certManager *certificateIdentityManager) createCSR() (keyBytes []byte, csrBytes []byte, err error) {
+	key, err := rsa.GenerateKey(rand.Reader, keyLength)
+	if err != nil {
+		klog.Error(err)
+		return nil, nil, err
+	}
+
+	subj := pkix.Name{
+		CommonName:   certManager.localClusterID.GetClusterID(),
+		Organization: []string{defaultOrganization},
+	}
+	rawSubj := subj.ToRDNSequence()
+
+	asn1Subj, err := asn1.Marshal(rawSubj)
+	if err != nil {
+		klog.Error(err)
+		return nil, nil, err
+	}
+
+	template := x509.CertificateRequest{
+		RawSubject:         asn1Subj,
+		SignatureAlgorithm: x509.SHA256WithRSA,
+	}
+
+	csrBytes, err = x509.CreateCertificateRequest(rand.Reader, &template, key)
+	if err != nil {
+		klog.Error(err)
+		return nil, nil, err
+	}
+	csrBytes = pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE REQUEST",
+		Bytes: csrBytes,
+	})
+
+	keyBytes = x509.MarshalPKCS1PrivateKey(key)
+	keyBytes = pem.EncodeToMemory(&pem.Block{
+		Type:  "PRIVATE KEY",
+		Bytes: keyBytes,
+	})
+	return keyBytes, csrBytes, nil
+}
+
+// create a new key and a new csr to be used as an identity to authenticate with a remote cluster in a given namespace
+func (certManager *certificateIdentityManager) createIdentityInNamespace(remoteClusterID string, namespace string) (*v1.Secret, error) {
+	key, csrBytes, err := certManager.createCSR()
+	if err != nil {
+		klog.Error(err)
+		return nil, err
+	}
+
+	secret := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: strings.Join([]string{identitySecretRoot, ""}, "-"),
+			Namespace:    namespace,
+			Labels: map[string]string{
+				localIdentitySecretLabel: "true",
+				discovery.ClusterIdLabel: remoteClusterID,
+			},
+			Annotations: map[string]string{
+				// one year starting from now
+				certificateExpireTimeAnnotation: fmt.Sprintf("%v", time.Now().AddDate(1, 0, 0).Unix()),
+			},
+		},
+		Data: map[string][]byte{
+			privateKeySecretKey: key,
+			csrSecretKey:        csrBytes,
+		},
+	}
+
+	return certManager.client.CoreV1().Secrets(namespace).Create(context.TODO(), secret, metav1.CreateOptions{})
+}
+
+// read the expire time from the annotations of the secret
+func getExpireTime(secret *v1.Secret) int64 {
+	now := time.Now().Unix()
+	if secret.Annotations == nil {
+		klog.Warningf("annotation %v not found in secret %v/%v", certificateExpireTimeAnnotation, secret.Namespace, secret.Name)
+		return now
+	}
+
+	timeStr, ok := secret.Annotations[certificateExpireTimeAnnotation]
+	if !ok {
+		klog.Warningf("annotation %v not found in secret %v/%v", certificateExpireTimeAnnotation, secret.Namespace, secret.Name)
+		return now
+	}
+
+	if n, err := strconv.ParseInt(timeStr, 10, 64); err != nil {
+		klog.Warning(err)
+		return now
+	} else {
+		return n
+	}
+}

--- a/pkg/identityManager/client.go
+++ b/pkg/identityManager/client.go
@@ -1,0 +1,9 @@
+package identityManager
+
+import "k8s.io/client-go/rest"
+
+// get a rest config from the secret, given the remote clusterID
+func (certManager *certificateIdentityManager) GetConfig(remoteClusterID string, masterUrl string) (*rest.Config, error) {
+	// TODO: implementation
+	panic("TODO: GetConfig")
+}

--- a/pkg/identityManager/const.go
+++ b/pkg/identityManager/const.go
@@ -1,0 +1,22 @@
+package identityManager
+
+const keyLength = 2048
+
+const defaultOrganization = "Liqo"
+
+const (
+	localIdentitySecretLabel  = "discovery.liqo.io/local-identity"
+	randomIDLabel             = "discovery.liqo.io/random-id"
+	certificateAvailableLabel = "discovery.liqo.io/certificate-available"
+)
+
+const (
+	certificateExpireTimeAnnotation = "discovery.liqo.io/certificate-expire-time"
+)
+
+const (
+	identitySecretRoot   = "liqo-identity"
+	privateKeySecretKey  = "private-key"
+	csrSecretKey         = "csr"
+	certificateSecretKey = "certificate"
+)

--- a/pkg/identityManager/identityManager.go
+++ b/pkg/identityManager/identityManager.go
@@ -1,0 +1,22 @@
+package identityManager
+
+import (
+	"github.com/liqotech/liqo/pkg/clusterID"
+	"github.com/liqotech/liqo/pkg/tenantControlNamespace"
+	"k8s.io/client-go/kubernetes"
+)
+
+type certificateIdentityManager struct {
+	client           kubernetes.Interface
+	localClusterID   clusterID.ClusterID
+	namespaceManager tenantControlNamespace.TenantControlNamespaceManager
+}
+
+// get a new certificate identity manager
+func NewCertificateIdentityManager(client kubernetes.Interface, localClusterID clusterID.ClusterID, namespaceManager tenantControlNamespace.TenantControlNamespaceManager) IdentityManager {
+	return &certificateIdentityManager{
+		client:           client,
+		localClusterID:   localClusterID,
+		namespaceManager: namespaceManager,
+	}
+}

--- a/pkg/identityManager/identityManager_test.go
+++ b/pkg/identityManager/identityManager_test.go
@@ -1,0 +1,185 @@
+package identityManager
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/liqotech/liqo/pkg/clusterID/test"
+	"github.com/liqotech/liqo/pkg/discovery"
+	"github.com/liqotech/liqo/pkg/tenantControlNamespace"
+	"github.com/liqotech/liqo/pkg/testUtils"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	certv1beta1 "k8s.io/api/certificates/v1beta1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+)
+
+func TestIdentityManager(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "IdentityManager Suite")
+}
+
+var _ = Describe("IdentityManager", func() {
+
+	var (
+		cluster         testUtils.Cluster
+		client          kubernetes.Interface
+		localClusterID  test.ClusterIDMock
+		remoteClusterID string
+
+		namespace *v1.Namespace
+
+		identityManager  IdentityManager
+		namespaceManager tenantControlNamespace.TenantControlNamespaceManager
+	)
+
+	BeforeSuite(func() {
+		localClusterID = test.ClusterIDMock{
+			Id: "localID",
+		}
+		remoteClusterID = "remoteID"
+
+		var err error
+		cluster, _, err = testUtils.NewTestCluster([]string{filepath.Join("..", "..", "deployments", "liqo", "crds")})
+		if err != nil {
+			By(err.Error())
+			os.Exit(1)
+		}
+
+		client = cluster.GetClient().Client()
+
+		namespaceManager = tenantControlNamespace.NewTenantControlNamespaceManager(client)
+		identityManager = NewCertificateIdentityManager(cluster.GetClient().Client(), &localClusterID, namespaceManager)
+
+		namespace, err = namespaceManager.CreateNamespace(remoteClusterID)
+		if err != nil {
+			By(err.Error())
+			os.Exit(1)
+		}
+	})
+
+	AfterSuite(func() {
+		err := cluster.GetEnv().Stop()
+		if err != nil {
+			By(err.Error())
+			os.Exit(1)
+		}
+	})
+
+	Context("Local Manager", func() {
+
+		It("Create Identity", func() {
+			secret, err := identityManager.CreateIdentity(remoteClusterID)
+			Expect(err).To(BeNil())
+			Expect(secret).NotTo(BeNil())
+			Expect(secret.Namespace).To(Equal(namespace.Name))
+
+			Expect(secret.Labels).NotTo(BeNil())
+			_, ok := secret.Labels[localIdentitySecretLabel]
+			Expect(ok).To(BeTrue())
+			v, ok := secret.Labels[discovery.ClusterIdLabel]
+			Expect(ok).To(BeTrue())
+			Expect(v).To(Equal(remoteClusterID))
+
+			Expect(secret.Annotations).NotTo(BeNil())
+			_, ok = secret.Annotations[certificateExpireTimeAnnotation]
+			Expect(ok).To(BeTrue())
+
+			privateKey, ok := secret.Data[privateKeySecretKey]
+			Expect(ok).To(BeTrue())
+			Expect(len(privateKey)).NotTo(Equal(0))
+
+			b, _ := pem.Decode(privateKey)
+			_, err = x509.ParsePKCS1PrivateKey(b.Bytes)
+			Expect(err).To(BeNil())
+		})
+
+		It("Get Signing Request", func() {
+			csrBytes, err := identityManager.GetSigningRequest(remoteClusterID)
+			Expect(err).To(BeNil())
+
+			b, _ := pem.Decode(csrBytes)
+			csr, err := x509.ParseCertificateRequest(b.Bytes)
+			Expect(err).To(BeNil())
+			Expect(csr.Subject.CommonName).To(Equal(localClusterID.GetClusterID()))
+		})
+
+		It("Get Signing Request with multiple secrets", func() {
+			// we need that at least 1 second passed since the creation of the previous identity
+			time.Sleep(1 * time.Second)
+
+			secret, err := identityManager.CreateIdentity(remoteClusterID)
+			Expect(err).To(BeNil())
+
+			csrBytes, err := identityManager.GetSigningRequest(remoteClusterID)
+			Expect(err).To(BeNil())
+
+			csrBytesSecret, ok := secret.Data[csrSecretKey]
+			Expect(ok).To(BeTrue())
+
+			// check that it returns the data for the last identity
+			Expect(csrBytes).To(Equal(csrBytesSecret))
+		})
+
+	})
+
+	Context("Remote Manager", func() {
+
+		var csrBytes []byte
+		var err error
+		var stopChan chan struct{}
+
+		BeforeEach(func() {
+			csrBytes, err = identityManager.GetSigningRequest(remoteClusterID)
+			Expect(err).To(BeNil())
+
+			// we need an informer to fill the certificate field, since no api server is running
+			informer := cache.NewSharedIndexInformer(&cache.ListWatch{
+				ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+					return client.CertificatesV1beta1().CertificateSigningRequests().List(context.TODO(), options)
+				},
+				WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+					return client.CertificatesV1beta1().CertificateSigningRequests().Watch(context.TODO(), options)
+				},
+			}, &certv1beta1.CertificateSigningRequest{}, 0, cache.Indexers{})
+
+			stopChan = make(chan struct{})
+			informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+				UpdateFunc: func(oldObj interface{}, newObj interface{}) {
+					csr, ok := newObj.(*certv1beta1.CertificateSigningRequest)
+					Expect(ok).To(BeTrue())
+
+					if csr.Status.Certificate == nil {
+						csr.Status.Certificate = []byte("test")
+						_, _ = client.CertificatesV1beta1().CertificateSigningRequests().UpdateStatus(context.TODO(), csr, metav1.UpdateOptions{})
+					}
+				},
+			})
+
+			go informer.Run(stopChan)
+		})
+
+		AfterEach(func() {
+			close(stopChan)
+		})
+
+		It("Approve Signing Request", func() {
+			certificate, err := identityManager.ApproveSigningRequest(csrBytes)
+			Expect(err).To(BeNil())
+			Expect(certificate).NotTo(BeNil())
+			Expect(certificate).To(Equal([]byte("test")))
+		})
+
+	})
+
+})

--- a/pkg/identityManager/interface.go
+++ b/pkg/identityManager/interface.go
@@ -1,0 +1,25 @@
+package identityManager
+
+import (
+	"k8s.io/api/core/v1"
+	"k8s.io/client-go/rest"
+)
+
+type IdentityManager interface {
+	localManager
+	remoteManager
+}
+
+// interface that allows to manage the identity in the owner cluster
+type localManager interface {
+	CreateIdentity(remoteClusterID string) (*v1.Secret, error)
+	GetSigningRequest(remoteClusterID string) ([]byte, error)
+	StoreCertificate(remoteClusterID string, certificate []byte) error
+
+	GetConfig(remoteClusterID string, masterUrl string) (*rest.Config, error)
+}
+
+// interface that allows to manage the identity in the target cluster, where this identity has to be used
+type remoteManager interface {
+	ApproveSigningRequest(signingRequest []byte) (certificate []byte, err error)
+}

--- a/pkg/identityManager/signingRequest.go
+++ b/pkg/identityManager/signingRequest.go
@@ -1,0 +1,141 @@
+package identityManager
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"time"
+
+	certv1beta1 "k8s.io/api/certificates/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+)
+
+// random package initialization
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
+
+// Approve a remote CertificateSigningRequest.
+// It creates a CertificateSigningRequest CR to be issued by the local cluster, and approves it.
+// This function will wait (with a timeout) for an available certificate before returning.
+func (certManager *certificateIdentityManager) ApproveSigningRequest(signingRequest []byte) (certificate []byte, err error) {
+	rnd := fmt.Sprintf("%v", rand.Int63())
+
+	// TODO: move client-go to a newer version to use certificates/v1
+	cert := &certv1beta1.CertificateSigningRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: identitySecretRoot,
+			Labels: map[string]string{
+				// the informer needs to select it by label, this is a temporal ID for this request
+				randomIDLabel: rnd,
+			},
+		},
+		Spec: certv1beta1.CertificateSigningRequestSpec{
+			Groups: []string{
+				"system:authenticated",
+			},
+			Request: signingRequest,
+			Usages: []certv1beta1.KeyUsage{
+				certv1beta1.UsageDigitalSignature,
+				certv1beta1.UsageKeyEncipherment,
+				certv1beta1.UsageClientAuth,
+			},
+		},
+	}
+
+	cert, err = certManager.client.CertificatesV1beta1().CertificateSigningRequests().Create(context.TODO(), cert, metav1.CreateOptions{})
+	if err != nil {
+		klog.Error(err)
+		return nil, err
+	}
+
+	cert.Status.Conditions = append(cert.Status.Conditions, certv1beta1.CertificateSigningRequestCondition{
+		Type:           certv1beta1.CertificateApproved,
+		Reason:         "IdentityManagerApproval",
+		Message:        "This CSR was approved by Liqo Identity Manager",
+		LastUpdateTime: metav1.Now(),
+	})
+
+	cert, err = certManager.client.CertificatesV1beta1().CertificateSigningRequests().UpdateApproval(context.TODO(), cert, metav1.UpdateOptions{})
+	if err != nil {
+		klog.Error(err)
+		return nil, err
+	}
+	return certManager.getCertificate(cert, rnd)
+}
+
+// Retrieve the certificate given the CertificateSigningRequest and its randomID.
+// If the certificate is not ready yet, it will wait for it (with a timeout)
+func (certManager *certificateIdentityManager) getCertificate(csr *certv1beta1.CertificateSigningRequest, randomID string) ([]byte, error) {
+	var certificate []byte
+
+	// define a function that will check if a generic object is a CSR with a issued certificate
+	checkCertificate := func(obj interface{}) bool {
+		csr, ok := obj.(*certv1beta1.CertificateSigningRequest)
+		if !ok {
+			klog.Errorf("this object is not a CertificateSigningRequest: %v", obj)
+			return false
+		}
+
+		res := (csr.Status.Certificate != nil && len(csr.Status.Certificate) > 0)
+		if res {
+			certificate = csr.Status.Certificate
+		}
+		return res
+	}
+
+	if checkCertificate(csr) {
+		// the csr is already valid, don't wait for the certificate
+		return csr.Status.Certificate, nil
+	}
+
+	// create an informer to be notified when the certificate will be available
+	// this informer will only watch one CSR, thanks to the random ID
+	labelSelector := labels.Set(map[string]string{
+		randomIDLabel: randomID,
+	}).AsSelector()
+
+	informer := cache.NewSharedIndexInformer(&cache.ListWatch{
+		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+			options.LabelSelector = labelSelector.String()
+			return certManager.client.CertificatesV1beta1().CertificateSigningRequests().List(context.TODO(), options)
+		},
+		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			options.LabelSelector = labelSelector.String()
+			return certManager.client.CertificatesV1beta1().CertificateSigningRequests().Watch(context.TODO(), options)
+		},
+	}, &certv1beta1.CertificateSigningRequest{}, 0, cache.Indexers{})
+
+	stopChan := make(chan struct{})
+	informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			if checkCertificate(obj) {
+				close(stopChan)
+			}
+		},
+		UpdateFunc: func(oldObj interface{}, newObj interface{}) {
+			if checkCertificate(newObj) {
+				close(stopChan)
+			}
+		},
+	})
+
+	go informer.Run(stopChan)
+
+	// wait for the certificate, with a timeout
+	select {
+	case <-stopChan:
+		// finished successfully
+		return certificate, nil
+	case <-time.NewTimer(30 * time.Second).C:
+		err := fmt.Errorf("timeout exceeded waiting for the approved certificate")
+		klog.Error(err)
+		close(stopChan)
+		return nil, err
+	}
+}


### PR DESCRIPTION
# Description

This pr adds a manager to handle the identity certificate lifecycle. In particular, it allows the creation of a new key and the related Certificate Signing Request. This request can be issued in a remote cluster to be used as a valid identity.

Ref. #573 

# How Has This Been Tested?

- [x] add unit tests
