### PR TITLE
Replication of Namespaced Resources in Tenant Namespaces

### DIFF
--- a/apis/discovery/v1alpha1/resourcerequest_types.go
+++ b/apis/discovery/v1alpha1/resourcerequest_types.go
@@ -42,6 +42,7 @@ type ResourceRequest struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
 
 // ResourceRequestList contains a list of ResourceRequest.
 type ResourceRequestList struct {

--- a/deployments/liqo/files/liqo-remote-peering-basic-ClusterRole.yaml
+++ b/deployments/liqo/files/liqo-remote-peering-basic-ClusterRole.yaml
@@ -4,6 +4,7 @@ rules:
   resources:
   - resourcerequests
   verbs:
+  - create
   - delete
   - get
   - list
@@ -15,6 +16,7 @@ rules:
   resources:
   - resourcerequests/status
   verbs:
+  - create
   - delete
   - get
   - list

--- a/deployments/liqo/files/liqo-remote-peering-incoming-ClusterRole.yaml
+++ b/deployments/liqo/files/liqo-remote-peering-incoming-ClusterRole.yaml
@@ -4,6 +4,7 @@ rules:
   resources:
   - networkconfigs
   verbs:
+  - create
   - delete
   - get
   - list
@@ -15,6 +16,7 @@ rules:
   resources:
   - networkconfigs/status
   verbs:
+  - create
   - delete
   - get
   - list

--- a/deployments/liqo/files/liqo-remote-peering-outgoing-ClusterRole.yaml
+++ b/deployments/liqo/files/liqo-remote-peering-outgoing-ClusterRole.yaml
@@ -4,6 +4,7 @@ rules:
   resources:
   - resourceoffers
   verbs:
+  - create
   - delete
   - get
   - list
@@ -15,6 +16,7 @@ rules:
   resources:
   - resourceoffers/status
   verbs:
+  - create
   - delete
   - get
   - list
@@ -26,6 +28,7 @@ rules:
   resources:
   - networkconfigs
   verbs:
+  - create
   - delete
   - get
   - list
@@ -37,6 +40,7 @@ rules:
   resources:
   - networkconfigs/status
   verbs:
+  - create
   - delete
   - get
   - list

--- a/internal/crdReplicator/crdReplicator-config.go
+++ b/internal/crdReplicator/crdReplicator-config.go
@@ -1,4 +1,4 @@
-package crdReplicator
+package crdreplicator
 
 import (
 	"reflect"

--- a/internal/crdReplicator/crdReplicator-config_test.go
+++ b/internal/crdReplicator/crdReplicator-config_test.go
@@ -1,4 +1,4 @@
-package crdReplicator
+package crdreplicator
 
 import (
 	"testing"

--- a/internal/crdReplicator/doc.go
+++ b/internal/crdReplicator/doc.go
@@ -1,0 +1,3 @@
+// Package crdreplicator implements the logic for the replication of CustomResourceDefinitions
+// between the peered clusters.
+package crdreplicator

--- a/internal/crdReplicator/env_test.go
+++ b/internal/crdReplicator/env_test.go
@@ -1,4 +1,4 @@
-package crdReplicator
+package crdreplicator
 
 import (
 	"strings"
@@ -8,6 +8,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/dynamic/dynamicinformer"
+	"k8s.io/client-go/kubernetes"
 
 	netv1alpha1 "github.com/liqotech/liqo/apis/net/v1alpha1"
 
@@ -24,6 +25,7 @@ import (
 var (
 	k8sManagerLocal ctrl.Manager
 	testEnvLocal    *envtest.Environment
+	k8sclient       kubernetes.Interface
 	dynClient       dynamic.Interface
 	dynFac          dynamicinformer.DynamicSharedInformerFactory
 	localDynFac     dynamicinformer.DynamicSharedInformerFactory
@@ -51,6 +53,8 @@ func setupEnv() {
 		klog.Error(err, "an error occurred while setting up the local testing environment")
 		os.Exit(-1)
 	}
+
+	k8sclient = kubernetes.NewForConfigOrDie(configLocal)
 
 	k8sManagerLocal, err = ctrl.NewManager(configLocal, ctrl.Options{
 		Scheme:             scheme.Scheme,

--- a/internal/crdReplicator/namespaceTranslation.go
+++ b/internal/crdReplicator/namespaceTranslation.go
@@ -1,0 +1,31 @@
+package crdreplicator
+
+import (
+	"k8s.io/klog/v2"
+)
+
+func (c *Controller) localToRemoteNamespace(namespace string) string {
+	if namespace == "" {
+		// if the namespaces is empty, the resource is cluster scoped, so we do no need namespace translations
+		return namespace
+	}
+
+	if ns, ok := c.LocalToRemoteNamespaceMapper[namespace]; ok {
+		return ns
+	}
+	klog.V(5).Infof("local namespace %v translation not found, returning the original namespace", namespace)
+	return namespace
+}
+
+func (c *Controller) remoteToLocalNamespace(namespace string) string {
+	if namespace == "" {
+		// if the namespaces is empty, the resource is cluster scoped, so we do no need namespace translations
+		return namespace
+	}
+
+	if ns, ok := c.RemoteToLocalNamespaceMapper[namespace]; ok {
+		return ns
+	}
+	klog.V(5).Infof("remote namespace %v translation not found, returning the original namespace", namespace)
+	return namespace
+}

--- a/internal/discovery/discovery-config.go
+++ b/internal/discovery/discovery-config.go
@@ -118,7 +118,7 @@ func (discovery *Controller) handleDispatcherConfig(config *configv1alpha1.Dispa
 	rules := []rbacv1.PolicyRule{}
 	for _, res := range config.ResourcesToReplicate {
 		rules = append(rules, rbacv1.PolicyRule{
-			Verbs:     []string{"*"},
+			Verbs:     []string{"get", "update", "patch", "list", "watch", "delete", "create"},
 			APIGroups: []string{res.Group},
 			Resources: []string{res.Resource, res.Resource + "/status"},
 		})

--- a/internal/discovery/foreign-cluster-operator/foreign-cluster-controller.go
+++ b/internal/discovery/foreign-cluster-operator/foreign-cluster-controller.go
@@ -38,7 +38,7 @@ import (
 	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
 	netv1alpha1 "github.com/liqotech/liqo/apis/net/v1alpha1"
 	advtypes "github.com/liqotech/liqo/apis/sharing/v1alpha1"
-	"github.com/liqotech/liqo/internal/crdReplicator"
+	crdreplicator "github.com/liqotech/liqo/internal/crdReplicator"
 	"github.com/liqotech/liqo/internal/discovery"
 	"github.com/liqotech/liqo/internal/discovery/utils"
 	"github.com/liqotech/liqo/pkg/auth"
@@ -1152,14 +1152,14 @@ func (r *ForeignClusterReconciler) getAutoJoinUntrusted(fc *discoveryv1alpha1.Fo
 
 func (r *ForeignClusterReconciler) checkNetwork(fc *discoveryv1alpha1.ForeignCluster, requireUpdate *bool) error {
 	// local NetworkConfig
-	labelSelector := strings.Join([]string{crdReplicator.DestinationLabel, fc.Spec.ClusterIdentity.ClusterID}, "=")
+	labelSelector := strings.Join([]string{crdreplicator.DestinationLabel, fc.Spec.ClusterIdentity.ClusterID}, "=")
 	if err := r.updateNetwork(labelSelector, &fc.Status.Network.LocalNetworkConfig, requireUpdate); err != nil {
 		klog.Error(err)
 		return err
 	}
 
 	// remote NetworkConfig
-	labelSelector = strings.Join([]string{crdReplicator.RemoteLabelSelector, fc.Spec.ClusterIdentity.ClusterID}, "=")
+	labelSelector = strings.Join([]string{crdreplicator.RemoteLabelSelector, fc.Spec.ClusterIdentity.ClusterID}, "=")
 	return r.updateNetwork(labelSelector, &fc.Status.Network.RemoteNetworkConfig, requireUpdate)
 }
 

--- a/internal/discovery/foreign-cluster-operator/resourceRequest.go
+++ b/internal/discovery/foreign-cluster-operator/resourceRequest.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/klog"
 
 	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
+	crdreplicator "github.com/liqotech/liqo/internal/crdReplicator"
 )
 
 // createResourceRequest creates a resource request to be sent to the specified ForeignCluster.
@@ -48,6 +49,10 @@ func (r *ForeignClusterReconciler) createResourceRequest(
 						Name: foreignCluster.Name,
 						UID:  foreignCluster.UID,
 					},
+				},
+				Labels: map[string]string{
+					crdreplicator.LocalLabelSelector: "true",
+					crdreplicator.DestinationLabel:   remoteClusterID,
 				},
 			},
 			Spec: discoveryv1alpha1.ResourceRequestSpec{

--- a/internal/liqonet/tunnelEndpointCreator/secretWatcher.go
+++ b/internal/liqonet/tunnelEndpointCreator/secretWatcher.go
@@ -16,7 +16,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	netv1alpha1 "github.com/liqotech/liqo/apis/net/v1alpha1"
-	"github.com/liqotech/liqo/internal/crdReplicator"
+	crdreplicator "github.com/liqotech/liqo/internal/crdReplicator"
 	"github.com/liqotech/liqo/pkg/liqonet/tunnel/wireguard"
 )
 
@@ -73,7 +73,7 @@ func (tec *TunnelEndpointCreator) secretHandlerAdd(obj interface{}) {
 		tec.wgConfigured = true
 	}
 	netConfigs := &netv1alpha1.NetworkConfigList{}
-	labels := client.MatchingLabels{crdReplicator.LocalLabelSelector: "true"}
+	labels := client.MatchingLabels{crdreplicator.LocalLabelSelector: "true"}
 	err = tec.Client.List(context.Background(), netConfigs, labels)
 	if err != nil {
 		klog.Errorf("unable to retrieve the existing resources of type %s in order to update the publicKey for the vpn backend: %v", netv1alpha1.NetworkConfigGroupVersionResource.String(), err)

--- a/internal/liqonet/tunnelEndpointCreator/serviceWatcher.go
+++ b/internal/liqonet/tunnelEndpointCreator/serviceWatcher.go
@@ -16,7 +16,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	netv1alpha1 "github.com/liqotech/liqo/apis/net/v1alpha1"
-	"github.com/liqotech/liqo/internal/crdReplicator"
+	crdreplicator "github.com/liqotech/liqo/internal/crdReplicator"
 	"github.com/liqotech/liqo/pkg/liqonet/tunnel/wireguard"
 )
 
@@ -118,7 +118,7 @@ func (tec *TunnelEndpointCreator) serviceHandlerAdd(obj interface{}) {
 			tec.svcConfigured = true
 		}
 		netConfigs := &netv1alpha1.NetworkConfigList{}
-		labels := client.MatchingLabels{crdReplicator.LocalLabelSelector: "true"}
+		labels := client.MatchingLabels{crdreplicator.LocalLabelSelector: "true"}
 		err = tec.Client.List(context.Background(), netConfigs, labels)
 		if err != nil {
 			klog.Errorf("unable to retrieve the existing resources of type %s in order to update the publicKey for the vpn backend: %v", netv1alpha1.NetworkConfigGroupVersionResource.String(), err)

--- a/internal/liqonet/tunnelEndpointCreator/tunnelEndpointCreator-operator.go
+++ b/internal/liqonet/tunnelEndpointCreator/tunnelEndpointCreator-operator.go
@@ -42,7 +42,7 @@ import (
 	netv1alpha1 "github.com/liqotech/liqo/apis/net/v1alpha1"
 
 	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
-	"github.com/liqotech/liqo/internal/crdReplicator"
+	crdreplicator "github.com/liqotech/liqo/internal/crdReplicator"
 	liqoconst "github.com/liqotech/liqo/pkg/consts"
 	liqonet "github.com/liqotech/liqo/pkg/liqonet"
 	"github.com/liqotech/liqo/pkg/liqonet/tunnel/wireguard"
@@ -199,10 +199,10 @@ func (tec *TunnelEndpointCreator) Reconcile(ctx context.Context, req ctrl.Reques
 
 	// check if the netconfig is local or remote
 	labels := netConfig.GetLabels()
-	if val, ok := labels[crdReplicator.LocalLabelSelector]; ok && val == "true" {
+	if val, ok := labels[crdreplicator.LocalLabelSelector]; ok && val == "true" {
 		return result, tec.processLocalNetConfig(&netConfig)
 	}
-	if _, ok := labels[crdReplicator.RemoteLabelSelector]; ok {
+	if _, ok := labels[crdreplicator.RemoteLabelSelector]; ok {
 		return result, tec.processRemoteNetConfig(&netConfig)
 	}
 	return result, nil
@@ -252,8 +252,8 @@ func (tec *TunnelEndpointCreator) createNetConfig(fc *discoveryv1alpha1.ForeignC
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: netConfigNamePrefix,
 			Labels: map[string]string{
-				crdReplicator.LocalLabelSelector: "true",
-				crdReplicator.DestinationLabel:   clusterID,
+				crdreplicator.LocalLabelSelector: "true",
+				crdreplicator.DestinationLabel:   clusterID,
 			},
 			OwnerReferences: []metav1.OwnerReference{
 				{
@@ -299,7 +299,7 @@ func (tec *TunnelEndpointCreator) createNetConfig(fc *discoveryv1alpha1.ForeignC
 func (tec *TunnelEndpointCreator) deleteNetConfig(fc *discoveryv1alpha1.ForeignCluster) error {
 	clusterID := fc.Spec.ClusterIdentity.ClusterID
 	netConfigList := &netv1alpha1.NetworkConfigList{}
-	labels := client.MatchingLabels{crdReplicator.DestinationLabel: clusterID}
+	labels := client.MatchingLabels{crdreplicator.DestinationLabel: clusterID}
 	err := tec.List(context.Background(), netConfigList, labels)
 	if err != nil {
 		klog.Errorf("an error occurred while listing resources: %s", err)
@@ -342,7 +342,7 @@ func (tec *TunnelEndpointCreator) GetNetworkConfig(destinationClusterID string) 
 	error) {
 	clusterID := destinationClusterID
 	networkConfigList := &netv1alpha1.NetworkConfigList{}
-	labels := client.MatchingLabels{crdReplicator.DestinationLabel: clusterID}
+	labels := client.MatchingLabels{crdreplicator.DestinationLabel: clusterID}
 	err := tec.List(context.Background(), networkConfigList, labels)
 	if err != nil {
 		klog.Errorf("an error occurred while listing resources of type %s: %s", netv1alpha1.GroupVersion, err)
@@ -366,7 +366,7 @@ func (tec *TunnelEndpointCreator) processRemoteNetConfig(netConfig *netv1alpha1.
 	// the clusterid of the destination cluster(the local cluster in this case)
 	// In order to take the ClusterID of the sender we need to retrieve it from the labels.
 	podCIDR, externalCIDR, err := tec.IPManager.GetSubnetsPerCluster(netConfig.Spec.PodCIDR,
-		netConfig.Spec.ExternalCIDR, netConfig.Labels[crdReplicator.RemoteLabelSelector])
+		netConfig.Spec.ExternalCIDR, netConfig.Labels[crdreplicator.RemoteLabelSelector])
 	if err != nil {
 		klog.Errorf("an error occurred while getting a new subnet for resource %s: %s", netConfig.Name, err)
 		return err
@@ -431,7 +431,7 @@ func (tec *TunnelEndpointCreator) processRemoteNetConfig(netConfig *netv1alpha1.
 func (tec *TunnelEndpointCreator) processLocalNetConfig(netConfig *netv1alpha1.NetworkConfig) error {
 	// first check that this is the only resource for the remote cluster
 	netConfigList := &netv1alpha1.NetworkConfigList{}
-	labels := client.MatchingLabels{crdReplicator.DestinationLabel: netConfig.Labels[crdReplicator.DestinationLabel]}
+	labels := client.MatchingLabels{crdreplicator.DestinationLabel: netConfig.Labels[crdreplicator.DestinationLabel]}
 	err := tec.List(context.Background(), netConfigList, labels)
 	if err != nil {
 		klog.Errorf("an error occurred while listing resources: %s", err)
@@ -459,7 +459,7 @@ func (tec *TunnelEndpointCreator) processLocalNetConfig(netConfig *netv1alpha1.N
 	}
 	// we get the remote netconfig related to this one
 	netConfigList = &netv1alpha1.NetworkConfigList{}
-	labels = client.MatchingLabels{crdReplicator.RemoteLabelSelector: netConfig.Spec.ClusterID}
+	labels = client.MatchingLabels{crdreplicator.RemoteLabelSelector: netConfig.Spec.ClusterID}
 	err = tec.List(context.Background(), netConfigList, labels)
 	if err != nil {
 		klog.Errorf("an error occurred while listing resources: %s", err)

--- a/pkg/clusterid/staticClusterID.go
+++ b/pkg/clusterid/staticClusterID.go
@@ -1,0 +1,22 @@
+package clusterid
+
+type staticClusterID struct {
+	id string
+}
+
+// NewStaticClusterID returns a clusterID interface compliant object that stores a read-only clusterID.
+func NewStaticClusterID(clusterID string) ClusterID {
+	return &staticClusterID{
+		id: clusterID,
+	}
+}
+
+// SetupClusterID function not implemented.
+func (staticCID *staticClusterID) SetupClusterID(namespace string) error {
+	panic("not implemented")
+}
+
+// GetClusterID returns the clusterID string.
+func (staticCID *staticClusterID) GetClusterID() string {
+	return staticCID.id
+}

--- a/pkg/peering-roles/basic/basic.go
+++ b/pkg/peering-roles/basic/basic.go
@@ -3,5 +3,5 @@
 // this ClusterRole has the basic permissions to give to a remote cluster
 package basic
 
-// +kubebuilder:rbac:groups=discovery.liqo.io,resources=resourcerequests,verbs=get;update;patch;list;watch;delete
-// +kubebuilder:rbac:groups=discovery.liqo.io,resources=resourcerequests/status,verbs=get;update;patch;list;watch;delete
+// +kubebuilder:rbac:groups=discovery.liqo.io,resources=resourcerequests,verbs=get;update;patch;list;watch;delete;create
+// +kubebuilder:rbac:groups=discovery.liqo.io,resources=resourcerequests/status,verbs=get;update;patch;list;watch;delete;create

--- a/pkg/peering-roles/incoming/incoming.go
+++ b/pkg/peering-roles/incoming/incoming.go
@@ -4,5 +4,5 @@
 // when the Pods will be offloaded to the local cluster
 package incoming
 
-// +kubebuilder:rbac:groups=net.liqo.io,resources=networkconfigs,verbs=get;update;patch;list;watch;delete
-// +kubebuilder:rbac:groups=net.liqo.io,resources=networkconfigs/status,verbs=get;update;patch;list;watch;delete
+// +kubebuilder:rbac:groups=net.liqo.io,resources=networkconfigs,verbs=get;update;patch;list;watch;delete;create
+// +kubebuilder:rbac:groups=net.liqo.io,resources=networkconfigs/status,verbs=get;update;patch;list;watch;delete;create

--- a/pkg/peering-roles/outgoing/outgoing.go
+++ b/pkg/peering-roles/outgoing/outgoing.go
@@ -4,8 +4,8 @@
 // when the Pods will be offloaded from the local cluster
 package outgoing
 
-// +kubebuilder:rbac:groups=net.liqo.io,resources=networkconfigs,verbs=get;update;patch;list;watch;delete
-// +kubebuilder:rbac:groups=net.liqo.io,resources=networkconfigs/status,verbs=get;update;patch;list;watch;delete
+// +kubebuilder:rbac:groups=net.liqo.io,resources=networkconfigs,verbs=get;update;patch;list;watch;delete;create
+// +kubebuilder:rbac:groups=net.liqo.io,resources=networkconfigs/status,verbs=get;update;patch;list;watch;delete;create
 
-// +kubebuilder:rbac:groups=discovery.liqo.io,resources=resourceoffers,verbs=get;update;patch;list;watch;delete
-// +kubebuilder:rbac:groups=discovery.liqo.io,resources=resourceoffers/status,verbs=get;update;patch;list;watch;delete
+// +kubebuilder:rbac:groups=discovery.liqo.io,resources=resourceoffers,verbs=get;update;patch;list;watch;delete;create
+// +kubebuilder:rbac:groups=discovery.liqo.io,resources=resourceoffers/status,verbs=get;update;patch;list;watch;delete;create

--- a/test/unit/crdReplicator/crdReplicator-operator_test.go
+++ b/test/unit/crdReplicator/crdReplicator-operator_test.go
@@ -17,7 +17,7 @@ import (
 	"k8s.io/klog/v2"
 
 	netv1alpha1 "github.com/liqotech/liqo/apis/net/v1alpha1"
-	"github.com/liqotech/liqo/internal/crdReplicator"
+	crdreplicator "github.com/liqotech/liqo/internal/crdReplicator"
 )
 
 var (
@@ -36,8 +36,8 @@ var (
 func setupDispatcherOperator() error {
 	var err error
 	localDynClient := dynamic.NewForConfigOrDie(k8sManagerLocal.GetConfig())
-	localDynFac := dynamicinformer.NewFilteredDynamicSharedInformerFactory(localDynClient, crdReplicator.ResyncPeriod, metav1.NamespaceAll, crdReplicator.SetLabelsForLocalResources)
-	dOperator = &crdReplicator.Controller{
+	localDynFac := dynamicinformer.NewFilteredDynamicSharedInformerFactory(localDynClient, crdreplicator.ResyncPeriod, metav1.NamespaceAll, crdreplicator.SetLabelsForLocalResources)
+	dOperator = &crdreplicator.Controller{
 		Scheme:                         k8sManagerLocal.GetScheme(),
 		Client:                         k8sManagerLocal.GetClient(),
 		ClientSet:                      nil,
@@ -153,8 +153,8 @@ func TestReplication2(t *testing.T) {
 		tun := getTunnelEndpointResource()
 		tun.SetName(clusterID)
 		tun.SetLabels(map[string]string{
-			crdReplicator.DestinationLabel:   clusterID,
-			crdReplicator.LocalLabelSelector: "true",
+			crdreplicator.DestinationLabel:   clusterID,
+			crdreplicator.LocalLabelSelector: "true",
 		})
 		newTun, err := dOperator.LocalDynClient.Resource(tunGVR).Create(context.TODO(), tun, metav1.CreateOptions{})
 		assert.Nil(t, err, "error should be nil")
@@ -191,8 +191,8 @@ func TestReplication4(t *testing.T) {
 		tun := getTunnelEndpointResource()
 		tun.SetName(clusterID)
 		tun.SetLabels(map[string]string{
-			crdReplicator.DestinationLabel:   clusterID,
-			crdReplicator.LocalLabelSelector: "true",
+			crdreplicator.DestinationLabel:   clusterID,
+			crdreplicator.LocalLabelSelector: "true",
 		})
 		newTun, err := dOperator.LocalDynClient.Resource(tunGVR).Create(context.TODO(), tun, metav1.CreateOptions{})
 		assert.Nil(t, err, "error should be nil")
@@ -256,8 +256,8 @@ func TestReplication3(t *testing.T) {
 		tun := getTunnelEndpointResource()
 		tun.SetName(clusterID)
 		tun.SetLabels(map[string]string{
-			crdReplicator.DestinationLabel:   clusterID,
-			crdReplicator.LocalLabelSelector: "true",
+			crdreplicator.DestinationLabel:   clusterID,
+			crdreplicator.LocalLabelSelector: "true",
 		})
 		newTun, err := dOperator.LocalDynClient.Resource(tunGVR).Create(context.TODO(), tun, metav1.CreateOptions{})
 		assert.Nil(t, err, "error should be nil")

--- a/test/unit/crdReplicator/env_test.go
+++ b/test/unit/crdReplicator/env_test.go
@@ -21,7 +21,7 @@ import (
 	configv1alpha1 "github.com/liqotech/liqo/apis/config/v1alpha1"
 	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
 	netv1alpha1 "github.com/liqotech/liqo/apis/net/v1alpha1"
-	"github.com/liqotech/liqo/internal/crdReplicator"
+	crdreplicator "github.com/liqotech/liqo/internal/crdReplicator"
 	crdclient "github.com/liqotech/liqo/pkg/crdClient"
 )
 
@@ -37,7 +37,7 @@ var (
 	configClusterClient         *crdclient.CRDClient
 	k8sManagerLocal             ctrl.Manager
 	testEnvLocal                *envtest.Environment
-	dOperator                   *crdReplicator.Controller
+	dOperator                   *crdreplicator.Controller
 )
 
 func TestMain(m *testing.M) {
@@ -133,9 +133,9 @@ func setupEnv() {
 		peeringClustersManagers[peeringClusterID] = manager
 		dynClient := dynamic.NewForConfigOrDie(manager.GetConfig())
 		peeringClustersDynClients[peeringClusterID] = dynClient
-		dynFac := dynamicinformer.NewFilteredDynamicSharedInformerFactory(dynClient, crdReplicator.ResyncPeriod, metav1.NamespaceAll, func(options *metav1.ListOptions) {
+		dynFac := dynamicinformer.NewFilteredDynamicSharedInformerFactory(dynClient, crdreplicator.ResyncPeriod, metav1.NamespaceAll, func(options *metav1.ListOptions) {
 			//we want to watch only the resources that have been created by us on the remote cluster
-			options.LabelSelector = crdReplicator.RemoteLabelSelector + "=" + localClusterID
+			options.LabelSelector = crdreplicator.RemoteLabelSelector + "=" + localClusterID
 		})
 		peeringClustersDynFactories[peeringClusterID] = dynFac
 	}


### PR DESCRIPTION
# Description

This pr includes a new feature for the CrdReplicator that allows Liqo to replicate resources in different namespaces. This feature will be used to replicate the peering-related resources in the Tenant Control Namespaces over the two peered clusters.

Ref #573

# How Has This Been Tested?

- [x] add unit test on namespace translation
- [x] locally on KinD
