### PR TITLE
Fix: ExternalCIDR initial setting could affect PodCIDR/ServiceCIDR setting

### DIFF
--- a/internal/liqonet/tunnelEndpointCreator/tunnelEndpointCreator-config.go
+++ b/internal/liqonet/tunnelEndpointCreator/tunnelEndpointCreator-config.go
@@ -19,10 +19,6 @@ import (
 func (tec *TunnelEndpointCreator) setNetParameters(config *configv1alpha1.ClusterConfig) {
 	podCIDR := config.Spec.LiqonetConfig.PodCIDR
 	serviceCIDR := config.Spec.LiqonetConfig.ServiceCIDR
-	externalCIDR, err := tec.IPManager.GetExternalCIDR(liqonet.GetMask(podCIDR))
-	if err != nil {
-		klog.Error(err)
-	}
 	if tec.PodCIDR != podCIDR {
 		if err := tec.IPManager.SetPodCIDR(podCIDR); err != nil {
 			klog.Error(err)
@@ -36,6 +32,10 @@ func (tec *TunnelEndpointCreator) setNetParameters(config *configv1alpha1.Cluste
 		}
 		klog.Infof("ServiceCIDR set to %s", serviceCIDR)
 		tec.ServiceCIDR = serviceCIDR
+	}
+	externalCIDR, err := tec.IPManager.GetExternalCIDR(liqonet.GetMask(podCIDR))
+	if err != nil {
+		klog.Error(err)
 	}
 	if tec.ExternalCIDR != externalCIDR {
 		klog.Infof("ExternalCIDR set to %s", externalCIDR)

--- a/pkg/liqonet/ipam_test.go
+++ b/pkg/liqonet/ipam_test.go
@@ -510,6 +510,26 @@ var _ = Describe("Ipam", func() {
 				Expect(err).ToNot(BeNil())
 			})
 		})
+		Context("Call after SetPodCIDR", func() {
+			It("should return no errors", func() {
+				err := ipam.SetPodCIDR("10.0.0.0/24")
+				Expect(err).To(BeNil())
+				externalCIDR, err := ipam.GetExternalCIDR(24)
+				Expect(err).To(BeNil())
+				Expect(externalCIDR).To(Equal("10.0.1.0/24"))
+			})
+		})
+		Context("Call before SetPodCIDR", func() {
+			It("should produce an error in SetPodCIDR", func() {
+				externalCIDR, err := ipam.GetExternalCIDR(24)
+				Expect(err).To(BeNil())
+				Expect(externalCIDR).To(Equal("10.0.0.0/24"))
+				// ExternalCIDR has been assigned "10.0.0.0/24", so the network
+				// is not available anymore.
+				err = ipam.SetPodCIDR("10.0.0.0/24")
+				Expect(err).ToNot(BeNil())
+			})
+		})
 	})
 
 	Describe("SetPodCIDR", func() {


### PR DESCRIPTION
# Description

Currently, the network manager first tries to set the ExternalCIDR and then the PodCIDR and ServiceCIDR. This could generate a failure if the the pod subnet IP is set to 10.0.0.0, since the network is first assigned to ExternalCIDR.
