### PR TITLE
[WIP] Improve the Replication of Namespaced Resources

### DIFF
--- a/apis/config/v1alpha1/clusterconfig_types.go
+++ b/apis/config/v1alpha1/clusterconfig_types.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes/scheme"
 
+	"github.com/liqotech/liqo/pkg/consts"
 	crdclient "github.com/liqotech/liqo/pkg/crdClient"
 	"github.com/liqotech/liqo/pkg/labelPolicy"
 )
@@ -206,6 +207,10 @@ type Resource struct {
 	Group    string `json:"group"`
 	Version  string `json:"version"`
 	Resource string `json:"resource"`
+
+	// +kubebuilder:validation:Enum="All";"Established";"Incoming";"Outgoing";"Bidirectional"
+	// +kubebuilder:default="All"
+	PeeringPhase consts.PeeringPhase `json:"peeringPhase,omitempty"`
 }
 
 // DispatcherConfig defines the configuration of the CRDReplicator.

--- a/apis/config/v1alpha1/clusterconfig_types.go
+++ b/apis/config/v1alpha1/clusterconfig_types.go
@@ -208,8 +208,8 @@ type Resource struct {
 	Version  string `json:"version"`
 	Resource string `json:"resource"`
 
-	// +kubebuilder:validation:Enum="All";"Established";"Incoming";"Outgoing";"Bidirectional"
-	// +kubebuilder:default="All"
+	// +kubebuilder:validation:Enum="Any";"Established";"Incoming";"Outgoing";"Bidirectional"
+	// +kubebuilder:default="Any"
 	PeeringPhase consts.PeeringPhase `json:"peeringPhase,omitempty"`
 }
 

