### PR TITLE
Fix Test Container Build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ test: unit e2e
 test-container:
 ifeq (, $(shell docker image ls | grep liqo-test))
 	@{ \
-	docker build -t liqo-test build/liqo-test/ ; \
+	docker build -t liqo-test -f build/liqo-test/Dockerfile . ; \
 	}
 endif
 


### PR DESCRIPTION
# Description

This pr fixes the building working directory of the liqo-test container. With the wrong path, the docker builder was not able to copy the go.mod file in the building image.

# How Has This Been Tested?

- [x] locally
