### PR TITLE
Fix some typos in the Authentication page in docs

### DIFF
--- a/docs/pages/User/Post-Install/authentication.md
+++ b/docs/pages/User/Post-Install/authentication.md
@@ -74,7 +74,7 @@ ForeignCluster. To get the id of the cluster you want to authenticate with, iden
 and type:
 
 ```bash
-FOREIGN_CLUSTER_ID=$(kubectl get foreigncluster <foreign-cluster> -o=jsonpath="{['spec.clusterIdentity.clusterID']})"
+FOREIGN_CLUSTER_ID=$(kubectl get foreigncluster <foreign-cluster> -o=jsonpath="{['spec.clusterIdentity.clusterID']}")
 ```
 
 >__NOTE__: in v0.2 the foreign cluster resource name is the cluster-id, therefore it is enough to list the
@@ -98,7 +98,7 @@ if [ "$#" -ne 1 ]; then
   exit 1
 fi
 
-liqoNamespace="{$NAMESPACE:-liqo}"
+liqoNamespace="${NAMESPACE:-liqo}"
 fcName="$1"
 
 clusterId=$(kubectl get foreignclusters "$fcName" \


### PR DESCRIPTION
# Description

This PR corrects some typos in the authentication page of the documentation