### PR TITLE
Update the bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,38 +1,22 @@
 ---
 name: Bug report
-about: Create a report to help us improve
-title: ''
-labels: ''
-assignees: ''
+about: Report a bug encountered while using Liqo
+labels: kind/bug
 
 ---
 
-**Describe the bug**
-A clear and concise description of what the bug is.
+#### What happened:
 
-**To Reproduce**
-Steps to reproduce the behavior:
-1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
-4. See error
+#### What you expected to happen:
 
-**Expected behavior**
-A clear and concise description of what you expected to happen.
+#### How to reproduce it (as minimally and precisely as possible):
 
-**Screenshots**
-If applicable, add screenshots to help explain your problem.
+#### Anything else we need to know?:
 
-**Desktop (please complete the following information):**
- - OS: [e.g. iOS]
- - Browser [e.g. chrome, safari]
- - Version [e.g. 22]
-
-**Smartphone (please complete the following information):**
- - Device: [e.g. iPhone6]
- - OS: [e.g. iOS8.1]
- - Browser [e.g. stock browser, safari]
- - Version [e.g. 22]
-
-**Additional context**
-Add any other context about the problem here.
+#### Environment:
+- Liqo version:
+- Kubernetes version (use `kubectl version`):
+- Cloud provider or hardware configuration:
+- Network plugin and version:
+- Install tools:
+- Others:


### PR DESCRIPTION
# Description

This PR updates the bug report template to include information more relevant according to the project focus. The template is strongly inspired from the one used in Kubernetes, as Liqo users may already be familiar with it.
