### PR TITLE
Migrate unit test pipeline to docker

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -76,6 +76,7 @@ jobs:
         - auth-service
         - cert-creator
         - crd-replicator
+        - liqo-test
         - discovery
         - init-virtual-kubelet
         - liqonet
@@ -237,7 +238,7 @@ jobs:
   test:
     name: Launch Test
     runs-on: ubuntu-20.04
-    needs: configure
+    needs: [configure, build]
     if: needs.configure.outputs.ok-to-continue == 'true' && github.event.pull_request.draft == false
     steps:
 
@@ -254,20 +255,22 @@ jobs:
         repository: "${{ needs.configure.outputs.repo-name }}"
         persist-credentials: false
 
-    - name: Install Kubebuilder
-      run: |
-        version=2.3.1 # latest stable version
-        arch=amd64
-        curl -L -O "https://github.com/kubernetes-sigs/kubebuilder/releases/download/v${version}/kubebuilder_${version}_linux_${arch}.tar.gz"
-        tar -zxvf kubebuilder_${version}_linux_${arch}.tar.gz
-        mv kubebuilder_${version}_linux_${arch} kubebuilder && sudo mv kubebuilder /usr/local/
+    - name: Login to DockerHub
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
 
-    - name: Get dependencies for Test execution
-      run: |
-        go get -u github.com/ory/go-acc
-
-    - name: Launch Test
-      run: go-acc ./... --ignore liqo/test/e2e
+    - name: Launch Test (Docker Container)
+      uses: addnab/docker-run-action@v3
+      with:
+        options: |
+            --mount type=bind,src=${{ github.workspace }},dst=/go/src/liqotech/liqo
+            --workdir /go/src/liqotech/liqo
+            --cap-add=NET_ADMIN
+        image: liqo/liqo-test${{ needs.configure.outputs.repo-suffix }}:${{ needs.configure.outputs.commit_ref }}
+        run: |
+          go-acc ./... --ignore liqo/test/e2e
 
     - name: Send coverage
       uses: shogo82148/actions-goveralls@v1.4.3

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ ifeq (, $(shell docker image ls | grep liqo-test))
 endif
 
 # Run unit tests
-unit: test-container gen
+unit: test-container
 	docker run --mount type=bind,src=$(shell pwd),dst=/go/src/liqo -w /go/src/liqo --rm liqo-test
 
 # Run e2e tests

--- a/build/advertisement-broadcaster/Dockerfile
+++ b/build/advertisement-broadcaster/Dockerfile
@@ -1,8 +1,11 @@
 FROM golang:1.16 as builder
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
 ENV GOPATH /go
-COPY . /go/src/github.com/liqotech/liqo
 WORKDIR /go/src/github.com/liqotech/liqo
+COPY go.mod ./go.mod
+COPY go.sum ./go.sum
+RUN  go mod download
+COPY . ./
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=$(go env GOARCH) go build ./cmd/advertisement-broadcaster/
 RUN cp advertisement-broadcaster /usr/bin/advertisement-broadcaster
 

--- a/build/advertisement-operator/Dockerfile
+++ b/build/advertisement-operator/Dockerfile
@@ -1,8 +1,11 @@
 FROM golang:1.16 as builder
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
 ENV GOPATH /go
-COPY . /go/src/github.com/liqotech/liqo
 WORKDIR /go/src/github.com/liqotech/liqo
+COPY go.mod ./go.mod
+COPY go.sum ./go.sum
+RUN  go mod download
+COPY . ./
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=$(go env GOARCH) go build ./cmd/advertisement-operator/
 RUN cp advertisement-operator /usr/bin/advertisement-operator
 

--- a/build/auth-service/Dockerfile
+++ b/build/auth-service/Dockerfile
@@ -1,8 +1,11 @@
 FROM golang:1.16 as builder
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
 ENV GOPATH /go
-COPY . /go/src/github.com/liqotech/liqo
 WORKDIR /go/src/github.com/liqotech/liqo
+COPY go.mod ./go.mod
+COPY go.sum ./go.sum
+RUN  go mod download
+COPY . ./
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=$(go env GOARCH) go build ./cmd/auth-service/
 RUN cp auth-service /usr/bin/auth-service
 

--- a/build/crd-replicator/Dockerfile
+++ b/build/crd-replicator/Dockerfile
@@ -1,8 +1,11 @@
 FROM golang:1.16 as builder
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
 ENV GOPATH /go
-COPY . /go/src/github.com/liqotech/liqo
 WORKDIR /go/src/github.com/liqotech/liqo
+COPY go.mod ./go.mod
+COPY go.sum ./go.sum
+RUN  go mod download
+COPY . ./
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=$(go env GOARCH) go build ./cmd/crd-replicator/
 RUN cp crd-replicator /usr/bin/crd-replicator
 

--- a/build/discovery/Dockerfile
+++ b/build/discovery/Dockerfile
@@ -1,8 +1,11 @@
 FROM golang:1.16 as builder
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
 ENV GOPATH /go
-COPY . /go/src/github.com/liqotech/liqo
 WORKDIR /go/src/github.com/liqotech/liqo
+COPY go.mod ./go.mod
+COPY go.sum ./go.sum
+RUN  go mod download
+COPY . ./
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=$(go env GOARCH) go build ./cmd/discovery/
 RUN cp discovery /usr/bin/discovery
 

--- a/build/init-virtual-kubelet/Dockerfile
+++ b/build/init-virtual-kubelet/Dockerfile
@@ -1,10 +1,11 @@
 FROM golang:1.16 as builder
-
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
 ENV GOPATH /go
-COPY . /go/src/github.com/liqotech/liqo
 WORKDIR /go/src/github.com/liqotech/liqo
