### PR TITLE
Changing Webhook behavior

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ rbacs: controller-gen
 # Run go fmt against code
 fmt:
 	go fmt ./...
-	find $(pwd) -type f -name '*.go' -a ! -name '*zz_generated*' -exec goimports -local github.com/liqotech/liqo -w {} \;
+	find $(pwd) -type f -name '*.go' -a ! -name '*zz_generated*' -exec gci -local github.com/liqotech/liqo -w {} \;
 
 # Run go vet against code
 vet:

--- a/apis/offloading/v1alpha1/groupversion_info.go
+++ b/apis/offloading/v1alpha1/groupversion_info.go
@@ -28,6 +28,9 @@ var (
 	// GroupVersion is group version used to register these objects.
 	GroupVersion = schema.GroupVersion{Group: "offloading.liqo.io", Version: "v1alpha1"}
 
+	// GroupResource is group and resource used to register these objects.
+	GroupResource = schema.GroupResource{Group: GroupVersion.Group, Resource: "namespaceoffloadings"}
+
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme.
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
 

--- a/deployments/liqo/files/liqo-webhook-ClusterRole.yaml
+++ b/deployments/liqo/files/liqo-webhook-ClusterRole.yaml
@@ -8,4 +8,12 @@ rules:
   - list
   - patch
   - update
+- apiGroups:
+  - offloading.liqo.io
+  resources:
+  - namespaceoffloadings
+  verbs:
+  - get
+  - list
+  - watch
 

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	cloud.google.com/go v0.56.0 // indirect
 	github.com/containernetworking/plugins v0.8.6
 	github.com/coreos/go-iptables v0.4.5
+	github.com/daixiang0/gci v0.2.9 // indirect
 	github.com/google/go-cmp v0.5.5
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/uuid v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -258,6 +258,8 @@ github.com/d2g/dhcp4 v0.0.0-20170904100407-a1d1b6c41b1c/go.mod h1:Ct2BUK8SB0YC1S
 github.com/d2g/dhcp4client v1.0.0/go.mod h1:j0hNfjhrt2SxUOw55nL0ATM/z4Yt3t2Kd1mW34z5W5s=
 github.com/d2g/dhcp4server v0.0.0-20181031114812-7d4a0a7f59a5/go.mod h1:Eo87+Kg/IX2hfWJfwxMzLyuSZyxSoAug2nGa1G2QAi8=
 github.com/d2g/hardwareaddr v0.0.0-20190221164911-e7d9fbe030e4/go.mod h1:bMl4RjIciD2oAxI7DmWRx6gbeqrkoLqv3MV0vzNad+I=
+github.com/daixiang0/gci v0.2.9 h1:iwJvwQpBZmMg31w+QQ6jsyZ54KEATn6/nfARbBNW294=
+github.com/daixiang0/gci v0.2.9/go.mod h1:+4dZ7TISfSmqfAGv59ePaHfNzgGtIkHAhhdKggP1JAc=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -1289,6 +1291,7 @@ golang.org/x/tools v0.0.0-20200304193943-95d2e580d8eb/go.mod h1:o4KQGtdN14AW+yjs
 golang.org/x/tools v0.0.0-20200331025713-a30bf2db82d4/go.mod h1:Sl4aGygMT6LrqrWclx+PTx3U+LnKx/seiNR+3G19Ar8=
 golang.org/x/tools v0.0.0-20200505023115-26f46d2f7ef8/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
+golang.org/x/tools v0.0.0-20201118003311-bd56c0adb394/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.0 h1:po9/4sTYwZU9lPhi1tOrb4hCv3qrhiQ77LZfGa2OjwY=

--- a/pkg/consts/namespace_mapping.go
+++ b/pkg/consts/namespace_mapping.go
@@ -8,6 +8,7 @@ const (
 	// TypeLabel is the key of a Liqo label that identifies different types of nodes.
 	TypeLabel = "liqo.io/type"
 	// TypeNode is the value of a Liqo label that identifies Liqo virtual nodes.
+	// todo: change to VirtualNodeType
 	TypeNode = "virtual-node"
 	// NamespaceMapControllerFinalizer is the finalizer inserted on NamespaceMap by NamespaceMap Controller.
 	// todo: has to be removed after VirtualNode Controller refactor

--- a/pkg/consts/webhook.go
+++ b/pkg/consts/webhook.go
@@ -1,0 +1,7 @@
+package consts
+
+const (
+	// VirtualNodeTolerationKey all Pods that have to be scheduled on virtual nodes must have this toleration
+	// to Liqo taint.
+	VirtualNodeTolerationKey = "virtual-node.liqo.io/not-allowed"
+)

--- a/pkg/liqo-controller-manager/virtualNode-controller/virtualnode_controller_test.go
+++ b/pkg/liqo-controller-manager/virtualNode-controller/virtualnode_controller_test.go
@@ -9,7 +9,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/kubernetes/pkg/util/slice"
 	"k8s.io/utils/pointer"
@@ -105,7 +104,7 @@ var _ = Describe("VirtualNode controller", func() {
 				return len(nms.Items) == 1
 			}, timeout, interval).Should(BeTrue())
 
-			expectedOwnerReference := v1.OwnerReference{
+			expectedOwnerReference := metav1.OwnerReference{
 				APIVersion:         "v1",
 				BlockOwnerDeletion: pointer.BoolPtr(true),
 				Kind:               "Node",
@@ -145,7 +144,7 @@ var _ = Describe("VirtualNode controller", func() {
 				return len(nms.Items) == 1
 			}, timeout, interval).Should(BeTrue())
 
-			expectedOwnerReference := v1.OwnerReference{
+			expectedOwnerReference := metav1.OwnerReference{
 				APIVersion:         "v1",
 				BlockOwnerDeletion: pointer.BoolPtr(true),
 				Kind:               "Node",

--- a/pkg/mapperUtils/mapper.go
+++ b/pkg/mapperUtils/mapper.go
@@ -14,6 +14,7 @@ import (
 	configv1alpha1 "github.com/liqotech/liqo/apis/config/v1alpha1"
 	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
 	netv1alpha1 "github.com/liqotech/liqo/apis/net/v1alpha1"
+	offv1alpha1 "github.com/liqotech/liqo/apis/offloading/v1alpha1"
 	sharingv1alpha1 "github.com/liqotech/liqo/apis/sharing/v1alpha1"
 	virtualKubeletv1alpha1 "github.com/liqotech/liqo/apis/virtualKubelet/v1alpha1"
 )
@@ -66,7 +67,9 @@ func addDefaults(dClient *discovery.DiscoveryClient, mapper *meta.DefaultRESTMap
 	if err = addGroup(dClient, virtualKubeletv1alpha1.GroupVersion, mapper); err != nil {
 		return err
 	}
-
+	if err = addGroup(dClient, offv1alpha1.GroupVersion, mapper); err != nil {
+		return err
+	}
 	// Kubernetes groups
 	if err = addGroup(dClient, corev1.SchemeGroupVersion, mapper); err != nil {
 		return err

--- a/pkg/mutate/doc.go
+++ b/pkg/mutate/doc.go
@@ -1,0 +1,2 @@
+// Package mutate defines the logic of Liqo Mutating Webhook.
+package mutate

--- a/pkg/mutate/manage_pod_mutation.go
+++ b/pkg/mutate/manage_pod_mutation.go
@@ -1,0 +1,158 @@
+package mutate
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+
+	offv1alpha1 "github.com/liqotech/liqo/apis/offloading/v1alpha1"
+	liqoconst "github.com/liqotech/liqo/pkg/consts"
+)
+
+// getVirtualNodeToleration returns a new Toleration for the Liqo's virtual-nodes.
+func getVirtualNodeToleration() corev1.Toleration {
+	return corev1.Toleration{
+		Key:      liqoconst.VirtualNodeTolerationKey,
+		Operator: corev1.TolerationOpExists,
+		Effect:   corev1.TaintEffectNoExecute,
+	}
+}
+
+// createTolerationFromNamespaceOffloading creates a new virtualNodeToleration in case of LocalAndRemotePodOffloadingStrategyType
+// or RemotePodOffloadingStrategyType. In case of PodOffloadingStrategyType not recognized, returns an error.
+func createTolerationFromNamespaceOffloading(strategy offv1alpha1.PodOffloadingStrategyType) (corev1.Toleration, error) {
+	var toleration corev1.Toleration
+	switch {
+	case strategy == offv1alpha1.LocalAndRemotePodOffloadingStrategyType, strategy == offv1alpha1.RemotePodOffloadingStrategyType:
+		// The virtual-node toleration must be added.
+		toleration = getVirtualNodeToleration()
+	default:
+		err := fmt.Errorf("PodOffloadingStrategyType '%s' not recognized", strategy)
+		klog.Error(err)
+		return corev1.Toleration{}, err
+	}
+	return toleration, nil
+}
+
+// createNodeSelectorFromNamespaceOffloading creates the right NodeSelector according to the PodOffloadingStrategy chosen.
+func createNodeSelectorFromNamespaceOffloading(nsoff *offv1alpha1.NamespaceOffloading) (corev1.NodeSelector, error) {
+	nodeSelector := nsoff.Spec.ClusterSelector
+	switch {
+	case nsoff.Spec.PodOffloadingStrategy == offv1alpha1.RemotePodOffloadingStrategyType:
+		// To ensure that the pod is not scheduled on local nodes is necessary to add to every NodeSelectorTerm a
+		// new NodeSelectorRequirement. This NodeSelectorRequirement requires explicitly the label
+		// "liqo.io/type=virtual-node" to exclude local nodes from the scheduler choice.
+		for i := range nodeSelector.NodeSelectorTerms {
+			nodeSelector.NodeSelectorTerms[i].MatchExpressions = append(nodeSelector.NodeSelectorTerms[i].MatchExpressions,
+				corev1.NodeSelectorRequirement{
+					Key:      liqoconst.TypeLabel,
+					Operator: corev1.NodeSelectorOpIn,
+					Values:   []string{liqoconst.TypeNode},
+				})
+		}
+	case nsoff.Spec.PodOffloadingStrategy == offv1alpha1.LocalAndRemotePodOffloadingStrategyType:
+		// A new NodeSelectorTerm that allows scheduling the pod also on local nodes is added.
+		newNodeSelectorTerm := corev1.NodeSelectorTerm{
+			MatchExpressions: []corev1.NodeSelectorRequirement{{
+				Key:      liqoconst.TypeLabel,
+				Operator: corev1.NodeSelectorOpNotIn,
+				Values:   []string{liqoconst.TypeNode},
+			}},
+		}
+		nodeSelector.NodeSelectorTerms = append(nodeSelector.NodeSelectorTerms, newNodeSelectorTerm)
+	default:
+		err := fmt.Errorf("PodOffloadingStrategyType '%s' not recognized", nsoff.Spec.PodOffloadingStrategy)
+		klog.Error(err)
+		return corev1.NodeSelector{}, err
+	}
+	return nodeSelector, nil
+}
+
+// getMergedNodeSelector gets the old PodNodeSelector and merges it with the ImposedNodeSelector.
+// Every MatchExpression of the PodNodeSelector must be merged with all the MatchExpressions of the ImposedNodeSelector:
+// n PodNodeSelector MatchExpressions.
+// m ImposedNodeSelector MatchExpressions.
+// m * n MergedNoseSelector MatchExpressions.
+func getMergedNodeSelector(podNodeSelector *corev1.NodeSelector,
+	imposedNodeSelector *corev1.NodeSelector) corev1.NodeSelector {
+	mergedNodeSelector := corev1.NodeSelector{NodeSelectorTerms: []corev1.NodeSelectorTerm{}}
+	for i := range podNodeSelector.NodeSelectorTerms {
+		for j := range imposedNodeSelector.NodeSelectorTerms {
+			newMatchExpression := append(imposedNodeSelector.NodeSelectorTerms[j].MatchExpressions,
+				podNodeSelector.NodeSelectorTerms[i].MatchExpressions...)
+			mergedNodeSelector.NodeSelectorTerms = append(mergedNodeSelector.NodeSelectorTerms, corev1.NodeSelectorTerm{
+				MatchExpressions: newMatchExpression,
+			})
+		}
+	}
+	return mergedNodeSelector
+}
+
+// fillPodWithTheNewNodeSelector gets the previously computed NodeSelector imposed by the PodOffloadingStrategy and
+// merges it with the Pod NodeSelector if it is already present. It simply adds it to the Pod if previously unset.
+func fillPodWithTheNewNodeSelector(imposedNodeSelector *corev1.NodeSelector, pod *corev1.Pod) {
+	// To preserve the Pod Affinity content, it is necessary to add the imposedNodeSelector according to what
+	// is already present in the Pod Affinity.
+	switch {
+	case pod.Spec.Affinity == nil:
+		pod.Spec.Affinity = &corev1.Affinity{
+			NodeAffinity: &corev1.NodeAffinity{
+				RequiredDuringSchedulingIgnoredDuringExecution: imposedNodeSelector.DeepCopy(),
+			},
+		}
+	case pod.Spec.Affinity.NodeAffinity == nil:
+		pod.Spec.Affinity.NodeAffinity = &corev1.NodeAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: imposedNodeSelector.DeepCopy(),
+		}
+	case pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution == nil ||
+		len(pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms) == 0:
+		pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution = imposedNodeSelector.DeepCopy()
+	default:
+		*pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution =
+			getMergedNodeSelector(pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution,
+				imposedNodeSelector)
+	}
+}
+
+// mutatePod checks the NamespaceOffloading CR associated with the Pod's Namespace.
+// The pod is modified in different ways according to the PodOffloadingStrategyType
+// chosen in the CR. Two possible modifications:
+// - The VirtualNodeToleration is added to the Pod Toleration if necessary.
+// - The old Pod NodeSelector is substituted with a new one according to the PodOffloadingStrategyType.
+func mutatePod(namespaceOffloading *offv1alpha1.NamespaceOffloading, pod *corev1.Pod) error {
+	// The NamespaceOffloading CR contains information about the PodOffloadingStrategy and
+	// the NodeSelector inserted by the user (ClusterSelector field).
+	klog.V(5).Infof("Chosen strategy: %s", namespaceOffloading.Spec.PodOffloadingStrategy)
+
+	// If strategy is equal to LocalPodOffloadingStrategy there is nothing to do
+	if namespaceOffloading.Spec.PodOffloadingStrategy == offv1alpha1.LocalPodOffloadingStrategyType {
+		return nil
+	}
+
+	// Create the right Toleration according to the PodOffloadingStrategy case.
+	toleration, err := createTolerationFromNamespaceOffloading(namespaceOffloading.Spec.PodOffloadingStrategy)
+	if err != nil {
+		klog.Errorf("The NamespaceOffloading in namespace '%s' has unknown strategy '%s'",
+			namespaceOffloading.Namespace, namespaceOffloading.Spec.PodOffloadingStrategy)
+		return err
+	}
+	klog.V(5).Infof("Generated Toleration: %s", toleration)
+
+	// Create the right NodeSelector according to the PodOffloadingStrategy case.
+	imposedNodeSelector, err := createNodeSelectorFromNamespaceOffloading(namespaceOffloading)
+	if err != nil {
+		klog.Errorf("The NamespaceOffloading in namespace '%s' has unknown strategy '%s'",
+			namespaceOffloading.Namespace, namespaceOffloading.Spec.PodOffloadingStrategy)
+		return err
+	}
+	klog.V(5).Infof("ImposedNodeSelector: %s", imposedNodeSelector)
+
+	// It is necessary to add the just created toleration.
+	pod.Spec.Tolerations = append(pod.Spec.Tolerations, toleration)
+
+	// Enforce the new NodeSelector policy imposed by the NamespaceOffloading creator.
+	fillPodWithTheNewNodeSelector(&imposedNodeSelector, pod)
+	klog.V(5).Infof("Pod NodeSelector: %s", imposedNodeSelector)
+	return nil
+}

--- a/pkg/mutate/testUtils/doc.go
+++ b/pkg/mutate/testUtils/doc.go
@@ -1,0 +1,2 @@
+// Package mutatetestutils provides utility funcition for webhook testing.
+package mutatetestutils

--- a/pkg/mutate/testUtils/webhook_test_utils.go
+++ b/pkg/mutate/testUtils/webhook_test_utils.go
@@ -1,0 +1,435 @@
+package mutatetestutils
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	offv1alpha1 "github.com/liqotech/liqo/apis/offloading/v1alpha1"
+	liqoconst "github.com/liqotech/liqo/pkg/consts"
+)
+
+// GetNamespaceOffloading gets the right NamespaceOffloading according to the specified strategy.
+func GetNamespaceOffloading(strategy offv1alpha1.PodOffloadingStrategyType) offv1alpha1.NamespaceOffloading {
+	return offv1alpha1.NamespaceOffloading{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "offloading",
+			Namespace: "test",
+		},
+		Spec: offv1alpha1.NamespaceOffloadingSpec{
+			NamespaceMappingStrategy: offv1alpha1.EnforceSameNameMappingStrategyType,
+			PodOffloadingStrategy:    strategy,
+			ClusterSelector:          GetImposedNodeSelector(""),
+		},
+	}
+}
+
+// GetImposedNodeSelector gets the right imposedSelector according to the specified strategy.
+func GetImposedNodeSelector(strategy offv1alpha1.PodOffloadingStrategyType) corev1.NodeSelector {
+	var nodeSelector corev1.NodeSelector
+	switch {
+	case strategy == offv1alpha1.RemotePodOffloadingStrategyType:
+		nodeSelector = corev1.NodeSelector{NodeSelectorTerms: []corev1.NodeSelectorTerm{
+			{
+				MatchExpressions: []corev1.NodeSelectorRequirement{
+					{
+						Key:      "region",
+						Operator: corev1.NodeSelectorOpIn,
+						Values:   []string{"A,B"},
+					},
+					{
+						Key:      "provider",
+						Operator: corev1.NodeSelectorOpExists,
+					},
+					{
+						Key:      liqoconst.TypeLabel,
+						Operator: corev1.NodeSelectorOpIn,
+						Values:   []string{liqoconst.TypeNode},
+					},
+				},
+			},
+			{
+				MatchExpressions: []corev1.NodeSelectorRequirement{
+					{
+						Key:      "region",
+						Operator: corev1.NodeSelectorOpIn,
+						Values:   []string{"C,D"},
+					},
+					{
+						Key:      "NotProvider",
+						Operator: corev1.NodeSelectorOpExists,
+					},
+					{
+						Key:      liqoconst.TypeLabel,
+						Operator: corev1.NodeSelectorOpIn,
+						Values:   []string{liqoconst.TypeNode},
+					},
+				},
+			},
+		}}
+	case strategy == offv1alpha1.LocalAndRemotePodOffloadingStrategyType:
+		nodeSelector = corev1.NodeSelector{NodeSelectorTerms: []corev1.NodeSelectorTerm{
+			{
+				MatchExpressions: []corev1.NodeSelectorRequirement{
+					{
+						Key:      "region",
+						Operator: corev1.NodeSelectorOpIn,
+						Values:   []string{"A,B"},
+					},
+					{
+						Key:      "provider",
+						Operator: corev1.NodeSelectorOpExists,
+					},
+				},
+			},
+			{
+				MatchExpressions: []corev1.NodeSelectorRequirement{
+					{
+						Key:      "region",
+						Operator: corev1.NodeSelectorOpIn,
+						Values:   []string{"C,D"},
+					},
+					{
+						Key:      "NotProvider",
+						Operator: corev1.NodeSelectorOpExists,
+					},
+				},
+			},
+			{
+				MatchExpressions: []corev1.NodeSelectorRequirement{
+					{
+						Key:      liqoconst.TypeLabel,
+						Operator: corev1.NodeSelectorOpNotIn,
+						Values:   []string{liqoconst.TypeNode},
+					},
+				},
+			},
+		}}
+	default:
+		// This NodeSelector is imposed by the NamespaceOffloading.
+		nodeSelector = corev1.NodeSelector{NodeSelectorTerms: []corev1.NodeSelectorTerm{
+			{
+				MatchExpressions: []corev1.NodeSelectorRequirement{
+					{
+						Key:      "region",
+						Operator: corev1.NodeSelectorOpIn,
+						Values:   []string{"A,B"},
+					},
+					{
+						Key:      "provider",
+						Operator: corev1.NodeSelectorOpExists,
+					},
+				},
+			},
+			{
+				MatchExpressions: []corev1.NodeSelectorRequirement{
+					{
+						Key:      "region",
+						Operator: corev1.NodeSelectorOpIn,
+						Values:   []string{"C,D"},
+					}, {
+						Key:      "NotProvider",
+						Operator: corev1.NodeSelectorOpExists,
+					},
+				},
+			},
+		},
+		}
+	}
+	return nodeSelector
+}
+
+// GetPodNodeSelector gets a generic Pod NodeSelector.
+func GetPodNodeSelector() corev1.NodeSelector {
+	return corev1.NodeSelector{NodeSelectorTerms: []corev1.NodeSelectorTerm{
+		{
+			MatchExpressions: []corev1.NodeSelectorRequirement{
+				{
+					Key:      "storage",
+					Operator: corev1.NodeSelectorOpExists,
+				}},
+		},
+		{
+			MatchExpressions: []corev1.NodeSelectorRequirement{
+				{
+					Key:      "provider",
+					Operator: corev1.NodeSelectorOpIn,
+					Values:   []string{"AWS"},
+				}},
+		},
+	},
+	}
+}
+
+// GetMergedNodeSelector gets the right mergedNodeSelector according to the specified strategy.
+func GetMergedNodeSelector(strategy offv1alpha1.PodOffloadingStrategyType) corev1.NodeSelector {
+	var mergedNodeSelector corev1.NodeSelector
+	switch {
+	case strategy == offv1alpha1.RemotePodOffloadingStrategyType:
+		mergedNodeSelector = corev1.NodeSelector{NodeSelectorTerms: []corev1.NodeSelectorTerm{
+			{
+				MatchExpressions: []corev1.NodeSelectorRequirement{
+					{
+						Key:      "region",
+						Operator: corev1.NodeSelectorOpIn,
+						Values:   []string{"A,B"},
+					},
+					{
+						Key:      "provider",
+						Operator: corev1.NodeSelectorOpExists,
+					},
+					{
+						Key:      liqoconst.TypeLabel,
+						Operator: corev1.NodeSelectorOpIn,
+						Values:   []string{liqoconst.TypeNode},
+					},
+					{
+						Key:      "storage",
+						Operator: corev1.NodeSelectorOpExists,
+					},
+				},
+			},
+			{
+				MatchExpressions: []corev1.NodeSelectorRequirement{
+					{
+						Key:      "region",
+						Operator: corev1.NodeSelectorOpIn,
+						Values:   []string{"C,D"},
+					},
+					{
+						Key:      "NotProvider",
+						Operator: corev1.NodeSelectorOpExists,
+					},
+					{
+						Key:      liqoconst.TypeLabel,
+						Operator: corev1.NodeSelectorOpIn,
+						Values:   []string{liqoconst.TypeNode},
+					},
+					{
+						Key:      "storage",
+						Operator: corev1.NodeSelectorOpExists,
+					},
+				},
+			},
+			{
+				MatchExpressions: []corev1.NodeSelectorRequirement{
+					{
+						Key:      "region",
+						Operator: corev1.NodeSelectorOpIn,
+						Values:   []string{"A,B"},
+					},
+					{
+						Key:      "provider",
+						Operator: corev1.NodeSelectorOpExists,
+					},
+					{
+						Key:      liqoconst.TypeLabel,
+						Operator: corev1.NodeSelectorOpIn,
+						Values:   []string{liqoconst.TypeNode},
+					},
+					{
+						Key:      "provider",
+						Operator: corev1.NodeSelectorOpIn,
+						Values:   []string{"AWS"},
+					},
+				},
+			},
+			{
+				MatchExpressions: []corev1.NodeSelectorRequirement{
+					{
+						Key:      "region",
+						Operator: corev1.NodeSelectorOpIn,
+						Values:   []string{"C,D"},
+					},
+					{
+						Key:      "NotProvider",
+						Operator: corev1.NodeSelectorOpExists,
+					},
+					{
+						Key:      liqoconst.TypeLabel,
+						Operator: corev1.NodeSelectorOpIn,
+						Values:   []string{liqoconst.TypeNode},
+					},
+					{
+						Key:      "provider",
+						Operator: corev1.NodeSelectorOpIn,
+						Values:   []string{"AWS"},
+					},
+				},
+			},
+		}}
+	case strategy == offv1alpha1.LocalAndRemotePodOffloadingStrategyType:
+		mergedNodeSelector = corev1.NodeSelector{NodeSelectorTerms: []corev1.NodeSelectorTerm{
+			{
+				MatchExpressions: []corev1.NodeSelectorRequirement{
+					{
+						Key:      "region",
+						Operator: corev1.NodeSelectorOpIn,
+						Values:   []string{"A,B"},
+					},
+					{
+						Key:      "provider",
+						Operator: corev1.NodeSelectorOpExists,
+					},
+					{
+						Key:      "storage",
+						Operator: corev1.NodeSelectorOpExists,
+					},
+				},
+			},
+			{
+				MatchExpressions: []corev1.NodeSelectorRequirement{
+					{
+						Key:      "region",
+						Operator: corev1.NodeSelectorOpIn,
+						Values:   []string{"C,D"},
+					},
+					{
+						Key:      "NotProvider",
+						Operator: corev1.NodeSelectorOpExists,
+					},
+					{
+						Key:      "storage",
+						Operator: corev1.NodeSelectorOpExists,
+					},
+				},
+			},
+			{
+				MatchExpressions: []corev1.NodeSelectorRequirement{
+					{
+						Key:      liqoconst.TypeLabel,
+						Operator: corev1.NodeSelectorOpNotIn,
+						Values:   []string{liqoconst.TypeNode},
+					},
+					{
+						Key:      "storage",
+						Operator: corev1.NodeSelectorOpExists,
+					},
+				},
+			},
+			{
+				MatchExpressions: []corev1.NodeSelectorRequirement{
+					{
+						Key:      "region",
+						Operator: corev1.NodeSelectorOpIn,
+						Values:   []string{"A,B"},
+					},
+					{
+						Key:      "provider",
+						Operator: corev1.NodeSelectorOpExists,
+					},
+					{
+						Key:      "provider",
+						Operator: corev1.NodeSelectorOpIn,
+						Values:   []string{"AWS"},
+					},
+				},
+			},
+			{
+				MatchExpressions: []corev1.NodeSelectorRequirement{
+					{
+						Key:      "region",
+						Operator: corev1.NodeSelectorOpIn,
+						Values:   []string{"C,D"},
+					},
+					{
+						Key:      "NotProvider",
+						Operator: corev1.NodeSelectorOpExists,
+					},
+					{
+						Key:      "provider",
+						Operator: corev1.NodeSelectorOpIn,
+						Values:   []string{"AWS"},
+					},
+				},
+			},
+			{
+				MatchExpressions: []corev1.NodeSelectorRequirement{
+					{
+						Key:      liqoconst.TypeLabel,
+						Operator: corev1.NodeSelectorOpNotIn,
+						Values:   []string{liqoconst.TypeNode},
+					},
+					{
+						Key:      "provider",
+						Operator: corev1.NodeSelectorOpIn,
+						Values:   []string{"AWS"},
+					},
+				},
+			},
+		}}
+	default:
+		mergedNodeSelector = corev1.NodeSelector{NodeSelectorTerms: []corev1.NodeSelectorTerm{
+			{
+				MatchExpressions: []corev1.NodeSelectorRequirement{
+					{
+						Key:      "region",
+						Operator: corev1.NodeSelectorOpIn,
+						Values:   []string{"A,B"},
+					},
+					{
+						Key:      "provider",
+						Operator: corev1.NodeSelectorOpExists,
+					},
+					{
+						Key:      "storage",
+						Operator: corev1.NodeSelectorOpExists,
+					},
+				},
+			},
+			{
+				MatchExpressions: []corev1.NodeSelectorRequirement{
+					{
+						Key:      "region",
+						Operator: corev1.NodeSelectorOpIn,
+						Values:   []string{"C,D"},
+					},
+					{
+						Key:      "NotProvider",
+						Operator: corev1.NodeSelectorOpExists,
+					},
+					{
+						Key:      "storage",
+						Operator: corev1.NodeSelectorOpExists,
+					},
+				},
+			},
+			{
+				MatchExpressions: []corev1.NodeSelectorRequirement{
+					{
+						Key:      "region",
+						Operator: corev1.NodeSelectorOpIn,
+						Values:   []string{"A,B"},
+					},
+					{
+						Key:      "provider",
+						Operator: corev1.NodeSelectorOpExists,
+					},
+					{
+						Key:      "provider",
+						Operator: corev1.NodeSelectorOpIn,
+						Values:   []string{"AWS"},
+					},
+				},
+			},
+			{
+				MatchExpressions: []corev1.NodeSelectorRequirement{
+					{
+						Key:      "region",
+						Operator: corev1.NodeSelectorOpIn,
+						Values:   []string{"C,D"},
+					},
+					{
+						Key:      "NotProvider",
+						Operator: corev1.NodeSelectorOpExists,
+					},
+					{
+						Key:      "provider",
+						Operator: corev1.NodeSelectorOpIn,
+						Values:   []string{"AWS"},
+					},
+				},
+			},
+		}}
+	}
+	return mergedNodeSelector
+}

--- a/pkg/mutate/webhook_test.go
+++ b/pkg/mutate/webhook_test.go
@@ -1,0 +1,259 @@
+package mutate
+
+import (
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	offv1alpha1 "github.com/liqotech/liqo/apis/offloading/v1alpha1"
+	liqoconst "github.com/liqotech/liqo/pkg/consts"
+	testutils "github.com/liqotech/liqo/pkg/mutate/testUtils"
+)
+
+func TestWebhookManager(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Webhook Suite")
+}
+
+var _ = Describe("Webhook", func() {
+
+	var (
+		virtualNodeToleration = corev1.Toleration{
+			Key:      liqoconst.VirtualNodeTolerationKey,
+			Operator: corev1.TolerationOpExists,
+			Effect:   corev1.TaintEffectNoExecute,
+		}
+	)
+
+	Context("1 - Check the new created toleration according to the PodOffloadingStrategy", func() {
+		emptyToleration := corev1.Toleration{}
+		DescribeTable("3 Different type of PodOffloadingStrategy",
+			func(strategy offv1alpha1.PodOffloadingStrategyType, expectedToleration corev1.Toleration) {
+				By(fmt.Sprintf("Testing %s", strategy))
+				toleration, err := createTolerationFromNamespaceOffloading(strategy)
+				if strategy == offv1alpha1.LocalPodOffloadingStrategyType {
+					Expect(err != nil).Should(BeTrue())
+				}
+				Expect(toleration.MatchToleration(&expectedToleration)).To(BeTrue())
+			},
+			Entry("LocalPodOffloadingStrategyType", offv1alpha1.LocalPodOffloadingStrategyType, emptyToleration),
+			Entry("RemotePodOffloadingStrategyType", offv1alpha1.RemotePodOffloadingStrategyType, virtualNodeToleration),
+			Entry("LocalAndRemotePodOffloadingStrategyType", offv1alpha1.LocalAndRemotePodOffloadingStrategyType, virtualNodeToleration),
+		)
+	})
+
+	Context("2 - Check the NodeSelector imposed by the NamespaceOffloading", func() {
+		// slice with 3 namespaceOffloading one for each PodOffloadingStrategy
+		namespaceOffloadings := []offv1alpha1.NamespaceOffloading{
+			testutils.GetNamespaceOffloading(offv1alpha1.LocalPodOffloadingStrategyType),
+			testutils.GetNamespaceOffloading(offv1alpha1.RemotePodOffloadingStrategyType),
+			testutils.GetNamespaceOffloading(offv1alpha1.LocalAndRemotePodOffloadingStrategyType),
+		}
+
+		nodeSelectors := []corev1.NodeSelector{
+			{},
+			testutils.GetImposedNodeSelector(offv1alpha1.RemotePodOffloadingStrategyType),
+			testutils.GetImposedNodeSelector(offv1alpha1.LocalAndRemotePodOffloadingStrategyType),
+		}
+		DescribeTable("3 Different type of PodOffloadingStrategy",
+			func(namespaceOffloading offv1alpha1.NamespaceOffloading, expectedNodeSelector corev1.NodeSelector) {
+				By(fmt.Sprintf("Testing %s", namespaceOffloading.Spec.PodOffloadingStrategy))
+				nodeSelector, err := createNodeSelectorFromNamespaceOffloading(&namespaceOffloading)
+				if namespaceOffloading.Spec.PodOffloadingStrategy == offv1alpha1.LocalPodOffloadingStrategyType {
+					Expect(err != nil).Should(BeTrue())
+				}
+				Expect(nodeSelector).To(Equal(expectedNodeSelector))
+			},
+			Entry("LocalPodOffloadingStrategyType", namespaceOffloadings[0], nodeSelectors[0]),
+			Entry("RemotePodOffloadingStrategyType", namespaceOffloadings[1], nodeSelectors[1]),
+			Entry("LocalAndRemotePodOffloadingStrategyType", namespaceOffloadings[2], nodeSelectors[2]),
+		)
+	})
+
+	Context("3 - Check if the pod NodeSelector is correctly merged with the NamespaceOffloading NodeSelector", func() {
+		It("Check the merged NodeSelector", func() {
+			podNodeSelector := testutils.GetPodNodeSelector()
+			imposedNodeSelector := testutils.GetImposedNodeSelector("")
+			mergedNodeSelector := getMergedNodeSelector(&podNodeSelector, &imposedNodeSelector)
+			expectedMergedNodeSelector := testutils.GetMergedNodeSelector("")
+			Expect(mergedNodeSelector).To(Equal(expectedMergedNodeSelector))
+		})
+	})
+
+	Context("4 - Check how the new NodeSelector is inserted into the pod", func() {
+		// imposedNodeSelector that all Pod without NodeAffinity specified by user must have
+		imposedNodeSelector := testutils.GetImposedNodeSelector("")
+		// mergedNodeSelector is a merge of NodeSelector specified in NamespaceOffloading and NodeSelector
+		// specified by the user
+		mergedNodeSelector := testutils.GetMergedNodeSelector("")
+		// A fake PodAffinity to test if it is preserved.
+		podAffinity := corev1.PodAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{{
+				TopologyKey: "fake-value",
+			}},
+		}
+		podNodeSelector := testutils.GetPodNodeSelector()
+		// There are 6 pods:
+		// 0 - Pod without Affinity.
+		// 1 - Pod with Affinity but no NodeAffinity.
+		// 2 - Pod with Affinity and PodAffinity, but no NodeAffinity.
+		// 3 - Pod with Affinity and NodeAffinity but no RequiredDuringSchedulingIgnoredDuringExecution.
+		// 4 - Pod with Affinity and NodeAffinity and RequiredDuringSchedulingIgnoredDuringExecution but with 0 NodeSelectorTerms.
+		// 5 - Pod with Affinity and NodeAffinity and RequiredDuringSchedulingIgnoredDuringExecution specified by the user.
+		pods := []corev1.Pod{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod",
+					Namespace: "test",
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod",
+					Namespace: "test",
+				},
+				Spec: corev1.PodSpec{
+					Affinity: &corev1.Affinity{
+						NodeAffinity:    nil,
+						PodAffinity:     nil,
+						PodAntiAffinity: nil,
+					},
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod",
+					Namespace: "test",
+				},
+				Spec: corev1.PodSpec{
+					Affinity: &corev1.Affinity{
+						NodeAffinity:    nil,
+						PodAffinity:     &podAffinity,
+						PodAntiAffinity: nil,
+					},
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod",
+					Namespace: "test",
+				},
+				Spec: corev1.PodSpec{
+					Affinity: &corev1.Affinity{
+						NodeAffinity: &corev1.NodeAffinity{
+							RequiredDuringSchedulingIgnoredDuringExecution: nil,
+						},
+						PodAntiAffinity: nil,
+					},
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod",
+					Namespace: "test",
+				},
+				Spec: corev1.PodSpec{
+					Affinity: &corev1.Affinity{
+						NodeAffinity: &corev1.NodeAffinity{
+							RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{NodeSelectorTerms: []corev1.NodeSelectorTerm{}},
+						},
+						PodAntiAffinity: nil,
+					},
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod",
+					Namespace: "test",
+				},
+				Spec: corev1.PodSpec{
+					Affinity: &corev1.Affinity{
+						NodeAffinity: &corev1.NodeAffinity{
+							RequiredDuringSchedulingIgnoredDuringExecution: podNodeSelector.DeepCopy(),
+						},
+						PodAntiAffinity: nil,
+					},
+				},
+			},
+		}
+
+		DescribeTable("6 Pods with different Affinity",
+			func(imposedNodeSelector corev1.NodeSelector, pod corev1.Pod, expectedNodeSelector corev1.NodeSelector) {
+				newPod := pod.DeepCopy()
+				newNodeSelector := imposedNodeSelector.DeepCopy()
+				fillPodWithTheNewNodeSelector(newNodeSelector, newPod)
+				By("Checking the NodeSelector is not changed")
+				Expect(*newNodeSelector).To(Equal(imposedNodeSelector))
+				By("Checking the NodeSelector inserted in the Pod")
+				Expect(*newPod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution).To(Equal(expectedNodeSelector))
+			},
+			Entry("0 - Pod without Affinity", imposedNodeSelector, pods[0], imposedNodeSelector),
+			Entry("1 - Pod with Affinity but no NodeAffinity", imposedNodeSelector, pods[1], imposedNodeSelector),
+			Entry("2 - Pod with Affinity and PodAffinity, but no NodeAffinity", imposedNodeSelector, pods[2], imposedNodeSelector),
+			Entry("3 - Pod with Affinity and NodeAffinity but no RequiredDuringSchedulingIgnoredDuringExecution",
+				imposedNodeSelector, pods[3], imposedNodeSelector),
+			Entry("4 - Pod with Affinity and NodeAffinity and RequiredDuringSchedulingIgnoredDuringExecution but with 0 NodeSelectorTerms",
+				imposedNodeSelector, pods[4], imposedNodeSelector),
+			Entry("5 - Pod with Affinity and NodeAffinity and RequiredDuringSchedulingIgnoredDuringExecution specified by the user",
+				imposedNodeSelector, pods[5], mergedNodeSelector),
+		)
+
+		It("Test that the PodAffinity in the case 2 is preserved", func() {
+			newPod := pods[2].DeepCopy()
+			newNodeSelector := imposedNodeSelector.DeepCopy()
+			fillPodWithTheNewNodeSelector(newNodeSelector, newPod)
+			Expect(*newPod.Spec.Affinity.PodAffinity).To(Equal(podAffinity))
+		})
+	})
+
+	Context("5 - Call the mutatePod function and observe the pod is correctly mutated", func() {
+
+		podNodeSelector := testutils.GetPodNodeSelector()
+		pod := corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pod",
+				Namespace: "test",
+			},
+			Spec: corev1.PodSpec{
+				Tolerations: []corev1.Toleration{{
+					Key:               "test",
+					Operator:          "",
+					Value:             "",
+					TolerationSeconds: nil,
+				}},
+				Affinity: &corev1.Affinity{
+					NodeAffinity: &corev1.NodeAffinity{
+						RequiredDuringSchedulingIgnoredDuringExecution: podNodeSelector.DeepCopy(),
+					},
+					PodAntiAffinity: nil,
+				},
+			},
+		}
+
+		It("Check the toleration added and the new NodeSelector", func() {
+			namespaceOffloading := testutils.GetNamespaceOffloading(offv1alpha1.LocalAndRemotePodOffloadingStrategyType)
+			podTest := pod.DeepCopy()
+			err := mutatePod(&namespaceOffloading, podTest)
+			Expect(err == nil).To(BeTrue())
+			Expect(len(podTest.Spec.Tolerations) == 2).To(BeTrue())
+			Expect(podTest.Spec.Tolerations[1].MatchToleration(&virtualNodeToleration)).To(BeTrue())
+			mergedNodeSelector := testutils.GetMergedNodeSelector(offv1alpha1.LocalAndRemotePodOffloadingStrategyType)
+			Expect(*podTest.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution).To(Equal(mergedNodeSelector))
+		})
+
+		It("With LocalPodOffloadingStrategy check that pod is not mutated ", func() {
+			namespaceOffloading := testutils.GetNamespaceOffloading(offv1alpha1.LocalPodOffloadingStrategyType)
+			podTest := pod.DeepCopy()
+			oldPodNodeSelector := *podTest.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution
+			err := mutatePod(&namespaceOffloading, podTest)
+			Expect(err == nil).To(BeTrue())
+			Expect(len(podTest.Spec.Tolerations) == 1).To(BeTrue())
+			Expect(*podTest.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution).To(Equal(oldPodNodeSelector))
+		})
+	})
+})

