### PR TITLE
Added Docker container for unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,9 +19,17 @@ docs: helm-docs
 #run all tests
 test: unit e2e
 
+# Check if test image exists
+test-container:
+ifeq (, $(shell docker image ls | grep liqo-test))
+	@{ \
+	docker build -t liqo-test build/liqo-test/ ; \
+	}
+endif
+
 # Run unit tests
-unit: gen
-	go test $(shell go list ./... | grep -v "e2e")
+unit: test-container gen
+	docker run --mount type=bind,src=$(shell pwd),dst=/go/src/liqo -w /go/src/liqo --rm liqo-test
 
 # Run e2e tests
 e2e: gen

--- a/build/liqo-test/Dockerfile
+++ b/build/liqo-test/Dockerfile
@@ -1,0 +1,12 @@
+FROM golang:1.14 as builder
+ENV PATH /go/bin:/usr/local/go/bin:/usr/local/kubebuilder/bin:$PATH
+ENV GOPATH /go
+
+# Install kubebuilder
+RUN curl -sL https://go.kubebuilder.io/dl/2.3.0/$(go env GOOS)/$(go env GOARCH) | tar -xz -C /tmp/
+RUN mv /tmp/kubebuilder_2.3.0_$(go env GOOS)_$(go env GOARCH) /usr/local/kubebuilder
+
+# Install goimports
+RUN GO111MODULE="on" go get golang.org/x/tools/cmd/goimports@v0.1.1
+
+ENTRYPOINT go test -cover $(go list ./... | grep -v "e2e")

--- a/internal/resource-request-operator/suite_test.go
+++ b/internal/resource-request-operator/suite_test.go
@@ -55,7 +55,8 @@ var _ = BeforeSuite(func(done Done) {
 	// +kubebuilder:scaffold:scheme
 
 	k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
-		Scheme: scheme.Scheme,
+		Scheme:             scheme.Scheme,
+		MetricsBindAddress: "0", // this avoids port binding collision
 	})
 	Expect(err).ToNot(HaveOccurred())
 	id, _ := uuid.NewUUID()

--- a/pkg/liqo-controller-manager/namespace-controller/suite_test.go
+++ b/pkg/liqo-controller-manager/namespace-controller/suite_test.go
@@ -100,7 +100,8 @@ var _ = BeforeSuite(func(done Done) {
 	// +kubebuilder:scaffold:scheme
 
 	k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
-		Scheme: scheme.Scheme,
+		Scheme:             scheme.Scheme,
+		MetricsBindAddress: "0", // this avoids port binding collision
 	})
 	Expect(err).ToNot(HaveOccurred())
 

--- a/pkg/liqo-controller-manager/virtualNode-controller/suite_test.go
+++ b/pkg/liqo-controller-manager/virtualNode-controller/suite_test.go
@@ -109,7 +109,8 @@ var _ = BeforeSuite(func(done Done) {
 	// +kubebuilder:scaffold:scheme
 
 	k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
-		Scheme: scheme.Scheme,
+		Scheme:             scheme.Scheme,
+		MetricsBindAddress: "0", // this avoids port binding collision
 	})
 	Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
# Description

Currently, in order to not modify the network infrastructure of the host that runs the tests, some functions are used to mock interfaces or routing tables. This PR introduces a new Docker container used to carry out unit tests, so that we can drop mock functions and use the container network namespace.
