### PR TITLE
Direct Route Manager Implementation

### DIFF
--- a/pkg/liqonet/errors.go
+++ b/pkg/liqonet/errors.go
@@ -1,0 +1,40 @@
+package liqonet
+
+import "strings"
+
+const (
+	// GreaterOrEqual used as reason of failure in WrongParameter error.
+	GreaterOrEqual = ">="
+	// MinorOrEqual used as reason of failure in WrongParameter error.
+	MinorOrEqual = "<="
+	// AtLeastOneValid used as reason of failure in WrongParameter error.
+	AtLeastOneValid = "at least one of the arguments has to be valid"
+)
+
+// ParseIPError it is returned when net.ParseIP() fails to parse and ip address.
+type ParseIPError struct {
+	IPToBeParsed string
+}
+
+func (pie *ParseIPError) Error() string {
+	return "please check that the IP address is in che correct format: " + pie.IPToBeParsed
+}
+
+// WrongParameter it is returned when parameters passed to a function are not correct.
+type WrongParameter struct {
+	Reason    string
+	Parameter string
+}
+
+func (wp *WrongParameter) Error() string {
+	return strings.Join([]string{wp.Parameter, " must be ", wp.Reason}, "")
+}
+
+// NoRouteFound it is returned when no route is found for a given destination network.
+type NoRouteFound struct {
+	IPAddress string
+}
+
+func (nrf *NoRouteFound) Error() string {
+	return strings.Join([]string{"no route found for IP address: ", nrf.IPAddress}, "")
+}

--- a/pkg/liqonet/routing/directRouting.go
+++ b/pkg/liqonet/routing/directRouting.go
@@ -1,0 +1,113 @@
+package routing
+
+import (
+	"net"
+	"strconv"
+
+	"golang.org/x/sys/unix"
+	"k8s.io/klog/v2"
+
+	"github.com/liqotech/liqo/pkg/liqonet"
+
+	netv1alpha1 "github.com/liqotech/liqo/apis/net/v1alpha1"
+)
+
+// DirectRoutingManager implements the routing manager interface.
+// Nodes has to be on the same network otherwise this solution will not work.
+type DirectRoutingManager struct {
+	routingTableID int
+	podIP          string
+}
+
+// NewDirectRoutingManager accepts as input a routing table ID and the IP address of the pod.
+// Returns a DirectRoutingManager ready to be used or an error.
+func NewDirectRoutingManager(routingTableID int, podIP string) (Routing, error) {
+	klog.Infof("starting Direct Routing Manager with routing table ID %d and podIP %s", routingTableID, podIP)
+	// Check the validity of input parameters.
+	if routingTableID > unix.RT_TABLE_MAX {
+		return nil, &liqonet.WrongParameter{Parameter: "routingTableID", Reason: liqonet.MinorOrEqual + strconv.Itoa(unix.RT_TABLE_MAX)}
+	}
+	if routingTableID < 0 {
+		return nil, &liqonet.WrongParameter{Parameter: "routingTableID", Reason: liqonet.GreaterOrEqual + strconv.Itoa(0)}
+	}
+	ip := net.ParseIP(podIP)
+	if ip == nil {
+		return nil, &liqonet.ParseIPError{
+			IPToBeParsed: podIP,
+		}
+	}
+	return &DirectRoutingManager{
+		routingTableID: routingTableID,
+		podIP:          podIP,
+	}, nil
+}
+
+// EnsureRoutesPerCluster accepts as input a netv1alpha.tunnelendpoint.
+// It inserts the routes if they do not exist or updates them if they are outdated.
+// Returns true if the routes have been configured, false if the routes are already configured.
+// An error if something goes wrong and the routes can not be configured.
+func (drm *DirectRoutingManager) EnsureRoutesPerCluster(tep *netv1alpha1.TunnelEndpoint) (bool, error) {
+	var routeAdd, policyRuleAdd, configured bool
+	clusterID := tep.Spec.ClusterID
+	// Extract and save route information from the given tep.
+	dstNet, gatewayIP, iFaceIndex, err := getRouteConfig(tep, drm.podIP)
+	if err != nil {
+		return false, err
+	}
+	// Add policy routing rule for the given cluster.
+	klog.Infof("%s -> adding policy routing rule for destination {%s} to lookup routing table with ID {%d}", clusterID, dstNet, drm.routingTableID)
+	if policyRuleAdd, err = addPolicyRoutingRule("", dstNet, drm.routingTableID); err != nil {
+		return policyRuleAdd, err
+	}
+	// Add route for the given cluster.
+	klog.Infof("%s -> adding route for destination {%s} with gateway {%s} in routing table with ID {%d}",
+		clusterID, dstNet, gatewayIP, drm.routingTableID)
+	routeAdd, err = addRoute(dstNet, gatewayIP, iFaceIndex, drm.routingTableID)
+	if err != nil {
+		return routeAdd, err
+	}
+	if routeAdd || policyRuleAdd {
+		configured = true
+	}
+	return configured, nil
+}
+
+// RemoveRoutesPerCluster accepts as input a netv1alpha.tunnelendpoint.
+// It deletes the routes if they do exist.
+// Returns true if the routes exist and have been deleted, false if nothing is removed.
+// An error if something goes wrong and the routes can not be removed.
+func (drm *DirectRoutingManager) RemoveRoutesPerCluster(tep *netv1alpha1.TunnelEndpoint) (bool, error) {
+	var routeDel, policyRuleDel, configured bool
+	clusterID := tep.Spec.ClusterID
+	// Extract and save route information from the given tep.
+	dstNet, gatewayIP, iFaceIndex, err := getRouteConfig(tep, drm.podIP)
+	if err != nil {
+		return false, err
+	}
+	// Delete policy routing rule for the given cluster.
+	klog.Infof("%s -> deleting policy routing rule for destination {%s} to lookup routing table with ID {%d}", clusterID, dstNet, drm.routingTableID)
+	if policyRuleDel, err = delPolicyRoutingRule("", dstNet, drm.routingTableID); err != nil {
+		return policyRuleDel, err
+	}
+	// Delete route for the given cluster.
+	klog.Infof("%s -> deleting route for destination {%s} with gateway {%s} in routing table with ID {%d}",
+		clusterID, dstNet, gatewayIP, drm.routingTableID)
+	routeDel, err = delRoute(dstNet, gatewayIP, iFaceIndex, drm.routingTableID)
+	if err != nil {
+		return routeDel, err
+	}
+	if routeDel || policyRuleDel {
+		configured = true
+	}
+	return configured, nil
+}
+
+// CleanRoutingTable removes all the routes from the custom routing table used by the route manager.
+func (drm *DirectRoutingManager) CleanRoutingTable() error {
+	return flushRoutesForRoutingTable(drm.routingTableID)
+}
+
+// CleanPolicyRules removes all the policy rules pointing to the custom routing table used by the route manager.
+func (drm *DirectRoutingManager) CleanPolicyRules() error {
+	return flushRulesForRoutingTable(drm.routingTableID)
+}

