### PR TITLE
Virtual Kubelet: propagate resync period to cache manager

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,6 +5,10 @@ run:
     - ".*_test.go"
 
 linters-settings:
+  exhaustive:
+    check-generated: false
+    default-signifies-exhaustive: true
+
   lll:
     line-length: 150
   gomodguard:
@@ -56,6 +60,7 @@ linters:
     - errcheck
     - errorlint
     - exhaustive
+    - exportloopref
   # - funlen
   # - gochecknoglobals
   # - gochecknoinits
@@ -85,7 +90,6 @@ linters:
     - nolintlint
   # - prealloc
     - rowserrcheck
-    - scopelint
     - staticcheck
     - structcheck
     - stylecheck
@@ -100,11 +104,11 @@ linters:
 
 issues:
   #fix: true
+
   max-issues-per-linter: 0
   max-same-issues: 0
+
   # Disable the default exclude patterns (as they disable the mandatory comments)
-  max-issues-per-linter: 0
-  max-same-issues: 0
   exclude-use-default: false
   exclude:
     # errcheck: Almost all programs ignore errors on these functions and in most cases it's ok

--- a/cmd/virtual-kubelet/provider/store.go
+++ b/cmd/virtual-kubelet/provider/store.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"sync"
+	"time"
 
 	"github.com/liqotech/liqo/internal/utils/errdefs"
 	"github.com/liqotech/liqo/pkg/virtualKubelet/manager"