--- a/pkg/utils/cachedClient/get_cached_client.go
+++ b/pkg/utils/cachedClient/get_cached_client.go
@@ -1,0 +1,52 @@
+// Package cachedclient contains utility methods to create a new controller runtime client with cache.
+package cachedclient
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/klog/v2"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/cluster"
+
+	"github.com/liqotech/liqo/pkg/mapperUtils"
+)
+
+// GetCachedClient returns a controller runtime client with the cache initialized only for the resources added to
+// the scheme.
+func GetCachedClient(ctx context.Context, scheme *runtime.Scheme) (client.Client, error) {
+	conf := ctrl.GetConfigOrDie()
+	if conf == nil {
+		err := fmt.Errorf("unable to get config file for cluster home")
+		klog.Error(err)
+		return nil, err
+	}
+
+	mapper, err := (mapperUtils.LiqoMapperProvider(scheme))(conf)
+	if err != nil {
+		klog.Errorf("mapper: %s", err)
+		return nil, err
+	}
+
+	clientCache, err := cache.New(conf, cache.Options{Scheme: scheme, Mapper: mapper})
+	if err != nil {
+		klog.Errorf("cache: %s", err)
+		return nil, err
+	}
+
+	go func() {
+		if err = clientCache.Start(ctx); err != nil {
+			klog.Errorf("unable to start cache: %s", err)
+		}
+	}()
+
+	newClient, err := cluster.DefaultNewClient(clientCache, conf, client.Options{Scheme: scheme, Mapper: mapper})
+	if err != nil {
+		klog.Errorf("unable to create the client: %s", err)
+		return nil, err
+	}
+	return newClient, nil
+}

--- a/pkg/vkMachinery/forge/forge.go
+++ b/pkg/vkMachinery/forge/forge.go
@@ -148,7 +148,7 @@ func forgeVKContainers(
 				},
 				{
 					Name:  "VKUBELET_TAINT_KEY",
-					Value: "virtual-node.liqo.io/not-allowed",
+					Value: liqoconst.VirtualNodeTolerationKey,
 				},
 				{
 					Name:  "VKUBELET_TAINT_VALUE",


### PR DESCRIPTION
# Description

When a new `Pod` is deployed in a `Namespace` labeled with `liqo.io/scheduling="true"`, the Webhook must set the right `Pod Affinity` according to what the admin has specified in the `NamespaceOffloading.Spec.ClusterSelector` field. If the user deploys a `Pod` with some affinities, these are merged with the ones selected by the administrator in the `ClusterSelector`; if there is a conflict between the two sets of `Affinity` the `Pod` remains pending until someone deletes it.

