### PR TITLE
Refactor of Liqo controllers constants

### DIFF
--- a/internal/advertisement-operator/broadcaster.go
+++ b/internal/advertisement-operator/broadcaster.go
@@ -9,10 +9,11 @@ import (
 	"sync"
 	"time"
 
+	liqoconst "github.com/liqotech/liqo/pkg/consts"
 	"github.com/liqotech/liqo/pkg/crdClient"
 	"github.com/liqotech/liqo/pkg/kubeconfig"
 	"github.com/liqotech/liqo/pkg/labelPolicy"
-	liqoControllerManager "github.com/liqotech/liqo/pkg/liqo-controller-manager"
+
 	"github.com/liqotech/liqo/pkg/utils"
 	pkg "github.com/liqotech/liqo/pkg/virtualKubelet"
 	"github.com/liqotech/liqo/pkg/virtualKubelet/forge"
@@ -270,12 +271,12 @@ func (b *AdvertisementBroadcaster) CreateAdvertisement(advRes *AdvResources) adv
 
 func (b *AdvertisementBroadcaster) GetResourcesForAdv() (advRes *AdvResources, err error) {
 	// get physical and virtual nodes in the cluster
-	physicalNodes, err := b.LocalClient.Client().CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{LabelSelector: fmt.Sprintf("%v != %v", liqoControllerManager.TypeLabel, liqoControllerManager.TypeNode)})
+	physicalNodes, err := b.LocalClient.Client().CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{LabelSelector: fmt.Sprintf("%v != %v", liqoconst.TypeLabel, liqoconst.TypeNode)})
 	if err != nil {
 		klog.Errorln("Could not get physical nodes, retry in 1 minute")
 		return nil, err
 	}