@@ -62,15 +63,16 @@ func (s *Store) Exists(name string) bool {
 
 // InitConfig is the config passed to initialize a registered provider.
 type InitConfig struct {
-	ConfigPath        string
-	NodeName          string
-	InternalIP        string
-	DaemonPort        int32
-	KubeClusterDomain string
-	ResourceManager   *manager.ResourceManager
-	ClusterId         string
-	RemoteKubeConfig  string
-	HomeClusterId     string
+	ConfigPath           string
+	NodeName             string
+	InternalIP           string
+	DaemonPort           int32
+	KubeClusterDomain    string
+	ResourceManager      *manager.ResourceManager
+	ClusterId            string
+	RemoteKubeConfig     string
+	HomeClusterId        string
+	InformerResyncPeriod time.Duration
 }
 
 type InitFunc func(InitConfig) (Provider, error)

--- a/cmd/virtual-kubelet/provider/store.go
+++ b/cmd/virtual-kubelet/provider/store.go
@@ -14,6 +14,7 @@ type Store struct {
 	ls map[string]InitFunc
 }
 
+// NewStore creates a new Store instance.
 func NewStore() *Store {
 	return &Store{
 		ls: make(map[string]InitFunc),
@@ -63,16 +64,17 @@ func (s *Store) Exists(name string) bool {
 
 // InitConfig is the config passed to initialize a registered provider.
 type InitConfig struct {
-	ConfigPath           string
 	NodeName             string
 	InternalIP           string
 	DaemonPort           int32
 	KubeClusterDomain    string
 	ResourceManager      *manager.ResourceManager
-	ClusterId            string
+	HomeKubeConfig       string
 	RemoteKubeConfig     string
-	HomeClusterId        string
+	HomeClusterID        string
+	RemoteClusterID      string
 	InformerResyncPeriod time.Duration
 }
 
+// InitFunc defines the signature of the function creating a Provider instance based on the corresponding configuration.
 type InitFunc func(InitConfig) (Provider, error)

--- a/cmd/virtual-kubelet/register.go
+++ b/cmd/virtual-kubelet/register.go
@@ -6,14 +6,14 @@ import (
 )
 
 func registerKubernetes(s *provider.Store) error {
-	return s.Register("kubernetes", func(cfg provider.InitConfig) (provider.Provider, error) { //nolint:errcheck
+	return s.Register("kubernetes", func(cfg provider.InitConfig) (provider.Provider, error) {
 		return liqoProvider.NewLiqoProvider(
 			cfg.NodeName,
-			cfg.ClusterId,
-			cfg.HomeClusterId,
+			cfg.RemoteClusterID,
+			cfg.HomeClusterID,
 			cfg.InternalIP,
 			cfg.DaemonPort,
-			cfg.ConfigPath,
+			cfg.HomeKubeConfig,
 			cfg.RemoteKubeConfig,
 			cfg.InformerResyncPeriod,
 		)

--- a/cmd/virtual-kubelet/register.go
+++ b/cmd/virtual-kubelet/register.go
@@ -15,6 +15,7 @@ func registerKubernetes(s *provider.Store) error {
 			cfg.DaemonPort,
 			cfg.ConfigPath,
 			cfg.RemoteKubeConfig,
+			cfg.InformerResyncPeriod,
 		)
 	})
 }

--- a/cmd/virtual-kubelet/root/root.go
+++ b/cmd/virtual-kubelet/root/root.go
@@ -111,15 +111,16 @@ func runRootCommand(ctx context.Context, s *provider.Store, c *Opts) error {
 	}
 
 	initConfig := provider.InitConfig{
-		ConfigPath:        c.HomeKubeconfig,
-		NodeName:          c.NodeName,
-		ResourceManager:   rm,
-		DaemonPort:        c.ListenPort,
-		InternalIP:        os.Getenv("VKUBELET_POD_IP"),
-		KubeClusterDomain: c.KubeClusterDomain,
-		ClusterId:         c.ForeignClusterId,
-		HomeClusterId:     c.HomeClusterId,
-		RemoteKubeConfig:  c.ForeignKubeconfig,
+		ConfigPath:           c.HomeKubeconfig,
+		NodeName:             c.NodeName,
+		ResourceManager:      rm,
+		DaemonPort:           c.ListenPort,
+		InternalIP:           os.Getenv("VKUBELET_POD_IP"),
+		KubeClusterDomain:    c.KubeClusterDomain,
+		ClusterId:            c.ForeignClusterId,
+		HomeClusterId:        c.HomeClusterId,
+		RemoteKubeConfig:     c.ForeignKubeconfig,
+		InformerResyncPeriod: c.InformerResyncPeriod,
 	}
 
 	pInit := s.Get(c.Provider)

--- a/pkg/virtualKubelet/apiReflection/controller/controller.go
+++ b/pkg/virtualKubelet/apiReflection/controller/controller.go
@@ -19,7 +19,8 @@ const (
 	nIncomingReflectionWorkers = 2
 )
 
-type ApiController interface {
+// APIController defines the interface exposed by a controller implementing API reflection.
+type APIController interface {
 	SetInformingFunc(apiReflection.ApiType, func(interface{}))
 	CacheManager() storage.CacheManagerReaderAdder
 	StartController()
@@ -27,6 +28,7 @@ type ApiController interface {
 	StopReflection(restart bool)
 }
 
+// Controller is a concrete implementation of the ApiController interface.
 type Controller struct {
 	mapper                       namespacesMapping.MapperController
 	cacheManager                 storage.CacheManagerReaderAdder
@@ -45,7 +47,9 @@ type Controller struct {
 	stopController chan struct{}
 }
 
-func NewApiController(homeClient, foreignClient kubernetes.Interface, informerResyncPeriod time.Duration, mapper namespacesMapping.MapperController, opts map[options.OptionKey]options.Option, tepReady chan struct{}) *Controller {
+// NewAPIController returns a Controller instance for a given set of home and foreign clients.
+func NewAPIController(homeClient, foreignClient kubernetes.Interface, informerResyncPeriod time.Duration,
+	mapper namespacesMapping.MapperController, opts map[options.OptionKey]options.Option, tepReady chan struct{}) *Controller {
 	klog.V(2).Infof("starting reflection manager")
 
 	outgoingReflectionInforming := make(chan apiReflection.ApiEvent)
@@ -109,14 +113,17 @@ func (c *Controller) incomingReflectionControlLoop() {
 	}
 }
 
+// SetInformingFunc configures the handlers triggered for a certain API type by incoming reflection events.
 func (c *Controller) SetInformingFunc(api apiReflection.ApiType, handler func(interface{})) {
 	c.incomingReflectorsController.SetInforming(api, handler)
 }
 
+// CacheManager returns the CacheManager associated with the controller.
 func (c *Controller) CacheManager() storage.CacheManagerReaderAdder {
 	return c.cacheManager
 }
 
+// StartController spawns the worker threads and starts the reflection control loops.
 func (c *Controller) StartController() {
 	klog.V(2).Info("starting api controller")
 
@@ -139,6 +146,7 @@ func (c *Controller) StartController() {
 	klog.V(2).Infof("api controller started with %v workers", nOutgoingReflectionWorkers)
 }
 
+// StopController stops the controller and the reflection control loops.
 func (c *Controller) StopController() error {
 	select {
 	case <-c.stopController:
@@ -154,6 +162,7 @@ func (c *Controller) StopController() error {
 	return nil
 }
 
+// StopReflection stops the reflection control loops, optionally restarting them.
 func (c *Controller) StopReflection(restart bool) {
 	klog.V(2).Info("stopping reflection manager")
 

--- a/pkg/virtualKubelet/apiReflection/controller/controller.go
+++ b/pkg/virtualKubelet/apiReflection/controller/controller.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"errors"
 	"sync"
+	"time"
 
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog"
@@ -44,12 +45,12 @@ type Controller struct {
 	stopController chan struct{}
 }
 
-func NewApiController(homeClient, foreignClient kubernetes.Interface, mapper namespacesMapping.MapperController, opts map[options.OptionKey]options.Option, tepReady chan struct{}) *Controller {
+func NewApiController(homeClient, foreignClient kubernetes.Interface, informerResyncPeriod time.Duration, mapper namespacesMapping.MapperController, opts map[options.OptionKey]options.Option, tepReady chan struct{}) *Controller {
 	klog.V(2).Infof("starting reflection manager")
 
 	outgoingReflectionInforming := make(chan apiReflection.ApiEvent)
 	incomingReflectionInforming := make(chan apiReflection.ApiEvent)
-	cacheManager := storage.NewManager(homeClient, foreignClient)
+	cacheManager := storage.NewManager(homeClient, foreignClient, informerResyncPeriod)
 
 	c := &Controller{
 		mapper:                       mapper,

--- a/pkg/virtualKubelet/provider/pods.go
+++ b/pkg/virtualKubelet/provider/pods.go
@@ -155,7 +155,7 @@ func (p *LiqoProvider) GetPod(_ context.Context, namespace, name string) (pod *c
 		return nil, nil
 	}
 
-	_, err = p.apiController.CacheManager().GetForeignApiByIndex(apimgmgt.Pods, foreignNamespace, name)
+	_, err = p.apiController.CacheManager().GetForeignAPIByIndex(apimgmgt.Pods, foreignNamespace, name)
 	if err != nil {
 		klog.V(4).Infof("PROVIDER: cannot get remote pod %s/%s because of error %v, requeueing", pod.Namespace, pod.Name, err)
 		return nil, nil
@@ -183,7 +183,7 @@ func (p *LiqoProvider) GetPodStatus(_ context.Context, namespace, name string) (
 		return nil, nil
 	}
 
-	foreignPod, err := p.apiController.CacheManager().GetForeignApiByIndex(apimgmgt.Pods, foreignNamespace, name)
+	foreignPod, err := p.apiController.CacheManager().GetForeignAPIByIndex(apimgmgt.Pods, foreignNamespace, name)
 	if err != nil {
 		return nil, errors.Wrap(err, "error while retrieving foreign pod")
 	}
@@ -223,7 +223,7 @@ func (p *LiqoProvider) RunInContainer(_ context.Context, homeNamespace string, h
 		return err
 	}
 
-	foreignObj, err := p.apiController.CacheManager().GetForeignApiByIndex(apimgmgt.Pods, foreignNamespace, homePodName)
+	foreignObj, err := p.apiController.CacheManager().GetForeignAPIByIndex(apimgmgt.Pods, foreignNamespace, homePodName)
 	if err != nil {
 		return errors.Wrap(err, "error while retrieving foreign pod")
 	}
@@ -269,7 +269,7 @@ func (p *LiqoProvider) GetContainerLogs(_ context.Context, homeNamespace string,
 		return nil, err
 	}
 
-	foreignObj, err := p.apiController.CacheManager().GetForeignApiByIndex(apimgmgt.Pods, foreignNamespace, homePodName)
+	foreignObj, err := p.apiController.CacheManager().GetForeignAPIByIndex(apimgmgt.Pods, foreignNamespace, homePodName)
 	if err != nil {
 		return nil, errors.Wrap(err, "error while retrieving foreign pod")
 	}

--- a/pkg/virtualKubelet/provider/provider.go
+++ b/pkg/virtualKubelet/provider/provider.go
@@ -53,7 +53,7 @@ type LiqoProvider struct { // nolint:golint]
 }
 
 // NewKubernetesProviderKubernetes creates a new KubernetesV0Provider. Kubernetes legacy provider does not implement the new asynchronous podnotifier interface.
-func NewLiqoProvider(nodeName, foreignClusterId, homeClusterId string, internalIP string, daemonEndpointPort int32, kubeconfig, remoteKubeConfig string) (*LiqoProvider, error) {
+func NewLiqoProvider(nodeName, foreignClusterId, homeClusterId string, internalIP string, daemonEndpointPort int32, kubeconfig, remoteKubeConfig string, informerResyncPeriod time.Duration) (*LiqoProvider, error) {
 	var err error
 
 	if err = nattingv1.AddToScheme(clientgoscheme.Scheme); err != nil {
@@ -116,7 +116,7 @@ func NewLiqoProvider(nodeName, foreignClusterId, homeClusterId string, internalI
 	tepReady := make(chan struct{})
 
 	provider := LiqoProvider{
-		apiController:         controller.NewApiController(client.Client(), foreignClient, mapper, opts, tepReady),
+		apiController:         controller.NewApiController(client.Client(), foreignClient, informerResyncPeriod, mapper, opts, tepReady),
 		namespaceMapper:       mapper,
 		nodeName:              virtualNodeNameOpt,
 		internalIP:            internalIP,

--- a/pkg/virtualKubelet/provider/virtualNodeupdater.go
+++ b/pkg/virtualKubelet/provider/virtualNodeupdater.go
@@ -24,7 +24,7 @@ import (
 
 func (p *LiqoProvider) StartNodeUpdater(nodeRunner *module.NodeController) (chan struct{}, chan struct{}, error) {
 	stop := make(chan struct{}, 1)
-	advName := strings.Join([]string{virtualKubelet.AdvertisementPrefix, p.foreignClusterId}, "")
+	advName := strings.Join([]string{virtualKubelet.AdvertisementPrefix, p.foreignClusterID}, "")
 	advWatcher, err := p.advClient.Resource("advertisements").Watch(&metav1.ListOptions{
 		FieldSelector: strings.Join([]string{"metadata.name", advName}, "="),
 		Watch:         true,
@@ -34,7 +34,7 @@ func (p *LiqoProvider) StartNodeUpdater(nodeRunner *module.NodeController) (chan
 	}
 
 	tepWatcher, err := p.tunEndClient.Resource("tunnelendpoints").Watch(&metav1.ListOptions{
-		LabelSelector: strings.Join([]string{liqoconst.ClusterIDLabelName, p.foreignClusterId}, "="),
+		LabelSelector: strings.Join([]string{liqoconst.ClusterIDLabelName, p.foreignClusterID}, "="),
 		Watch:         true,
 	})
 	if err != nil {
@@ -68,7 +68,7 @@ func (p *LiqoProvider) StartNodeUpdater(nodeRunner *module.NodeController) (chan
 					klog.Error(err)
 					tepWatcher.Stop()
 					tepWatcher, err = p.tunEndClient.Resource("tunnelendpoints").Watch(&metav1.ListOptions{
-						LabelSelector: strings.Join([]string{liqoconst.ClusterIDLabelName, p.foreignClusterId}, "="),
+						LabelSelector: strings.Join([]string{liqoconst.ClusterIDLabelName, p.foreignClusterID}, "="),
 						Watch:         true,
 					})
 					if err != nil {
@@ -169,7 +169,7 @@ func (p *LiqoProvider) updateFromAdv(adv advtypes.Advertisement) error {
 	}
 
 	no.SetAnnotations(map[string]string{
-		"cluster-id": p.foreignClusterId,
+		"cluster-id": p.foreignClusterID,
 	})
 	no.SetLabels(mergeMaps(no.GetLabels(), adv.Spec.Labels))
 	no, err = p.nntClient.Client().CoreV1().Nodes().Update(context.TODO(), no, metav1.UpdateOptions{})

--- a/pkg/virtualKubelet/storage/cache.go
+++ b/pkg/virtualKubelet/storage/cache.go
@@ -7,7 +7,7 @@ import (
 
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/cache"
+	clientgocache "k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/retry"
 
 	apimgmt "github.com/liqotech/liqo/pkg/virtualKubelet/apiReflection"
@@ -46,7 +46,7 @@ func (ac *NamespacedAPICaches) AddNamespace(namespace string) error {
 	}
 
 	ac.apiInformers[namespace] = &APICaches{
-		caches: make(map[apimgmt.ApiType]cache.SharedIndexInformer),
+		caches: make(map[apimgmt.ApiType]clientgocache.SharedIndexInformer),
 	}
 
 	factory := informers.NewSharedInformerFactoryWithOptions(ac.client, ac.resyncPeriod, informers.WithNamespace(namespace))
@@ -80,26 +80,26 @@ func (ac *NamespacedAPICaches) removeNamespace(namespace string) {
 
 // APICaches represents a set of informers for a set of APIs.
 type APICaches struct {
-	caches map[apimgmt.ApiType]cache.SharedIndexInformer
+	caches map[apimgmt.ApiType]clientgocache.SharedIndexInformer
 }
 
 // informer retrieves the cache for a specific api. If the cache does not exist, it returns nil.
-func (cache *APICaches) informer(api apimgmt.ApiType) cache.SharedIndexInformer {
+func (cache *APICaches) informer(api apimgmt.ApiType) clientgocache.SharedIndexInformer {
 	return cache.caches[api]
 }
 
-// getApi gets a specific given object for a specific given api.
-func (cache *APICaches) getApi(api apimgmt.ApiType, key string) (interface{}, error) {
+// getAPI gets a specific given object for a specific given api.
+func (cache *APICaches) getAPI(api apimgmt.ApiType, key string) (interface{}, error) {
 	return utils.GetObject(cache.caches[api], key, defaultBackoff)
 }
 
-// listApiByIndex lists all the api matching a specific index.
-func (cache *APICaches) listApiByIndex(api apimgmt.ApiType, key string) ([]interface{}, error) {
+// listAPIByIndex lists all the api matching a specific index.
+func (cache *APICaches) listAPIByIndex(api apimgmt.ApiType, key string) ([]interface{}, error) {
 	return utils.ListIndexedObjects(cache.caches[api], apimgmt.ApiNames[api], key)
 }
 
-// listApi lists the content of a given cached api.
-func (cache *APICaches) listApi(api apimgmt.ApiType) ([]interface{}, error) {
+// listAPI lists the content of a given cached api.
+func (cache *APICaches) listAPI(api apimgmt.ApiType) ([]interface{}, error) {
 	return utils.ListObjects(cache.caches[api])
 }
 

--- a/pkg/virtualKubelet/storage/cache.go
+++ b/pkg/virtualKubelet/storage/cache.go
@@ -15,8 +15,7 @@ import (
 )
 
 var (
-	defaultResyncPeriod = 30 * time.Second
-	defaultBackoff      = retry.DefaultBackoff
+	defaultBackoff = retry.DefaultBackoff
 )
 
 type NamespacedAPICaches struct {
@@ -25,6 +24,7 @@ type NamespacedAPICaches struct {
 	apiInformers      map[string]*APICaches
 	informerFactories map[string]informers.SharedInformerFactory
 	client            kubernetes.Interface
+	resyncPeriod      time.Duration
 }
 
 func (ac *NamespacedAPICaches) Namespace(namespace string) *APICaches {
@@ -49,7 +49,7 @@ func (ac *NamespacedAPICaches) AddNamespace(namespace string) error {
 		caches: make(map[apimgmt.ApiType]cache.SharedIndexInformer),
 	}
 
-	factory := informers.NewSharedInformerFactoryWithOptions(ac.client, defaultResyncPeriod, informers.WithNamespace(namespace))
+	factory := informers.NewSharedInformerFactoryWithOptions(ac.client, ac.resyncPeriod, informers.WithNamespace(namespace))
 	for api, builder := range InformerBuilders {
 		informer := builder(factory)
 		if indexers, ok := InformerIndexers[api]; ok {

--- a/pkg/virtualKubelet/storage/cacheManager.go
+++ b/pkg/virtualKubelet/storage/cacheManager.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/pkg/errors"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -92,17 +93,19 @@ func checkNamespaceCaching(backoff *wait.Backoff, rc *readyCaches, informers *Na
 	return nil
 }
 
-func NewManager(homeClient, foreignClient kubernetes.Interface) *Manager {
+func NewManager(homeClient, foreignClient kubernetes.Interface, resyncPeriod time.Duration) *Manager {
 	homeInformers := &NamespacedAPICaches{
 		apiInformers:      make(map[string]*APICaches),
 		informerFactories: make(map[string]informers.SharedInformerFactory),
 		client:            homeClient,
+		resyncPeriod:      resyncPeriod,
 	}
 
 	foreignInformers := &NamespacedAPICaches{
 		apiInformers:      make(map[string]*APICaches),
 		informerFactories: make(map[string]informers.SharedInformerFactory),
 		client:            foreignClient,
+		resyncPeriod:      resyncPeriod,
 	}
 
 	manager := &Manager{

--- a/pkg/virtualKubelet/storage/cacheManager_test.go
+++ b/pkg/virtualKubelet/storage/cacheManager_test.go
@@ -1,6 +1,8 @@
 package storage
 
 import (
+	"time"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"k8s.io/client-go/kubernetes/fake"
@@ -40,13 +42,14 @@ var _ = Describe("CacheManager", func() {
 		})
 
 		Context("cache manager correctly formed", func() {
+			const informerResyncPeriod = 1 * time.Minute
 			var (
 				manager *Manager
 				err     error
 			)
 
 			BeforeEach(func() {
-				manager = NewManager(homeClient, foreignClient)
+				manager = NewManager(homeClient, foreignClient, informerResyncPeriod)
 			})
 
 			Context("cache Manager check", func() {

--- a/pkg/virtualKubelet/storage/interfaces.go
+++ b/pkg/virtualKubelet/storage/interfaces.go
@@ -29,8 +29,8 @@ type CacheManagerReader interface {
 	GetForeignNamespacedObject(apimgmt.ApiType, string, string) (interface{}, error)
 	ListHomeNamespacedObject(apimgmt.ApiType, string) ([]interface{}, error)
 	ListForeignNamespacedObject(apimgmt.ApiType, string) ([]interface{}, error)
-	GetHomeApiByIndex(apimgmt.ApiType, string, string) (interface{}, error)
-	GetForeignApiByIndex(apimgmt.ApiType, string, string) (interface{}, error)
+	GetHomeAPIByIndex(apimgmt.ApiType, string, string) (interface{}, error)
+	GetForeignAPIByIndex(apimgmt.ApiType, string, string) (interface{}, error)
 }
 
 type CacheManagerReaderAdder interface {

--- a/pkg/virtualKubelet/storage/test/mockCacheManager.go
+++ b/pkg/virtualKubelet/storage/test/mockCacheManager.go
@@ -116,10 +116,12 @@ func (m *MockManager) ResyncListForeignNamespacedObject(apiType apimgmt.ApiType,
 	panic("implement me")
 }
 
-func (m *MockManager) GetHomeApiByIndex(apiType apimgmt.ApiType, s string, s2 string) (interface{}, error) {
+// GetHomeAPIByIndex is a mock implementation of the corresponding function (unimplemented).
+func (m *MockManager) GetHomeAPIByIndex(apiType apimgmt.ApiType, s, s2 string) (interface{}, error) {
 	panic("implement me")
 }
 
-func (m *MockManager) GetForeignApiByIndex(apiType apimgmt.ApiType, s string, s2 string) (interface{}, error) {
+// GetForeignAPIByIndex is a mock implementation of the corresponding function (unimplemented).
+func (m *MockManager) GetForeignAPIByIndex(apiType apimgmt.ApiType, s, s2 string) (interface{}, error) {
 	panic("implement me")
 }


### PR DESCRIPTION
# Description

This PR adds the possibility to configure the resync period of the reflectors through the same command line flag already used for the local informers. Specifically, this allows to reduce the resync period and improve the performance when dealing with high numbers of pods. 

Additionally, it fixes some linting issues in the files that have been modified.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Automated testing
- [x] Manual testing (10K pod offloading), to verify the performance improvement.