--- a/apis/discovery/v1alpha1/resourcerequest_types.go
+++ b/apis/discovery/v1alpha1/resourcerequest_types.go
@@ -31,6 +31,7 @@ type ResourceRequestStatus struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
 
 // ResourceRequest is the Schema for the ResourceRequests API.
 type ResourceRequest struct {

--- a/cmd/crd-replicator/main.go
+++ b/cmd/crd-replicator/main.go
@@ -17,7 +17,7 @@ import (
 
 	configv1alpha1 "github.com/liqotech/liqo/apis/config/v1alpha1"
 	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
-	"github.com/liqotech/liqo/internal/crdReplicator"
+	crdreplicator "github.com/liqotech/liqo/internal/crdReplicator"
 	"github.com/liqotech/liqo/pkg/clusterid"
 	identitymanager "github.com/liqotech/liqo/pkg/identityManager"
 	util "github.com/liqotech/liqo/pkg/liqonet"
@@ -81,8 +81,8 @@ func main() {
 	clusterIdInterface := clusterid.NewStaticClusterID(clusterId)
 	namespaceManager := tenantcontrolnamespace.NewTenantControlNamespaceManager(k8sClient)
 	dynClient := dynamic.NewForConfigOrDie(cfg)
-	dynFac := dynamicinformer.NewFilteredDynamicSharedInformerFactory(dynClient, crdReplicator.ResyncPeriod, metav1.NamespaceAll, crdReplicator.SetLabelsForLocalResources)
-	d := &crdReplicator.Controller{
+	dynFac := dynamicinformer.NewFilteredDynamicSharedInformerFactory(dynClient, crdreplicator.ResyncPeriod, metav1.NamespaceAll, crdreplicator.SetLabelsForLocalResources)
+	d := &crdreplicator.Controller{
 		Scheme:                         mgr.GetScheme(),
 		Client:                         mgr.GetClient(),
 		ClientSet:                      k8sClient,

--- a/cmd/crd-replicator/main.go
+++ b/cmd/crd-replicator/main.go
@@ -19,10 +19,10 @@ import (
 	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
 	"github.com/liqotech/liqo/internal/crdReplicator"
 	"github.com/liqotech/liqo/pkg/clusterid"
-	"github.com/liqotech/liqo/pkg/identityManager"
+	identitymanager "github.com/liqotech/liqo/pkg/identityManager"
 	util "github.com/liqotech/liqo/pkg/liqonet"
 	"github.com/liqotech/liqo/pkg/mapperUtils"
-	"github.com/liqotech/liqo/pkg/tenantControlNamespace"
+	tenantcontrolnamespace "github.com/liqotech/liqo/pkg/tenantControlNamespace"
 )
 
 var (
@@ -79,7 +79,7 @@ func main() {
 		klog.Infof("setting local clusterID to: %s", clusterId)
 	}
 	clusterIdInterface := clusterid.NewStaticClusterID(clusterId)
-	namespaceManager := tenantControlNamespace.NewTenantControlNamespaceManager(k8sClient)
+	namespaceManager := tenantcontrolnamespace.NewTenantControlNamespaceManager(k8sClient)
 	dynClient := dynamic.NewForConfigOrDie(cfg)
 	dynFac := dynamicinformer.NewFilteredDynamicSharedInformerFactory(dynClient, crdReplicator.ResyncPeriod, metav1.NamespaceAll, crdReplicator.SetLabelsForLocalResources)
 	d := &crdReplicator.Controller{
@@ -96,8 +96,7 @@ func main() {
 		RemoteWatchers:                 make(map[string]map[string]chan struct{}),
 		RemoteDynSharedInformerFactory: make(map[string]dynamicinformer.DynamicSharedInformerFactory),
 		UseNewAuth:                     useNewAuth,
-		NamespaceManager:               namespaceManager,
-		IdentityManager:                identityManager.NewCertificateIdentityManager(k8sClient, clusterIdInterface, namespaceManager),
+		IdentityManager:                identitymanager.NewCertificateIdentityManager(k8sClient, clusterIdInterface, namespaceManager),
 		LocalToRemoteNamespaceMapper:   map[string]string{},
 		RemoteToLocalNamespaceMapper:   map[string]string{},
 	}

--- a/deployments/liqo/crds/config.liqo.io_clusterconfigs.yaml
+++ b/deployments/liqo/crds/config.liqo.io_clusterconfigs.yaml
@@ -277,6 +277,15 @@ spec:
                       properties:
                         group:
                           type: string
+                        peeringPhase:
+                          default: All
+                          enum:
+                          - All
+                          - Established
+                          - Incoming
+                          - Outgoing
+                          - Bidirectional
+                          type: string
                         resource:
                           type: string
                         version:

--- a/deployments/liqo/crds/config.liqo.io_clusterconfigs.yaml
+++ b/deployments/liqo/crds/config.liqo.io_clusterconfigs.yaml
@@ -278,11 +278,11 @@ spec:
                         group:
                           type: string
                         peeringPhase:
-                          default: All
+                          default: Any
                           description: PeeringPhase contains the status of the peering
                             with a remote cluster.
                           enum:
-                          - All
+                          - Any
                           - Established
                           - Incoming
                           - Outgoing

--- a/deployments/liqo/crds/config.liqo.io_clusterconfigs.yaml
+++ b/deployments/liqo/crds/config.liqo.io_clusterconfigs.yaml
@@ -279,6 +279,8 @@ spec:
                           type: string
                         peeringPhase:
                           default: All
+                          description: PeeringPhase contains the status of the peering
+                            with a remote cluster.
                           enum:
                           - All
                           - Established

--- a/deployments/liqo/crds/discovery.liqo.io_resourcerequests.yaml
+++ b/deployments/liqo/crds/discovery.liqo.io_resourcerequests.yaml
@@ -79,6 +79,8 @@ spec:
         type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/deployments/liqo/files/liqo-crd-replicator-ClusterRole.yaml
+++ b/deployments/liqo/files/liqo-crd-replicator-ClusterRole.yaml
@@ -8,6 +8,13 @@ rules:
   - list
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+- apiGroups:
   - discovery.liqo.io
   resources:
   - foreignclusters

--- a/deployments/liqo/files/liqo-remote-peering-basic-ClusterRole.yaml
+++ b/deployments/liqo/files/liqo-remote-peering-basic-ClusterRole.yaml
@@ -4,6 +4,7 @@ rules:
   resources:
   - resourcerequests
   verbs:
+  - create
   - delete
   - get
   - list
@@ -15,6 +16,7 @@ rules:
   resources:
   - resourcerequests/status
   verbs:
+  - create
   - delete
   - get
   - list

--- a/deployments/liqo/files/liqo-remote-peering-incoming-ClusterRole.yaml
+++ b/deployments/liqo/files/liqo-remote-peering-incoming-ClusterRole.yaml
@@ -4,6 +4,7 @@ rules:
   resources:
   - networkconfigs
   verbs:
+  - create
   - delete
   - get
   - list
@@ -15,6 +16,7 @@ rules:
   resources:
   - networkconfigs/status
   verbs:
+  - create
   - delete
   - get
   - list

--- a/deployments/liqo/files/liqo-remote-peering-outgoing-ClusterRole.yaml
+++ b/deployments/liqo/files/liqo-remote-peering-outgoing-ClusterRole.yaml
@@ -1,29 +1,5 @@
 rules:
 - apiGroups:
-  - discovery.liqo.io
-  resources:
-  - resourceoffers
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - discovery.liqo.io
-  resources:
-  - resourceoffers/status
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
   - net.liqo.io
   resources:
   - networkconfigs
@@ -39,6 +15,30 @@ rules:
   - net.liqo.io
   resources:
   - networkconfigs/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - sharing.liqo.io
+  resources:
+  - resourceoffers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - sharing.liqo.io
+  resources:
+  - resourceoffers/status
   verbs:
   - create
   - delete

--- a/deployments/liqo/files/liqo-remote-peering-outgoing-ClusterRole.yaml
+++ b/deployments/liqo/files/liqo-remote-peering-outgoing-ClusterRole.yaml
@@ -4,6 +4,7 @@ rules:
   resources:
   - resourceoffers
   verbs:
+  - create
   - delete
   - get
   - list
@@ -15,6 +16,7 @@ rules:
   resources:
   - resourceoffers/status
   verbs:
+  - create
   - delete
   - get
   - list
@@ -26,6 +28,7 @@ rules:
   resources:
   - networkconfigs
   verbs:
+  - create
   - delete
   - get
   - list
@@ -37,6 +40,7 @@ rules:
   resources:
   - networkconfigs/status
   verbs:
+  - create
   - delete
   - get
   - list

--- a/deployments/liqo/templates/clusterconfig.yaml
+++ b/deployments/liqo/templates/clusterconfig.yaml
@@ -49,15 +49,18 @@ spec:
     {{- .Values.networkManager.config | toYaml | nindent 4 }}
   dispatcherConfig:
     resourcesToReplicate:
-    #- group: net.liqo.io
-    #  version: v1alpha1
-    #  resource: networkconfigs
+    - group: net.liqo.io
+      version: v1alpha1
+      resource: networkconfigs
+      peeringPhase: Established
     - group: discovery.liqo.io
       version: v1alpha1
       resource: resourcerequests
-    #- group: sharing.liqo.io
-    #  version: v1alpha1
-    #  resource: resourceoffers
+      peeringPhase: All
+    - group: sharing.liqo.io
+      version: v1alpha1
+      resource: resourceoffers
+      peeringPhase: Incoming
   agentConfig:
     dashboardConfig:
       namespace: {{ .Release.Namespace }}

--- a/deployments/liqo/templates/clusterconfig.yaml
+++ b/deployments/liqo/templates/clusterconfig.yaml
@@ -49,14 +49,14 @@ spec:
     {{- .Values.networkManager.config | toYaml | nindent 4 }}
   dispatcherConfig:
     resourcesToReplicate:
-    - group: net.liqo.io
-      version: v1alpha1
-      resource: networkconfigs
-      peeringPhase: Established
+#    - group: net.liqo.io
+#      version: v1alpha1
+#      resource: networkconfigs
+#      peeringPhase: Established
     - group: discovery.liqo.io
       version: v1alpha1
       resource: resourcerequests
-      peeringPhase: All
+      peeringPhase: Any
     - group: sharing.liqo.io
       version: v1alpha1
       resource: resourceoffers

--- a/deployments/liqo/templates/clusterconfig.yaml
+++ b/deployments/liqo/templates/clusterconfig.yaml
@@ -49,9 +49,15 @@ spec:
     {{- .Values.networkManager.config | toYaml | nindent 4 }}
   dispatcherConfig:
     resourcesToReplicate:
-    - group: net.liqo.io
+    #- group: net.liqo.io
+    #  version: v1alpha1
+    #  resource: networkconfigs
+    - group: discovery.liqo.io
       version: v1alpha1
-      resource: networkconfigs
+      resource: resourcerequests
+    #- group: sharing.liqo.io
+    #  version: v1alpha1
+    #  resource: resourceoffers
   agentConfig:
     dashboardConfig:
       namespace: {{ .Release.Namespace }}

--- a/deployments/liqo/templates/liqo-crd-replicator-deployment.yaml
+++ b/deployments/liqo/templates/liqo-crd-replicator-deployment.yaml
@@ -35,11 +35,15 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+          {{- if .Values.useNewAuth }}
+          args:
+          - "--useNewAuth"
+          {{- end }}
           resources:
-           limits:
-             cpu: 30m
-             memory: 50M
-           requests:
-             cpu: 30m
-             memory: 50M
+            limits:
+              cpu: 30m
+              memory: 50M
+            requests:
+              cpu: 30m
+              memory: 50M
 ---

--- a/deployments/liqo/templates/liqo-remote-peering-rbac.yaml
+++ b/deployments/liqo/templates/liqo-remote-peering-rbac.yaml
@@ -4,6 +4,7 @@
 
 {{- $authConfig := (merge (dict "name" "auth" "module" "discovery") .) -}}
 {{- $discoveryConfig := (merge (dict "name" "discovery" "module" "discovery") .) -}}
+{{- $crdReplicatorConfig := (merge (dict "name" "crd-replicator" "module" "dispatcher") .) -}}
 
 # to be enabled with the creation of the Tenant Control Namespace,
 # this ClusterRole has the basic permissions to give to a remote cluster
@@ -50,6 +51,9 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "liqo.prefixedName" $discoveryConfig }}
     namespace: {{ .Release.Namespace }}
+  - kind: ServiceAccount
+    name: {{ include "liqo.prefixedName" $crdReplicatorConfig }}
+    namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -68,6 +72,9 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "liqo.prefixedName" $discoveryConfig }}
     namespace: {{ .Release.Namespace }}
+  - kind: ServiceAccount
+    name: {{ include "liqo.prefixedName" $crdReplicatorConfig }}
+    namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -85,6 +92,9 @@ subjects:
     namespace: {{ .Release.Namespace }}
   - kind: ServiceAccount
     name: {{ include "liqo.prefixedName" $discoveryConfig }}
+    namespace: {{ .Release.Namespace }}
+  - kind: ServiceAccount
+    name: {{ include "liqo.prefixedName" $crdReplicatorConfig }}
     namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/internal/crdReplicator/crdReplicator-config.go
+++ b/internal/crdReplicator/crdReplicator-config.go
@@ -1,4 +1,4 @@
-package crdReplicator
+package crdreplicator
 
 import (
 	"reflect"
@@ -13,6 +13,7 @@ import (
 	"github.com/liqotech/liqo/pkg/utils"
 )
 
+// WatchConfiguration starts a goroutine to watch the cluster configuration.
 func (c *Controller) WatchConfiguration(config *rest.Config, gv *schema.GroupVersion) error {
 	config.ContentConfig.GroupVersion = gv
 	config.APIPath = "/apis"
@@ -27,6 +28,7 @@ func (c *Controller) WatchConfiguration(config *rest.Config, gv *schema.GroupVer
 	return nil
 }
 
+// UpdateConfig updates the local configration copy.
 func (c *Controller) UpdateConfig(cfg *configv1alpha1.ClusterConfig) {
 	resources := c.GetConfig(cfg)
 	if !reflect.DeepEqual(c.RegisteredResources, resources) {
@@ -37,6 +39,7 @@ func (c *Controller) UpdateConfig(cfg *configv1alpha1.ClusterConfig) {
 	}
 }
 
+// GetConfig returns the list of resources that need replication.
 func (c *Controller) GetConfig(cfg *configv1alpha1.ClusterConfig) []resourceToReplicate {
 	resourceList := cfg.Spec.DispatcherConfig
 	config := []resourceToReplicate{}
@@ -53,6 +56,7 @@ func (c *Controller) GetConfig(cfg *configv1alpha1.ClusterConfig) []resourceToRe
 	return config
 }
 
+// GetRemovedResources returns the resources where the replication is no more required.
 func (c *Controller) GetRemovedResources(resources []resourceToReplicate) []string {
 	oldRes := []string{}
 	diffRes := []string{}

--- a/internal/crdReplicator/crdReplicator-config.go
+++ b/internal/crdReplicator/crdReplicator-config.go
@@ -37,30 +37,33 @@ func (c *Controller) UpdateConfig(cfg *configv1alpha1.ClusterConfig) {
 	}
 }
 
-func (c *Controller) GetConfig(cfg *configv1alpha1.ClusterConfig) []schema.GroupVersionResource {
+func (c *Controller) GetConfig(cfg *configv1alpha1.ClusterConfig) []resourceToReplicate {
 	resourceList := cfg.Spec.DispatcherConfig
-	config := []schema.GroupVersionResource{}
+	config := []resourceToReplicate{}
 	for _, res := range resourceList.ResourcesToReplicate {
-		config = append(config, schema.GroupVersionResource{
-			Group:    res.Group,
-			Version:  res.Version,
-			Resource: res.Resource,
+		config = append(config, resourceToReplicate{
+			groupVersionResource: schema.GroupVersionResource{
+				Group:    res.Group,
+				Version:  res.Version,
+				Resource: res.Resource,
+			},
+			peeringPhase: res.PeeringPhase,
 		})
 	}
 	return config
 }
 
-func (c *Controller) GetRemovedResources(resources []schema.GroupVersionResource) []string {
+func (c *Controller) GetRemovedResources(resources []resourceToReplicate) []string {
 	oldRes := []string{}
 	diffRes := []string{}
 	newRes := []string{}
 	//save the resources as strings in 'newRes'
 	for _, r := range resources {
-		newRes = append(newRes, r.String())
+		newRes = append(newRes, r.groupVersionResource.String())
 	}
 	//get the old resources
 	for _, r := range c.RegisteredResources {
-		oldRes = append(oldRes, r.String())
+		oldRes = append(oldRes, r.groupVersionResource.String())
 	}
 	//save in diffRes all the resources that appears in oldRes but not in newRes
 	flag := false

--- a/internal/crdReplicator/crdReplicator-config.go
+++ b/internal/crdReplicator/crdReplicator-config.go
@@ -30,7 +30,7 @@ func (c *Controller) WatchConfiguration(config *rest.Config, gv *schema.GroupVer
 
 // UpdateConfig updates the local configration copy.
 func (c *Controller) UpdateConfig(cfg *configv1alpha1.ClusterConfig) {
-	resources := c.GetConfig(cfg)
+	resources := c.getConfig(cfg)
 	if !reflect.DeepEqual(c.RegisteredResources, resources) {
 		klog.Info("updating the list of registered resources to be replicated")
 		c.UnregisteredResources = c.GetRemovedResources(resources)
@@ -39,8 +39,8 @@ func (c *Controller) UpdateConfig(cfg *configv1alpha1.ClusterConfig) {
 	}
 }
 
-// GetConfig returns the list of resources that need replication.
-func (c *Controller) GetConfig(cfg *configv1alpha1.ClusterConfig) []resourceToReplicate {
+// getConfig returns the list of resources that need replication.
+func (c *Controller) getConfig(cfg *configv1alpha1.ClusterConfig) []resourceToReplicate {
 	resourceList := cfg.Spec.DispatcherConfig
 	config := []resourceToReplicate{}
 	for _, res := range resourceList.ResourcesToReplicate {

--- a/internal/crdReplicator/crdReplicator-config_test.go
+++ b/internal/crdReplicator/crdReplicator-config_test.go
@@ -1,4 +1,4 @@
-package crdReplicator
+package crdreplicator
 
 import (
 	"testing"

--- a/internal/crdReplicator/crdReplicator-config_test.go
+++ b/internal/crdReplicator/crdReplicator-config_test.go
@@ -8,6 +8,7 @@ import (
 
 	configv1alpha1 "github.com/liqotech/liqo/apis/config/v1alpha1"
 	netv1alpha1 "github.com/liqotech/liqo/apis/net/v1alpha1"
+	"github.com/liqotech/liqo/pkg/consts"
 )
 
 func TestDispatcherReconciler_GetConfig(t *testing.T) {
@@ -50,50 +51,70 @@ func TestDispatcherReconciler_GetConfig(t *testing.T) {
 
 func TestDispatcherReconciler_GetRemovedResources(t *testing.T) {
 	dispatcher := Controller{
-		RegisteredResources: []schema.GroupVersionResource{
+		RegisteredResources: []resourceToReplicate{
 			{
-				Group:    netv1alpha1.GroupVersion.Group,
-				Version:  netv1alpha1.GroupVersion.Version,
-				Resource: "networkconfigs",
+				groupVersionResource: schema.GroupVersionResource{
+					Group:    netv1alpha1.GroupVersion.Group,
+					Version:  netv1alpha1.GroupVersion.Version,
+					Resource: "networkconfigs",
+				},
+				peeringPhase: consts.PeeringPhaseEstablished,
 			},
 			{
-				Group:    netv1alpha1.GroupVersion.Group,
-				Version:  netv1alpha1.GroupVersion.Version,
-				Resource: "tunnelendpoints",
+				groupVersionResource: schema.GroupVersionResource{
+					Group:    netv1alpha1.GroupVersion.Group,
+					Version:  netv1alpha1.GroupVersion.Version,
+					Resource: "tunnelendpoints",
+				},
+				peeringPhase: consts.PeeringPhaseEstablished,
 			},
 		},
 	}
 	// test 1
 	// the configuration does not change, is the same
 	// so we expect expect to get a 0 length list
-	t1 := []schema.GroupVersionResource{
+	t1 := []resourceToReplicate{
 		{
-			Group:    netv1alpha1.GroupVersion.Group,
-			Version:  netv1alpha1.GroupVersion.Version,
-			Resource: "networkconfigs"},
+			groupVersionResource: schema.GroupVersionResource{
+				Group:    netv1alpha1.GroupVersion.Group,
+				Version:  netv1alpha1.GroupVersion.Version,
+				Resource: "networkconfigs",
+			},
+			peeringPhase: consts.PeeringPhaseEstablished,
+		},
 		{
-			Group:    netv1alpha1.GroupVersion.Group,
-			Version:  netv1alpha1.GroupVersion.Version,
-			Resource: "tunnelendpoints",
+			groupVersionResource: schema.GroupVersionResource{
+				Group:    netv1alpha1.GroupVersion.Group,
+				Version:  netv1alpha1.GroupVersion.Version,
+				Resource: "tunnelendpoints",
+			},
+			peeringPhase: consts.PeeringPhaseEstablished,
 		},
 	}
 	// test2
 	// we remove a resource from the configuration and add a new one to it
 	// so we expect to get a list with 1 element
-	t2 := []schema.GroupVersionResource{
+	t2 := []resourceToReplicate{
 		{
-			Group:    netv1alpha1.GroupVersion.Group,
-			Version:  netv1alpha1.GroupVersion.Version,
-			Resource: "networkconfigs"},
+			groupVersionResource: schema.GroupVersionResource{
+				Group:    netv1alpha1.GroupVersion.Group,
+				Version:  netv1alpha1.GroupVersion.Version,
+				Resource: "networkconfigs",
+			},
+			peeringPhase: consts.PeeringPhaseEstablished,
+		},
 		{
-			Group:    netv1alpha1.GroupVersion.Group,
-			Version:  netv1alpha1.GroupVersion.Version,
-			Resource: "tunnelendpoints-wrong",
+			groupVersionResource: schema.GroupVersionResource{
+				Group:    netv1alpha1.GroupVersion.Group,
+				Version:  netv1alpha1.GroupVersion.Version,
+				Resource: "tunnelendpoints-wrong",
+			},
+			peeringPhase: consts.PeeringPhaseEstablished,
 		},
 	}
 
 	tests := []struct {
-		config           []schema.GroupVersionResource
+		config           []resourceToReplicate
 		expectedElements int
 	}{
 		{t1, 0},

--- a/internal/crdReplicator/crdReplicator-config_test.go
+++ b/internal/crdReplicator/crdReplicator-config_test.go
@@ -44,7 +44,7 @@ func TestDispatcherReconciler_GetConfig(t *testing.T) {
 			},
 			Status: configv1alpha1.ClusterConfigStatus{},
 		}
-		res := dispatcher.GetConfig(cfg)
+		res := dispatcher.getConfig(cfg)
 		assert.Equal(t, test.expectedElements, len(res), "length should be equal")
 	}
 }

--- a/internal/crdReplicator/crdReplicator-operator.go
+++ b/internal/crdReplicator/crdReplicator-operator.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+	"sync"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -28,9 +29,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	"github.com/liqotech/liqo/apis/discovery/v1alpha1"
-	"github.com/liqotech/liqo/pkg/identityManager"
-	utils "github.com/liqotech/liqo/pkg/liqonet"
-	"github.com/liqotech/liqo/pkg/tenantControlNamespace"
+	"github.com/liqotech/liqo/pkg/consts"
+	identitymanager "github.com/liqotech/liqo/pkg/identityManager"
 )
 
 var (
@@ -49,6 +49,11 @@ const (
 	ReplicationStatuslabel = "liqo.io/replicated"
 )
 
+type resourceToReplicate struct {
+	groupVersionResource schema.GroupVersionResource
+	peeringPhase         consts.PeeringPhase
+}
+
 type Controller struct {
 	Scheme *runtime.Scheme
 	client.Client
@@ -58,16 +63,17 @@ type Controller struct {
 	RemoteDynSharedInformerFactory map[string]dynamicinformer.DynamicSharedInformerFactory // for each remote cluster we save the dynamic shared informer factory
 	LocalDynClient                 dynamic.Interface                                       // dynamic client pointing to the local API server
 	LocalDynSharedInformerFactory  dynamicinformer.DynamicSharedInformerFactory            // local dynamic shared informer factory
-	RegisteredResources            []schema.GroupVersionResource                           // a list of GVRs of resources to be replicated
+	RegisteredResources            []resourceToReplicate                                   // a list of GVRs of resources to be replicated, with the associated peering phase when the replication has to occur
 	UnregisteredResources          []string                                                // each time a resource is removed from the configuration it is saved in this list, it stays here until the associated watcher, if running, is stopped
 	LocalWatchers                  map[string]chan struct{}                                // we save all the running watchers monitoring the local resources:(registeredResource, chan))
 	RemoteWatchers                 map[string]map[string]chan struct{}                     // for each peering cluster we save all the running watchers monitoring the replicated resources:(clusterID, (registeredResource, chan))
 
 	UseNewAuth                   bool
-	NamespaceManager             tenantControlNamespace.TenantControlNamespaceManager
-	IdentityManager              identityManager.IdentityManager
+	IdentityManager              identitymanager.IdentityManager
 	LocalToRemoteNamespaceMapper map[string]string
 	RemoteToLocalNamespaceMapper map[string]string
+	peeringPhases                map[string]consts.PeeringPhase
+	peeringPhasesMutex           sync.RWMutex
 }
 
 // cluster-role
@@ -95,7 +101,7 @@ func (c *Controller) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	}
 	remoteClusterID := fc.Spec.ClusterIdentity.ClusterID
 	// examine DeletionTimestamp to determine if object is under deletion
-	if fc.ObjectMeta.DeletionTimestamp.IsZero() {
+	/*if fc.ObjectMeta.DeletionTimestamp.IsZero() {
 		// the finalizer is added only if a join is active with the remote cluster
 		if !fc.Status.Incoming.Joined && !fc.Status.Outgoing.Joined {
 			if utils.ContainsString(fc.ObjectMeta.Finalizers, finalizer) {
@@ -140,13 +146,18 @@ func (c *Controller) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 			}
 			return result, nil
 		}
-	}
+	}*/
 	// check if the client already exists
 	// check if the dynamic dynamic client and informer factory exists
 	_, dynClientOk := c.RemoteDynClients[remoteClusterID]
 	_, dynFacOk := c.RemoteDynSharedInformerFactory[remoteClusterID]
 	if dynClientOk && dynFacOk {
 		return result, nil
+	}
+
+	currentPhase := getPeeringPhase(&fc)
+	if oldPhase := c.getPeeringPhase(remoteClusterID); oldPhase != currentPhase {
+		c.setPeeringPhase(remoteClusterID, currentPhase)
 	}
 
 	if c.UseNewAuth {
@@ -361,30 +372,36 @@ func (c *Controller) StartWatchers() {
 			watchers = make(map[string]chan struct{})
 		}
 		for _, res := range c.RegisteredResources {
+			if !isReplicationEnabled(c.getPeeringPhase(remCluster), res) {
+				continue
+			}
+
+			gvr := res.groupVersionResource
 			// if there is not then start one
-			if _, ok := watchers[res.String()]; !ok {
+			if _, ok := watchers[gvr.String()]; !ok {
 				stopCh := make(chan struct{})
-				watchers[res.String()] = stopCh
-				go c.Watcher(remDynFac, res, cache.ResourceEventHandlerFuncs{
+				watchers[gvr.String()] = stopCh
+				go c.Watcher(remDynFac, gvr, cache.ResourceEventHandlerFuncs{
 					UpdateFunc: c.remoteModifiedWrapper,
 				}, stopCh)
-				klog.Infof("%s -> starting remote watcher for resource: %s", remCluster, res.String())
+				klog.Infof("%s -> starting remote watcher for resource: %s", remCluster, gvr.String())
 			}
 		}
 		c.RemoteWatchers[remCluster] = watchers
 	}
 	// check if the local watchers are running for each registered resource
 	for _, res := range c.RegisteredResources {
+		gvr := res.groupVersionResource
 		// if there is not a running local watcher then start one
-		if _, ok := c.LocalWatchers[res.String()]; !ok {
+		if _, ok := c.LocalWatchers[gvr.String()]; !ok {
 			stopCh := make(chan struct{})
-			c.LocalWatchers[res.String()] = stopCh
-			go c.Watcher(c.LocalDynSharedInformerFactory, res, cache.ResourceEventHandlerFuncs{
+			c.LocalWatchers[gvr.String()] = stopCh
+			go c.Watcher(c.LocalDynSharedInformerFactory, gvr, cache.ResourceEventHandlerFuncs{
 				AddFunc:    c.AddFunc,
 				UpdateFunc: c.UpdateFunc,
 				DeleteFunc: c.DeleteFunc,
 			}, stopCh)
-			klog.Infof("%s -> starting local watcher for resource: %s", c.ClusterID, res.String())
+			klog.Infof("%s -> starting local watcher for resource: %s", c.ClusterID, gvr.String())
 		}
 	}
 }
@@ -402,6 +419,22 @@ func (c *Controller) StopWatchers() {
 				}
 			}
 		}
+
+		// stop watchers for those resources no more needed
+		for _, res := range c.RegisteredResources {
+			if isReplicationEnabled(c.getPeeringPhase(remCluster), res) {
+				continue
+			}
+
+			if ch, ok := watchers[res.groupVersionResource.String()]; ok {
+				if ok {
+					close(ch)
+					delete(watchers, res.groupVersionResource.String())
+					klog.Infof("%s -> stopping remote watcher for resource: %s", remCluster, res)
+				}
+			}
+		}
+
 		c.RemoteWatchers[remCluster] = watchers
 	}
 	// stop all local watchers

--- a/internal/crdReplicator/crdReplicator-operator.go
+++ b/internal/crdReplicator/crdReplicator-operator.go
@@ -31,6 +31,7 @@ import (
 	"github.com/liqotech/liqo/apis/discovery/v1alpha1"
 	"github.com/liqotech/liqo/pkg/consts"
 	identitymanager "github.com/liqotech/liqo/pkg/identityManager"
+	utils "github.com/liqotech/liqo/pkg/liqonet"
 )
 
 var (
@@ -86,6 +87,9 @@ type Controller struct {
 // +kubebuilder:rbac:groups=core,namespace="do-not-care",resources=secrets,verbs=get;list
 // +kubebuilder:rbac:groups=core,namespace="do-not-care",resources=configmaps,verbs=get;list
 
+// identity management
+// +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list
+
 func (c *Controller) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	var fc v1alpha1.ForeignCluster
 	ctx := context.Background()
@@ -101,7 +105,7 @@ func (c *Controller) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	}
 	remoteClusterID := fc.Spec.ClusterIdentity.ClusterID
 	// examine DeletionTimestamp to determine if object is under deletion
-	/*if fc.ObjectMeta.DeletionTimestamp.IsZero() {
+	if fc.ObjectMeta.DeletionTimestamp.IsZero() {
 		// the finalizer is added only if a join is active with the remote cluster
 		if !fc.Status.Incoming.Joined && !fc.Status.Outgoing.Joined {
 			if utils.ContainsString(fc.ObjectMeta.Finalizers, finalizer) {
@@ -112,7 +116,7 @@ func (c *Controller) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 				}
 				return result, nil
 			}
-			return result, nil
+			// return result, nil
 		}
 		if !utils.ContainsString(fc.ObjectMeta.Finalizers, finalizer) {
 			fc.ObjectMeta.Finalizers = append(fc.Finalizers, finalizer)
@@ -146,7 +150,7 @@ func (c *Controller) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 			}
 			return result, nil
 		}
-	}*/
+	}
 	// check if the client already exists
 	// check if the dynamic dynamic client and informer factory exists
 	_, dynClientOk := c.RemoteDynClients[remoteClusterID]

--- a/internal/crdReplicator/crdReplicator-operator.go
+++ b/internal/crdReplicator/crdReplicator-operator.go
@@ -1,4 +1,4 @@
-package crdReplicator
+package crdreplicator
 
 import (
 	"context"

--- a/internal/crdReplicator/crdReplicator-operator_test.go
+++ b/internal/crdReplicator/crdReplicator-operator_test.go
@@ -1,4 +1,4 @@
-package crdReplicator
+package crdreplicator
 
 import (
 	"context"

--- a/internal/crdReplicator/crdReplicator-operator_test.go
+++ b/internal/crdReplicator/crdReplicator-operator_test.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/client-go/dynamic/dynamicinformer"
 
 	netv1alpha1 "github.com/liqotech/liqo/apis/net/v1alpha1"
+	"github.com/liqotech/liqo/pkg/consts"
 )
 
 var (
@@ -171,21 +172,27 @@ func TestCRDReplicatorReconciler_StartAndStopWatchers(t *testing.T) {
 	d := getCRDReplicator()
 	//we add two kind of resources to be watched
 	//then unregister them and check that the watchers have been closed as well
-	test1 := []schema.GroupVersionResource{{
-		Group:    netv1alpha1.GroupVersion.Group,
-		Version:  netv1alpha1.GroupVersion.Version,
-		Resource: "networkconfigs",
+	test1 := []resourceToReplicate{{
+		groupVersionResource: schema.GroupVersionResource{
+			Group:    netv1alpha1.GroupVersion.Group,
+			Version:  netv1alpha1.GroupVersion.Version,
+			Resource: "networkconfigs",
+		},
+		peeringPhase: consts.PeeringPhaseEstablished,
 	}, {
-		Group:    netv1alpha1.GroupVersion.Group,
-		Version:  netv1alpha1.GroupVersion.Version,
-		Resource: "tunnelendpoints",
+		groupVersionResource: schema.GroupVersionResource{
+			Group:    netv1alpha1.GroupVersion.Group,
+			Version:  netv1alpha1.GroupVersion.Version,
+			Resource: "tunnelendpoints",
+		},
+		peeringPhase: consts.PeeringPhaseEstablished,
 	}}
 	d.RegisteredResources = test1
 	d.StartWatchers()
 	assert.Equal(t, 2, len(d.RemoteWatchers[remoteClusterID]), "it should be 2")
 	assert.Equal(t, 2, len(d.LocalWatchers), "it should be 2")
 	for _, r := range test1 {
-		d.UnregisteredResources = append(d.UnregisteredResources, r.String())
+		d.UnregisteredResources = append(d.UnregisteredResources, r.groupVersionResource.String())
 	}
 	d.StopWatchers()
 	assert.Equal(t, 0, len(d.RemoteWatchers[remoteClusterID]), "it should be 0")

--- a/internal/crdReplicator/env_test.go
+++ b/internal/crdReplicator/env_test.go
@@ -1,4 +1,4 @@
-package crdReplicator
+package crdreplicator
 
 import (
 	"strings"

--- a/internal/crdReplicator/namespaceTranslation.go
+++ b/internal/crdReplicator/namespaceTranslation.go
@@ -1,4 +1,4 @@
-package crdReplicator
+package crdreplicator
 
 import (
 	"k8s.io/klog/v2"
@@ -7,17 +7,15 @@ import (
 func (c *Controller) localToRemoteNamespace(namespace string) string {
 	if ns, ok := c.LocalToRemoteNamespaceMapper[namespace]; ok {
 		return ns
-	} else {
-		klog.V(5).Infof("local namespace %v translation not found, returning the original namespace", namespace)
-		return namespace
 	}
+	klog.V(5).Infof("local namespace %v translation not found, returning the original namespace", namespace)
+	return namespace
 }
 
 func (c *Controller) remoteToLocalNamespace(namespace string) string {
 	if ns, ok := c.RemoteToLocalNamespaceMapper[namespace]; ok {
 		return ns
-	} else {
-		klog.V(5).Infof("remote namespace %v translation not found, returning the original namespace", namespace)
-		return namespace
 	}
+	klog.V(5).Infof("remote namespace %v translation not found, returning the original namespace", namespace)
+	return namespace
 }

--- a/internal/crdReplicator/namespaceTranslation.go
+++ b/internal/crdReplicator/namespaceTranslation.go
@@ -1,0 +1,23 @@
+package crdReplicator
+
+import (
+	"k8s.io/klog/v2"
+)
+
+func (c *Controller) localToRemoteNamespace(namespace string) string {
+	if ns, ok := c.LocalToRemoteNamespaceMapper[namespace]; ok {
+		return ns
+	} else {
+		klog.V(5).Infof("local namespace %v translation not found, returning the original namespace", namespace)
+		return namespace
+	}
+}
+
+func (c *Controller) remoteToLocalNamespace(namespace string) string {
+	if ns, ok := c.RemoteToLocalNamespaceMapper[namespace]; ok {
+		return ns
+	} else {
+		klog.V(5).Infof("remote namespace %v translation not found, returning the original namespace", namespace)
+		return namespace
+	}
+}

--- a/internal/crdReplicator/peeringPhase.go
+++ b/internal/crdReplicator/peeringPhase.go
@@ -1,0 +1,62 @@
+package crdReplicator
+
+import (
+	"k8s.io/klog/v2"
+
+	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
+	"github.com/liqotech/liqo/pkg/consts"
+)
+
+func (c *Controller) getPeeringPhase(clusterID string) consts.PeeringPhase {
+	c.peeringPhasesMutex.RLock()
+	defer c.peeringPhasesMutex.RUnlock()
+	if c.peeringPhases == nil {
+		return consts.PeeringPhaseNone
+	}
+	if phase, ok := c.peeringPhases[clusterID]; ok {
+		return phase
+	} else {
+		return consts.PeeringPhaseNone
+	}
+}
+
+func (c *Controller) setPeeringPhase(clusterID string, phase consts.PeeringPhase) {
+	c.peeringPhasesMutex.Lock()
+	defer c.peeringPhasesMutex.Unlock()
+	if c.peeringPhases == nil {
+		c.peeringPhases = map[string]consts.PeeringPhase{}
+	}
+	c.peeringPhases[clusterID] = phase
+}
+
+func getPeeringPhase(fc *discoveryv1alpha1.ForeignCluster) consts.PeeringPhase {
+	if fc.Status.Incoming.Joined && fc.Status.Outgoing.Joined {
+		return consts.PeeringPhaseBidirectional
+	} else if fc.Status.Incoming.Joined {
+		return consts.PeeringPhaseIncoming
+	} else if fc.Status.Outgoing.Joined {
+		return consts.PeeringPhaseOutgoing
+	} else {
+		return consts.PeeringPhaseNone
+	}
+}
+
+func isReplicationEnabled(peeringPhase consts.PeeringPhase, resource resourceToReplicate) bool {
+	switch resource.peeringPhase {
+	case consts.PeeringPhaseNone:
+		return false
+	case consts.PeeringPhaseAll:
+		return true
+	case consts.PeeringPhaseBidirectional:
+		return peeringPhase == consts.PeeringPhaseBidirectional
+	case consts.PeeringPhaseIncoming:
+		return peeringPhase == consts.PeeringPhaseBidirectional || peeringPhase == consts.PeeringPhaseIncoming
+	case consts.PeeringPhaseOutgoing:
+		return peeringPhase == consts.PeeringPhaseBidirectional || peeringPhase == consts.PeeringPhaseOutgoing
+	case consts.PeeringPhaseEstablished:
+		return peeringPhase == consts.PeeringPhaseBidirectional || peeringPhase == consts.PeeringPhaseIncoming || peeringPhase == consts.PeeringPhaseOutgoing
+	default:
+		klog.Info("unknown peeringPhase %v", resource.peeringPhase)
+		return false
+	}
+}

--- a/internal/crdReplicator/peeringPhase.go
+++ b/internal/crdReplicator/peeringPhase.go
@@ -15,9 +15,8 @@ func (c *Controller) getPeeringPhase(clusterID string) consts.PeeringPhase {
 	}
 	if phase, ok := c.peeringPhases[clusterID]; ok {
 		return phase
-	} else {
-		return consts.PeeringPhaseNone
 	}
+	return consts.PeeringPhaseNone
 }
 
 func (c *Controller) setPeeringPhase(clusterID string, phase consts.PeeringPhase) {
@@ -55,7 +54,10 @@ func isReplicationEnabled(peeringPhase consts.PeeringPhase, resource resourceToR
 	case consts.PeeringPhaseOutgoing:
 		return peeringPhase == consts.PeeringPhaseBidirectional || peeringPhase == consts.PeeringPhaseOutgoing
 	case consts.PeeringPhaseEstablished:
-		return peeringPhase == consts.PeeringPhaseBidirectional || peeringPhase == consts.PeeringPhaseIncoming || peeringPhase == consts.PeeringPhaseOutgoing
+		bidirectional := peeringPhase == consts.PeeringPhaseBidirectional
+		incoming := peeringPhase == consts.PeeringPhaseIncoming
+		outgoing := peeringPhase == consts.PeeringPhaseOutgoing
+		return bidirectional || incoming || outgoing
 	default:
 		klog.Info("unknown peeringPhase %v", resource.peeringPhase)
 		return false

--- a/internal/crdReplicator/peeringPhase.go
+++ b/internal/crdReplicator/peeringPhase.go
@@ -1,4 +1,4 @@
-package crdReplicator
+package crdreplicator
 
 import (
 	"k8s.io/klog/v2"
@@ -32,20 +32,21 @@ func (c *Controller) setPeeringPhase(clusterID string, phase consts.PeeringPhase
 func getPeeringPhase(fc *discoveryv1alpha1.ForeignCluster) consts.PeeringPhase {
 	if fc.Status.Incoming.Joined && fc.Status.Outgoing.Joined {
 		return consts.PeeringPhaseBidirectional
-	} else if fc.Status.Incoming.Joined {
-		return consts.PeeringPhaseIncoming
-	} else if fc.Status.Outgoing.Joined {
-		return consts.PeeringPhaseOutgoing
-	} else {
-		return consts.PeeringPhaseNone
 	}
+	if fc.Status.Incoming.Joined {
+		return consts.PeeringPhaseIncoming
+	}
+	if fc.Status.Outgoing.Joined {
+		return consts.PeeringPhaseOutgoing
+	}
+	return consts.PeeringPhaseNone
 }
 
 func isReplicationEnabled(peeringPhase consts.PeeringPhase, resource resourceToReplicate) bool {
 	switch resource.peeringPhase {
 	case consts.PeeringPhaseNone:
 		return false
-	case consts.PeeringPhaseAll:
+	case consts.PeeringPhaseAny:
 		return true
 	case consts.PeeringPhaseBidirectional:
 		return peeringPhase == consts.PeeringPhaseBidirectional

--- a/internal/discovery/discovery-config.go
+++ b/internal/discovery/discovery-config.go
@@ -118,7 +118,7 @@ func (discovery *Controller) handleDispatcherConfig(config *configv1alpha1.Dispa
 	rules := []rbacv1.PolicyRule{}
 	for _, res := range config.ResourcesToReplicate {
 		rules = append(rules, rbacv1.PolicyRule{
-			Verbs:     []string{"*"},
+			Verbs:     []string{"get", "update", "patch", "list", "watch", "delete", "create"},
 			APIGroups: []string{res.Group},
 			Resources: []string{res.Resource, res.Resource + "/status"},
 		})

--- a/internal/discovery/foreign-cluster-operator/foreign-cluster-controller.go
+++ b/internal/discovery/foreign-cluster-operator/foreign-cluster-controller.go
@@ -497,7 +497,6 @@ func (r *ForeignClusterReconciler) Peer(
 // peerNamespaced enables the peering creating the resources in the correct TenantControlNamespace.
 func (r *ForeignClusterReconciler) peerNamespaced(foreignCluster *discoveryv1alpha1.ForeignCluster) (*discoveryv1alpha1.ForeignCluster, error) {
 	// create ResourceRequest
-	klog.Infof("[%v] Creating ResourceRequest", foreignCluster.Spec.ClusterIdentity.ClusterID)
 	resourceRequest, err := r.createResourceRequest(foreignCluster)
 	if err != nil {
 		klog.Error(err)
@@ -550,6 +549,7 @@ func (r *ForeignClusterReconciler) unpeerNamespaced(foreignCluster *discoveryv1a
 	}
 
 	foreignCluster.Status.Outgoing.Joined = false
+	klog.Infof("[%v] ResourceRequest Deleted", foreignCluster.Spec.ClusterIdentity.ClusterID)
 	return foreignCluster, nil
 }
 

--- a/internal/discovery/foreign-cluster-operator/foreign-cluster-controller.go
+++ b/internal/discovery/foreign-cluster-operator/foreign-cluster-controller.go
@@ -356,7 +356,7 @@ func (r *ForeignClusterReconciler) Reconcile( //nolint:gocyclo // this function 
 
 	// if join is required (both automatically or by user) and status is not set to joined
 	// create new peering request
-	if (foreignDiscoveryClient != nil || r.useNewAuth) && fc.Spec.Join && !fc.Status.Outgoing.Joined {
+	if (foreignDiscoveryClient != nil || r.useNewAuth) && fc.Spec.Join && !fc.Status.Outgoing.Joined && fc.DeletionTimestamp.IsZero() {
 		fc, err = r.Peer(fc, foreignDiscoveryClient)
 		if err != nil {
 			return ctrl.Result{
@@ -556,6 +556,7 @@ func (r *ForeignClusterReconciler) checkJoined(fc *discoveryv1alpha1.ForeignClus
 		_, err := r.crdClient.Resource("resourcerequests").Namespace(
 			fc.Status.TenantControlNamespace.Local).Get(r.clusterID.GetClusterID(), &metav1.GetOptions{})
 		if err != nil {
+			klog.Error(err)
 			fc.Status.Outgoing.Joined = false
 			if slice.ContainsString(fc.Finalizers, FinalizerString, nil) {
 				fc.Finalizers = slice.RemoveString(fc.Finalizers, FinalizerString, nil)

--- a/internal/discovery/foreign-cluster-operator/foreign-cluster-controller.go
+++ b/internal/discovery/foreign-cluster-operator/foreign-cluster-controller.go
@@ -38,7 +38,7 @@ import (
 	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
 	netv1alpha1 "github.com/liqotech/liqo/apis/net/v1alpha1"
 	advtypes "github.com/liqotech/liqo/apis/sharing/v1alpha1"
-	"github.com/liqotech/liqo/internal/crdReplicator"
+	crdreplicator "github.com/liqotech/liqo/internal/crdReplicator"
 	"github.com/liqotech/liqo/internal/discovery"
 	"github.com/liqotech/liqo/internal/discovery/utils"
 	"github.com/liqotech/liqo/pkg/auth"
@@ -1140,14 +1140,14 @@ func (r *ForeignClusterReconciler) getAutoJoinUntrusted(fc *discoveryv1alpha1.Fo
 
 func (r *ForeignClusterReconciler) checkNetwork(fc *discoveryv1alpha1.ForeignCluster, requireUpdate *bool) error {
 	// local NetworkConfig
-	labelSelector := strings.Join([]string{crdReplicator.DestinationLabel, fc.Spec.ClusterIdentity.ClusterID}, "=")
+	labelSelector := strings.Join([]string{crdreplicator.DestinationLabel, fc.Spec.ClusterIdentity.ClusterID}, "=")
 	if err := r.updateNetwork(labelSelector, &fc.Status.Network.LocalNetworkConfig, requireUpdate); err != nil {
 		klog.Error(err)
 		return err
 	}
 
 	// remote NetworkConfig
-	labelSelector = strings.Join([]string{crdReplicator.RemoteLabelSelector, fc.Spec.ClusterIdentity.ClusterID}, "=")
+	labelSelector = strings.Join([]string{crdreplicator.RemoteLabelSelector, fc.Spec.ClusterIdentity.ClusterID}, "=")
 	return r.updateNetwork(labelSelector, &fc.Status.Network.RemoteNetworkConfig, requireUpdate)
 }
 

--- a/internal/discovery/foreign-cluster-operator/foreign-cluster-controller.go
+++ b/internal/discovery/foreign-cluster-operator/foreign-cluster-controller.go
@@ -354,9 +354,23 @@ func (r *ForeignClusterReconciler) Reconcile( //nolint:gocyclo // this function 
 		requireUpdate = true
 	}
 
+	if update, err := r.getRemoteTenantNamespace(fc); err != nil {
+		klog.Error(err)
+		return ctrl.Result{
+			Requeue:      true,
+			RequeueAfter: r.RequeueAfter,
+		}, err
+	} else if update {
+		requireUpdate = true
+	}
+	remoteNamespace := ""
+	if r.useNewAuth {
+		remoteNamespace = fc.Status.TenantControlNamespace.Remote
+	}
+
 	// if join is required (both automatically or by user) and status is not set to joined
 	// create new peering request
-	if (foreignDiscoveryClient != nil || r.useNewAuth) && fc.Spec.Join && !fc.Status.Outgoing.Joined && fc.DeletionTimestamp.IsZero() {
+	if (foreignDiscoveryClient != nil || remoteNamespace != "") && fc.Spec.Join && !fc.Status.Outgoing.Joined && fc.DeletionTimestamp.IsZero() {
 		fc, err = r.Peer(fc, foreignDiscoveryClient)
 		if err != nil {
 			return ctrl.Result{
@@ -370,7 +384,7 @@ func (r *ForeignClusterReconciler) Reconcile( //nolint:gocyclo // this function 
 	// if join is no more required and status is set to joined
 	// or if this foreign cluster is being deleted
 	// delete peering request
-	if (foreignDiscoveryClient != nil || r.useNewAuth) && (!fc.Spec.Join || !fc.DeletionTimestamp.IsZero()) && fc.Status.Outgoing.Joined {
+	if (foreignDiscoveryClient != nil || remoteNamespace != "") && (!fc.Spec.Join || !fc.DeletionTimestamp.IsZero()) && fc.Status.Outgoing.Joined {
 		fc, err = r.Unpeer(fc, foreignDiscoveryClient)
 		if err != nil {
 			return ctrl.Result{
@@ -403,7 +417,7 @@ func (r *ForeignClusterReconciler) Reconcile( //nolint:gocyclo // this function 
 	}
 
 	// check if peering request really exists on foreign cluster
-	if (foreignDiscoveryClient != nil || r.useNewAuth) && fc.Spec.Join && fc.Status.Outgoing.Joined {
+	if (foreignDiscoveryClient != nil || remoteNamespace != "") && fc.Spec.Join && fc.Status.Outgoing.Joined {
 		_, err = r.checkJoined(fc, foreignDiscoveryClient)
 		if err != nil {
 			klog.Error(err, err.Error())

--- a/internal/discovery/foreign-cluster-operator/resourceRequest.go
+++ b/internal/discovery/foreign-cluster-operator/resourceRequest.go
@@ -27,6 +27,7 @@ func (r *ForeignClusterReconciler) createResourceRequest(
 	resourceRequest, ok := tmp.(*discoveryv1alpha1.ResourceRequest)
 	// if resource request does not exists
 	if errors.IsNotFound(err) || !ok {
+		klog.Infof("[%v] Creating ResourceRequest", foreignCluster.Spec.ClusterIdentity.ClusterID)
 		if _, err = r.namespaceManager.BindClusterRoles(remoteClusterID, r.peeringPermission.Outgoing...); err != nil {
 			klog.Error(err)
 			return nil, err
@@ -73,6 +74,7 @@ func (r *ForeignClusterReconciler) createResourceRequest(
 		if !ok {
 			return nil, goerrors.New("created object is not a ResourceRequest")
 		}
+		klog.Infof("[%v] ResourceRequest Created", foreignCluster.Spec.ClusterIdentity.ClusterID)
 	}
 	// already exists
 	return resourceRequest, nil

--- a/internal/discovery/foreign-cluster-operator/resourceRequest.go
+++ b/internal/discovery/foreign-cluster-operator/resourceRequest.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/klog"
 
 	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
+	"github.com/liqotech/liqo/internal/crdReplicator"
 )
 
 // createResourceRequest creates a resource request to be sent to the specified ForeignCluster.
@@ -48,6 +49,10 @@ func (r *ForeignClusterReconciler) createResourceRequest(
 						Name: foreignCluster.Name,
 						UID:  foreignCluster.UID,
 					},
+				},
+				Labels: map[string]string{
+					crdReplicator.LocalLabelSelector: "true",
+					crdReplicator.DestinationLabel:   remoteClusterID,
 				},
 			},
 			Spec: discoveryv1alpha1.ResourceRequestSpec{

--- a/internal/discovery/foreign-cluster-operator/resourceRequest.go
+++ b/internal/discovery/foreign-cluster-operator/resourceRequest.go
@@ -9,7 +9,7 @@ import (
 	"k8s.io/klog"
 
 	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
-	"github.com/liqotech/liqo/internal/crdReplicator"
+	crdreplicator "github.com/liqotech/liqo/internal/crdReplicator"
 )
 
 // createResourceRequest creates a resource request to be sent to the specified ForeignCluster.
@@ -51,8 +51,8 @@ func (r *ForeignClusterReconciler) createResourceRequest(
 					},
 				},
 				Labels: map[string]string{
-					crdReplicator.LocalLabelSelector: "true",
-					crdReplicator.DestinationLabel:   remoteClusterID,
+					crdreplicator.LocalLabelSelector: "true",
+					crdreplicator.DestinationLabel:   remoteClusterID,
 				},
 			},
 			Spec: discoveryv1alpha1.ResourceRequestSpec{

--- a/internal/liqonet/tunnelEndpointCreator/secretWatcher.go
+++ b/internal/liqonet/tunnelEndpointCreator/secretWatcher.go
@@ -16,7 +16,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	netv1alpha1 "github.com/liqotech/liqo/apis/net/v1alpha1"
-	"github.com/liqotech/liqo/internal/crdReplicator"
+	crdreplicator "github.com/liqotech/liqo/internal/crdReplicator"
 	"github.com/liqotech/liqo/pkg/liqonet/tunnel/wireguard"
 )
 
@@ -73,7 +73,7 @@ func (tec *TunnelEndpointCreator) secretHandlerAdd(obj interface{}) {
 		tec.wgConfigured = true
 	}
 	netConfigs := &netv1alpha1.NetworkConfigList{}
-	labels := client.MatchingLabels{crdReplicator.LocalLabelSelector: "true"}
+	labels := client.MatchingLabels{crdreplicator.LocalLabelSelector: "true"}
 	err = tec.Client.List(context.Background(), netConfigs, labels)
 	if err != nil {
 		klog.Errorf("unable to retrieve the existing resources of type %s in order to update the publicKey for the vpn backend: %v", netv1alpha1.NetworkConfigGroupVersionResource.String(), err)

--- a/internal/liqonet/tunnelEndpointCreator/serviceWatcher.go
+++ b/internal/liqonet/tunnelEndpointCreator/serviceWatcher.go
@@ -16,7 +16,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	netv1alpha1 "github.com/liqotech/liqo/apis/net/v1alpha1"
-	"github.com/liqotech/liqo/internal/crdReplicator"
+	crdreplicator "github.com/liqotech/liqo/internal/crdReplicator"
 	"github.com/liqotech/liqo/pkg/liqonet/tunnel/wireguard"
 )
 
@@ -118,7 +118,7 @@ func (tec *TunnelEndpointCreator) serviceHandlerAdd(obj interface{}) {
 			tec.svcConfigured = true
 		}
 		netConfigs := &netv1alpha1.NetworkConfigList{}
-		labels := client.MatchingLabels{crdReplicator.LocalLabelSelector: "true"}
+		labels := client.MatchingLabels{crdreplicator.LocalLabelSelector: "true"}
 		err = tec.Client.List(context.Background(), netConfigs, labels)
 		if err != nil {
 			klog.Errorf("unable to retrieve the existing resources of type %s in order to update the publicKey for the vpn backend: %v", netv1alpha1.NetworkConfigGroupVersionResource.String(), err)

--- a/internal/liqonet/tunnelEndpointCreator/tunnelEndpointCreator-operator.go
+++ b/internal/liqonet/tunnelEndpointCreator/tunnelEndpointCreator-operator.go
@@ -42,7 +42,7 @@ import (
 	netv1alpha1 "github.com/liqotech/liqo/apis/net/v1alpha1"
 
 	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
-	"github.com/liqotech/liqo/internal/crdReplicator"
+	crdreplicator "github.com/liqotech/liqo/internal/crdReplicator"
 	liqoconst "github.com/liqotech/liqo/pkg/consts"
 	liqonet "github.com/liqotech/liqo/pkg/liqonet"
 	"github.com/liqotech/liqo/pkg/liqonet/tunnel/wireguard"
@@ -197,10 +197,10 @@ func (tec *TunnelEndpointCreator) Reconcile(req ctrl.Request) (ctrl.Result, erro
 
 	// check if the netconfig is local or remote
 	labels := netConfig.GetLabels()
-	if val, ok := labels[crdReplicator.LocalLabelSelector]; ok && val == "true" {
+	if val, ok := labels[crdreplicator.LocalLabelSelector]; ok && val == "true" {
 		return result, tec.processLocalNetConfig(&netConfig)
 	}
-	if _, ok := labels[crdReplicator.RemoteLabelSelector]; ok {
+	if _, ok := labels[crdreplicator.RemoteLabelSelector]; ok {
 		return result, tec.processRemoteNetConfig(&netConfig)
 	}
 	return result, nil
@@ -248,8 +248,8 @@ func (tec *TunnelEndpointCreator) createNetConfig(fc *discoveryv1alpha1.ForeignC
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: netConfigNamePrefix,
 			Labels: map[string]string{
-				crdReplicator.LocalLabelSelector: "true",
-				crdReplicator.DestinationLabel:   clusterID,
+				crdreplicator.LocalLabelSelector: "true",
+				crdreplicator.DestinationLabel:   clusterID,
 			},
 			OwnerReferences: []metav1.OwnerReference{
 				{
@@ -295,7 +295,7 @@ func (tec *TunnelEndpointCreator) createNetConfig(fc *discoveryv1alpha1.ForeignC
 func (tec *TunnelEndpointCreator) deleteNetConfig(fc *discoveryv1alpha1.ForeignCluster) error {
 	clusterID := fc.Spec.ClusterIdentity.ClusterID
 	netConfigList := &netv1alpha1.NetworkConfigList{}
-	labels := client.MatchingLabels{crdReplicator.DestinationLabel: clusterID}
+	labels := client.MatchingLabels{crdreplicator.DestinationLabel: clusterID}
 	err := tec.List(context.Background(), netConfigList, labels)
 	if err != nil {
 		klog.Errorf("an error occurred while listing resources: %s", err)
@@ -338,7 +338,7 @@ func (tec *TunnelEndpointCreator) GetNetworkConfig(destinationClusterID string) 
 	error) {
 	clusterID := destinationClusterID
 	networkConfigList := &netv1alpha1.NetworkConfigList{}
-	labels := client.MatchingLabels{crdReplicator.DestinationLabel: clusterID}
+	labels := client.MatchingLabels{crdreplicator.DestinationLabel: clusterID}
 	err := tec.List(context.Background(), networkConfigList, labels)
 	if err != nil {
 		klog.Errorf("an error occurred while listing resources of type %s: %s", netv1alpha1.GroupVersion, err)
@@ -362,7 +362,7 @@ func (tec *TunnelEndpointCreator) processRemoteNetConfig(netConfig *netv1alpha1.
 	// the clusterid of the destination cluster(the local cluster in this case)
 	// In order to take the ClusterID of the sender we need to retrieve it from the labels.
 	podCIDR, externalCIDR, err := tec.IPManager.GetSubnetsPerCluster(netConfig.Spec.PodCIDR,
-		netConfig.Spec.ExternalCIDR, netConfig.Labels[crdReplicator.RemoteLabelSelector])
+		netConfig.Spec.ExternalCIDR, netConfig.Labels[crdreplicator.RemoteLabelSelector])
 	if err != nil {
 		klog.Errorf("an error occurred while getting a new subnet for resource %s: %s", netConfig.Name, err)
 		return err
@@ -427,7 +427,7 @@ func (tec *TunnelEndpointCreator) processRemoteNetConfig(netConfig *netv1alpha1.
 func (tec *TunnelEndpointCreator) processLocalNetConfig(netConfig *netv1alpha1.NetworkConfig) error {
 	// first check that this is the only resource for the remote cluster
 	netConfigList := &netv1alpha1.NetworkConfigList{}
-	labels := client.MatchingLabels{crdReplicator.DestinationLabel: netConfig.Labels[crdReplicator.DestinationLabel]}
+	labels := client.MatchingLabels{crdreplicator.DestinationLabel: netConfig.Labels[crdreplicator.DestinationLabel]}
 	err := tec.List(context.Background(), netConfigList, labels)
 	if err != nil {
 		klog.Errorf("an error occurred while listing resources: %s", err)
@@ -455,7 +455,7 @@ func (tec *TunnelEndpointCreator) processLocalNetConfig(netConfig *netv1alpha1.N
 	}
 	// we get the remote netconfig related to this one
 	netConfigList = &netv1alpha1.NetworkConfigList{}
-	labels = client.MatchingLabels{crdReplicator.RemoteLabelSelector: netConfig.Spec.ClusterID}
+	labels = client.MatchingLabels{crdreplicator.RemoteLabelSelector: netConfig.Spec.ClusterID}
 	err = tec.List(context.Background(), netConfigList, labels)
 	if err != nil {
 		klog.Errorf("an error occurred while listing resources: %s", err)

--- a/pkg/clusterid/staticClusterID.go
+++ b/pkg/clusterid/staticClusterID.go
@@ -4,16 +4,19 @@ type staticClusterID struct {
 	id string
 }
 
+// NewStaticClusterID returns a clusterID interface compliant object that stores a read-only clusterID.
 func NewStaticClusterID(clusterID string) ClusterID {
 	return &staticClusterID{
 		id: clusterID,
 	}
 }
 
+// SetupClusterID function not implemented.
 func (staticCID *staticClusterID) SetupClusterID(namespace string) error {
 	panic("not implemented")
 }
 
+// GetClusterID returns the clusterID string.
 func (staticCID *staticClusterID) GetClusterID() string {
 	return staticCID.id
 }

--- a/pkg/clusterid/staticClusterID.go
+++ b/pkg/clusterid/staticClusterID.go
@@ -1,0 +1,19 @@
+package clusterid
+
+type staticClusterID struct {
+	id string
+}
+
+func NewStaticClusterID(clusterID string) ClusterID {
+	return &staticClusterID{
+		id: clusterID,
+	}
+}
+
+func (staticCID *staticClusterID) SetupClusterID(namespace string) error {
+	panic("not implemented")
+}
+
+func (staticCID *staticClusterID) GetClusterID() string {
+	return staticCID.id
+}

--- a/pkg/consts/peering.go
+++ b/pkg/consts/peering.go
@@ -1,0 +1,12 @@
+package consts
+
+type PeeringPhase string
+
+const (
+	PeeringPhaseNone          PeeringPhase = "None"
+	PeeringPhaseAll           PeeringPhase = "All"
+	PeeringPhaseEstablished   PeeringPhase = "Established"
+	PeeringPhaseIncoming      PeeringPhase = "Incoming"
+	PeeringPhaseOutgoing      PeeringPhase = "Outgoing"
+	PeeringPhaseBidirectional PeeringPhase = "Bidirectional"
+)

--- a/pkg/consts/peering.go
+++ b/pkg/consts/peering.go
@@ -1,12 +1,19 @@
 package consts
 
+// PeeringPhase contains the status of the peering with a remote cluster.
 type PeeringPhase string
 
 const (
-	PeeringPhaseNone          PeeringPhase = "None"
-	PeeringPhaseAll           PeeringPhase = "All"
-	PeeringPhaseEstablished   PeeringPhase = "Established"
-	PeeringPhaseIncoming      PeeringPhase = "Incoming"
-	PeeringPhaseOutgoing      PeeringPhase = "Outgoing"
+	// PeeringPhaseNone no pering has been established.
+	PeeringPhaseNone PeeringPhase = "None"
+	// PeeringPhaseAny indicates that we have not be in any specific peering phase.
+	PeeringPhaseAny PeeringPhase = "Any"
+	// PeeringPhaseEstablished the peering has been established.
+	PeeringPhaseEstablished PeeringPhase = "Established"
+	// PeeringPhaseIncoming an incoming peering has been established.
+	PeeringPhaseIncoming PeeringPhase = "Incoming"
+	// PeeringPhaseOutgoing an outgoing peering has been established.
+	PeeringPhaseOutgoing PeeringPhase = "Outgoing"
+	// PeeringPhaseBidirectional both incoming and outgoing peerings has been established.
 	PeeringPhaseBidirectional PeeringPhase = "Bidirectional"
 )

--- a/pkg/identityManager/interface.go
+++ b/pkg/identityManager/interface.go
@@ -20,6 +20,7 @@ type localManager interface {
 	StoreCertificate(remoteClusterID string, identityResponse auth.CertificateIdentityResponse) error
 
 	GetConfig(remoteClusterID string, namespace string) (*rest.Config, error)
+	GetRemoteTenantNamespace(remoteClusterID string, namespace string) (string, error)
 }
 
 // interface that allows to manage the identity in the target cluster, where this identity has to be used.

--- a/pkg/peering-roles/basic/basic.go
+++ b/pkg/peering-roles/basic/basic.go
@@ -3,5 +3,5 @@
 // this ClusterRole has the basic permissions to give to a remote cluster
 package basic
 
-// +kubebuilder:rbac:groups=discovery.liqo.io,resources=resourcerequests,verbs=get;update;patch;list;watch;delete
-// +kubebuilder:rbac:groups=discovery.liqo.io,resources=resourcerequests/status,verbs=get;update;patch;list;watch;delete
+// +kubebuilder:rbac:groups=discovery.liqo.io,resources=resourcerequests,verbs=get;update;patch;list;watch;delete;create
+// +kubebuilder:rbac:groups=discovery.liqo.io,resources=resourcerequests/status,verbs=get;update;patch;list;watch;delete;create

--- a/pkg/peering-roles/incoming/incoming.go
+++ b/pkg/peering-roles/incoming/incoming.go
@@ -4,5 +4,5 @@
 // when the Pods will be offloaded to the local cluster
 package incoming
 
-// +kubebuilder:rbac:groups=net.liqo.io,resources=networkconfigs,verbs=get;update;patch;list;watch;delete
-// +kubebuilder:rbac:groups=net.liqo.io,resources=networkconfigs/status,verbs=get;update;patch;list;watch;delete
+// +kubebuilder:rbac:groups=net.liqo.io,resources=networkconfigs,verbs=get;update;patch;list;watch;delete;create
+// +kubebuilder:rbac:groups=net.liqo.io,resources=networkconfigs/status,verbs=get;update;patch;list;watch;delete;create

--- a/pkg/peering-roles/outgoing/outgoing.go
+++ b/pkg/peering-roles/outgoing/outgoing.go
@@ -7,5 +7,5 @@ package outgoing
 // +kubebuilder:rbac:groups=net.liqo.io,resources=networkconfigs,verbs=get;update;patch;list;watch;delete;create
 // +kubebuilder:rbac:groups=net.liqo.io,resources=networkconfigs/status,verbs=get;update;patch;list;watch;delete;create
 
-// +kubebuilder:rbac:groups=discovery.liqo.io,resources=resourceoffers,verbs=get;update;patch;list;watch;delete;create
-// +kubebuilder:rbac:groups=discovery.liqo.io,resources=resourceoffers/status,verbs=get;update;patch;list;watch;delete;create
+// +kubebuilder:rbac:groups=sharing.liqo.io,resources=resourceoffers,verbs=get;update;patch;list;watch;delete;create
+// +kubebuilder:rbac:groups=sharing.liqo.io,resources=resourceoffers/status,verbs=get;update;patch;list;watch;delete;create

--- a/pkg/peering-roles/outgoing/outgoing.go
+++ b/pkg/peering-roles/outgoing/outgoing.go
@@ -4,8 +4,8 @@
 // when the Pods will be offloaded from the local cluster
 package outgoing
 
-// +kubebuilder:rbac:groups=net.liqo.io,resources=networkconfigs,verbs=get;update;patch;list;watch;delete
-// +kubebuilder:rbac:groups=net.liqo.io,resources=networkconfigs/status,verbs=get;update;patch;list;watch;delete
+// +kubebuilder:rbac:groups=net.liqo.io,resources=networkconfigs,verbs=get;update;patch;list;watch;delete;create
+// +kubebuilder:rbac:groups=net.liqo.io,resources=networkconfigs/status,verbs=get;update;patch;list;watch;delete;create
 
-// +kubebuilder:rbac:groups=discovery.liqo.io,resources=resourceoffers,verbs=get;update;patch;list;watch;delete
-// +kubebuilder:rbac:groups=discovery.liqo.io,resources=resourceoffers/status,verbs=get;update;patch;list;watch;delete
+// +kubebuilder:rbac:groups=discovery.liqo.io,resources=resourceoffers,verbs=get;update;patch;list;watch;delete;create
+// +kubebuilder:rbac:groups=discovery.liqo.io,resources=resourceoffers/status,verbs=get;update;patch;list;watch;delete;create

--- a/test/unit/crdReplicator/crdReplicator-operator_test.go
+++ b/test/unit/crdReplicator/crdReplicator-operator_test.go
@@ -17,7 +17,7 @@ import (
 	"k8s.io/klog/v2"
 
 	netv1alpha1 "github.com/liqotech/liqo/apis/net/v1alpha1"
-	"github.com/liqotech/liqo/internal/crdReplicator"
+	crdreplicator "github.com/liqotech/liqo/internal/crdReplicator"
 )
 
 var (
@@ -36,8 +36,8 @@ var (
 func setupDispatcherOperator() error {
 	var err error
 	localDynClient := dynamic.NewForConfigOrDie(k8sManagerLocal.GetConfig())
-	localDynFac := dynamicinformer.NewFilteredDynamicSharedInformerFactory(localDynClient, crdReplicator.ResyncPeriod, metav1.NamespaceAll, crdReplicator.SetLabelsForLocalResources)
-	dOperator = &crdReplicator.Controller{
+	localDynFac := dynamicinformer.NewFilteredDynamicSharedInformerFactory(localDynClient, crdreplicator.ResyncPeriod, metav1.NamespaceAll, crdreplicator.SetLabelsForLocalResources)
+	dOperator = &crdreplicator.Controller{
 		Scheme:                         k8sManagerLocal.GetScheme(),
 		Client:                         k8sManagerLocal.GetClient(),
 		ClientSet:                      nil,
@@ -153,8 +153,8 @@ func TestReplication2(t *testing.T) {
 		tun := getTunnelEndpointResource()
 		tun.SetName(clusterID)
 		tun.SetLabels(map[string]string{
-			crdReplicator.DestinationLabel:   clusterID,
-			crdReplicator.LocalLabelSelector: "true",
+			crdreplicator.DestinationLabel:   clusterID,
+			crdreplicator.LocalLabelSelector: "true",
 		})
 		newTun, err := dOperator.LocalDynClient.Resource(tunGVR).Create(context.TODO(), tun, metav1.CreateOptions{})
 		assert.Nil(t, err, "error should be nil")
@@ -191,8 +191,8 @@ func TestReplication4(t *testing.T) {
 		tun := getTunnelEndpointResource()
 		tun.SetName(clusterID)
 		tun.SetLabels(map[string]string{
-			crdReplicator.DestinationLabel:   clusterID,
-			crdReplicator.LocalLabelSelector: "true",
+			crdreplicator.DestinationLabel:   clusterID,
+			crdreplicator.LocalLabelSelector: "true",
 		})
 		newTun, err := dOperator.LocalDynClient.Resource(tunGVR).Create(context.TODO(), tun, metav1.CreateOptions{})
 		assert.Nil(t, err, "error should be nil")
@@ -256,8 +256,8 @@ func TestReplication3(t *testing.T) {
 		tun := getTunnelEndpointResource()
 		tun.SetName(clusterID)
 		tun.SetLabels(map[string]string{
-			crdReplicator.DestinationLabel:   clusterID,
-			crdReplicator.LocalLabelSelector: "true",
+			crdreplicator.DestinationLabel:   clusterID,
+			crdreplicator.LocalLabelSelector: "true",
 		})
 		newTun, err := dOperator.LocalDynClient.Resource(tunGVR).Create(context.TODO(), tun, metav1.CreateOptions{})
 		assert.Nil(t, err, "error should be nil")

--- a/test/unit/crdReplicator/env_test.go
+++ b/test/unit/crdReplicator/env_test.go
@@ -21,7 +21,7 @@ import (
 	configv1alpha1 "github.com/liqotech/liqo/apis/config/v1alpha1"
 	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
 	netv1alpha1 "github.com/liqotech/liqo/apis/net/v1alpha1"
-	"github.com/liqotech/liqo/internal/crdReplicator"
+	crdreplicator "github.com/liqotech/liqo/internal/crdReplicator"
 	crdclient "github.com/liqotech/liqo/pkg/crdClient"
 )
 
@@ -37,7 +37,7 @@ var (
 	configClusterClient         *crdclient.CRDClient
 	k8sManagerLocal             ctrl.Manager
 	testEnvLocal                *envtest.Environment
-	dOperator                   *crdReplicator.Controller
+	dOperator                   *crdreplicator.Controller
 )
 
 func TestMain(m *testing.M) {
@@ -133,9 +133,9 @@ func setupEnv() {
 		peeringClustersManagers[peeringClusterID] = manager
 		dynClient := dynamic.NewForConfigOrDie(manager.GetConfig())
 		peeringClustersDynClients[peeringClusterID] = dynClient
-		dynFac := dynamicinformer.NewFilteredDynamicSharedInformerFactory(dynClient, crdReplicator.ResyncPeriod, metav1.NamespaceAll, func(options *metav1.ListOptions) {
+		dynFac := dynamicinformer.NewFilteredDynamicSharedInformerFactory(dynClient, crdreplicator.ResyncPeriod, metav1.NamespaceAll, func(options *metav1.ListOptions) {
 			//we want to watch only the resources that have been created by us on the remote cluster
-			options.LabelSelector = crdReplicator.RemoteLabelSelector + "=" + localClusterID
+			options.LabelSelector = crdreplicator.RemoteLabelSelector + "=" + localClusterID
 		})
 		peeringClustersDynFactories[peeringClusterID] = dynFac
 	}


### PR DESCRIPTION
# Description

This pr includes a new feature for the CrdReplicator that allows Liqo to replicate resources in different namespaces. This feature will be used to replicate the peering-related resources in the Tenant Control Namespaces over the two peered clusters.

This also includes a logic to tell the CrdReplicator in which peering phase each resource replication has to be active.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B