--- a/pkg/liqonet/routing/directRouting_test.go
+++ b/pkg/liqonet/routing/directRouting_test.go
@@ -1,0 +1,244 @@
+package routing
+
+import (
+	"net"
+	"strconv"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
+
+	"github.com/liqotech/liqo/pkg/liqonet"
+)
+
+var (
+	routingTableIDDRM = 18953
+	routesDRM         = []routingInfo{
+		{
+			destinationNet: "10.100.0.0/16",
+			gatewayIP:      "10.0.0.100",
+			iFaceIndex:     0,
+			routingTableID: routingTableIDDRM,
+		},
+		{
+			destinationNet: "10.101.0.0/16",
+			gatewayIP:      "",
+			iFaceIndex:     0,
+			routingTableID: routingTableIDDRM,
+		}}
+	existingRoutesDRM []*netlink.Route
+)
+
+var _ = Describe("DirectRouting", func() {
+	BeforeEach(func() {
+		// Populate the index of the routes with the correct one.
+		for i := range routesDRM {
+			routesDRM[i].iFaceIndex = dummylink1.Attrs().Index
+		}
+	})
+	Describe("creating new Direct Route Manager", func() {
+
+		Context("when parameters are not valid", func() {
+			It("routingTableID parameter out of range: a negative number", func() {
+				drm, err := NewDirectRoutingManager(-244, gwIPCorrect)
+				Expect(drm).Should(BeNil())
+				Expect(err).Should(Equal(&liqonet.WrongParameter{Parameter: "routingTableID", Reason: liqonet.GreaterOrEqual + strconv.Itoa(0)}))
+			})
+
+			It("routingTableID parameter out of range: superior to max value ", func() {
+				drm, err := NewDirectRoutingManager(unix.RT_TABLE_MAX+1, gwIPCorrect)
+				Expect(drm).Should(BeNil())
+				Expect(err).Should(Equal(&liqonet.WrongParameter{Parameter: "routingTableID", Reason: liqonet.MinorOrEqual + strconv.Itoa(unix.RT_TABLE_MAX)}))
+			})
+
+			It("podIP is not in right format", func() {
+				drm, err := NewDirectRoutingManager(244, gwIPWrong)
+				Expect(drm).Should(BeNil())
+				Expect(err).Should(Equal(&liqonet.ParseIPError{IPToBeParsed: gwIPWrong}))
+			})
+		})
+
+		Context("when parameters are correct", func() {
+			It("right parameters", func() {
+				drm, err := NewDirectRoutingManager(244, gwIPCorrect)
+				Expect(drm).ShouldNot(BeNil())
+				Expect(err).Should(BeNil())
+			})
+		})
+	})
+
+	Describe("configuring routes for a remote peering cluster", func() {
+		Context("when tep holds malformed parameters", func() {
+			It("route configuration fails while extracting route information from tep", func() {
+				tepCopy := tep
+				tepCopy.Status.GatewayIP = notReachableIP
+				added, err := drm.EnsureRoutesPerCluster(&tepCopy)
+				Expect(err).Should(Equal(&liqonet.NoRouteFound{IPAddress: tepCopy.Status.GatewayIP}))
+				Expect(added).Should(BeFalse())
+				Expect(err).NotTo(BeNil())
+			})
+
+			It("route configuration fails while adding policy routing rule", func() {
+				tepCopy := tep
+				tepCopy.Status.RemoteNATPodCIDR = ""
+				added, err := drm.EnsureRoutesPerCluster(&tepCopy)
+				Expect(err).Should(Equal(&liqonet.WrongParameter{
+					Parameter: "fromSubnet and toSubnet",
+					Reason:    liqonet.AtLeastOneValid,
+				}))
+				Expect(added).Should(BeFalse())
+				Expect(err).NotTo(BeNil())
+			})
+
+			It("route configuration fails while adding route", func() {
+				tepCopy := tep
+				tepCopy.Status.GatewayIP = ipAddress1NoSubnet
+				added, err := drm.EnsureRoutesPerCluster(&tepCopy)
+				Expect(err).Should(Equal(unix.ENODEV))
+				Expect(added).Should(BeFalse())
+				Expect(err).NotTo(BeNil())
+			})
+		})
+
+		Context("when tep holds correct parameters", func() {
+			JustBeforeEach(func() {
+				existingRoutesDRM = setUpRoutes(routesDRM)
+			})
+
+			JustAfterEach(func() {
+				tearDownRoutes(routingTableIDDRM)
+			})
+
+			It("route configuration should be correctly inserted", func() {
+				added, err := drm.EnsureRoutesPerCluster(&tep)
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(added).Should(BeTrue())
+				// Get the inserted route
+				_, dstNet, err := net.ParseCIDR(tep.Status.RemoteNATPodCIDR)
+				Expect(err).ShouldNot(HaveOccurred())
+				routes, err := netlink.RouteListFiltered(netlink.FAMILY_V4, &netlink.Route{Dst: dstNet, Table: routingTableIDDRM}, netlink.RT_FILTER_DST|netlink.RT_FILTER_TABLE)
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(routes[0].Dst.String()).Should(Equal(tep.Status.RemoteNATPodCIDR))
+				Expect(routes[0].Gw.String()).Should(Equal(tep.Status.GatewayIP))
+			})
+
+			It("route already exists, should return false and nil", func() {
+				tepCopy := tep
+				tepCopy.Status.RemoteNATPodCIDR = existingRoutesDRM[0].Dst.String()
+				tepCopy.Status.GatewayIP = existingRoutesDRM[0].Gw.String()
+				added, err := drm.EnsureRoutesPerCluster(&tepCopy)
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(added).Should(BeFalse())
+			})
+
+			It("route is outdated, should return true and nil", func() {
+				tepCopy := tep
+				tepCopy.Status.RemoteNATPodCIDR = existingRoutesDRM[1].Dst.String()
+				tepCopy.Status.GatewayIP = gwIPCorrect
+				added, err := drm.EnsureRoutesPerCluster(&tepCopy)
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(added).Should(BeTrue())
+				// Check that the route has been updated.
+				routes, err := netlink.RouteListFiltered(netlink.FAMILY_V4, existingRoutesDRM[1], netlink.RT_FILTER_DST|netlink.RT_FILTER_TABLE)
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(routes[0].Dst.String()).Should(Equal(tepCopy.Status.RemoteNATPodCIDR))
+				Expect(routes[0].Gw.String()).Should(Equal(tepCopy.Status.GatewayIP))
+			})
+		})
+	})
+
+	Describe("removing route configuration for a remote peering cluster", func() {
+		Context("when tep holds malformed parameters", func() {
+			It("fails to remove route configuration while extracting route information from tep", func() {
+				tepCopy := tep
+				tepCopy.Status.GatewayIP = notReachableIP
+				added, err := drm.RemoveRoutesPerCluster(&tepCopy)
+				Expect(err).Should(Equal(&liqonet.NoRouteFound{IPAddress: tepCopy.Status.GatewayIP}))
+				Expect(added).Should(BeFalse())
+				Expect(err).NotTo(BeNil())
+			})
+
+			It("fails to remove route configuration while removing policy routing rule", func() {
+				tepCopy := tep
+				tepCopy.Status.RemoteNATPodCIDR = ""
+				added, err := drm.RemoveRoutesPerCluster(&tepCopy)
+				Expect(err).Should(Equal(&liqonet.WrongParameter{
+					Parameter: "fromSubnet and toSubnet",
+					Reason:    liqonet.AtLeastOneValid,
+				}))
+				Expect(added).Should(BeFalse())
+				Expect(err).NotTo(BeNil())
+			})
+		})
+
+		Context("when tep holds correct parameters", func() {
+			JustBeforeEach(func() {
+				existingRoutesDRM = setUpRoutes(routesDRM)
+			})
+
+			JustAfterEach(func() {
+				tearDownRoutes(routingTableIDDRM)
+			})
+
+			It("route configuration should be correctly removed", func() {
+				tepCopy := tep
+				tepCopy.Status.RemoteNATPodCIDR = existingRoutesDRM[0].Dst.String()
+				tepCopy.Status.GatewayIP = existingRoutesDRM[0].Gw.String()
+				added, err := drm.RemoveRoutesPerCluster(&tepCopy)
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(added).Should(BeTrue())
+				// Try to get the remove route.
+				routes, err := netlink.RouteListFiltered(netlink.FAMILY_V4, existingRoutesDRM[0], netlink.RT_FILTER_DST|netlink.RT_FILTER_TABLE)
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(len(routes)).Should(BeZero())
+			})
+
+			It("route does not exist, should return false and nil", func() {
+				added, err := drm.RemoveRoutesPerCluster(&tep)
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(added).Should(BeFalse())
+			})
+		})
+	})
+
+	Describe("removing all routes configurations managed by the direct route manager", func() {
+		Context("removing routes, should return nil", func() {
+			JustBeforeEach(func() {
+				existingRoutesDRM = setUpRoutes(routesDRM)
+			})
+
+			JustAfterEach(func() {
+				tearDownRoutes(routingTableIDDRM)
+			})
+
+			It("routes should be correctly removed", func() {
+				err := drm.CleanRoutingTable()
+				Expect(err).ShouldNot(HaveOccurred())
+				// Try to list rules
+				routes, err := netlink.RouteListFiltered(netlink.FAMILY_V4, existingRoutesDRM[0], netlink.RT_FILTER_TABLE)
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(len(routes)).Should(BeZero())
+			})
+		})
+
+		Context("removing policy routing rules, should return nil", func() {
+			JustBeforeEach(func() {
+				existingRoutesDRM = setUpRoutes(routesDRM)
+			})
+
+			JustAfterEach(func() {
+				tearDownRoutes(routingTableIDDRM)
+			})
+
+			It("policy routing rules should be correctly removed", func() {
+				err := drm.CleanPolicyRules()
+				Expect(err).ShouldNot(HaveOccurred())
+				// Try to list rules
+				exists, err := existsRuleForRoutingTable(routingTableIDDRM)
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(exists).Should(BeFalse())
+			})
+		})
+	})
+})

--- a/pkg/liqonet/routing/routingInterface.go
+++ b/pkg/liqonet/routing/routingInterface.go
@@ -1,0 +1,15 @@
+package routing
+
+import netv1alpha1 "github.com/liqotech/liqo/apis/net/v1alpha1"
+
+const (
+	routingTableID = 18952
+)
+
+// Routing interface used to configure the routing rules for peering clusters.
+type Routing interface {
+	EnsureRoutesPerCluster(tep *netv1alpha1.TunnelEndpoint) (bool, error)
+	RemoveRoutesPerCluster(tep *netv1alpha1.TunnelEndpoint) (bool, error)
+	CleanRoutingTable() error
+	CleanPolicyRules() error
+}


### PR DESCRIPTION
# Description

This PR implements the Route Manager interface using the custom routing tables and policy routing rules introduced with PR #635. The implementation handles the case of direct routing. Each node is configured to send the traffic for remote clusters to the Gateway using the existing network infrastructure. No overlay networks are used.

Fixes #(issue)

# How Has This Been Tested?

Unit tests have been written for each function.