-	virtualNodes, err := b.LocalClient.Client().CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{LabelSelector: fmt.Sprintf("%v = %v", liqoControllerManager.TypeLabel, liqoControllerManager.TypeNode)})
+	virtualNodes, err := b.LocalClient.Client().CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{LabelSelector: fmt.Sprintf("%v = %v", liqoconst.TypeLabel, liqoconst.TypeNode)})
 	if err != nil {
 		klog.Errorln("Could not get virtual nodes, retry in 1 minute")
 		return nil, err

--- a/internal/discovery/foreign-cluster-operator/foreign-cluster-controller.go
+++ b/internal/discovery/foreign-cluster-operator/foreign-cluster-controller.go
@@ -31,10 +31,11 @@ import (
 	"github.com/liqotech/liqo/internal/discovery"
 	"github.com/liqotech/liqo/internal/discovery/utils"
 	"github.com/liqotech/liqo/pkg/clusterID"
+	liqoconst "github.com/liqotech/liqo/pkg/consts"
 	"github.com/liqotech/liqo/pkg/crdClient"
 	discoveryPkg "github.com/liqotech/liqo/pkg/discovery"
 	"github.com/liqotech/liqo/pkg/kubeconfig"
-	liqoControllerManager "github.com/liqotech/liqo/pkg/liqo-controller-manager"
+
 	apiv1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -518,9 +519,9 @@ func (r *ForeignClusterReconciler) getAddress() (string, error) {
 	labelSelector, err := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{
 		MatchExpressions: []metav1.LabelSelectorRequirement{
 			{
-				Key:      liqoControllerManager.TypeLabel,
+				Key:      liqoconst.TypeLabel,
 				Operator: metav1.LabelSelectorOpNotIn,
-				Values:   []string{liqoControllerManager.TypeNode},
+				Values:   []string{liqoconst.TypeNode},
 			},
 		},
 	})

--- a/pkg/consts/namespaceMapping.go
+++ b/pkg/consts/namespaceMapping.go
@@ -1,9 +1,10 @@
-package liqo_controller_manager
+package consts
 
 const (
-	VirtualNodeClusterId            = "cluster-id" //"remote.liqo.io/clusterId"
+	VirtualNodeClusterId            = "cluster-id" // "remote.liqo.io/clusterId"
 	MapNamespaceName                = "default"
 	TypeLabel                       = "liqo.io/type"
 	TypeNode                        = "virtual-node"
 	NamespaceMapControllerFinalizer = "namespacemap-controller.liqo.io/finalizer"
+	DocumentationUrl                = "https://doc.liqo.io/"
 )

--- a/pkg/liqo-controller-manager/namespace-controller/manage_namespace_labels.go
+++ b/pkg/liqo-controller-manager/namespace-controller/manage_namespace_labels.go
@@ -1,7 +1,7 @@
 package namespace_controller
 
 import (
-	const_ctrl "github.com/liqotech/liqo/pkg/liqo-controller-manager"
+	liqoconst "github.com/liqotech/liqo/pkg/consts"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/klog"
 	"k8s.io/kubernetes/pkg/util/slice"
@@ -15,7 +15,7 @@ func checkOffloadingLabels(na *corev1.Namespace, n *corev1.Node) bool {
 	for key := range n.GetLabels() {
 		if strings.HasPrefix(key, offloadingPrefixLabel) {
 			if _, ok := na.GetLabels()[key]; !ok {
-				klog.Infof(" Namespace '%s' cannot be offloaded on remote cluster: %s", na.GetName(), n.Annotations[const_ctrl.VirtualNodeClusterId])
+				klog.Infof(" Namespace '%s' cannot be offloaded on remote cluster: %s", na.GetName(), n.Annotations[liqoconst.VirtualNodeClusterId])
 				return false
 			}
 		}

--- a/pkg/liqo-controller-manager/namespace-controller/namespace_controller.go
+++ b/pkg/liqo-controller-manager/namespace-controller/namespace_controller.go
@@ -19,7 +19,8 @@ package namespace_controller
 import (
 	"context"
 	mapsv1alpha1 "github.com/liqotech/liqo/apis/virtualKubelet/v1alpha1"
-	const_ctrl "github.com/liqotech/liqo/pkg/liqo-controller-manager"
+	liqoconst "github.com/liqotech/liqo/pkg/consts"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/klog"
@@ -61,7 +62,7 @@ func (r *NamespaceReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 
 	removeMappings := make(map[string]mapsv1alpha1.NamespaceMap)
 	for _, namespaceMap := range namespaceMaps.Items {
-		removeMappings[namespaceMap.GetLabels()[const_ctrl.VirtualNodeClusterId]] = namespaceMap
+		removeMappings[namespaceMap.GetLabels()[liqoconst.VirtualNodeClusterId]] = namespaceMap
 	}
 
 	if !namespace.GetDeletionTimestamp().IsZero() {
@@ -108,7 +109,7 @@ func (r *NamespaceReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 			// 2.b Iterate on all virtual nodes' labels, if the namespace has all the requested labels, is necessary to
 			// offload it onto remote cluster associated with the virtual node
 			nodes := &corev1.NodeList{}
-			if err := r.List(context.TODO(), nodes, client.MatchingLabels{const_ctrl.TypeLabel: const_ctrl.TypeNode}); err != nil {
+			if err := r.List(context.TODO(), nodes, client.MatchingLabels{liqoconst.TypeLabel: liqoconst.TypeNode}); err != nil {
 				klog.Error(err, " --> Unable to List all virtual nodes")
 				return ctrl.Result{}, err
 			}
@@ -120,11 +121,11 @@ func (r *NamespaceReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 
 			for _, node := range nodes.Items {
 				if checkOffloadingLabels(namespace, &node) {
-					if err := r.addDesiredMapping(namespace, remoteNamespaceName, removeMappings[node.Annotations[const_ctrl.VirtualNodeClusterId]]); err != nil {
+					if err := r.addDesiredMapping(namespace, remoteNamespaceName, removeMappings[node.Annotations[liqoconst.VirtualNodeClusterId]]); err != nil {
 						return ctrl.Result{}, err
 					}
-					delete(removeMappings, node.Annotations[const_ctrl.VirtualNodeClusterId])
-					klog.Infof(" Offload namespace '%s' on remote cluster: %s", namespace.GetName(), node.Annotations[const_ctrl.VirtualNodeClusterId])
+					delete(removeMappings, node.Annotations[liqoconst.VirtualNodeClusterId])
+					klog.Infof(" Offload namespace '%s' on remote cluster: %s", namespace.GetName(), node.Annotations[liqoconst.VirtualNodeClusterId])
 				}
 
 			}

--- a/pkg/liqo-controller-manager/namespace-controller/namespace_controller_test.go
+++ b/pkg/liqo-controller-manager/namespace-controller/namespace_controller_test.go
@@ -4,7 +4,8 @@ import (
 	"context"
 	"fmt"
 	mapsv1alpha1 "github.com/liqotech/liqo/apis/virtualKubelet/v1alpha1"
-	const_ctrl "github.com/liqotech/liqo/pkg/liqo-controller-manager"
+	liqoconst "github.com/liqotech/liqo/pkg/consts"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/types"
@@ -50,7 +51,7 @@ var _ = Describe("Namespace controller", func() {
 
 			By(fmt.Sprintf("Check if NamespaceMap associated to %s is cleaned by the controller", remoteClusterId1))
 			Eventually(func() bool {
-				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(const_ctrl.MapNamespaceName), client.MatchingLabels{const_ctrl.VirtualNodeClusterId: remoteClusterId1}); err != nil {
+				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(liqoconst.MapNamespaceName), client.MatchingLabels{liqoconst.VirtualNodeClusterId: remoteClusterId1}); err != nil {
 					return false
 				}
 				if len(nms.Items) != 1 {
@@ -65,7 +66,7 @@ var _ = Describe("Namespace controller", func() {
 
 			By(fmt.Sprintf("Check if NamespaceMap associated to %s is cleaned by the controller ", remoteClusterId2))
 			Eventually(func() bool {
-				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(const_ctrl.MapNamespaceName), client.MatchingLabels{const_ctrl.VirtualNodeClusterId: remoteClusterId2}); err != nil {
+				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(liqoconst.MapNamespaceName), client.MatchingLabels{liqoconst.VirtualNodeClusterId: remoteClusterId2}); err != nil {
 					return false
 				}
 				if len(nms.Items) != 1 {
@@ -126,7 +127,7 @@ var _ = Describe("Namespace controller", func() {
 
 			By(fmt.Sprintf("Try to get NamespaceMap associated to: %s", remoteClusterId1))
 			Eventually(func() bool {
-				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(const_ctrl.MapNamespaceName), client.MatchingLabels{const_ctrl.VirtualNodeClusterId: remoteClusterId1}); err != nil {
+				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(liqoconst.MapNamespaceName), client.MatchingLabels{liqoconst.VirtualNodeClusterId: remoteClusterId1}); err != nil {
 					return false
 				}
 				if len(nms.Items) != 1 {
@@ -141,7 +142,7 @@ var _ = Describe("Namespace controller", func() {
 
 			By(fmt.Sprintf("Try to get NamespaceMap: associated to %s", remoteClusterId2))
 			Eventually(func() bool {
-				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(const_ctrl.MapNamespaceName), client.MatchingLabels{const_ctrl.VirtualNodeClusterId: remoteClusterId2}); err != nil {
+				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(liqoconst.MapNamespaceName), client.MatchingLabels{liqoconst.VirtualNodeClusterId: remoteClusterId2}); err != nil {
 					return false
 				}
 				if len(nms.Items) != 1 {
@@ -177,7 +178,7 @@ var _ = Describe("Namespace controller", func() {
 
 			By(fmt.Sprintf("Check if entry is also on NamespaceMap associated to: %s", remoteClusterId2))
 			Eventually(func() bool {
-				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(const_ctrl.MapNamespaceName), client.MatchingLabels{const_ctrl.VirtualNodeClusterId: remoteClusterId2}); err != nil {
+				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(liqoconst.MapNamespaceName), client.MatchingLabels{liqoconst.VirtualNodeClusterId: remoteClusterId2}); err != nil {
 					return false
 				}
 				if len(nms.Items) != 1 {
@@ -213,7 +214,7 @@ var _ = Describe("Namespace controller", func() {
 
 			By(fmt.Sprintf("Try to get NamespaceMap associated to %s", remoteClusterId1))
 			Eventually(func() bool {
-				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(const_ctrl.MapNamespaceName), client.MatchingLabels{const_ctrl.VirtualNodeClusterId: remoteClusterId1}); err != nil {
+				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(liqoconst.MapNamespaceName), client.MatchingLabels{liqoconst.VirtualNodeClusterId: remoteClusterId1}); err != nil {
 					return false
 				}
 				if len(nms.Items) != 1 {
@@ -230,7 +231,7 @@ var _ = Describe("Namespace controller", func() {
 
 			By(fmt.Sprintf("Try to get NamespaceMap associated to %s", remoteClusterId2))
 			Consistently(func() bool {
-				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(const_ctrl.MapNamespaceName), client.MatchingLabels{const_ctrl.VirtualNodeClusterId: remoteClusterId2}); err != nil {
+				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(liqoconst.MapNamespaceName), client.MatchingLabels{liqoconst.VirtualNodeClusterId: remoteClusterId2}); err != nil {
 					return true
 				}
 				if len(nms.Items) != 1 {
@@ -265,7 +266,7 @@ var _ = Describe("Namespace controller", func() {
 
 			By(fmt.Sprintf("Try to get NamespaceMap associated to: %s", remoteClusterId1))
 			Eventually(func() bool {
-				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(const_ctrl.MapNamespaceName), client.MatchingLabels{const_ctrl.VirtualNodeClusterId: remoteClusterId1}); err != nil {
+				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(liqoconst.MapNamespaceName), client.MatchingLabels{liqoconst.VirtualNodeClusterId: remoteClusterId1}); err != nil {
 					return false
 				}
 				if len(nms.Items) != 1 {
@@ -281,7 +282,7 @@ var _ = Describe("Namespace controller", func() {
 
 			By(fmt.Sprintf("Try to get NamespaceMap associated to: %s", remoteClusterId2))
 			Eventually(func() bool {
-				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(const_ctrl.MapNamespaceName), client.MatchingLabels{const_ctrl.VirtualNodeClusterId: remoteClusterId2}); err != nil {
+				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(liqoconst.MapNamespaceName), client.MatchingLabels{liqoconst.VirtualNodeClusterId: remoteClusterId2}); err != nil {
 					return false
 				}
 				if len(nms.Items) != 1 {
@@ -347,7 +348,7 @@ var _ = Describe("Namespace controller", func() {
 
 			By(fmt.Sprintf("Try to get NamespaceMap associated to: %s", remoteClusterId1))
 			Eventually(func() bool {
-				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(const_ctrl.MapNamespaceName), client.MatchingLabels{const_ctrl.VirtualNodeClusterId: remoteClusterId1}); err != nil {
+				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(liqoconst.MapNamespaceName), client.MatchingLabels{liqoconst.VirtualNodeClusterId: remoteClusterId1}); err != nil {
 					return false
 				}
 				if len(nms.Items) != 1 {
@@ -363,7 +364,7 @@ var _ = Describe("Namespace controller", func() {
 
 			By(fmt.Sprintf("Try to get NamespaceMap associated to: %s", remoteClusterId2))
 			Eventually(func() bool {
-				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(const_ctrl.MapNamespaceName), client.MatchingLabels{const_ctrl.VirtualNodeClusterId: remoteClusterId2}); err != nil {
+				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(liqoconst.MapNamespaceName), client.MatchingLabels{liqoconst.VirtualNodeClusterId: remoteClusterId2}); err != nil {
 					return false
 				}
 				if len(nms.Items) != 1 {
@@ -396,7 +397,7 @@ var _ = Describe("Namespace controller", func() {
 
 			By(fmt.Sprintf("Check if NamespaceMap associated to %s is cleaned by the controller", remoteClusterId1))
 			Eventually(func() bool {
-				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(const_ctrl.MapNamespaceName), client.MatchingLabels{const_ctrl.VirtualNodeClusterId: remoteClusterId1}); err != nil {
+				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(liqoconst.MapNamespaceName), client.MatchingLabels{liqoconst.VirtualNodeClusterId: remoteClusterId1}); err != nil {
 					return false
 				}
 				if len(nms.Items) != 1 {
@@ -413,7 +414,7 @@ var _ = Describe("Namespace controller", func() {
 
 			By(fmt.Sprintf("Check if NamespaceMap associated to %s is cleaned by the controller", remoteClusterId2))
 			Eventually(func() bool {
-				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(const_ctrl.MapNamespaceName), client.MatchingLabels{const_ctrl.VirtualNodeClusterId: remoteClusterId2}); err != nil {
+				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(liqoconst.MapNamespaceName), client.MatchingLabels{liqoconst.VirtualNodeClusterId: remoteClusterId2}); err != nil {
 					return false
 				}
 				if len(nms.Items) != 1 {
@@ -446,7 +447,7 @@ var _ = Describe("Namespace controller", func() {
 
 			By(fmt.Sprintf("Check if NamespaceMap associated to %s is cleaned by the controller", remoteClusterId1))
 			Eventually(func() bool {
-				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(const_ctrl.MapNamespaceName), client.MatchingLabels{const_ctrl.VirtualNodeClusterId: remoteClusterId1}); err != nil {
+				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(liqoconst.MapNamespaceName), client.MatchingLabels{liqoconst.VirtualNodeClusterId: remoteClusterId1}); err != nil {
 					return false
 				}
 				if len(nms.Items) != 1 {
@@ -463,7 +464,7 @@ var _ = Describe("Namespace controller", func() {
 
 			By(fmt.Sprintf("Check if NamespaceMap associated to %s is cleaned by the controller", remoteClusterId2))
 			Eventually(func() bool {
-				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(const_ctrl.MapNamespaceName), client.MatchingLabels{const_ctrl.VirtualNodeClusterId: remoteClusterId2}); err != nil {
+				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(liqoconst.MapNamespaceName), client.MatchingLabels{liqoconst.VirtualNodeClusterId: remoteClusterId2}); err != nil {
 					return false
 				}
 				if len(nms.Items) != 1 {

--- a/pkg/liqo-controller-manager/namespace-controller/suite_test.go
+++ b/pkg/liqo-controller-manager/namespace-controller/suite_test.go
@@ -17,7 +17,7 @@ import (
 	"flag"
 	"fmt"
 	mapsv1alpha1 "github.com/liqotech/liqo/apis/virtualKubelet/v1alpha1"
-	const_ctrl "github.com/liqotech/liqo/pkg/liqo-controller-manager"
+	liqoconst "github.com/liqotech/liqo/pkg/consts"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"path/filepath"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -137,10 +137,10 @@ var _ = BeforeSuite(func(done Done) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: nameVirtualNode1,
 			Annotations: map[string]string{
-				const_ctrl.VirtualNodeClusterId: remoteClusterId1,
+				liqoconst.VirtualNodeClusterId: remoteClusterId1,
 			},
 			Labels: map[string]string{
-				const_ctrl.TypeLabel:     const_ctrl.TypeNode,
+				liqoconst.TypeLabel:      liqoconst.TypeNode,
 				offloadingCluster1Label1: "",
 				offloadingCluster1Label2: "",
 			},
@@ -155,10 +155,10 @@ var _ = BeforeSuite(func(done Done) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: nameVirtualNode2,
 			Annotations: map[string]string{
-				const_ctrl.VirtualNodeClusterId: remoteClusterId2,
+				liqoconst.VirtualNodeClusterId: remoteClusterId2,
 			},
 			Labels: map[string]string{
-				const_ctrl.TypeLabel:     const_ctrl.TypeNode,
+				liqoconst.TypeLabel:      liqoconst.TypeNode,
 				offloadingCluster2Label1: "",
 				offloadingCluster2Label2: "",
 			},
@@ -174,7 +174,7 @@ var _ = BeforeSuite(func(done Done) {
 			GenerateName: fmt.Sprintf("%s-", remoteClusterId1),
 			Namespace:    mapNamespaceName,
 			Labels: map[string]string{
-				const_ctrl.VirtualNodeClusterId: remoteClusterId1,
+				liqoconst.VirtualNodeClusterId: remoteClusterId1,
 			},
 		},
 	}
@@ -188,7 +188,7 @@ var _ = BeforeSuite(func(done Done) {
 			GenerateName: fmt.Sprintf("%s-", remoteClusterId2),
 			Namespace:    mapNamespaceName,
 			Labels: map[string]string{
-				const_ctrl.VirtualNodeClusterId: remoteClusterId2,
+				liqoconst.VirtualNodeClusterId: remoteClusterId2,
 			},
 		},
 	}

--- a/pkg/liqo-controller-manager/namespaceMap-controller/manage_remote_namespaces.go
+++ b/pkg/liqo-controller-manager/namespaceMap-controller/manage_remote_namespaces.go
@@ -3,7 +3,7 @@ package namespaceMap_controller
 import (
 	"context"
 	mapsv1alpha1 "github.com/liqotech/liqo/apis/virtualKubelet/v1alpha1"
-	const_ctrl "github.com/liqotech/liqo/pkg/liqo-controller-manager"
+	liqoconst "github.com/liqotech/liqo/pkg/consts"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -67,7 +67,7 @@ func (r *NamespaceMapReconciler) manageRemoteNamespaces(nm *mapsv1alpha1.Namespa
 	// if DesiredMapping field has more entries than CurrentMapping, is necessary to create new remote namespaces
 	for localName, remoteName := range nm.Spec.DesiredMapping {
 		if _, ok := nm.Status.CurrentMapping[localName]; !ok {
-			if err := r.createRemoteNamespace(nm.Labels[const_ctrl.VirtualNodeClusterId], remoteName); err != nil {
+			if err := r.createRemoteNamespace(nm.Labels[liqoconst.VirtualNodeClusterId], remoteName); err != nil {
 				return err
 			}
 			nm.Status.CurrentMapping[localName] = mapsv1alpha1.RemoteNamespaceStatus{
@@ -85,7 +85,7 @@ func (r *NamespaceMapReconciler) manageRemoteNamespaces(nm *mapsv1alpha1.Namespa
 	// if DesiredMapping field has less entries than CurrentMapping, is necessary to remove some remote namespaces
 	for localName, remoteStatus := range nm.Status.CurrentMapping {
 		if _, ok := nm.Spec.DesiredMapping[localName]; !ok {
-			if err := r.deleteRemoteNamespace(nm.Labels[const_ctrl.VirtualNodeClusterId], remoteStatus.RemoteNamespace); err != nil {
+			if err := r.deleteRemoteNamespace(nm.Labels[liqoconst.VirtualNodeClusterId], remoteStatus.RemoteNamespace); err != nil {
 				return err
 			}
 			// Update Map status

--- a/pkg/liqo-controller-manager/namespaceMap-controller/namespaceMap_controller.go
+++ b/pkg/liqo-controller-manager/namespaceMap-controller/namespaceMap_controller.go
@@ -19,7 +19,7 @@ package namespaceMap_controller
 import (
 	"context"
 	mapsv1alpha1 "github.com/liqotech/liqo/apis/virtualKubelet/v1alpha1"
-	const_ctrl "github.com/liqotech/liqo/pkg/liqo-controller-manager"
+	liqoconst "github.com/liqotech/liqo/pkg/consts"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/klog"
@@ -49,10 +49,10 @@ func (r *NamespaceMapReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
-	if !ctrlutils.ContainsFinalizer(namespaceMap, const_ctrl.NamespaceMapControllerFinalizer) {
-		ctrlutils.AddFinalizer(namespaceMap, const_ctrl.NamespaceMapControllerFinalizer)
+	if !ctrlutils.ContainsFinalizer(namespaceMap, liqoconst.NamespaceMapControllerFinalizer) {
+		ctrlutils.AddFinalizer(namespaceMap, liqoconst.NamespaceMapControllerFinalizer)
 		if err := r.Patch(context.TODO(), namespaceMap, client.Merge); err != nil {
-			klog.Errorf("%s --> Unable to add '%s' to the NamespaceMap '%s'", err, const_ctrl.NamespaceMapControllerFinalizer, namespaceMap.GetName())
+			klog.Errorf("%s --> Unable to add '%s' to the NamespaceMap '%s'", err, liqoconst.NamespaceMapControllerFinalizer, namespaceMap.GetName())
 			return ctrl.Result{}, err
 		}
 		klog.Infof("Finalizer correctly added on NamespaceMap '%s'", namespaceMap.GetName())
@@ -63,9 +63,9 @@ func (r *NamespaceMapReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error
 	}
 
 	if len(namespaceMap.Status.CurrentMapping) == 0 {
-		ctrlutils.RemoveFinalizer(namespaceMap, const_ctrl.NamespaceMapControllerFinalizer)
+		ctrlutils.RemoveFinalizer(namespaceMap, liqoconst.NamespaceMapControllerFinalizer)
 		if err := r.Update(context.TODO(), namespaceMap); err != nil {
-			klog.Errorf("%s --> Unable to remove '%s' from NamespaceMap '%s'", err, const_ctrl.NamespaceMapControllerFinalizer, namespaceMap.GetName())
+			klog.Errorf("%s --> Unable to remove '%s' from NamespaceMap '%s'", err, liqoconst.NamespaceMapControllerFinalizer, namespaceMap.GetName())
 			return ctrl.Result{}, err
 		}
 		klog.Infof("Finalizer correctly removed from NamespaceMap '%s'", namespaceMap.GetName())

--- a/pkg/liqo-controller-manager/virtualNode-controller/namespaceMap_lifecycle.go
+++ b/pkg/liqo-controller-manager/virtualNode-controller/namespaceMap_lifecycle.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 	mapsv1alpha1 "github.com/liqotech/liqo/apis/virtualKubelet/v1alpha1"
-	constctrl "github.com/liqotech/liqo/pkg/liqo-controller-manager"
+	liqoconst "github.com/liqotech/liqo/pkg/consts"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog"
@@ -35,7 +35,7 @@ func (r *VirtualNodeReconciler) removeAllDesiredMappings(nm mapsv1alpha1.Namespa
 // remove Finalizer and Update the NamespaceMap
 func (r *VirtualNodeReconciler) removeNamespaceMapFinalizers(nm mapsv1alpha1.NamespaceMap) error {
 	ctrlutils.RemoveFinalizer(&nm, virtualNodeControllerFinalizer)
-	ctrlutils.RemoveFinalizer(&nm, constctrl.NamespaceMapControllerFinalizer)
+	ctrlutils.RemoveFinalizer(&nm, liqoconst.NamespaceMapControllerFinalizer)
 
 	klog.Infof("The NamespaceMap '%s' is requested to be deleted", nm.GetName())
 
@@ -53,18 +53,18 @@ func (r *VirtualNodeReconciler) removeNamespaceMapFinalizers(nm mapsv1alpha1.Nam
 // create a new NamespaceMap with Finalizer and OwnerReference
 func (r *VirtualNodeReconciler) createNamespaceMap(n corev1.Node, stat mapsv1alpha1.NamespaceMapStatus, spec mapsv1alpha1.NamespaceMapSpec) error {
 
-	if _, ok := n.GetAnnotations()[constctrl.VirtualNodeClusterId]; !ok {
-		err := fmt.Errorf("label '%s' is not found on node '%s'", constctrl.VirtualNodeClusterId, n.GetName())
+	if _, ok := n.GetAnnotations()[liqoconst.VirtualNodeClusterId]; !ok {
+		err := fmt.Errorf("label '%s' is not found on node '%s'", liqoconst.VirtualNodeClusterId, n.GetName())
 		klog.Error(err)
 		return err
 	}
 
 	nm := &mapsv1alpha1.NamespaceMap{
 		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: fmt.Sprintf("%s-", n.GetAnnotations()[constctrl.VirtualNodeClusterId]),
-			Namespace:    constctrl.MapNamespaceName,
+			GenerateName: fmt.Sprintf("%s-", n.GetAnnotations()[liqoconst.VirtualNodeClusterId]),
+			Namespace:    liqoconst.MapNamespaceName,
 			Labels: map[string]string{
-				constctrl.VirtualNodeClusterId: n.GetAnnotations()[constctrl.VirtualNodeClusterId],
+				liqoconst.VirtualNodeClusterId: n.GetAnnotations()[liqoconst.VirtualNodeClusterId],
 			},
 		},
 		Spec:   spec,
@@ -72,7 +72,7 @@ func (r *VirtualNodeReconciler) createNamespaceMap(n corev1.Node, stat mapsv1alp
 	}
 
 	if len(nm.Status.CurrentMapping) > 0 {
-		ctrlutils.AddFinalizer(nm, constctrl.NamespaceMapControllerFinalizer)
+		ctrlutils.AddFinalizer(nm, liqoconst.NamespaceMapControllerFinalizer)
 	}
 
 	ctrlutils.AddFinalizer(nm, virtualNodeControllerFinalizer)
@@ -106,8 +106,8 @@ func (r *VirtualNodeReconciler) regenerateNamespaceMap(nm mapsv1alpha1.Namespace
 func (r *VirtualNodeReconciler) namespaceMapLifecycle(n corev1.Node) error {
 
 	nms := &mapsv1alpha1.NamespaceMapList{}
-	if err := r.List(context.TODO(), nms, client.InNamespace(constctrl.MapNamespaceName),
-		client.MatchingLabels{constctrl.VirtualNodeClusterId: n.GetAnnotations()[constctrl.VirtualNodeClusterId]}); err != nil {
+	if err := r.List(context.TODO(), nms, client.InNamespace(liqoconst.MapNamespaceName),
+		client.MatchingLabels{liqoconst.VirtualNodeClusterId: n.GetAnnotations()[liqoconst.VirtualNodeClusterId]}); err != nil {
 		klog.Errorf("%s --> Unable to List NamespaceMaps of virtual node '%s'", err, n.GetName())
 		return err
 	}

--- a/pkg/liqo-controller-manager/virtualNode-controller/node_controller.go
+++ b/pkg/liqo-controller-manager/virtualNode-controller/node_controller.go
@@ -19,7 +19,7 @@ package virtualNode_controller
 import (
 	"context"
 	mapsv1alpha1 "github.com/liqotech/liqo/apis/virtualKubelet/v1alpha1"
-	constctrl "github.com/liqotech/liqo/pkg/liqo-controller-manager"
+	liqoconst "github.com/liqotech/liqo/pkg/consts"
 	ctrlutils "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	corev1 "k8s.io/api/core/v1"
@@ -64,8 +64,8 @@ func (r *VirtualNodeReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error)
 		klog.Infof("The virtual node '%s' is requested to be deleted", node.GetName())
 
 		nms := &mapsv1alpha1.NamespaceMapList{}
-		if err := r.List(context.TODO(), nms, client.InNamespace(constctrl.MapNamespaceName),
-			client.MatchingLabels{constctrl.VirtualNodeClusterId: node.GetAnnotations()[constctrl.VirtualNodeClusterId]}); err != nil {
+		if err := r.List(context.TODO(), nms, client.InNamespace(liqoconst.MapNamespaceName),
+			client.MatchingLabels{liqoconst.VirtualNodeClusterId: node.GetAnnotations()[liqoconst.VirtualNodeClusterId]}); err != nil {
 			klog.Errorf("%s --> Unable to List NamespaceMaps of virtual node '%s'", err, node.GetName())
 			return ctrl.Result{}, err
 		}
@@ -103,7 +103,7 @@ func filterVirtualNodes() predicate.Predicate {
 			// if the resource has no namespace, it surely a node, so we have to check if it is virtual or not, we are
 			// interested only in virtual-nodes' deletion, not common nodes' deletion.
 			if e.MetaNew.GetNamespace() == "" {
-				if value, ok := (e.MetaNew.GetLabels())[constctrl.TypeLabel]; !ok || value != constctrl.TypeNode {
+				if value, ok := (e.MetaNew.GetLabels())[liqoconst.TypeLabel]; !ok || value != liqoconst.TypeNode {
 					return false
 				}
 			}
@@ -113,7 +113,7 @@ func filterVirtualNodes() predicate.Predicate {
 		CreateFunc: func(e event.CreateEvent) bool {
 			// listen only virtual-node creation, not simple node
 			if e.Meta.GetNamespace() == "" {
-				if value, ok := (e.Meta.GetLabels())[constctrl.TypeLabel]; !ok || value != constctrl.TypeNode {
+				if value, ok := (e.Meta.GetLabels())[liqoconst.TypeLabel]; !ok || value != liqoconst.TypeNode {
 					return false
 				}
 			}
@@ -125,7 +125,7 @@ func filterVirtualNodes() predicate.Predicate {
 		},
 		GenericFunc: func(e event.GenericEvent) bool {
 			if e.Meta.GetNamespace() == "" {
-				if value, ok := (e.Meta.GetLabels())[constctrl.TypeLabel]; !ok || value != constctrl.TypeNode {
+				if value, ok := (e.Meta.GetLabels())[liqoconst.TypeLabel]; !ok || value != liqoconst.TypeNode {
 					return false
 				}
 			}

--- a/pkg/liqo-controller-manager/virtualNode-controller/node_controller_test.go
+++ b/pkg/liqo-controller-manager/virtualNode-controller/node_controller_test.go
@@ -2,7 +2,7 @@ package virtualNode_controller
 
 import (
 	mapsv1alpha1 "github.com/liqotech/liqo/apis/virtualKubelet/v1alpha1"
-	const_ctrl "github.com/liqotech/liqo/pkg/liqo-controller-manager"
+	liqoconst "github.com/liqotech/liqo/pkg/consts"
 
 	"context"
 	"fmt"
@@ -32,7 +32,7 @@ var _ = Describe("VirtualNode controller", func() {
 
 			By(fmt.Sprintf("Try to get NamespaceMap associated to: %s", remoteClusterId1))
 			Eventually(func() bool {
-				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(const_ctrl.MapNamespaceName), client.MatchingLabels{const_ctrl.VirtualNodeClusterId: remoteClusterId1}); err != nil {
+				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(liqoconst.MapNamespaceName), client.MatchingLabels{liqoconst.VirtualNodeClusterId: remoteClusterId1}); err != nil {
 					return false
 				}
 				if len(nms.Items) != 1 {
@@ -51,7 +51,7 @@ var _ = Describe("VirtualNode controller", func() {
 
 			By(fmt.Sprintf("Try to get NamespaceMap associated to: %s", remoteClusterId2))
 			Eventually(func() bool {
-				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(const_ctrl.MapNamespaceName), client.MatchingLabels{const_ctrl.VirtualNodeClusterId: remoteClusterId2}); err != nil {
+				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(liqoconst.MapNamespaceName), client.MatchingLabels{liqoconst.VirtualNodeClusterId: remoteClusterId2}); err != nil {
 					return false
 				}
 				if len(nms.Items) != 1 {
@@ -82,7 +82,7 @@ var _ = Describe("VirtualNode controller", func() {
 
 			By(fmt.Sprintf("Try to get NamespaceMap associated to: %s", remoteClusterId1))
 			Eventually(func() bool {
-				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(const_ctrl.MapNamespaceName), client.MatchingLabels{const_ctrl.VirtualNodeClusterId: remoteClusterId1}); err != nil {
+				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(liqoconst.MapNamespaceName), client.MatchingLabels{liqoconst.VirtualNodeClusterId: remoteClusterId1}); err != nil {
 					return false
 				}
 				if len(nms.Items) != 1 {
@@ -129,7 +129,7 @@ var _ = Describe("VirtualNode controller", func() {
 
 			By(fmt.Sprintf("Try to get NamespaceMap associated to: %s", remoteClusterId2))
 			Eventually(func() bool {
-				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(const_ctrl.MapNamespaceName), client.MatchingLabels{const_ctrl.VirtualNodeClusterId: remoteClusterId2}); err != nil {
+				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(liqoconst.MapNamespaceName), client.MatchingLabels{liqoconst.VirtualNodeClusterId: remoteClusterId2}); err != nil {
 					return false
 				}
 				if len(nms.Items) != 1 {
@@ -180,7 +180,7 @@ var _ = Describe("VirtualNode controller", func() {
 
 			By(fmt.Sprintf("Check absence of NamespaceMap associated to %s", remoteClusterIdSimpleNode))
 			Consistently(func() bool {
-				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(const_ctrl.MapNamespaceName), client.MatchingLabels{const_ctrl.VirtualNodeClusterId: remoteClusterIdSimpleNode}); err != nil {
+				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(liqoconst.MapNamespaceName), client.MatchingLabels{liqoconst.VirtualNodeClusterId: remoteClusterIdSimpleNode}); err != nil {
 					return false
 				}
 				if len(nms.Items) == 0 {
@@ -212,7 +212,7 @@ var _ = Describe("VirtualNode controller", func() {
 			oldName := ""
 			By(fmt.Sprintf("Try to delete NamespaceMap associated to: %s", remoteClusterId1))
 			Eventually(func() bool {
-				if err := k8sClient.List(context.TODO(), nms, client.MatchingLabels{const_ctrl.VirtualNodeClusterId: remoteClusterId1}); err != nil {
+				if err := k8sClient.List(context.TODO(), nms, client.MatchingLabels{liqoconst.VirtualNodeClusterId: remoteClusterId1}); err != nil {
 					return false
 				}
 				if len(nms.Items) != 1 {
@@ -248,7 +248,7 @@ var _ = Describe("VirtualNode controller", func() {
 
 			By(fmt.Sprintf("Try to get new NamespaceMap associated to: %s", remoteClusterId1))
 			Eventually(func() bool {
-				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(const_ctrl.MapNamespaceName), client.MatchingLabels{const_ctrl.VirtualNodeClusterId: remoteClusterId1}); err != nil {
+				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(liqoconst.MapNamespaceName), client.MatchingLabels{liqoconst.VirtualNodeClusterId: remoteClusterId1}); err != nil {
 					return false
 				}
 				if len(nms.Items) != 1 {
@@ -268,7 +268,7 @@ var _ = Describe("VirtualNode controller", func() {
 			oldName := ""
 			By(fmt.Sprintf("Try to delete NamespaceMap associated to: %s", remoteClusterId2))
 			Eventually(func() bool {
-				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(const_ctrl.MapNamespaceName), client.MatchingLabels{const_ctrl.VirtualNodeClusterId: remoteClusterId2}); err != nil {
+				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(liqoconst.MapNamespaceName), client.MatchingLabels{liqoconst.VirtualNodeClusterId: remoteClusterId2}); err != nil {
 					return false
 				}
 				if len(nms.Items) != 1 {
@@ -303,7 +303,7 @@ var _ = Describe("VirtualNode controller", func() {
 
 			By(fmt.Sprintf("Try to get new NamespaceMap associated to: %s", remoteClusterId2))
 			Eventually(func() bool {
-				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(const_ctrl.MapNamespaceName), client.MatchingLabels{const_ctrl.VirtualNodeClusterId: remoteClusterId2}); err != nil {
+				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(liqoconst.MapNamespaceName), client.MatchingLabels{liqoconst.VirtualNodeClusterId: remoteClusterId2}); err != nil {
 					return false
 				}
 				if len(nms.Items) != 1 {

--- a/pkg/liqo-controller-manager/virtualNode-controller/suite_test.go
+++ b/pkg/liqo-controller-manager/virtualNode-controller/suite_test.go
@@ -17,7 +17,8 @@ import (
 	"context"
 	"flag"
 	mapsv1alpha1 "github.com/liqotech/liqo/apis/virtualKubelet/v1alpha1"
-	const_ctrl "github.com/liqotech/liqo/pkg/liqo-controller-manager"
+	liqoconst "github.com/liqotech/liqo/pkg/consts"
+
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -132,10 +133,10 @@ var _ = BeforeSuite(func(done Done) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: nameVirtualNode1,
 			Annotations: map[string]string{
-				const_ctrl.VirtualNodeClusterId: remoteClusterId1,
+				liqoconst.VirtualNodeClusterId: remoteClusterId1,
 			},
 			Labels: map[string]string{
-				const_ctrl.TypeLabel:     const_ctrl.TypeNode,
+				liqoconst.TypeLabel:      liqoconst.TypeNode,
 				offloadingCluster1Label1: "",
 				offloadingCluster1Label2: "",
 			},
@@ -150,10 +151,10 @@ var _ = BeforeSuite(func(done Done) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: nameVirtualNode2,
 			Annotations: map[string]string{
-				const_ctrl.VirtualNodeClusterId: remoteClusterId2,
+				liqoconst.VirtualNodeClusterId: remoteClusterId2,
 			},
 			Labels: map[string]string{
-				const_ctrl.TypeLabel:     const_ctrl.TypeNode,
+				liqoconst.TypeLabel:      liqoconst.TypeNode,
 				offloadingCluster2Label1: "",
 				offloadingCluster2Label2: "",
 			},
@@ -168,7 +169,7 @@ var _ = BeforeSuite(func(done Done) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: nameSimpleNode,
 			Annotations: map[string]string{
-				const_ctrl.VirtualNodeClusterId: remoteClusterIdSimpleNode,
+				liqoconst.VirtualNodeClusterId: remoteClusterIdSimpleNode,
 			},
 			Labels: map[string]string{
 				offloadingCluster1Label1: "",
@@ -179,7 +180,7 @@ var _ = BeforeSuite(func(done Done) {
 
 	mapNamespace = &corev1.Namespace{}
 	Eventually(func() bool {
-		if err = k8sClient.Get(context.TODO(), types.NamespacedName{Name: const_ctrl.MapNamespaceName}, mapNamespace); err != nil {
+		if err = k8sClient.Get(context.TODO(), types.NamespacedName{Name: liqoconst.MapNamespaceName}, mapNamespace); err != nil {
 			if errors.IsNotFound(err) {
 				if err = k8sClient.Create(context.TODO(), virtualNode1); err == nil {
 					return true

--- a/pkg/utils/cluster_info.go
+++ b/pkg/utils/cluster_info.go
@@ -1,0 +1,27 @@
+package utils
+
+import (
+	"context"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	clusterIDConfMap   = "cluster-id"
+	configMapNamespace = "liqo"
+)
+
+func GetClusterID(c client.Client) (string, error) {
+
+	configMap := &corev1.ConfigMap{}
+	if err := c.Get(context.TODO(), types.NamespacedName{Namespace: configMapNamespace, Name: clusterIDConfMap}, configMap); err != nil {
+		klog.Errorf("%s, unable to get ConfigMap '%s' in namespace '%s'", err, clusterIDConfMap, configMapNamespace)
+		return "", err
+	}
+
+	clusterID := configMap.Data[clusterIDConfMap]
+	klog.Infof("ClusterID is '%s'", clusterID)
+	return clusterID, nil
+}

--- a/pkg/virtualKubelet/forge/pods.go
+++ b/pkg/virtualKubelet/forge/pods.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/liqotech/liqo/internal/liqonet/tunnelEndpointCreator"
-	liqoControllerManager "github.com/liqotech/liqo/pkg/liqo-controller-manager"
+	liqoconst "github.com/liqotech/liqo/pkg/consts"
 	"github.com/liqotech/liqo/pkg/virtualKubelet"
 	apimgmt "github.com/liqotech/liqo/pkg/virtualKubelet/apiReflection"
 	"github.com/liqotech/liqo/pkg/virtualKubelet/apiReflection/reflectors"
@@ -16,7 +16,7 @@ import (
 	"k8s.io/klog"
 )
 
-const affinitySelector = liqoControllerManager.TypeNode
+const affinitySelector = liqoconst.TypeNode
 
 func (f *apiForger) podForeignToHome(foreignObj, homeObj runtime.Object, reflectionType string) (*corev1.Pod, error) {
 	var isNewObject bool
@@ -227,7 +227,7 @@ func forgeAffinity() *corev1.Affinity {
 					{
 						MatchExpressions: []corev1.NodeSelectorRequirement{
 							{
-								Key:      liqoControllerManager.TypeLabel,
+								Key:      liqoconst.TypeLabel,
 								Operator: corev1.NodeSelectorOpNotIn,
 								Values:   []string{affinitySelector},
 							},

--- a/pkg/virtualKubelet/provider/node.go
+++ b/pkg/virtualKubelet/provider/node.go
@@ -2,7 +2,7 @@ package provider
 
 import (
 	"context"
-	liqoControllerManager "github.com/liqotech/liqo/pkg/liqo-controller-manager"
+	liqoconst "github.com/liqotech/liqo/pkg/consts"
 	"go.opencensus.io/trace"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -25,7 +25,7 @@ func (p *LiqoProvider) ConfigureNode(ctx context.Context, n *v1.Node) {
 	n.Status.NodeInfo.Architecture = "amd64"
 	n.ObjectMeta.Labels["alpha.service-controller.kubernetes.io/exclude-balancer"] = "true"
 	n.ObjectMeta.Labels["node.kubernetes.io/exclude-from-external-load-balancers"] = "true"
-	n.Labels[liqoControllerManager.TypeLabel] = liqoControllerManager.TypeNode
+	n.Labels[liqoconst.TypeLabel] = liqoconst.TypeNode
 }
 
 // NodeConditions returns a list of conditions (Ready, OutOfDisk, etc), for updates to the node status

--- a/pkg/vkMachinery/forge/forge.go
+++ b/pkg/vkMachinery/forge/forge.go
@@ -2,7 +2,7 @@ package forge
 
 import (
 	advtypes "github.com/liqotech/liqo/apis/sharing/v1alpha1"
-	liqoControllerManager "github.com/liqotech/liqo/pkg/liqo-controller-manager"
+	liqoconst "github.com/liqotech/liqo/pkg/consts"
 	vk "github.com/liqotech/liqo/pkg/vkMachinery"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -21,9 +21,9 @@ func forgeVKAffinity() *v1.Affinity {
 					{
 						MatchExpressions: []v1.NodeSelectorRequirement{
 							{
-								Key:      liqoControllerManager.TypeNode,
+								Key:      liqoconst.TypeNode,
 								Operator: v1.NodeSelectorOpNotIn,
-								Values:   []string{liqoControllerManager.TypeNode},
+								Values:   []string{liqoconst.TypeNode},
 							},
 						},
 					},

--- a/test/e2e/deploy_app_test.go
+++ b/test/e2e/deploy_app_test.go
@@ -12,7 +12,7 @@ import (
 
 	http_helper "github.com/gruntwork-io/terratest/modules/http-helper"
 	"github.com/gruntwork-io/terratest/modules/k8s"
-	liqoControllerManager "github.com/liqotech/liqo/pkg/liqo-controller-manager"
+	liqoconst "github.com/liqotech/liqo/pkg/consts"
 )
 
 const (
@@ -92,7 +92,7 @@ func getNodes(t *testing.T, options *k8s.KubectlOptions) []v1.Node {
 	assert.NilError(t, err)
 
 	nodes, err := clientset.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{
-		LabelSelector: fmt.Sprintf("%v!=%v,!net.liqo.io/gateway", liqoControllerManager.TypeLabel, liqoControllerManager.TypeNode),
+		LabelSelector: fmt.Sprintf("%v!=%v,!net.liqo.io/gateway", liqoconst.TypeLabel, liqoconst.TypeNode),
 	})
 	assert.NilError(t, err)
 	return nodes.Items

--- a/test/e2e/net_test.go
+++ b/test/e2e/net_test.go
@@ -4,7 +4,8 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	liqoControllerManager "github.com/liqotech/liqo/pkg/liqo-controller-manager"
+	liqoconst "github.com/liqotech/liqo/pkg/consts"
+
 	"github.com/liqotech/liqo/pkg/virtualKubelet"
 	"github.com/liqotech/liqo/test/e2e/util"
 	"github.com/stretchr/testify/assert"
@@ -27,7 +28,7 @@ var (
 	namespaceNameCl1   = "test-connectivity-cl1"
 	namespaceNameCl2   = "test-connectivity-cl2"
 	//label to list only the real nodes excluding the virtual ones
-	labelSelectorNodes = fmt.Sprintf("%v!=%v", liqoControllerManager.TypeLabel, liqoControllerManager.TypeNode)
+	labelSelectorNodes = fmt.Sprintf("%v!=%v", liqoconst.TypeLabel, liqoconst.TypeNode)
 	//TODO: use the retry mechanism of curl without sleeping before running the command
 	command = "curl -s -o /dev/null -w '%{http_code}' "
 )
@@ -283,9 +284,9 @@ func DeployRemotePod(image, podName, namespace string) *v1.Pod {
 				NodeAffinity: &v1.NodeAffinity{
 					RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{NodeSelectorTerms: []v1.NodeSelectorTerm{{
 						MatchExpressions: []v1.NodeSelectorRequirement{{
-							Key:      liqoControllerManager.TypeLabel,
+							Key:      liqoconst.TypeLabel,
 							Operator: "In",
-							Values:   []string{liqoControllerManager.TypeNode},
+							Values:   []string{liqoconst.TypeNode},
 						}},
 						MatchFields: nil,
 					}}},
@@ -320,9 +321,9 @@ func DeployLocalPod(image, podName, namespace string) *v1.Pod {
 				NodeAffinity: &v1.NodeAffinity{
 					RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{NodeSelectorTerms: []v1.NodeSelectorTerm{{
 						MatchExpressions: []v1.NodeSelectorRequirement{{
-							Key:      liqoControllerManager.TypeLabel,
+							Key:      liqoconst.TypeLabel,
 							Operator: "NotIn",
-							Values:   []string{liqoControllerManager.TypeNode},
+							Values:   []string{liqoconst.TypeNode},
 						}},
 						MatchFields: nil,
 					}}},

--- a/test/e2e/unjoin_e2e/unjoin_test.go
+++ b/test/e2e/unjoin_e2e/unjoin_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"testing"
 
-	liqoControllerManager "github.com/liqotech/liqo/pkg/liqo-controller-manager"
+	liqoconst "github.com/liqotech/liqo/pkg/consts"
 	"github.com/liqotech/liqo/test/e2e/util"
 	"gotest.tools/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -32,7 +32,7 @@ func NoPods(clientset *kubernetes.Clientset, namespace string, t *testing.T, clu
 
 func NoJoined(clientset *kubernetes.Clientset, t *testing.T, clustername string) {
 	nodes, err := clientset.CoreV1().Nodes().List(context2.TODO(), metav1.ListOptions{
-		LabelSelector: fmt.Sprintf("%v=%v", liqoControllerManager.TypeLabel, liqoControllerManager.TypeNode),
+		LabelSelector: fmt.Sprintf("%v=%v", liqoconst.TypeLabel, liqoconst.TypeNode),
 	})
 	if err != nil {
 		klog.Error(err)

--- a/test/unit/advertisement-operator/broadcaster_test.go
+++ b/test/unit/advertisement-operator/broadcaster_test.go
@@ -7,8 +7,9 @@ import (
 	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
 	advtypes "github.com/liqotech/liqo/apis/sharing/v1alpha1"
 	advop "github.com/liqotech/liqo/internal/advertisement-operator"
+	liqoconst "github.com/liqotech/liqo/pkg/consts"
 	"github.com/liqotech/liqo/pkg/crdClient"
-	liqoControllerManager "github.com/liqotech/liqo/pkg/liqo-controller-manager"
+
 	"github.com/liqotech/liqo/pkg/utils"
 	pkg "github.com/liqotech/liqo/pkg/virtualKubelet"
 	"github.com/liqotech/liqo/pkg/virtualKubelet/provider/test"
@@ -113,7 +114,7 @@ func createFakeResources() (physicalNodes *corev1.NodeList, virtualNodes *corev1
 			vNodes[v] = corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:   "liqo-cluster" + strconv.Itoa(v),
-					Labels: map[string]string{liqoControllerManager.TypeLabel: liqoControllerManager.TypeNode},
+					Labels: map[string]string{liqoconst.TypeLabel: liqoconst.TypeNode},
 				},
 				Spec: corev1.NodeSpec{
 					PodCIDR: fmt.Sprintf("%d.%d.%d.%d/%d", i, i, i, i, 16),


### PR DESCRIPTION
# Description

This PR creates a new folder for Liqo controllers constants (from liqo/pkg/liqo-controller-manager to liqo/pkg/consts). Constants will be divided in files, which will specify their context.

