### PR TITLE
Translate Env Variables: skip default/kubernetes

### DIFF
--- a/pkg/virtualKubelet/translation/serviceEnv/serviceEnv.go
+++ b/pkg/virtualKubelet/translation/serviceEnv/serviceEnv.go
@@ -76,6 +76,11 @@ func getServiceEnvVarMap(ns string, enableServiceLinks bool, remoteNs string, ca
 		}
 		serviceName := service.Name
 
+		// Skipping the default/kubernetes service, as not reflected in the foreign namespace.
+		if service.Namespace == v1.NamespaceDefault && service.Name == "kubernetes" && remoteNs != v1.NamespaceDefault {
+			continue
+		}
+
 		if service.Namespace == ns && enableServiceLinks {
 			if err = addService(&serviceMap, cacheManager, remoteNs, serviceName, true); err != nil {
 				err := errors.Wrapf(err, "cannot add remote service")


### PR DESCRIPTION
# Description

This PR adds a check in the service environment variable translation to skip the lookup for the default/kubernetes service in the remote namespace, as never remapped. Hence, the lookup always failed, causing a non-necessary overhead for all pods offloaded from the default namespace.

Fixes #(issue)

# How Has This Been Tested?

Checking in the logs that the behavior was the expected one
