### PR TITLE
Add NamespaceMap-controller to Liqo's controllers

### DIFF
--- a/pkg/liqo-controller-manager/namespaceMap-controller/manage_remote_clients.go
+++ b/pkg/liqo-controller-manager/namespaceMap-controller/manage_remote_clients.go
@@ -1,0 +1,66 @@
+package namespaceMap_controller
+
+import (
+	"context"
+	"fmt"
+	discoveryV1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	"k8s.io/klog"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// This function returns a rest.Config from a Kubeconfig contained in a Secret
+func (r *NamespaceMapReconciler) getKubeConfig(reference *corev1.ObjectReference) (*rest.Config, error) {
+
+	if reference == nil {
+		return nil, fmt.Errorf("must specify reference")
+	}
+
+	secret := &corev1.Secret{}
+	if err := r.Get(context.TODO(), types.NamespacedName{Namespace: reference.Namespace, Name: reference.Name}, secret); err != nil {
+		klog.Errorf("unable to get Secret '%s'", reference.Name)
+		return nil, err
+	}
+
+	kubeconfig := func() (*clientcmdapi.Config, error) {
+		return clientcmd.Load(secret.Data["kubeconfig"])
+	}
+	return clientcmd.BuildConfigFromKubeconfigGetter("", kubeconfig)
+}
+
+// This function creates a new controller-runtime Client for a remote cluster, if it isn't already present
+// in RemoteClients Struct of NamespaceMap Controller. The secret's reference is taken from the ForeignCluster
+// associated with the remote cluster.
+func (r *NamespaceMapReconciler) checkRemoteClientPresence(clusterId string) error {
+	if r.RemoteClients == nil {
+		r.RemoteClients = map[string]client.Client{}
+	}
+
+	if _, ok := r.RemoteClients[clusterId]; !ok {
+		fcl := &discoveryV1alpha1.ForeignClusterList{}
+		if err := r.List(context.TODO(), fcl, client.MatchingLabels{clusterIdForeign: clusterId}); err != nil {
+			klog.Errorf("%s --> Unable to List ForeignClusters", err)
+			return err
+		}
+
+		if len(fcl.Items) != 1 {
+			return fmt.Errorf("there are %d ForeignClusters for the remote cluster '%s' , error", len(fcl.Items), clusterId)
+		}
+
+		config, err := r.getKubeConfig(fcl.Items[0].Status.Outgoing.IdentityRef)
+		if err != nil {
+			klog.Errorf("unable to get rest.config for cluster '%s'", clusterId)
+			return err
+		}
+
+		if r.RemoteClients[clusterId], err = client.New(config, client.Options{Scheme: r.Scheme, Mapper: r.Mapper}); err != nil {
+			klog.Errorf("unable to create client for cluster '%s'", clusterId)
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/liqo-controller-manager/namespaceMap-controller/manage_remote_namespaces.go
+++ b/pkg/liqo-controller-manager/namespaceMap-controller/manage_remote_namespaces.go
@@ -1,0 +1,103 @@
+package namespaceMap_controller
+
+import (
+	"context"
+	mapsv1alpha1 "github.com/liqotech/liqo/apis/virtualKubelet/v1alpha1"
+	const_ctrl "github.com/liqotech/liqo/pkg/liqo-controller-manager"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog"
+)
+
+// This function creates a new Namespace onto the remote cluster, the right client to use is chosen
+// by NamespaceMap's cluster-id
+func (r *NamespaceMapReconciler) createRemoteNamespace(clusterId string, remoteName string) error {
+
+	if err := r.checkRemoteClientPresence(clusterId); err != nil {
+		return err
+	}
+
+	namespace := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: remoteName,
+		},
+	}
+
+	if err := r.RemoteClients[clusterId].Create(context.TODO(), namespace); err != nil {
+		klog.Errorf("unable to create namespace '%s' onto remote cluster: '%s'", namespace.Name, clusterId)
+		return err
+	}
+
+	klog.Infof("Namespace '%s' created onto remote cluster: '%s'", namespace.Name, clusterId)
+	return nil
+}
+
+// This function  Namespace onto the remote cluster, the right client to use is chosen
+// by NamespaceMap's cluster-id
+func (r *NamespaceMapReconciler) deleteRemoteNamespace(clusterId string, remoteName string) error {
+
+	if err := r.checkRemoteClientPresence(clusterId); err != nil {
+		return err
+	}
+
+	remoteNamespace := &corev1.Namespace{}
+	if err := r.RemoteClients[clusterId].Get(context.TODO(), types.NamespacedName{Name: remoteName}, remoteNamespace); err != nil {
+		klog.Errorf("unable to get remote namespace '%s'", remoteName)
+		return err
+	}
+
+	if err := r.RemoteClients[clusterId].Delete(context.TODO(), remoteNamespace); err != nil {
+		klog.Errorf("unable to delete namespace '%s' onto remote cluster: '%s'", remoteName, clusterId)
+		return err
+	}
+
+	klog.Infof("Namespace '%s' correctly deleted onto remote cluster: '%s'", remoteName, clusterId)
+	return nil
+}
+
+// This function checks if there are Namespaces that have to be created or deleted, in accordance with DesiredMapping
+// and CurrentMapping fields
+func (r *NamespaceMapReconciler) manageRemoteNamespaces(nm *mapsv1alpha1.NamespaceMap) error {
+
+	if nm.Status.CurrentMapping == nil {
+		nm.Status.CurrentMapping = map[string]mapsv1alpha1.RemoteNamespaceStatus{}
+	}
+
+	// if DesiredMapping field has more entries than CurrentMapping, is necessary to create new remote namespaces
+	for localName, remoteName := range nm.Spec.DesiredMapping {
+		if _, ok := nm.Status.CurrentMapping[localName]; !ok {
+			if err := r.createRemoteNamespace(nm.Labels[const_ctrl.VirtualNodeClusterId], remoteName); err != nil {
+				return err
+			}
+			nm.Status.CurrentMapping[localName] = mapsv1alpha1.RemoteNamespaceStatus{
+				RemoteNamespace: remoteName,
+				Phase:           mapsv1alpha1.MappingAccepted,
+			}
+			if err := r.Update(context.TODO(), nm); err != nil {
+				klog.Errorf("unable to update NamespaceMap '%s' Status", nm.Name)
+				return err
+			}
+			klog.Infof("Status of NamespaceMap '%s' is correctly updated, new remote Namespace '%s'", nm.Name, remoteName)
+		}
+	}
+
+	// if DesiredMapping field has less entries than CurrentMapping, is necessary to remove some remote namespaces
+	for localName, remoteStatus := range nm.Status.CurrentMapping {
+		if _, ok := nm.Spec.DesiredMapping[localName]; !ok {
+			if err := r.deleteRemoteNamespace(nm.Labels[const_ctrl.VirtualNodeClusterId], remoteStatus.RemoteNamespace); err != nil {
+				return err
+			}
+			// Update Map status
+			delete(nm.Status.CurrentMapping, localName)
+			if err := r.Update(context.TODO(), nm); err != nil {
+				klog.Errorf("unable to update NamespaceMap '%s' Status", nm.Name)
+				return err
+			}
+			klog.Infof("Status of NamespaceMap '%s' is correctly updated, delete remote Namespace '%s'", nm.Name, remoteStatus.RemoteNamespace)
+
+		}
+	}
+
+	return nil
+}

--- a/pkg/liqo-controller-manager/namespaceMap-controller/namespaceMap_controller.go
+++ b/pkg/liqo-controller-manager/namespaceMap-controller/namespaceMap_controller.go
@@ -1,0 +1,98 @@
+/*
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package namespaceMap_controller
+
+import (
+	"context"
+	mapsv1alpha1 "github.com/liqotech/liqo/apis/virtualKubelet/v1alpha1"
+	const_ctrl "github.com/liqotech/liqo/pkg/liqo-controller-manager"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/klog"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlutils "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+type NamespaceMapReconciler struct {
+	client.Client
+	Scheme        *runtime.Scheme
+	Mapper        meta.RESTMapper
+	RemoteClients map[string]client.Client
+}
+
+const (
+	clusterIdForeign = "discovery.liqo.io/cluster-id"
+)
+
+func (r *NamespaceMapReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
+
+	namespaceMap := &mapsv1alpha1.NamespaceMap{}
+	if err := r.Get(context.TODO(), req.NamespacedName, namespaceMap); err != nil {
+		klog.Errorf("%s --> Unable to get NamespaceMap '%s'", err, req.Name)
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	if !ctrlutils.ContainsFinalizer(namespaceMap, const_ctrl.NamespaceMapControllerFinalizer) {
+		ctrlutils.AddFinalizer(namespaceMap, const_ctrl.NamespaceMapControllerFinalizer)
+		if err := r.Patch(context.TODO(), namespaceMap, client.Merge); err != nil {
+			klog.Errorf("%s --> Unable to add '%s' to the NamespaceMap '%s'", err, const_ctrl.NamespaceMapControllerFinalizer, namespaceMap.GetName())
+			return ctrl.Result{}, err
+		}
+		klog.Infof("Finalizer correctly added on NamespaceMap '%s'", namespaceMap.GetName())
+	}
+
+	if err := r.manageRemoteNamespaces(namespaceMap); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	if len(namespaceMap.Status.CurrentMapping) == 0 {
+		ctrlutils.RemoveFinalizer(namespaceMap, const_ctrl.NamespaceMapControllerFinalizer)
+		if err := r.Update(context.TODO(), namespaceMap); err != nil {
+			klog.Errorf("%s --> Unable to remove '%s' from NamespaceMap '%s'", err, const_ctrl.NamespaceMapControllerFinalizer, namespaceMap.GetName())
+			return ctrl.Result{}, err
+		}
+		klog.Infof("Finalizer correctly removed from NamespaceMap '%s'", namespaceMap.GetName())
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// The Controller is triggered only when the number of entries in DesiredMapping changes, so only when
+// a namespace's request is added or removed
+func manageDesiredMappings() predicate.Predicate {
+	return predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return len(e.ObjectOld.(*mapsv1alpha1.NamespaceMap).Spec.DesiredMapping) != len(e.ObjectNew.(*mapsv1alpha1.NamespaceMap).Spec.DesiredMapping)
+		},
+		CreateFunc: func(e event.CreateEvent) bool {
+			return false
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return false
+		},
+	}
+}
+
+func (r *NamespaceMapReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&mapsv1alpha1.NamespaceMap{}).
+		WithEventFilter(manageDesiredMappings()).
+		Complete(r)
+}


### PR DESCRIPTION
# Description

This new controller monitors NamespaceMap's Spec in order to create and remove remote Namespaces. Besides it updates NamespaceMap's status with the current status of the just created remote Namespace.

# Fixes

**STEP 3** #572 