### PR TITLE
Fix: Removed hardcoded value in reflector

### DIFF
--- a/pkg/liqonet/ipam.go
+++ b/pkg/liqonet/ipam.go
@@ -861,9 +861,9 @@ func (liqoIPAM *IPAM) mapEndpointIPInternal(clusterID, ip string) (string, error
 	}
 	// IP does not belong to cluster PodCIDR: Pod is a reflected Pod
 
-	// Check existence of RemoteExternalCIDR
+	// Check existence of Local NAT ExternalCIDR
 	if !exists || subnets.LocalNATExternalCIDR == "" {
-		return "", fmt.Errorf("remote cluster %s has not a remote ExternalCIDR:%w", clusterID, err)
+		return "", fmt.Errorf("remote cluster %s has not a Local NAT ExternalCIDR:%w", clusterID, err)
 	}
 
 	// Map IP to ExternalCIDR

--- a/pkg/liqonet/ipam_test.go
+++ b/pkg/liqonet/ipam_test.go
@@ -775,7 +775,7 @@ var _ = Describe("Ipam", func() {
 						ClusterID: "cluster1",
 						Ip:        "30.0.4.9",
 					})
-					Expect(err.Error()).To(ContainSubstring("remote cluster cluster1 has not a remote ExternalCIDR"))
+					Expect(err.Error()).To(ContainSubstring("remote cluster cluster1 has not a Local NAT ExternalCIDR"))
 				})
 			})
 		})

--- a/pkg/utils/cluster_info.go
+++ b/pkg/utils/cluster_info.go
@@ -2,11 +2,14 @@ package utils
 
 import (
 	"context"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/liqotech/liqo/pkg/virtualKubelet"
 )
 
 const (
@@ -24,4 +27,9 @@ func GetClusterID(c client.Client) (string, error) {
 	clusterID := configMap.Data[clusterIDConfMap]
 	klog.Infof("ClusterID is '%s'", clusterID)
 	return clusterID, nil
+}
+
+// GetClusterIDFromNodeName returns the clusterID from a node name.
+func GetClusterIDFromNodeName(nodeName string) string {
+	return strings.TrimPrefix(nodeName, virtualKubelet.VirtualNodePrefix)
 }

--- a/pkg/virtualKubelet/apiReflection/reflectors/outgoing/endpointSlices.go
+++ b/pkg/virtualKubelet/apiReflection/reflectors/outgoing/endpointSlices.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/klog"
 
 	"github.com/liqotech/liqo/pkg/liqonet"
+	"github.com/liqotech/liqo/pkg/utils"
 	apimgmt "github.com/liqotech/liqo/pkg/virtualKubelet/apiReflection"
 	"github.com/liqotech/liqo/pkg/virtualKubelet/apiReflection/reflectors"
 	ri "github.com/liqotech/liqo/pkg/virtualKubelet/apiReflection/reflectors/reflectorsInterfaces"
@@ -193,7 +194,7 @@ func filterEndpoints(slice *discoveryv1beta1.EndpointSlice, ipamClient liqonet.I
 		t := v.Topology["kubernetes.io/hostname"]
 		if t != nodeName {
 			response, err := ipamClient.MapEndpointIP(context.Background(),
-				&liqonet.MapRequest{ClusterID: strings.TrimPrefix(nodeName, "liqo-"), Ip: v.Addresses[0]})
+				&liqonet.MapRequest{ClusterID: utils.GetClusterIDFromNodeName(nodeName), Ip: v.Addresses[0]})
 			if err != nil {
 				klog.Error(err)
 			}


### PR DESCRIPTION
# Description

An hardcoded value for the node name has been substituted with a constant exposed by the virtual kubelet