### PR TITLE
Support for MappingLabel renaming and defaulting

### DIFF
--- a/cmd/discovery/main.go
+++ b/cmd/discovery/main.go
@@ -6,8 +6,8 @@ import (
 	nettypes "github.com/liqotech/liqo/apis/net/v1alpha1"
 	advtypes "github.com/liqotech/liqo/apis/sharing/v1alpha1"
 	"github.com/liqotech/liqo/internal/discovery"
-	foreign_cluster_operator "github.com/liqotech/liqo/internal/discovery/foreign-cluster-operator"
-	search_domain_operator "github.com/liqotech/liqo/internal/discovery/search-domain-operator"
+	foreignclusteroperator "github.com/liqotech/liqo/internal/discovery/foreign-cluster-operator"
+	searchdomainoperator "github.com/liqotech/liqo/internal/discovery/search-domain-operator"
 	"github.com/liqotech/liqo/pkg/clusterID"
 	"github.com/liqotech/liqo/pkg/mapperUtils"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -84,10 +84,10 @@ func main() {
 	}
 
 	klog.Info("Starting SearchDomain operator")
-	search_domain_operator.StartOperator(&mgr, time.Duration(requeueAfter)*time.Second, discoveryCtl, kubeconfigPath)
+	searchdomainoperator.StartOperator(&mgr, time.Duration(requeueAfter)*time.Second, discoveryCtl, kubeconfigPath)
 
 	klog.Info("Starting ForeignCluster operator")
-	foreign_cluster_operator.StartOperator(&mgr, namespace, time.Duration(requeueAfter)*time.Second, discoveryCtl, kubeconfigPath)
+	foreignclusteroperator.StartOperator(&mgr, namespace, time.Duration(requeueAfter)*time.Second, discoveryCtl, kubeconfigPath)
 
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
 		klog.Error(err, "problem running manager")

--- a/internal/advertisement-operator/broadcaster.go
+++ b/internal/advertisement-operator/broadcaster.go
@@ -12,8 +12,8 @@ import (
 	"github.com/liqotech/liqo/pkg/crdClient"
 	"github.com/liqotech/liqo/pkg/kubeconfig"
 	"github.com/liqotech/liqo/pkg/labelPolicy"
-	liqoControllerManager "github.com/liqotech/liqo/pkg/liqo-controller-manager"
 	"github.com/liqotech/liqo/pkg/utils"
+	liqocontrollerutils "github.com/liqotech/liqo/pkg/utils"
 	pkg "github.com/liqotech/liqo/pkg/virtualKubelet"
 	"github.com/liqotech/liqo/pkg/virtualKubelet/forge"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -270,12 +270,12 @@ func (b *AdvertisementBroadcaster) CreateAdvertisement(advRes *AdvResources) adv
 
 func (b *AdvertisementBroadcaster) GetResourcesForAdv() (advRes *AdvResources, err error) {
 	// get physical and virtual nodes in the cluster
-	physicalNodes, err := b.LocalClient.Client().CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{LabelSelector: fmt.Sprintf("%v != %v", liqoControllerManager.TypeLabel, liqoControllerManager.TypeNode)})
+	physicalNodes, err := b.LocalClient.Client().CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{LabelSelector: fmt.Sprintf("%v != %v", liqocontrollerutils.TypeLabel, liqocontrollerutils.TypeNode)})
 	if err != nil {
 		klog.Errorln("Could not get physical nodes, retry in 1 minute")
 		return nil, err
 	}
-	virtualNodes, err := b.LocalClient.Client().CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{LabelSelector: fmt.Sprintf("%v = %v", liqoControllerManager.TypeLabel, liqoControllerManager.TypeNode)})
+	virtualNodes, err := b.LocalClient.Client().CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{LabelSelector: fmt.Sprintf("%v = %v", liqocontrollerutils.TypeLabel, liqocontrollerutils.TypeNode)})
 	if err != nil {
 		klog.Errorln("Could not get virtual nodes, retry in 1 minute")
 		return nil, err

--- a/internal/discovery/foreign-cluster-operator/foreign-cluster-controller.go
+++ b/internal/discovery/foreign-cluster-operator/foreign-cluster-controller.go
@@ -34,7 +34,8 @@ import (
 	"github.com/liqotech/liqo/pkg/crdClient"
 	discoveryPkg "github.com/liqotech/liqo/pkg/discovery"
 	"github.com/liqotech/liqo/pkg/kubeconfig"
-	liqoControllerManager "github.com/liqotech/liqo/pkg/liqo-controller-manager"
+	liqocontrollerutils "github.com/liqotech/liqo/pkg/utils"
+
 	apiv1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -518,9 +519,9 @@ func (r *ForeignClusterReconciler) getAddress() (string, error) {
 	labelSelector, err := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{
 		MatchExpressions: []metav1.LabelSelectorRequirement{
 			{
-				Key:      liqoControllerManager.TypeLabel,
+				Key:      liqocontrollerutils.TypeLabel,
 				Operator: metav1.LabelSelectorOpNotIn,
-				Values:   []string{liqoControllerManager.TypeNode},
+				Values:   []string{liqocontrollerutils.TypeNode},
 			},
 		},
 	})

--- a/internal/liqonet/tunnelEndpointCreator/tunnelEndpointCreator-operator.go
+++ b/internal/liqonet/tunnelEndpointCreator/tunnelEndpointCreator-operator.go
@@ -27,7 +27,7 @@ import (
 
 	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
 	"github.com/liqotech/liqo/internal/crdReplicator"
-	liqonet "github.com/liqotech/liqo/pkg/liqonet"
+	"github.com/liqotech/liqo/pkg/liqonet"
 	"github.com/liqotech/liqo/pkg/liqonet/tunnel/wireguard"
 	"github.com/liqotech/liqo/pkg/owner"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/liqo-controller-manager/namespace-controller/manage_remote_namespaces.go
+++ b/pkg/liqo-controller-manager/namespace-controller/manage_remote_namespaces.go
@@ -2,7 +2,9 @@ package namespace_controller
 
 import (
 	"context"
+	"fmt"
 	mapsv1alpha1 "github.com/liqotech/liqo/apis/virtualKubelet/v1alpha1"
+	liqocontrollerutils "github.com/liqotech/liqo/pkg/utils"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/klog"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -42,16 +44,23 @@ func (r *NamespaceReconciler) addDesiredMapping(n *corev1.Namespace, remoteName 
 	}
 
 	if oldValue, ok := nm.Spec.DesiredMapping[n.GetName()]; ok {
-		// if entries are already here, but mappingLabel has a different value from the previous one, we force again the old value.
-		// Common user cannot change remote namespace name while the namespace is offloaded onto remote clusters
+		// if entry is already here, but mappingLabel has a different value from the previous one, we force again the old value.
+		// User's cannot change remote namespace name while the namespace is offloaded onto remote clusters
 		if oldValue != remoteName {
 			n.GetLabels()[mappingLabel] = oldValue
+			if n.GetAnnotations() == nil {
+				n.Annotations = map[string]string{}
+			}
+			n.GetAnnotations()[mappingAnnotationRenaming] = fmt.Sprintf("You cannot change the value of label [%s] because namespace's offload has already started with name [%s]. Please read our documentation for more info [%s]",
+				mappingLabel, oldValue, liqocontrollerutils.DocumentationUrl)
+
 			if err := r.Update(context.TODO(), n); err != nil {
 				klog.Errorf("%s --> Unable to update '%s' label for namespace '%s' ", err, mappingLabel, nm.GetName())
 				return err
 			}
 			klog.Infof("Label '%s' successfully updated on namespace '%s' ", mappingLabel, nm.GetName())
 		}
+
 	} else {
 		nm.Spec.DesiredMapping[n.GetName()] = remoteName
 		if err := r.Patch(context.TODO(), &nm, client.Merge); err != nil {

--- a/pkg/liqo-controller-manager/namespace-controller/manage_remote_namespaces.go
+++ b/pkg/liqo-controller-manager/namespace-controller/manage_remote_namespaces.go
@@ -51,7 +51,7 @@ func (r *NamespaceReconciler) addDesiredMapping(n *corev1.Namespace, remoteName 
 			if n.GetAnnotations() == nil {
 				n.Annotations = map[string]string{}
 			}
-			n.GetAnnotations()[mappingAnnotationRenaming] = fmt.Sprintf("You cannot change the value of label [%s] because namespace's offload has already started with name [%s]. Please read our documentation for more info [%s]",
+			n.GetAnnotations()[mappingAnnotationRenaming] = fmt.Sprintf("You cannot change the value of label [%s] because the namespace is already offloaded with name [%s]. Please read our documentation for more info [%s]",
 				mappingLabel, oldValue, liqocontrollerutils.DocumentationUrl)
 
 			if err := r.Update(context.TODO(), n); err != nil {

--- a/pkg/liqo-controller-manager/namespace-controller/namespace_controller_test.go
+++ b/pkg/liqo-controller-manager/namespace-controller/namespace_controller_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 	mapsv1alpha1 "github.com/liqotech/liqo/apis/virtualKubelet/v1alpha1"
-	const_ctrl "github.com/liqotech/liqo/pkg/liqo-controller-manager"
+	liqocontrollerutils "github.com/liqotech/liqo/pkg/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/types"
@@ -50,7 +50,7 @@ var _ = Describe("Namespace controller", func() {
 
 			By(fmt.Sprintf("Check if NamespaceMap associated to %s is cleaned by the controller", remoteClusterId1))
 			Eventually(func() bool {
-				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(const_ctrl.MapNamespaceName), client.MatchingLabels{const_ctrl.VirtualNodeClusterId: remoteClusterId1}); err != nil {
+				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(liqocontrollerutils.MapNamespaceName), client.MatchingLabels{liqocontrollerutils.VirtualNodeClusterId: remoteClusterId1}); err != nil {
 					return false
 				}
 				if len(nms.Items) != 1 {
@@ -65,7 +65,7 @@ var _ = Describe("Namespace controller", func() {
 
 			By(fmt.Sprintf("Check if NamespaceMap associated to %s is cleaned by the controller ", remoteClusterId2))
 			Eventually(func() bool {
-				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(const_ctrl.MapNamespaceName), client.MatchingLabels{const_ctrl.VirtualNodeClusterId: remoteClusterId2}); err != nil {
+				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(liqocontrollerutils.MapNamespaceName), client.MatchingLabels{liqocontrollerutils.VirtualNodeClusterId: remoteClusterId2}); err != nil {
 					return false
 				}
 				if len(nms.Items) != 1 {
@@ -126,7 +126,7 @@ var _ = Describe("Namespace controller", func() {
 
 			By(fmt.Sprintf("Try to get NamespaceMap associated to: %s", remoteClusterId1))
 			Eventually(func() bool {
-				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(const_ctrl.MapNamespaceName), client.MatchingLabels{const_ctrl.VirtualNodeClusterId: remoteClusterId1}); err != nil {
+				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(liqocontrollerutils.MapNamespaceName), client.MatchingLabels{liqocontrollerutils.VirtualNodeClusterId: remoteClusterId1}); err != nil {
 					return false
 				}
 				if len(nms.Items) != 1 {
@@ -141,7 +141,7 @@ var _ = Describe("Namespace controller", func() {
 
 			By(fmt.Sprintf("Try to get NamespaceMap: associated to %s", remoteClusterId2))
 			Eventually(func() bool {
-				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(const_ctrl.MapNamespaceName), client.MatchingLabels{const_ctrl.VirtualNodeClusterId: remoteClusterId2}); err != nil {
+				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(liqocontrollerutils.MapNamespaceName), client.MatchingLabels{liqocontrollerutils.VirtualNodeClusterId: remoteClusterId2}); err != nil {
 					return false
 				}
 				if len(nms.Items) != 1 {
@@ -177,7 +177,7 @@ var _ = Describe("Namespace controller", func() {
 
 			By(fmt.Sprintf("Check if entry is also on NamespaceMap associated to: %s", remoteClusterId2))
 			Eventually(func() bool {
-				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(const_ctrl.MapNamespaceName), client.MatchingLabels{const_ctrl.VirtualNodeClusterId: remoteClusterId2}); err != nil {
+				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(liqocontrollerutils.MapNamespaceName), client.MatchingLabels{liqocontrollerutils.VirtualNodeClusterId: remoteClusterId2}); err != nil {
 					return false
 				}
 				if len(nms.Items) != 1 {
@@ -213,7 +213,7 @@ var _ = Describe("Namespace controller", func() {
 
 			By(fmt.Sprintf("Try to get NamespaceMap associated to %s", remoteClusterId1))
 			Eventually(func() bool {
-				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(const_ctrl.MapNamespaceName), client.MatchingLabels{const_ctrl.VirtualNodeClusterId: remoteClusterId1}); err != nil {
+				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(liqocontrollerutils.MapNamespaceName), client.MatchingLabels{liqocontrollerutils.VirtualNodeClusterId: remoteClusterId1}); err != nil {
 					return false
 				}
 				if len(nms.Items) != 1 {
@@ -230,7 +230,7 @@ var _ = Describe("Namespace controller", func() {
 
 			By(fmt.Sprintf("Try to get NamespaceMap associated to %s", remoteClusterId2))
 			Consistently(func() bool {
-				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(const_ctrl.MapNamespaceName), client.MatchingLabels{const_ctrl.VirtualNodeClusterId: remoteClusterId2}); err != nil {
+				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(liqocontrollerutils.MapNamespaceName), client.MatchingLabels{liqocontrollerutils.VirtualNodeClusterId: remoteClusterId2}); err != nil {
 					return true
 				}
 				if len(nms.Items) != 1 {
@@ -265,7 +265,7 @@ var _ = Describe("Namespace controller", func() {
 
 			By(fmt.Sprintf("Try to get NamespaceMap associated to: %s", remoteClusterId1))
 			Eventually(func() bool {
-				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(const_ctrl.MapNamespaceName), client.MatchingLabels{const_ctrl.VirtualNodeClusterId: remoteClusterId1}); err != nil {
+				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(liqocontrollerutils.MapNamespaceName), client.MatchingLabels{liqocontrollerutils.VirtualNodeClusterId: remoteClusterId1}); err != nil {
 					return false
 				}
 				if len(nms.Items) != 1 {
@@ -281,7 +281,7 @@ var _ = Describe("Namespace controller", func() {
 
 			By(fmt.Sprintf("Try to get NamespaceMap associated to: %s", remoteClusterId2))
 			Eventually(func() bool {
-				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(const_ctrl.MapNamespaceName), client.MatchingLabels{const_ctrl.VirtualNodeClusterId: remoteClusterId2}); err != nil {
+				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(liqocontrollerutils.MapNamespaceName), client.MatchingLabels{liqocontrollerutils.VirtualNodeClusterId: remoteClusterId2}); err != nil {
 					return false
 				}
 				if len(nms.Items) != 1 {
@@ -347,7 +347,7 @@ var _ = Describe("Namespace controller", func() {
 
 			By(fmt.Sprintf("Try to get NamespaceMap associated to: %s", remoteClusterId1))
 			Eventually(func() bool {
-				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(const_ctrl.MapNamespaceName), client.MatchingLabels{const_ctrl.VirtualNodeClusterId: remoteClusterId1}); err != nil {
+				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(liqocontrollerutils.MapNamespaceName), client.MatchingLabels{liqocontrollerutils.VirtualNodeClusterId: remoteClusterId1}); err != nil {
 					return false
 				}
 				if len(nms.Items) != 1 {
@@ -363,7 +363,7 @@ var _ = Describe("Namespace controller", func() {
 
 			By(fmt.Sprintf("Try to get NamespaceMap associated to: %s", remoteClusterId2))
 			Eventually(func() bool {
-				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(const_ctrl.MapNamespaceName), client.MatchingLabels{const_ctrl.VirtualNodeClusterId: remoteClusterId2}); err != nil {
+				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(liqocontrollerutils.MapNamespaceName), client.MatchingLabels{liqocontrollerutils.VirtualNodeClusterId: remoteClusterId2}); err != nil {
 					return false
 				}
 				if len(nms.Items) != 1 {
@@ -396,7 +396,7 @@ var _ = Describe("Namespace controller", func() {
 
 			By(fmt.Sprintf("Check if NamespaceMap associated to %s is cleaned by the controller", remoteClusterId1))
 			Eventually(func() bool {
-				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(const_ctrl.MapNamespaceName), client.MatchingLabels{const_ctrl.VirtualNodeClusterId: remoteClusterId1}); err != nil {
+				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(liqocontrollerutils.MapNamespaceName), client.MatchingLabels{liqocontrollerutils.VirtualNodeClusterId: remoteClusterId1}); err != nil {
 					return false
 				}
 				if len(nms.Items) != 1 {
@@ -413,7 +413,7 @@ var _ = Describe("Namespace controller", func() {
 
 			By(fmt.Sprintf("Check if NamespaceMap associated to %s is cleaned by the controller", remoteClusterId2))
 			Eventually(func() bool {
-				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(const_ctrl.MapNamespaceName), client.MatchingLabels{const_ctrl.VirtualNodeClusterId: remoteClusterId2}); err != nil {
+				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(liqocontrollerutils.MapNamespaceName), client.MatchingLabels{liqocontrollerutils.VirtualNodeClusterId: remoteClusterId2}); err != nil {
 					return false
 				}
 				if len(nms.Items) != 1 {
@@ -446,7 +446,7 @@ var _ = Describe("Namespace controller", func() {
 
 			By(fmt.Sprintf("Check if NamespaceMap associated to %s is cleaned by the controller", remoteClusterId1))
 			Eventually(func() bool {
-				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(const_ctrl.MapNamespaceName), client.MatchingLabels{const_ctrl.VirtualNodeClusterId: remoteClusterId1}); err != nil {
+				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(liqocontrollerutils.MapNamespaceName), client.MatchingLabels{liqocontrollerutils.VirtualNodeClusterId: remoteClusterId1}); err != nil {
 					return false
 				}
 				if len(nms.Items) != 1 {
@@ -463,7 +463,7 @@ var _ = Describe("Namespace controller", func() {
 
 			By(fmt.Sprintf("Check if NamespaceMap associated to %s is cleaned by the controller", remoteClusterId2))
 			Eventually(func() bool {
-				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(const_ctrl.MapNamespaceName), client.MatchingLabels{const_ctrl.VirtualNodeClusterId: remoteClusterId2}); err != nil {
+				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(liqocontrollerutils.MapNamespaceName), client.MatchingLabels{liqocontrollerutils.VirtualNodeClusterId: remoteClusterId2}); err != nil {
 					return false
 				}
 				if len(nms.Items) != 1 {

--- a/pkg/liqo-controller-manager/namespace-controller/suite_test.go
+++ b/pkg/liqo-controller-manager/namespace-controller/suite_test.go
@@ -17,7 +17,7 @@ import (
 	"flag"
 	"fmt"
 	mapsv1alpha1 "github.com/liqotech/liqo/apis/virtualKubelet/v1alpha1"
-	const_ctrl "github.com/liqotech/liqo/pkg/liqo-controller-manager"
+	liqocontrollerutils "github.com/liqotech/liqo/pkg/utils"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"path/filepath"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -137,12 +137,12 @@ var _ = BeforeSuite(func(done Done) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: nameVirtualNode1,
 			Annotations: map[string]string{
-				const_ctrl.VirtualNodeClusterId: remoteClusterId1,
+				liqocontrollerutils.VirtualNodeClusterId: remoteClusterId1,
 			},
 			Labels: map[string]string{
-				const_ctrl.TypeLabel:     const_ctrl.TypeNode,
-				offloadingCluster1Label1: "",
-				offloadingCluster1Label2: "",
+				liqocontrollerutils.TypeLabel: liqocontrollerutils.TypeNode,
+				offloadingCluster1Label1:      "",
+				offloadingCluster1Label2:      "",
 			},
 		},
 	}
@@ -155,12 +155,12 @@ var _ = BeforeSuite(func(done Done) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: nameVirtualNode2,
 			Annotations: map[string]string{
-				const_ctrl.VirtualNodeClusterId: remoteClusterId2,
+				liqocontrollerutils.VirtualNodeClusterId: remoteClusterId2,
 			},
 			Labels: map[string]string{
-				const_ctrl.TypeLabel:     const_ctrl.TypeNode,
-				offloadingCluster2Label1: "",
-				offloadingCluster2Label2: "",
+				liqocontrollerutils.TypeLabel: liqocontrollerutils.TypeNode,
+				offloadingCluster2Label1:      "",
+				offloadingCluster2Label2:      "",
 			},
 		},
 	}
@@ -174,7 +174,7 @@ var _ = BeforeSuite(func(done Done) {
 			GenerateName: fmt.Sprintf("%s-", remoteClusterId1),
 			Namespace:    mapNamespaceName,
 			Labels: map[string]string{
-				const_ctrl.VirtualNodeClusterId: remoteClusterId1,
+				liqocontrollerutils.VirtualNodeClusterId: remoteClusterId1,
 			},
 		},
 	}
@@ -188,7 +188,7 @@ var _ = BeforeSuite(func(done Done) {
 			GenerateName: fmt.Sprintf("%s-", remoteClusterId2),
 			Namespace:    mapNamespaceName,
 			Labels: map[string]string{
-				const_ctrl.VirtualNodeClusterId: remoteClusterId2,
+				liqocontrollerutils.VirtualNodeClusterId: remoteClusterId2,
 			},
 		},
 	}

--- a/pkg/liqo-controller-manager/namespaceMap-controller/manage_remote_namespaces.go
+++ b/pkg/liqo-controller-manager/namespaceMap-controller/manage_remote_namespaces.go
@@ -3,7 +3,7 @@ package namespaceMap_controller
 import (
 	"context"
 	mapsv1alpha1 "github.com/liqotech/liqo/apis/virtualKubelet/v1alpha1"
-	const_ctrl "github.com/liqotech/liqo/pkg/liqo-controller-manager"
+	liqocontrollerutils "github.com/liqotech/liqo/pkg/utils"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -67,7 +67,7 @@ func (r *NamespaceMapReconciler) manageRemoteNamespaces(nm *mapsv1alpha1.Namespa
 	// if DesiredMapping field has more entries than CurrentMapping, is necessary to create new remote namespaces
 	for localName, remoteName := range nm.Spec.DesiredMapping {
 		if _, ok := nm.Status.CurrentMapping[localName]; !ok {
-			if err := r.createRemoteNamespace(nm.Labels[const_ctrl.VirtualNodeClusterId], remoteName); err != nil {
+			if err := r.createRemoteNamespace(nm.Labels[liqocontrollerutils.VirtualNodeClusterId], remoteName); err != nil {
 				return err
 			}
 			nm.Status.CurrentMapping[localName] = mapsv1alpha1.RemoteNamespaceStatus{
@@ -85,7 +85,7 @@ func (r *NamespaceMapReconciler) manageRemoteNamespaces(nm *mapsv1alpha1.Namespa
 	// if DesiredMapping field has less entries than CurrentMapping, is necessary to remove some remote namespaces
 	for localName, remoteStatus := range nm.Status.CurrentMapping {
 		if _, ok := nm.Spec.DesiredMapping[localName]; !ok {
-			if err := r.deleteRemoteNamespace(nm.Labels[const_ctrl.VirtualNodeClusterId], remoteStatus.RemoteNamespace); err != nil {
+			if err := r.deleteRemoteNamespace(nm.Labels[liqocontrollerutils.VirtualNodeClusterId], remoteStatus.RemoteNamespace); err != nil {
 				return err
 			}
 			// Update Map status

--- a/pkg/liqo-controller-manager/namespaceMap-controller/namespaceMap_controller.go
+++ b/pkg/liqo-controller-manager/namespaceMap-controller/namespaceMap_controller.go
@@ -19,7 +19,7 @@ package namespaceMap_controller
 import (
 	"context"
 	mapsv1alpha1 "github.com/liqotech/liqo/apis/virtualKubelet/v1alpha1"
-	const_ctrl "github.com/liqotech/liqo/pkg/liqo-controller-manager"
+	liqocontrollerutils "github.com/liqotech/liqo/pkg/utils"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/klog"
@@ -49,10 +49,10 @@ func (r *NamespaceMapReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
-	if !ctrlutils.ContainsFinalizer(namespaceMap, const_ctrl.NamespaceMapControllerFinalizer) {
-		ctrlutils.AddFinalizer(namespaceMap, const_ctrl.NamespaceMapControllerFinalizer)
+	if !ctrlutils.ContainsFinalizer(namespaceMap, liqocontrollerutils.NamespaceMapControllerFinalizer) {
+		ctrlutils.AddFinalizer(namespaceMap, liqocontrollerutils.NamespaceMapControllerFinalizer)
 		if err := r.Patch(context.TODO(), namespaceMap, client.Merge); err != nil {
-			klog.Errorf("%s --> Unable to add '%s' to the NamespaceMap '%s'", err, const_ctrl.NamespaceMapControllerFinalizer, namespaceMap.GetName())
+			klog.Errorf("%s --> Unable to add '%s' to the NamespaceMap '%s'", err, liqocontrollerutils.NamespaceMapControllerFinalizer, namespaceMap.GetName())
 			return ctrl.Result{}, err
 		}
 		klog.Infof("Finalizer correctly added on NamespaceMap '%s'", namespaceMap.GetName())
@@ -63,9 +63,9 @@ func (r *NamespaceMapReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error
 	}
 
 	if len(namespaceMap.Status.CurrentMapping) == 0 {
-		ctrlutils.RemoveFinalizer(namespaceMap, const_ctrl.NamespaceMapControllerFinalizer)
+		ctrlutils.RemoveFinalizer(namespaceMap, liqocontrollerutils.NamespaceMapControllerFinalizer)
 		if err := r.Update(context.TODO(), namespaceMap); err != nil {
-			klog.Errorf("%s --> Unable to remove '%s' from NamespaceMap '%s'", err, const_ctrl.NamespaceMapControllerFinalizer, namespaceMap.GetName())
+			klog.Errorf("%s --> Unable to remove '%s' from NamespaceMap '%s'", err, liqocontrollerutils.NamespaceMapControllerFinalizer, namespaceMap.GetName())
 			return ctrl.Result{}, err
 		}
 		klog.Infof("Finalizer correctly removed from NamespaceMap '%s'", namespaceMap.GetName())

--- a/pkg/liqo-controller-manager/virtualNode-controller/node_controller.go
+++ b/pkg/liqo-controller-manager/virtualNode-controller/node_controller.go
@@ -19,7 +19,7 @@ package virtualNode_controller
 import (
 	"context"
 	mapsv1alpha1 "github.com/liqotech/liqo/apis/virtualKubelet/v1alpha1"
-	constctrl "github.com/liqotech/liqo/pkg/liqo-controller-manager"
+	liqocontrollerutils "github.com/liqotech/liqo/pkg/utils"
 	ctrlutils "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	corev1 "k8s.io/api/core/v1"
@@ -64,8 +64,8 @@ func (r *VirtualNodeReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error)
 		klog.Infof("The virtual node '%s' is requested to be deleted", node.GetName())
 
 		nms := &mapsv1alpha1.NamespaceMapList{}
-		if err := r.List(context.TODO(), nms, client.InNamespace(constctrl.MapNamespaceName),
-			client.MatchingLabels{constctrl.VirtualNodeClusterId: node.GetAnnotations()[constctrl.VirtualNodeClusterId]}); err != nil {
+		if err := r.List(context.TODO(), nms, client.InNamespace(liqocontrollerutils.MapNamespaceName),
+			client.MatchingLabels{liqocontrollerutils.VirtualNodeClusterId: node.GetAnnotations()[liqocontrollerutils.VirtualNodeClusterId]}); err != nil {
 			klog.Errorf("%s --> Unable to List NamespaceMaps of virtual node '%s'", err, node.GetName())
 			return ctrl.Result{}, err
 		}
@@ -103,7 +103,7 @@ func filterVirtualNodes() predicate.Predicate {
 			// if the resource has no namespace, it surely a node, so we have to check if it is virtual or not, we are
 			// interested only in virtual-nodes' deletion, not common nodes' deletion.
 			if e.MetaNew.GetNamespace() == "" {
-				if value, ok := (e.MetaNew.GetLabels())[constctrl.TypeLabel]; !ok || value != constctrl.TypeNode {
+				if value, ok := (e.MetaNew.GetLabels())[liqocontrollerutils.TypeLabel]; !ok || value != liqocontrollerutils.TypeNode {
 					return false
 				}
 			}
@@ -113,7 +113,7 @@ func filterVirtualNodes() predicate.Predicate {
 		CreateFunc: func(e event.CreateEvent) bool {
 			// listen only virtual-node creation, not simple node
 			if e.Meta.GetNamespace() == "" {
-				if value, ok := (e.Meta.GetLabels())[constctrl.TypeLabel]; !ok || value != constctrl.TypeNode {
+				if value, ok := (e.Meta.GetLabels())[liqocontrollerutils.TypeLabel]; !ok || value != liqocontrollerutils.TypeNode {
 					return false
 				}
 			}
@@ -125,7 +125,7 @@ func filterVirtualNodes() predicate.Predicate {
 		},
 		GenericFunc: func(e event.GenericEvent) bool {
 			if e.Meta.GetNamespace() == "" {
-				if value, ok := (e.Meta.GetLabels())[constctrl.TypeLabel]; !ok || value != constctrl.TypeNode {
+				if value, ok := (e.Meta.GetLabels())[liqocontrollerutils.TypeLabel]; !ok || value != liqocontrollerutils.TypeNode {
 					return false
 				}
 			}

--- a/pkg/liqo-controller-manager/virtualNode-controller/node_controller_test.go
+++ b/pkg/liqo-controller-manager/virtualNode-controller/node_controller_test.go
@@ -2,7 +2,7 @@ package virtualNode_controller
 
 import (
 	mapsv1alpha1 "github.com/liqotech/liqo/apis/virtualKubelet/v1alpha1"
-	const_ctrl "github.com/liqotech/liqo/pkg/liqo-controller-manager"
+	liqocontrollerutils "github.com/liqotech/liqo/pkg/utils"
 
 	"context"
 	"fmt"
@@ -32,7 +32,7 @@ var _ = Describe("VirtualNode controller", func() {
 
 			By(fmt.Sprintf("Try to get NamespaceMap associated to: %s", remoteClusterId1))
 			Eventually(func() bool {
-				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(const_ctrl.MapNamespaceName), client.MatchingLabels{const_ctrl.VirtualNodeClusterId: remoteClusterId1}); err != nil {
+				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(liqocontrollerutils.MapNamespaceName), client.MatchingLabels{liqocontrollerutils.VirtualNodeClusterId: remoteClusterId1}); err != nil {
 					return false
 				}
 				if len(nms.Items) != 1 {
@@ -51,7 +51,7 @@ var _ = Describe("VirtualNode controller", func() {
 
 			By(fmt.Sprintf("Try to get NamespaceMap associated to: %s", remoteClusterId2))
 			Eventually(func() bool {
-				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(const_ctrl.MapNamespaceName), client.MatchingLabels{const_ctrl.VirtualNodeClusterId: remoteClusterId2}); err != nil {
+				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(liqocontrollerutils.MapNamespaceName), client.MatchingLabels{liqocontrollerutils.VirtualNodeClusterId: remoteClusterId2}); err != nil {
 					return false
 				}
 				if len(nms.Items) != 1 {
@@ -82,7 +82,7 @@ var _ = Describe("VirtualNode controller", func() {
 
 			By(fmt.Sprintf("Try to get NamespaceMap associated to: %s", remoteClusterId1))
 			Eventually(func() bool {
-				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(const_ctrl.MapNamespaceName), client.MatchingLabels{const_ctrl.VirtualNodeClusterId: remoteClusterId1}); err != nil {
+				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(liqocontrollerutils.MapNamespaceName), client.MatchingLabels{liqocontrollerutils.VirtualNodeClusterId: remoteClusterId1}); err != nil {
 					return false
 				}
 				if len(nms.Items) != 1 {
@@ -129,7 +129,7 @@ var _ = Describe("VirtualNode controller", func() {
 
 			By(fmt.Sprintf("Try to get NamespaceMap associated to: %s", remoteClusterId2))
 			Eventually(func() bool {
-				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(const_ctrl.MapNamespaceName), client.MatchingLabels{const_ctrl.VirtualNodeClusterId: remoteClusterId2}); err != nil {
+				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(liqocontrollerutils.MapNamespaceName), client.MatchingLabels{liqocontrollerutils.VirtualNodeClusterId: remoteClusterId2}); err != nil {
 					return false
 				}
 				if len(nms.Items) != 1 {
@@ -180,7 +180,7 @@ var _ = Describe("VirtualNode controller", func() {
 
 			By(fmt.Sprintf("Check absence of NamespaceMap associated to %s", remoteClusterIdSimpleNode))
 			Consistently(func() bool {
-				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(const_ctrl.MapNamespaceName), client.MatchingLabels{const_ctrl.VirtualNodeClusterId: remoteClusterIdSimpleNode}); err != nil {
+				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(liqocontrollerutils.MapNamespaceName), client.MatchingLabels{liqocontrollerutils.VirtualNodeClusterId: remoteClusterIdSimpleNode}); err != nil {
 					return false
 				}
 				if len(nms.Items) == 0 {
@@ -212,7 +212,7 @@ var _ = Describe("VirtualNode controller", func() {
 			oldName := ""
 			By(fmt.Sprintf("Try to delete NamespaceMap associated to: %s", remoteClusterId1))
 			Eventually(func() bool {
-				if err := k8sClient.List(context.TODO(), nms, client.MatchingLabels{const_ctrl.VirtualNodeClusterId: remoteClusterId1}); err != nil {
+				if err := k8sClient.List(context.TODO(), nms, client.MatchingLabels{liqocontrollerutils.VirtualNodeClusterId: remoteClusterId1}); err != nil {
 					return false
 				}
 				if len(nms.Items) != 1 {
@@ -248,7 +248,7 @@ var _ = Describe("VirtualNode controller", func() {
 
 			By(fmt.Sprintf("Try to get new NamespaceMap associated to: %s", remoteClusterId1))
 			Eventually(func() bool {
-				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(const_ctrl.MapNamespaceName), client.MatchingLabels{const_ctrl.VirtualNodeClusterId: remoteClusterId1}); err != nil {
+				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(liqocontrollerutils.MapNamespaceName), client.MatchingLabels{liqocontrollerutils.VirtualNodeClusterId: remoteClusterId1}); err != nil {
 					return false
 				}
 				if len(nms.Items) != 1 {
@@ -268,7 +268,7 @@ var _ = Describe("VirtualNode controller", func() {
 			oldName := ""
 			By(fmt.Sprintf("Try to delete NamespaceMap associated to: %s", remoteClusterId2))
 			Eventually(func() bool {
-				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(const_ctrl.MapNamespaceName), client.MatchingLabels{const_ctrl.VirtualNodeClusterId: remoteClusterId2}); err != nil {
+				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(liqocontrollerutils.MapNamespaceName), client.MatchingLabels{liqocontrollerutils.VirtualNodeClusterId: remoteClusterId2}); err != nil {
 					return false
 				}
 				if len(nms.Items) != 1 {
@@ -303,7 +303,7 @@ var _ = Describe("VirtualNode controller", func() {
 
 			By(fmt.Sprintf("Try to get new NamespaceMap associated to: %s", remoteClusterId2))
 			Eventually(func() bool {
-				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(const_ctrl.MapNamespaceName), client.MatchingLabels{const_ctrl.VirtualNodeClusterId: remoteClusterId2}); err != nil {
+				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(liqocontrollerutils.MapNamespaceName), client.MatchingLabels{liqocontrollerutils.VirtualNodeClusterId: remoteClusterId2}); err != nil {
 					return false
 				}
 				if len(nms.Items) != 1 {

--- a/pkg/liqo-controller-manager/virtualNode-controller/suite_test.go
+++ b/pkg/liqo-controller-manager/virtualNode-controller/suite_test.go
@@ -17,7 +17,7 @@ import (
 	"context"
 	"flag"
 	mapsv1alpha1 "github.com/liqotech/liqo/apis/virtualKubelet/v1alpha1"
-	const_ctrl "github.com/liqotech/liqo/pkg/liqo-controller-manager"
+	liqocontrollerutils "github.com/liqotech/liqo/pkg/utils"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -132,12 +132,12 @@ var _ = BeforeSuite(func(done Done) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: nameVirtualNode1,
 			Annotations: map[string]string{
-				const_ctrl.VirtualNodeClusterId: remoteClusterId1,
+				liqocontrollerutils.VirtualNodeClusterId: remoteClusterId1,
 			},
 			Labels: map[string]string{
-				const_ctrl.TypeLabel:     const_ctrl.TypeNode,
-				offloadingCluster1Label1: "",
-				offloadingCluster1Label2: "",
+				liqocontrollerutils.TypeLabel: liqocontrollerutils.TypeNode,
+				offloadingCluster1Label1:      "",
+				offloadingCluster1Label2:      "",
 			},
 		},
 	}
@@ -150,12 +150,12 @@ var _ = BeforeSuite(func(done Done) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: nameVirtualNode2,
 			Annotations: map[string]string{
-				const_ctrl.VirtualNodeClusterId: remoteClusterId2,
+				liqocontrollerutils.VirtualNodeClusterId: remoteClusterId2,
 			},
 			Labels: map[string]string{
-				const_ctrl.TypeLabel:     const_ctrl.TypeNode,
-				offloadingCluster2Label1: "",
-				offloadingCluster2Label2: "",
+				liqocontrollerutils.TypeLabel: liqocontrollerutils.TypeNode,
+				offloadingCluster2Label1:      "",
+				offloadingCluster2Label2:      "",
 			},
 		},
 	}
@@ -168,7 +168,7 @@ var _ = BeforeSuite(func(done Done) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: nameSimpleNode,
 			Annotations: map[string]string{
-				const_ctrl.VirtualNodeClusterId: remoteClusterIdSimpleNode,
+				liqocontrollerutils.VirtualNodeClusterId: remoteClusterIdSimpleNode,
 			},
 			Labels: map[string]string{
 				offloadingCluster1Label1: "",
@@ -179,7 +179,7 @@ var _ = BeforeSuite(func(done Done) {
 
 	mapNamespace = &corev1.Namespace{}
 	Eventually(func() bool {
-		if err = k8sClient.Get(context.TODO(), types.NamespacedName{Name: const_ctrl.MapNamespaceName}, mapNamespace); err != nil {
+		if err = k8sClient.Get(context.TODO(), types.NamespacedName{Name: liqocontrollerutils.MapNamespaceName}, mapNamespace); err != nil {
 			if errors.IsNotFound(err) {
 				if err = k8sClient.Create(context.TODO(), virtualNode1); err == nil {
 					return true

--- a/pkg/utils/cluster_info.go
+++ b/pkg/utils/cluster_info.go
@@ -1,0 +1,34 @@
+package utils
+
+import (
+	"context"
+	"fmt"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/klog"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	clusterIDConfMap = "cluster-id"
+	// Todo: Is there a place where i can get this?
+	configMapNamespace = "liqo"
+)
+
+func GetClusterID(c client.Client) (string, error) {
+
+	configMaps := &corev1.ConfigMapList{}
+	// possibility to specify "Liqo" namespace if it is possible to get it somewhere
+	if err := c.List(context.TODO(), configMaps, client.InNamespace(configMapNamespace)); err != nil {
+		klog.Error(err, "unable to get ConfigMapList")
+		return "", err
+	}
+	if len(configMaps.Items) != 1 {
+		err := fmt.Errorf("there are %d ConfigMaps at the moment, unstable condition", len(configMaps.Items))
+		klog.Error(err)
+		return "", err
+	}
+
+	clusterID := configMaps.Items[0].Data[clusterIDConfMap]
+	klog.Infof("ClusterID is '%s'", clusterID)
+	return clusterID, nil
+}

--- a/pkg/utils/cluster_info.go
+++ b/pkg/utils/cluster_info.go
@@ -2,33 +2,26 @@ package utils
 
 import (
 	"context"
-	"fmt"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
-	clusterIDConfMap = "cluster-id"
-	// Todo: Is there a place where i can get this?
+	clusterIDConfMap   = "cluster-id"
 	configMapNamespace = "liqo"
 )
 
 func GetClusterID(c client.Client) (string, error) {
 
-	configMaps := &corev1.ConfigMapList{}
-	// possibility to specify "Liqo" namespace if it is possible to get it somewhere
-	if err := c.List(context.TODO(), configMaps, client.InNamespace(configMapNamespace)); err != nil {
-		klog.Error(err, "unable to get ConfigMapList")
-		return "", err
-	}
-	if len(configMaps.Items) != 1 {
-		err := fmt.Errorf("there are %d ConfigMaps at the moment, unstable condition", len(configMaps.Items))
-		klog.Error(err)
+	configMap := &corev1.ConfigMap{}
+	if err := c.Get(context.TODO(), types.NamespacedName{Namespace: configMapNamespace, Name: clusterIDConfMap}, configMap); err != nil {
+		klog.Errorf("%s, unable to get ConfigMap '%s' in namespace '%s'", err, clusterIDConfMap, configMapNamespace)
 		return "", err
 	}
 
-	clusterID := configMaps.Items[0].Data[clusterIDConfMap]
+	clusterID := configMap.Data[clusterIDConfMap]
 	klog.Infof("ClusterID is '%s'", clusterID)
 	return clusterID, nil
 }

--- a/pkg/utils/const.go
+++ b/pkg/utils/const.go
@@ -1,4 +1,4 @@
-package liqo_controller_manager
+package utils
 
 const (
 	VirtualNodeClusterId            = "cluster-id" //"remote.liqo.io/clusterId"
@@ -6,4 +6,5 @@ const (
 	TypeLabel                       = "liqo.io/type"
 	TypeNode                        = "virtual-node"
 	NamespaceMapControllerFinalizer = "namespacemap-controller.liqo.io/finalizer"
+	DocumentationUrl                = "https://github.com/liqotech/liqo/tree/master/docs"
 )

--- a/pkg/utils/const.go
+++ b/pkg/utils/const.go
@@ -6,5 +6,5 @@ const (
 	TypeLabel                       = "liqo.io/type"
 	TypeNode                        = "virtual-node"
 	NamespaceMapControllerFinalizer = "namespacemap-controller.liqo.io/finalizer"
-	DocumentationUrl                = "https://github.com/liqotech/liqo/tree/master/docs"
+	DocumentationUrl                = "https://doc.liqo.io/"
 )

--- a/pkg/virtualKubelet/forge/pods.go
+++ b/pkg/virtualKubelet/forge/pods.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/liqotech/liqo/internal/liqonet/tunnelEndpointCreator"
-	liqoControllerManager "github.com/liqotech/liqo/pkg/liqo-controller-manager"
+	liqocontrollerutils "github.com/liqotech/liqo/pkg/utils"
 	"github.com/liqotech/liqo/pkg/virtualKubelet"
 	apimgmt "github.com/liqotech/liqo/pkg/virtualKubelet/apiReflection"
 	"github.com/liqotech/liqo/pkg/virtualKubelet/apiReflection/reflectors"
@@ -16,7 +16,7 @@ import (
 	"k8s.io/klog"
 )
 
-const affinitySelector = liqoControllerManager.TypeNode
+const affinitySelector = liqocontrollerutils.TypeNode
 
 func (f *apiForger) podForeignToHome(foreignObj, homeObj runtime.Object, reflectionType string) (*corev1.Pod, error) {
 	var isNewObject bool
@@ -227,7 +227,7 @@ func forgeAffinity() *corev1.Affinity {
 					{
 						MatchExpressions: []corev1.NodeSelectorRequirement{
 							{
-								Key:      liqoControllerManager.TypeLabel,
+								Key:      liqocontrollerutils.TypeLabel,
 								Operator: corev1.NodeSelectorOpNotIn,
 								Values:   []string{affinitySelector},
 							},

--- a/pkg/virtualKubelet/node/module/node_test.go
+++ b/pkg/virtualKubelet/node/module/node_test.go
@@ -26,7 +26,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	watch "k8s.io/apimachinery/pkg/watch"
+	"k8s.io/apimachinery/pkg/watch"
 	testclient "k8s.io/client-go/kubernetes/fake"
 )
 

--- a/pkg/virtualKubelet/provider/node.go
+++ b/pkg/virtualKubelet/provider/node.go
@@ -2,7 +2,7 @@ package provider
 
 import (
 	"context"
-	liqoControllerManager "github.com/liqotech/liqo/pkg/liqo-controller-manager"
+	liqocontrollerutils "github.com/liqotech/liqo/pkg/utils"
 	"go.opencensus.io/trace"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -25,7 +25,7 @@ func (p *LiqoProvider) ConfigureNode(ctx context.Context, n *v1.Node) {
 	n.Status.NodeInfo.Architecture = "amd64"
 	n.ObjectMeta.Labels["alpha.service-controller.kubernetes.io/exclude-balancer"] = "true"
 	n.ObjectMeta.Labels["node.kubernetes.io/exclude-from-external-load-balancers"] = "true"
-	n.Labels[liqoControllerManager.TypeLabel] = liqoControllerManager.TypeNode
+	n.Labels[liqocontrollerutils.TypeLabel] = liqocontrollerutils.TypeNode
 }
 
 // NodeConditions returns a list of conditions (Ready, OutOfDisk, etc), for updates to the node status

--- a/pkg/vkMachinery/forge/forge.go
+++ b/pkg/vkMachinery/forge/forge.go
@@ -2,7 +2,7 @@ package forge
 
 import (
 	advtypes "github.com/liqotech/liqo/apis/sharing/v1alpha1"
-	liqoControllerManager "github.com/liqotech/liqo/pkg/liqo-controller-manager"
+	liqocontrollerutils "github.com/liqotech/liqo/pkg/utils"
 	vk "github.com/liqotech/liqo/pkg/vkMachinery"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -21,9 +21,9 @@ func forgeVKAffinity() *v1.Affinity {
 					{
 						MatchExpressions: []v1.NodeSelectorRequirement{
 							{
-								Key:      liqoControllerManager.TypeNode,
+								Key:      liqocontrollerutils.TypeNode,
 								Operator: v1.NodeSelectorOpNotIn,
-								Values:   []string{liqoControllerManager.TypeNode},
+								Values:   []string{liqocontrollerutils.TypeNode},
 							},
 						},
 					},

--- a/test/e2e/deploy_app_test.go
+++ b/test/e2e/deploy_app_test.go
@@ -10,9 +10,9 @@ import (
 	"testing"
 	"time"
 
-	http_helper "github.com/gruntwork-io/terratest/modules/http-helper"
+	httphelper "github.com/gruntwork-io/terratest/modules/http-helper"
 	"github.com/gruntwork-io/terratest/modules/k8s"
-	liqoControllerManager "github.com/liqotech/liqo/pkg/liqo-controller-manager"
+	liqocontrollerutils "github.com/liqotech/liqo/pkg/utils"
 )
 
 const (
@@ -57,7 +57,7 @@ func testDeployApp(t *testing.T) {
 	assert.Assert(t, len(nodes) > 0)
 
 	url := fmt.Sprintf("http://%s:%d", getAddress(t, nodes[0].Status.Addresses), service.Spec.Ports[0].NodePort)
-	http_helper.HttpGetWithRetryWithCustomValidation(t, url, nil, retries, sleepBetweenRetries, func(code int, body string) bool {
+	httphelper.HttpGetWithRetryWithCustomValidation(t, url, nil, retries, sleepBetweenRetries, func(code int, body string) bool {
 		return code == 200
 	})
 }
@@ -92,7 +92,7 @@ func getNodes(t *testing.T, options *k8s.KubectlOptions) []v1.Node {
 	assert.NilError(t, err)
 
 	nodes, err := clientset.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{
-		LabelSelector: fmt.Sprintf("%v!=%v,!net.liqo.io/gateway", liqoControllerManager.TypeLabel, liqoControllerManager.TypeNode),
+		LabelSelector: fmt.Sprintf("%v!=%v,!net.liqo.io/gateway", liqocontrollerutils.TypeLabel, liqocontrollerutils.TypeNode),
 	})
 	assert.NilError(t, err)
 	return nodes.Items

--- a/test/e2e/net_test.go
+++ b/test/e2e/net_test.go
@@ -4,7 +4,8 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	liqoControllerManager "github.com/liqotech/liqo/pkg/liqo-controller-manager"
+	liqocontrollerutils "github.com/liqotech/liqo/pkg/utils"
+
 	"github.com/liqotech/liqo/pkg/virtualKubelet"
 	"github.com/liqotech/liqo/test/e2e/util"
 	"github.com/stretchr/testify/assert"
@@ -27,7 +28,7 @@ var (
 	namespaceNameCl1   = "test-connectivity-cl1"
 	namespaceNameCl2   = "test-connectivity-cl2"
 	//label to list only the real nodes excluding the virtual ones
-	labelSelectorNodes = fmt.Sprintf("%v!=%v", liqoControllerManager.TypeLabel, liqoControllerManager.TypeNode)
+	labelSelectorNodes = fmt.Sprintf("%v!=%v", liqocontrollerutils.TypeLabel, liqocontrollerutils.TypeNode)
 	//TODO: use the retry mechanism of curl without sleeping before running the command
 	command = "curl -s -o /dev/null -w '%{http_code}' "
 )
@@ -283,9 +284,9 @@ func DeployRemotePod(image, podName, namespace string) *v1.Pod {
 				NodeAffinity: &v1.NodeAffinity{
 					RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{NodeSelectorTerms: []v1.NodeSelectorTerm{{
 						MatchExpressions: []v1.NodeSelectorRequirement{{
-							Key:      liqoControllerManager.TypeLabel,
+							Key:      liqocontrollerutils.TypeLabel,
 							Operator: "In",
-							Values:   []string{liqoControllerManager.TypeNode},
+							Values:   []string{liqocontrollerutils.TypeNode},
 						}},
 						MatchFields: nil,
 					}}},
@@ -320,9 +321,9 @@ func DeployLocalPod(image, podName, namespace string) *v1.Pod {
 				NodeAffinity: &v1.NodeAffinity{
 					RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{NodeSelectorTerms: []v1.NodeSelectorTerm{{
 						MatchExpressions: []v1.NodeSelectorRequirement{{
-							Key:      liqoControllerManager.TypeLabel,
+							Key:      liqocontrollerutils.TypeLabel,
 							Operator: "NotIn",
-							Values:   []string{liqoControllerManager.TypeNode},
+							Values:   []string{liqocontrollerutils.TypeNode},
 						}},
 						MatchFields: nil,
 					}}},

--- a/test/e2e/unjoin_e2e/unjoin_test.go
+++ b/test/e2e/unjoin_e2e/unjoin_test.go
@@ -3,9 +3,9 @@ package unjoin_e2e
 import (
 	context2 "context"
 	"fmt"
+	liqocontrollerutils "github.com/liqotech/liqo/pkg/utils"
 	"testing"
 
-	liqoControllerManager "github.com/liqotech/liqo/pkg/liqo-controller-manager"
 	"github.com/liqotech/liqo/test/e2e/util"
 	"gotest.tools/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -32,7 +32,7 @@ func NoPods(clientset *kubernetes.Clientset, namespace string, t *testing.T, clu
 
 func NoJoined(clientset *kubernetes.Clientset, t *testing.T, clustername string) {
 	nodes, err := clientset.CoreV1().Nodes().List(context2.TODO(), metav1.ListOptions{
-		LabelSelector: fmt.Sprintf("%v=%v", liqoControllerManager.TypeLabel, liqoControllerManager.TypeNode),
+		LabelSelector: fmt.Sprintf("%v=%v", liqocontrollerutils.TypeLabel, liqocontrollerutils.TypeNode),
 	})
 	if err != nil {
 		klog.Error(err)

--- a/test/unit/advertisement-operator/broadcaster_test.go
+++ b/test/unit/advertisement-operator/broadcaster_test.go
@@ -8,8 +8,8 @@ import (
 	advtypes "github.com/liqotech/liqo/apis/sharing/v1alpha1"
 	advop "github.com/liqotech/liqo/internal/advertisement-operator"
 	"github.com/liqotech/liqo/pkg/crdClient"
-	liqoControllerManager "github.com/liqotech/liqo/pkg/liqo-controller-manager"
 	"github.com/liqotech/liqo/pkg/utils"
+	liqocontrollerutils "github.com/liqotech/liqo/pkg/utils"
 	pkg "github.com/liqotech/liqo/pkg/virtualKubelet"
 	"github.com/liqotech/liqo/pkg/virtualKubelet/provider/test"
 	"github.com/stretchr/testify/assert"
@@ -113,7 +113,7 @@ func createFakeResources() (physicalNodes *corev1.NodeList, virtualNodes *corev1
 			vNodes[v] = corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:   "liqo-cluster" + strconv.Itoa(v),
-					Labels: map[string]string{liqoControllerManager.TypeLabel: liqoControllerManager.TypeNode},
+					Labels: map[string]string{liqocontrollerutils.TypeLabel: liqocontrollerutils.TypeNode},
 				},
 				Spec: corev1.NodeSpec{
 					PodCIDR: fmt.Sprintf("%d.%d.%d.%d/%d", i, i, i, i, 16),


### PR DESCRIPTION
# Description

This PR adds the possibility to have a default value for mappingLabel if the user does not specify it. In case of MappingLabel renaming during offloading, an Annotation notifies user about the impossibility to perform this action. From now on liqo/pkg/utils will be the common place for controllers' utilities.