-ARG BUILD_TAGS=""
+COPY go.mod ./go.mod
+COPY go.sum ./go.sum
+RUN  go mod download
+COPY . ./
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=$(go env GOARCH) go build ./cmd/init-virtual-kubelet/
 RUN cp init-virtual-kubelet /usr/bin/init-virtual-kubelet
 

--- a/build/liqo-test/Dockerfile
+++ b/build/liqo-test/Dockerfile
@@ -1,12 +1,16 @@
 FROM golang:1.16 as builder
 ENV PATH /go/bin:/usr/local/go/bin:/usr/local/kubebuilder/bin:$PATH
 ENV GOPATH /go
+WORKDIR /go/src/github.com/liqotech/liqo
+COPY go.mod ./go.mod
+COPY go.sum ./go.sum
+RUN  go mod download
 
 # Install kubebuilder
 RUN curl -sL https://go.kubebuilder.io/dl/2.3.0/$(go env GOOS)/$(go env GOARCH) | tar -xz -C /tmp/
 RUN mv /tmp/kubebuilder_2.3.0_$(go env GOOS)_$(go env GOARCH) /usr/local/kubebuilder
 
 # Install goimports
-RUN GO111MODULE="on" go get golang.org/x/tools/cmd/goimports@v0.1.1
+RUN GO111MODULE="on" go get -u github.com/ory/go-acc
 
-ENTRYPOINT go test -cover $(go list ./... | grep -v "e2e")
+ENTRYPOINT go-acc ./... --ignore liqo/test/e2e

--- a/build/liqo-webhook/Dockerfile
+++ b/build/liqo-webhook/Dockerfile
@@ -1,8 +1,11 @@
 FROM golang:1.16 as builder
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
 ENV GOPATH /go
-COPY . /go/src/github.com/liqotech/liqo
 WORKDIR /go/src/github.com/liqotech/liqo
+COPY go.mod ./go.mod
+COPY go.sum ./go.sum
+RUN  go mod download
+COPY . ./
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=$(go env GOARCH) go build ./cmd/liqo-webhook/
 RUN cp liqo-webhook /usr/bin/liqo-webhook
 

--- a/build/liqonet/Dockerfile
+++ b/build/liqonet/Dockerfile
@@ -5,11 +5,14 @@ WORKDIR boringtun
 RUN rustup target add x86_64-unknown-linux-musl
 RUN cargo build --bin boringtun --release
 
-FROM golang:1.16-alpine AS goBuilder
+FROM golang:1.16 AS goBuilder
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
 ENV GOPATH /go
-RUN apk update && apk add git make
-COPY . /go/src/github.com/liqotech/liqo
+WORKDIR /go/src/github.com/liqotech/liqo
+COPY go.mod ./go.mod
+COPY go.sum ./go.sum
+RUN  go mod download
+COPY . ./
 WORKDIR /go/src/github.com/liqotech/liqo
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=$(go env GOARCH) go build ./cmd/liqonet/
 RUN cp liqonet /usr/bin/liqonet

--- a/build/peering-request-operator/Dockerfile
+++ b/build/peering-request-operator/Dockerfile
@@ -1,8 +1,11 @@
 FROM golang:1.16 as builder
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
 ENV GOPATH /go
-COPY . /go/src/github.com/liqotech/liqo
 WORKDIR /go/src/github.com/liqotech/liqo
+COPY go.mod ./go.mod
+COPY go.sum ./go.sum
+RUN  go mod download
+COPY . ./
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=$(go env GOARCH) go build ./cmd/peering-request-operator/
 RUN cp peering-request-operator /usr/bin/peering-request-operator
 

--- a/build/uninstaller/Dockerfile
+++ b/build/uninstaller/Dockerfile
@@ -1,10 +1,11 @@
 FROM golang:1.16 as builder
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
 ENV GOPATH /go
-COPY . /go/src/github.com/liqotech/liqo
 WORKDIR /go/src/github.com/liqotech/liqo
-
-ARG BUILD_TAGS=""
+COPY go.mod ./go.mod
+COPY go.sum ./go.sum
+RUN  go mod download
+COPY . ./
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=$(go env GOARCH) go build ./cmd/uninstaller/
 RUN cp uninstaller /usr/bin/uninstaller
 

--- a/build/virtual-kubelet/Dockerfile
+++ b/build/virtual-kubelet/Dockerfile
@@ -1,11 +1,11 @@
 FROM golang:1.16 as builder
-
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
 ENV GOPATH /go
-COPY . /go/src/github.com/liqotech/liqo
 WORKDIR /go/src/github.com/liqotech/liqo
-
-ARG BUILD_TAGS=""
+COPY go.mod ./go.mod
+COPY go.sum ./go.sum
+RUN  go mod download
+COPY . ./
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=$(go env GOARCH) go build ./cmd/virtual-kubelet/
 RUN cp virtual-kubelet /usr/bin/virtual-kubelet
 

--- a/build/webhook-configuration/Dockerfile
+++ b/build/webhook-configuration/Dockerfile
@@ -1,8 +1,11 @@
 FROM golang:1.16 as builder
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
 ENV GOPATH /go
-COPY . /go/src/github.com/liqotech/liqo
 WORKDIR /go/src/github.com/liqotech/liqo
+COPY go.mod ./go.mod
+COPY go.sum ./go.sum
+RUN  go mod download
+COPY . ./
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=$(go env GOARCH) go build ./cmd/webhook-configuration/
 RUN cp webhook-configuration /usr/bin/webhook-configuration
 


### PR DESCRIPTION
# Description

This PR:
- [x] migrates the unit tests to the new docker container introduced in #629.
- [x] reduces the time needed to build liqo images by optimizing the Dockerfile, fostering caching of container layers.
