### PR TITLE
Adding support for custom network namespace in the gateway operator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ endif
 
 # Run unit tests
 unit: test-container
-	docker run --cap-add=NET_ADMIN --mount type=bind,src=$(shell pwd),dst=/go/src/liqo -w /go/src/liqo --rm liqo-test
+	docker run --cap-add=NET_ADMIN --privileged=true --mount type=bind,src=$(shell pwd),dst=/go/src/liqo -w /go/src/liqo --rm liqo-test
 
 # Run e2e tests
 e2e: gen

--- a/cmd/liqonet/main.go
+++ b/cmd/liqonet/main.go
@@ -32,7 +32,7 @@ import (
 	clusterConfig "github.com/liqotech/liqo/apis/config/v1alpha1"
 	netv1alpha1 "github.com/liqotech/liqo/apis/net/v1alpha1"
 	route_operator "github.com/liqotech/liqo/internal/liqonet/route-operator"
-	tunnel_operator "github.com/liqotech/liqo/internal/liqonet/tunnel-operator"
+	tunneloperator "github.com/liqotech/liqo/internal/liqonet/tunnel-operator"
 	"github.com/liqotech/liqo/internal/liqonet/tunnelEndpointCreator"
 	liqoconst "github.com/liqotech/liqo/pkg/consts"
 	liqonetOperator "github.com/liqotech/liqo/pkg/liqonet"
@@ -96,13 +96,13 @@ func main() {
 			klog.Errorf("unable to start controller: %s", err)
 			os.Exit(1)
 		}
-	case tunnel_operator.OperatorName:
+	case tunneloperator.OperatorName:
 		wgc, err := wireguard.NewWgClient()
 		if err != nil {
 			klog.Errorf("an error occurred while creating wireguard client: %v", err)
 			os.Exit(1)
 		}
-		tc, err := tunnel_operator.NewTunnelController(mgr, wgc, wireguard.NewNetLinker())
+		tc, err := tunneloperator.NewTunnelController(mgr, wgc, wireguard.NewNetLinker())
 		if err != nil {
 			klog.Errorf("an error occurred while creating the tunnel controller: %v", err)
 			os.Exit(1)

--- a/go.mod
+++ b/go.mod
@@ -4,12 +4,14 @@ go 1.16
 
 require (
 	cloud.google.com/go v0.56.0 // indirect
+	github.com/containernetworking/plugins v0.8.6
 	github.com/coreos/go-iptables v0.4.5
 	github.com/google/go-cmp v0.5.3
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/uuid v1.2.0
 	github.com/gorilla/mux v1.8.0
 	github.com/grandcat/zeroconf v1.0.0
+	github.com/gruntwork-io/gruntwork-cli v0.7.0
 	github.com/gruntwork-io/terratest v0.30.7
 	github.com/jinzhu/copier v0.0.0-20201025035756-632e723a6687
 	github.com/julienschmidt/httprouter v1.3.0
@@ -25,6 +27,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.0
 	github.com/vishvananda/netlink v1.1.0
+	github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae
 	go.opencensus.io v0.23.0
 	go.uber.org/goleak v1.1.10
 	go.uber.org/multierr v1.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -222,7 +222,9 @@ github.com/containerd/typeurl v0.0.0-20190911142611-5eb25027c9fd/go.mod h1:GeKYz
 github.com/containerd/typeurl v1.0.1/go.mod h1:TB1hUtrpaiO88KEK56ijojHS1+NeF0izUACaJW2mdXg=
 github.com/containerd/zfs v0.0.0-20200918131355-0a33824f23a2/go.mod h1:8IgZOBdv8fAgXddBT4dBXJPtxyRsejFIpXoklgxgEjw=
 github.com/containernetworking/cni v0.7.1/go.mod h1:LGwApLUm2FpoOfxTDEeq8T9ipbpZ61X79hmU3w8FmsY=
+github.com/containernetworking/cni v0.8.0 h1:BT9lpgGoH4jw3lFC7Odz2prU5ruiYKcgAjMCbgybcKI=
 github.com/containernetworking/cni v0.8.0/go.mod h1:LGwApLUm2FpoOfxTDEeq8T9ipbpZ61X79hmU3w8FmsY=
+github.com/containernetworking/plugins v0.8.6 h1:npZTLiMa4CRn6m5P9+1Dz4O1j0UeFbm8VYN6dlsw568=
 github.com/containernetworking/plugins v0.8.6/go.mod h1:qnw5mN19D8fIwkqW7oHHYDHVlzhJpcY6TQxn/fUyDDM=
 github.com/containers/ocicrypt v1.0.1/go.mod h1:MeJDzk1RJHv89LjsH0Sp5KTY3ZYkjXO/C+bKAeWFIrc=
 github.com/coredns/corefile-migration v1.0.11/go.mod h1:RMy/mXdeDlYwzt0vdMEJvT2hGJ2I86/eO0UdXmH9XNI=
@@ -852,6 +854,7 @@ github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR
 github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
+github.com/safchain/ethtool v0.0.0-20190326074333-42ed695e3de8 h1:2c1EFnZHIPCW8qKWgHMH/fX2PkSabFc5mrVzfUNdg5U=
 github.com/safchain/ethtool v0.0.0-20190326074333-42ed695e3de8/go.mod h1:Z0q5wiBQGYcxhMZ6gUqHn6pYNLypFAvaL3UvgZLR0U4=
 github.com/samuel/go-zookeeper v0.0.0-20190923202752-2cc03de413da/go.mod h1:gi+0XIa01GRL2eRQVjQkKGqKF3SF9vZR/HnPullcV2E=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=

--- a/internal/liqonet/tunnel-operator/config.go
+++ b/internal/liqonet/tunnel-operator/config.go
@@ -1,4 +1,4 @@
-package tunnel_operator
+package tunneloperator
 
 import (
 	"os"
@@ -13,6 +13,7 @@ import (
 	"github.com/liqotech/liqo/pkg/utils"
 )
 
+// WatchConfiguration starts an informer in order to retrieve the latest configuration for the operator.
 func (tc *TunnelController) WatchConfiguration(config *rest.Config, gv *schema.GroupVersion) {
 	config.ContentConfig.GroupVersion = gv
 	config.APIPath = "/apis"
@@ -25,7 +26,7 @@ func (tc *TunnelController) WatchConfiguration(config *rest.Config, gv *schema.G
 	}
 
 	go utils.WatchConfiguration(func(configuration *configv1alpha1.ClusterConfig) {
-		//this section is executed at start-up time
+		// This section is executed at start-up time.
 		if !tc.isConfigured {
 			tc.isGKE = configuration.Spec.LiqonetConfig.GKEProvider
 			tc.configChan <- true

--- a/internal/liqonet/tunnel-operator/doc.go
+++ b/internal/liqonet/tunnel-operator/doc.go
@@ -1,0 +1,3 @@
+// Package tunneloperator contains the tunnel controller which configures the vpn tunnels, natting rules and
+// routes in order to comunicate with the remote peering clusters.
+package tunneloperator

--- a/internal/liqonet/tunnel-operator/serviceWatcher.go
+++ b/internal/liqonet/tunnel-operator/serviceWatcher.go
@@ -1,4 +1,4 @@
-package tunnel_operator
+package tunneloperator
 
 import (
 	"context"
@@ -19,12 +19,14 @@ var (
 	serviceLabelValue = "true"
 )
 
+// StartServiceWatcher starts the service informer.
 func (tc *TunnelController) StartServiceWatcher() {
 	go tc.serviceWatcher()
 }
 
 func (tc *TunnelController) serviceWatcher() {
-	factory := informers.NewSharedInformerFactoryWithOptions(tc.k8sClient, resyncPeriod, informers.WithNamespace(tc.namespace), informers.WithTweakListOptions(setServiceSelectorLabel))
+	factory := informers.NewSharedInformerFactoryWithOptions(tc.k8sClient, resyncPeriod, informers.WithNamespace(tc.namespace),
+		informers.WithTweakListOptions(setServiceSelectorLabel))
 	inf := factory.Core().V1().Services().Informer()
 	inf.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    tc.serviceHandlerAdd,
@@ -42,7 +44,8 @@ func (tc *TunnelController) serviceHandlerAdd(obj interface{}) {
 		return
 	}
 	if s.Spec.Type != corev1.ServiceTypeNodePort && s.Spec.Type != corev1.ServiceTypeLoadBalancer {
-		klog.Errorf("the service %s in namespace %s is of type %s, only types of %s and %s are accepted", s.GetName(), s.GetNamespace(), s.Spec.Type, corev1.ServiceTypeLoadBalancer, corev1.ServiceTypeNodePort)
+		klog.Errorf("the service %s in namespace %s is of type %s, only types of %s and %s are accepted", s.GetName(),
+			s.GetNamespace(), s.Spec.Type, corev1.ServiceTypeLoadBalancer, corev1.ServiceTypeNodePort)
 		return
 	}
 	currentPubKey := tc.wg.GetPubKey()
@@ -72,7 +75,7 @@ func (tc *TunnelController) serviceHandlerAdd(obj interface{}) {
 	}
 }
 
-func (tc *TunnelController) serviceHandlerUpdate(oldObj interface{}, newObj interface{}) {
+func (tc *TunnelController) serviceHandlerUpdate(oldObj, newObj interface{}) {
 	tc.serviceHandlerAdd(newObj)
 }
 

--- a/internal/liqonet/tunnel-operator/tunnel_operator_suite_test.go
+++ b/internal/liqonet/tunnel-operator/tunnel_operator_suite_test.go
@@ -1,0 +1,17 @@
+package tunneloperator
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var (
+	tc = &TunnelController{}
+)
+
+func TestTunnelOperator(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "TunnelOperator Suite")
+}

--- a/internal/liqonet/tunnel-operator/tunnel_operator_test.go
+++ b/internal/liqonet/tunnel-operator/tunnel_operator_test.go
@@ -1,0 +1,73 @@
+package tunneloperator
+
+import (
+	"net"
+
+	"github.com/containernetworking/plugins/pkg/ns"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/vishvananda/netlink"
+
+	"github.com/liqotech/liqo/pkg/liqonet/netns"
+)
+
+var _ = Describe("TunnelOperator", func() {
+	Describe("setup gateway namespace", func() {
+		Context("creating a new gateway namespace", func() {
+			JustAfterEach(func() {
+				link, err := netlink.LinkByName(hostVethName)
+				if err != nil {
+					Expect(err).Should(MatchError("Link not found"))
+				}
+				if err != nil && err.Error() != "Link not found" {
+					Expect(err).ShouldNot(HaveOccurred())
+				}
+				if link != nil {
+					Expect(netlink.LinkDel(link)).ShouldNot(HaveOccurred())
+				}
+				Expect(netns.DeleteNetns(gatewayNetnsName)).ShouldNot(HaveOccurred())
+			})
+			It("should return nil", func() {
+				tc := &TunnelController{}
+				err := tc.setUpGWNetns(gatewayNetnsName, hostVethName, gatewayVethName, "169.254.1.134/32", 1420)
+				Expect(err).ShouldNot(HaveOccurred())
+				// Check that we have the veth interface in host namespace
+				err = tc.hostNetns.Do(func(ns ns.NetNS) error {
+					defer GinkgoRecover()
+					link, err := netlink.LinkByName(hostVethName)
+					Expect(err).ShouldNot(HaveOccurred())
+					Expect(link.Attrs().MTU).Should(BeNumerically("==", 1420))
+					return nil
+				})
+				// Check that we have the veth interface in gateway namespace
+				err = tc.gatewayNetns.Do(func(ns ns.NetNS) error {
+					defer GinkgoRecover()
+					link, err := netlink.LinkByName(gatewayVethName)
+					Expect(err).ShouldNot(HaveOccurred())
+					Expect(link.Attrs().MTU).Should(BeNumerically("==", 1420))
+					addresses, err := netlink.AddrList(link, netlink.FAMILY_V4)
+					Expect(addresses[0].IPNet.String()).Should(Equal("169.254.1.134/32"))
+					Expect(err).ShouldNot(HaveOccurred())
+
+					return nil
+				})
+				Expect(tc.hostNetns.Close()).ShouldNot(HaveOccurred())
+				Expect(tc.gatewayNetns.Close()).ShouldNot(HaveOccurred())
+
+			})
+
+			It("incorrect name for veth interface, should return error", func() {
+				err := tc.setUpGWNetns(gatewayNetnsName, "", gatewayVethName, "169.254.1.134/24", 1420)
+				Expect(err).Should(HaveOccurred())
+				Expect(err).Should(MatchError("failed to make veth pair: LinkAttrs.Name cannot be empty"))
+			})
+
+			It("incorrect ip address for veth interface, should return error", func() {
+				tc := &TunnelController{}
+				err := tc.setUpGWNetns(gatewayNetnsName, hostVethName, gatewayVethName, "169.254.1.1.34/24", 1420)
+				Expect(err).Should(HaveOccurred())
+				Expect(err).Should(MatchError(&net.ParseError{Text: "169.254.1.1.34/24", Type: "CIDR address"}))
+			})
+		})
+	})
+})

--- a/pkg/liqonet/errors.go
+++ b/pkg/liqonet/errors.go
@@ -13,6 +13,8 @@ const (
 	StringNotEmpty = "not empty"
 	// ValidIP used as reason of failure in WrongParameter error.
 	ValidIP = "a valid IP address"
+	// NotNil used as reason of failure in WrongParameter error.
+	NotNil = "have to be not nil"
 )
 
 // ParseIPError it is returned when net.ParseIP() fails to parse and ip address.

--- a/pkg/liqonet/netns/doc.go
+++ b/pkg/liqonet/netns/doc.go
@@ -1,0 +1,2 @@
+// Package netns defines and implements basic functions used to create and configure new network namespaces.
+package netns

--- a/pkg/liqonet/netns/netns.go
+++ b/pkg/liqonet/netns/netns.go
@@ -1,0 +1,87 @@
+package netns
+
+import (
+	"time"
+
+	"github.com/containernetworking/plugins/pkg/ip"
+	"github.com/containernetworking/plugins/pkg/ns"
+	"github.com/gruntwork-io/gruntwork-cli/errors"
+	"github.com/vishvananda/netns"
+	"golang.org/x/sys/unix"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/retry"
+	"k8s.io/klog"
+
+	"github.com/liqotech/liqo/pkg/liqonet"
+)
+
+const (
+	nsPath = "/run/netns/"
+)
+
+// CreateNetns given a name it will check if a namespace exists with the given name
+// and will remove it. Then the namespace will be recreated. To start fresh with a clean
+// network namespace is preferred since we create a veth pair between network namespaces.
+// If the namespace exists it means that our operator has crashed, better clean the namespace,
+// because it's hard to check the existing configuration that spans multiple network namespaces.
+// Returns a handler to the newly created network namespace or an error in case
+// something goes wrong.
+func CreateNetns(name string) (ns.NetNS, error) {
+	namespacePath := nsPath + name
+	err := DeleteNetns(name)
+	if err != nil {
+		return nil, err
+	}
+	// Create a new network namespace.
+	_, err = netns.NewNamed(name)
+	if err != nil {
+		return nil, err
+	}
+	netNamespace, err := ns.GetNS(namespacePath)
+	if err != nil {
+		return nil, err
+	}
+	return netNamespace, nil
+}
+
+// DeleteNetns removes a given network namespace by name.
+// If the namespace does not exist does nothing, in case of error returns it.
+func DeleteNetns(name string) error {
+	if err := netns.DeleteNamed(name); err != nil && !errors.IsError(err, unix.ENOENT) {
+		klog.Errorf("an error occurred while removing network namespace with name %s: %v", name, err)
+		return err
+	}
+	return nil
+}
+
+// CreateVethPair it will create veth pair in originNetns and move one of them in dstNetns.
+// Error is returned if something goes wrong.
+func CreateVethPair(originVethName, dstVethName string, originNetns, dstNetns ns.NetNS, linkMTU int) error {
+	if originNetns == nil || dstNetns == nil {
+		return &liqonet.WrongParameter{
+			Parameter: "originNetns and dstNetns",
+			Reason:    liqonet.NotNil}
+	}
+	var createVethPair = func(hostNS ns.NetNS) error {
+		_, _, err := ip.SetupVethWithName(originVethName, dstVethName, linkMTU, dstNetns)
+		if err != nil {
+			klog.Errorf("an error occurred while creating veth pair between host and gateway namespace: %v", err)
+			return err
+		}
+		return nil
+	}
+	// If we just delete the old network namespace it would require some time for the kernel to
+	// remove the veth device in the host network, so we retry in case of temporary conflicts.
+	retryiable := func(err error) bool {
+		return true
+	}
+	tryToCreateVeth := func() error {
+		return originNetns.Do(createVethPair)
+	}
+	return retry.OnError(wait.Backoff{
+		Steps:    5,
+		Duration: 100 * time.Millisecond,
+		Factor:   1.0,
+		Jitter:   0.1,
+	}, retryiable, tryToCreateVeth)
+}

--- a/pkg/liqonet/netns/netns_suite_test.go
+++ b/pkg/liqonet/netns/netns_suite_test.go
@@ -1,0 +1,58 @@
+package netns
+
+import (
+	"testing"
+
+	"github.com/containernetworking/plugins/pkg/ns"
+	"github.com/vishvananda/netlink"
+	"github.com/vishvananda/netns"
+	"golang.org/x/sys/unix"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var (
+	netnsName             = "liqo-ns-test"
+	originNetns, newNetns ns.NetNS
+)
+
+func TestNetns(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Netns Suite")
+}
+
+var _ = BeforeSuite(func() {
+	var err error
+	originNetns, err = ns.GetCurrentNS()
+	Expect(err).ShouldNot(HaveOccurred())
+})
+
+func setUpNetns(name string) {
+	var err error
+	// Create a new network namespace.
+	newNs, err := netns.NewNamed(name)
+	Expect(err).ShouldNot(HaveOccurred())
+	Expect(newNs).ShouldNot(BeNil())
+	// Set the newly created newNs
+	err = netns.Set(newNs)
+	Expect(err).ShouldNot(HaveOccurred())
+	// Create a dummy network interface
+	err = netlink.LinkAdd(&netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: "foo"}})
+	Expect(err).ShouldNot(HaveOccurred())
+	err = originNetns.Set()
+	Expect(err).ShouldNot(HaveOccurred())
+	// Save newly created netns.
+	newNetns, err = ns.GetNS("/run/netns/" + netnsName)
+	Expect(err).ShouldNot(HaveOccurred())
+	defer newNs.Close()
+}
+
+func tearDownNetns(name string) {
+	err := netns.DeleteNamed(name)
+	if err != nil {
+		Expect(err).Should(Equal(unix.ENOENT))
+		return
+	}
+	Expect(err).ShouldNot(HaveOccurred())
+}

--- a/pkg/liqonet/netns/netns_test.go
+++ b/pkg/liqonet/netns/netns_test.go
@@ -1,0 +1,133 @@
+package netns
+
+import (
+	"github.com/containernetworking/plugins/pkg/ns"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/vishvananda/netlink"
+	"github.com/vishvananda/netns"
+	"golang.org/x/sys/unix"
+
+	"github.com/liqotech/liqo/pkg/liqonet"
+)
+
+var _ = Describe("Netns", func() {
+	Describe("creating new network namespace", func() {
+		Context("when network namespace does not exist and we want to create it", func() {
+			It("should return a new network namespace and nil", func() {
+				netnamespace, err := CreateNetns(netnsName)
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(netnamespace).ShouldNot(BeNil())
+				// Get the newly created namespace.
+				netnsNew, err := netns.GetFromName(netnsName)
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(netnsNew).ShouldNot(BeNil())
+				tearDownNetns(netnsName)
+			})
+		})
+
+		Context("when network namespace does exist and we want to create it", func() {
+			JustBeforeEach(func() {
+				setUpNetns(netnsName)
+			})
+			JustAfterEach(func() {
+				tearDownNetns(netnsName)
+			})
+			It("should remove the old one and create a new one, returning the new netns and nil", func() {
+				netnamespace, err := CreateNetns(netnsName)
+				defer netnamespace.Close()
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(netnamespace).ShouldNot(BeNil())
+				// Check that our dummy interface is not present in the newly created namespace.
+				err = netnamespace.Do(func(ns ns.NetNS) error {
+					links, err := netlink.LinkList()
+					Expect(err).ShouldNot(HaveOccurred())
+					Expect(len(links)).Should(BeNumerically("==", 1))
+					return nil
+				})
+				Expect(err).ShouldNot(HaveOccurred())
+			})
+		})
+	})
+
+	Describe("deleting a network namespace", func() {
+		Context("when network namespace does exist and we want to remove it", func() {
+			JustBeforeEach(func() {
+				setUpNetns(netnsName)
+			})
+			JustAfterEach(func() {
+				tearDownNetns(netnsName)
+			})
+			It("should remove the existing namespace and return nil", func() {
+				err := DeleteNetns(netnsName)
+				Expect(err).ShouldNot(HaveOccurred())
+				// Try to get the netns
+				_, err = netns.GetFromName(netnsName)
+				Expect(err).Should(Equal(unix.ENOENT))
+			})
+		})
+
+		Context("when network namespace does not exist and we want to remeove it", func() {
+			It("should do nothing and return nil", func() {
+				err := DeleteNetns(netnsName)
+				Expect(err).ShouldNot(HaveOccurred())
+			})
+		})
+	})
+
+	Describe("adding veth pair and moving one end to another network namespace", func() {
+		Context("when network namespaces does exist", func() {
+			JustBeforeEach(func() {
+				setUpNetns(netnsName)
+			})
+			JustAfterEach(func() {
+				tearDownNetns(netnsName)
+			})
+			It("should add veth pair and return nil", func() {
+				err := CreateVethPair("originVeth", "dstVeth", originNetns, newNetns, 1500)
+				Expect(err).ShouldNot(HaveOccurred())
+				// Get originVeth
+				or, err := netlink.LinkByName("originVeth")
+				Expect(err).ShouldNot(HaveOccurred())
+				// Get dstVeth
+				err = newNetns.Do(func(netNS ns.NetNS) error {
+					_, err = netlink.LinkByName("dstVeth")
+					if err != nil {
+						return err
+					}
+					return nil
+				})
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(netlink.LinkDel(or)).ShouldNot(HaveOccurred())
+
+			})
+		})
+
+		Context("when links with same name already exists", func() {
+			JustBeforeEach(func() {
+				setUpNetns(netnsName)
+			})
+			JustAfterEach(func() {
+				tearDownNetns(netnsName)
+			})
+			It("should return error", func() {
+				err := CreateVethPair("originVeth", "foo", originNetns, newNetns, 1500)
+				Expect(err).Should(HaveOccurred())
+			})
+		})
+
+		Context("when dst network namespace does not exist", func() {
+			It("should return error", func() {
+				err := CreateVethPair("originVeth", "dstVeth", nil, nil, 1500)
+				Expect(err).Should(Equal(&liqonet.WrongParameter{
+					Reason:    liqonet.NotNil,
+					Parameter: "originNetns and dstNetns",
+				}))
+				// Remove dangling veth pair.
+				veth, err := netlink.LinkByName("originVeth")
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(netlink.LinkDel(veth)).ShouldNot(HaveOccurred())
+			})
+		})
+	})
+})

--- a/pkg/liqonet/routing/common_test.go
+++ b/pkg/liqonet/routing/common_test.go
@@ -1,6 +1,7 @@
 package routing
 
 import (
+	"io/ioutil"
 	"net"
 
 	"github.com/liqotech/liqo/pkg/liqonet"
@@ -58,13 +59,13 @@ var _ = Describe("Common", func() {
 	Describe("adding new route", func() {
 		Context("when input parameters are not in the correct format", func() {
 			It("should return error on wrong destination net", func() {
-				added, err := addRoute(dstNetWrong, gwIPCorrect, dummylink1.Attrs().Index, routingTableID)
+				added, err := AddRoute(dstNetWrong, gwIPCorrect, dummylink1.Attrs().Index, routingTableID)
 				Expect(added).Should(Equal(false))
 				Expect(err).Should(Equal(&net.ParseError{Type: "CIDR address", Text: dstNetWrong}))
 			})
 
 			It("should return error on wrong gateway IP address", func() {
-				added, err := addRoute(dstNetCorrect, gwIPWrong, dummylink1.Attrs().Index, routingTableID)
+				added, err := AddRoute(dstNetCorrect, gwIPWrong, dummylink1.Attrs().Index, routingTableID)
 				Expect(added).Should(Equal(false))
 				Expect(err).Should(Equal(&liqonet.ParseIPError{IPToBeParsed: gwIPWrong}))
 			})
@@ -72,7 +73,7 @@ var _ = Describe("Common", func() {
 
 		Context("when an error occurred while adding a route", func() {
 			It("should return an error on non existing link", func() {
-				added, err := addRoute(dstNetCorrect, gwIPWrong, 0, routingTableID)
+				added, err := AddRoute(dstNetCorrect, gwIPWrong, 0, routingTableID)
 				Expect(added).Should(Equal(false))
 				Expect(err).To(HaveOccurred())
 			})
@@ -80,7 +81,7 @@ var _ = Describe("Common", func() {
 
 		Context("when route does not exist and we want to add it", func() {
 			It("no gatewayIP, should return true and nil", func() {
-				added, err := addRoute(dstNetCorrect, "", dummylink1.Attrs().Index, routingTableID)
+				added, err := AddRoute(dstNetCorrect, "", dummylink1.Attrs().Index, routingTableID)
 				Expect(added).Should(Equal(true))
 				Expect(err).NotTo(HaveOccurred())
 				// Get the route and check it has the right parameters
@@ -90,7 +91,7 @@ var _ = Describe("Common", func() {
 			})
 
 			It("with gatewayIP, should return true and nil", func() {
-				added, err := addRoute(dstNetCorrect, gwIPCorrect, dummylink1.Attrs().Index, routingTableID)
+				added, err := AddRoute(dstNetCorrect, gwIPCorrect, dummylink1.Attrs().Index, routingTableID)
 				Expect(added).Should(Equal(true))
 				Expect(err).NotTo(HaveOccurred())
 				// Get the route and check it has the right parameters
@@ -111,19 +112,19 @@ var _ = Describe("Common", func() {
 
 			It("should return false and nil", func() {
 				// Add existing route with GW.
-				added, err := addRoute(existingRoutesCM[0].Dst.String(), existingRoutesCM[0].Gw.String(), existingRoutesCM[0].LinkIndex, existingRoutesCM[0].Table)
+				added, err := AddRoute(existingRoutesCM[0].Dst.String(), existingRoutesCM[0].Gw.String(), existingRoutesCM[0].LinkIndex, existingRoutesCM[0].Table)
 				Expect(added).Should(Equal(false))
 				Expect(err).NotTo(HaveOccurred())
 
 				// Add existing route without GW.
-				added, err = addRoute(existingRoutesCM[1].Dst.String(), "", existingRoutesCM[1].LinkIndex, existingRoutesCM[1].Table)
+				added, err = AddRoute(existingRoutesCM[1].Dst.String(), "", existingRoutesCM[1].LinkIndex, existingRoutesCM[1].Table)
 				Expect(added).Should(Equal(false))
 				Expect(err).NotTo(HaveOccurred())
 			})
 
 			It("update gateway of existing route: should return true and nil", func() {
 				// Update route with GW
-				added, err := addRoute(existingRoutesCM[0].Dst.String(), "", existingRoutesCM[0].LinkIndex, existingRoutesCM[0].Table)
+				added, err := AddRoute(existingRoutesCM[0].Dst.String(), "", existingRoutesCM[0].LinkIndex, existingRoutesCM[0].Table)
 				Expect(added).Should(Equal(true))
 				Expect(err).NotTo(HaveOccurred())
 				// Get the route and check it has the right parameters
@@ -132,7 +133,7 @@ var _ = Describe("Common", func() {
 				Expect(routes[0].Gw).Should(BeNil())
 
 				// Update route without GW
-				added, err = addRoute(existingRoutesCM[1].Dst.String(), gwIPCorrect, existingRoutesCM[1].LinkIndex, existingRoutesCM[1].Table)
+				added, err = AddRoute(existingRoutesCM[1].Dst.String(), gwIPCorrect, existingRoutesCM[1].LinkIndex, existingRoutesCM[1].Table)
 				Expect(added).Should(Equal(true))
 				Expect(err).NotTo(HaveOccurred())
 				// Get the route and check it has the right parameters
@@ -143,7 +144,7 @@ var _ = Describe("Common", func() {
 
 			It("update link index of existing route: should return true and nil", func() {
 				// Update route with GW
-				added, err := addRoute(existingRoutesCM[0].Dst.String(), existingRoutesCM[0].Gw.String(), dummyLink2.Attrs().Index, existingRoutesCM[0].Table)
+				added, err := AddRoute(existingRoutesCM[0].Dst.String(), existingRoutesCM[0].Gw.String(), dummyLink2.Attrs().Index, existingRoutesCM[0].Table)
 				Expect(added).Should(Equal(true))
 				Expect(err).NotTo(HaveOccurred())
 				// Get the route and check it has the right parameters
@@ -152,7 +153,7 @@ var _ = Describe("Common", func() {
 				Expect(routes[0].LinkIndex).Should(BeNumerically("==", dummyLink2.Attrs().Index))
 
 				// Update route without GW
-				added, err = addRoute(existingRoutesCM[1].Dst.String(), gwIPCorrect, dummyLink2.Attrs().Index, existingRoutesCM[1].Table)
+				added, err = AddRoute(existingRoutesCM[1].Dst.String(), gwIPCorrect, dummyLink2.Attrs().Index, existingRoutesCM[1].Table)
 				Expect(added).Should(Equal(true))
 				Expect(err).NotTo(HaveOccurred())
 				// Get the route and check it has the right parameters
@@ -494,6 +495,39 @@ var _ = Describe("Common", func() {
 				_, _, _, err := getRouteConfig(&tepCopy, gwIPCorrect)
 				Expect(err).To(HaveOccurred())
 				Expect(err).Should(Equal(&liqonet.NoRouteFound{IPAddress: tepCopy.Status.GatewayIP}))
+			})
+		})
+	})
+
+	Describe("enabling ip forwarding for ipv4", func() {
+		Context("enable ip forwarding", func() {
+			It("should return nil", func() {
+				var enabled byte = '1'
+				err := EnableIPForwarding()
+				Expect(err).ShouldNot(HaveOccurred())
+				txt, err := ioutil.ReadFile("/proc/sys/net/ipv4/ip_forward")
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(txt[0]).Should(Equal(enabled))
+			})
+		})
+	})
+
+	Describe("enabling proxy arp", func() {
+		Context("enable proxy arp for an existing interface", func() {
+			It("should return nil", func() {
+				var enabled byte = '1'
+				err := EnableProxyArp(dummylink1.Attrs().Name)
+				Expect(err).ShouldNot(HaveOccurred())
+				txt, err := ioutil.ReadFile("/proc/sys/net/ipv4/conf/" + dummylink1.Attrs().Name + "/proxy_arp")
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(txt[0]).Should(Equal(enabled))
+			})
+		})
+
+		Context("enable proxy arp for non existing interface", func() {
+			It("should return error", func() {
+				err := EnableProxyArp("doesNotExist")
+				Expect(err).Should(HaveOccurred())
 			})
 		})
 	})

--- a/pkg/liqonet/routing/directRouting.go
+++ b/pkg/liqonet/routing/directRouting.go
@@ -62,7 +62,7 @@ func (drm *DirectRoutingManager) EnsureRoutesPerCluster(tep *netv1alpha1.TunnelE
 	// Add route for the given cluster.
 	klog.Infof("%s -> adding route for destination {%s} with gateway {%s} in routing table with ID {%d}",
 		clusterID, dstNet, gatewayIP, drm.routingTableID)
-	routeAdd, err = addRoute(dstNet, gatewayIP, iFaceIndex, drm.routingTableID)
+	routeAdd, err = AddRoute(dstNet, gatewayIP, iFaceIndex, drm.routingTableID)
 	if err != nil {
 		return routeAdd, err
 	}

--- a/pkg/liqonet/wireguard/wireguard.go
+++ b/pkg/liqonet/wireguard/wireguard.go
@@ -13,6 +13,11 @@ import (
 	"github.com/liqotech/liqo/internal/utils/errdefs"
 )
 
+const (
+	// LinkMTU defines mtu to use for a network interface.
+	LinkMTU = 1420
+)
+
 // WgConfig struct used to hold the configuration of wireguard device that we want to create.
 type WgConfig struct {
 	// Name the name used for the device.


### PR DESCRIPTION
# Description

Supporting the creation and configuration of a new network namespace for the gateway operator. The idea is to move the gateway pod in host network. In order to not put the iptables configuration in the node's namespace a new one is created. In the custom network namespace we put all the liqo configuration such as vpn tunnel and iptables rulespecs.

Fixes #(issue)

# How Has This Been Tested?

Unit tests have been written for all the new functions.
