### PR TITLE
Add new label remoteClusterId to offloaded pods.

### DIFF
--- a/pkg/virtualKubelet/forge/apiForger.go
+++ b/pkg/virtualKubelet/forge/apiForger.go
@@ -68,13 +68,14 @@ type apiForger struct {
 	remoteRemappedPodCidr options.ReadOnlyOption
 	virtualNodeName       options.ReadOnlyOption
 	liqoIpamServer        options.ReadOnlyOption
+	offloadClusterID      options.ReadOnlyOption
 }
 
 var forger apiForger
 
+// InitForger initialize forger component to set all necessary fields of offloaded resources.
 func InitForger(nattingTable namespacesMapping.NamespaceNatter, opts ...options.ReadOnlyOption) {
 	forger.nattingTable = nattingTable
-
 	for _, opt := range opts {
 		switch opt.Key() {
 		case types.LocalRemappedPodCIDR:
@@ -83,6 +84,8 @@ func InitForger(nattingTable namespacesMapping.NamespaceNatter, opts ...options.
 			forger.remoteRemappedPodCidr = opt
 		case types.VirtualNodeName:
 			forger.virtualNodeName = opt
+		case types.RemoteClusterID:
+			forger.offloadClusterID = opt
 		case types.LiqoIpamServer:
 			forger.liqoIpamServer = opt
 			initIpamClient()

--- a/pkg/virtualKubelet/forge/forge_test.go
+++ b/pkg/virtualKubelet/forge/forge_test.go
@@ -1,0 +1,42 @@
+package forge
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/liqotech/liqo/pkg/virtualKubelet/namespacesMapping/test"
+	"github.com/liqotech/liqo/pkg/virtualKubelet/options"
+	"github.com/liqotech/liqo/pkg/virtualKubelet/options/types"
+)
+
+var _ = Describe("Virtual Kubelet labels test", func() {
+	var (
+		namespaceNattingTable *test.MockNamespaceMapper
+		foreignClusterID      options.Option
+	)
+
+	Context("Testing Labels attached to offloaded pods", func() {
+		BeforeEach(
+			func() {
+				namespaceNattingTable = &test.MockNamespaceMapper{Cache: map[string]string{}}
+				namespaceNattingTable.Cache["homeNamespace"] = "homeNamespace-natted"
+				foreignClusterID = types.NewNetworkingOption(types.RemoteClusterID, "foreign-id")
+				InitForger(namespaceNattingTable, foreignClusterID)
+			},
+		)
+
+		It("Creating new pod to offload", func() {
+			foreignObj, err := HomeToForeign(nil, nil, LiqoOutgoingKey)
+			Expect(err).NotTo(HaveOccurred())
+			foreignPod := foreignObj.(*corev1.Pod)
+			Expect(foreignPod.Labels[LiqoOutgoingKey]).ShouldNot(BeNil())
+			Expect(foreignPod.Labels[LiqoOriginClusterID]).ShouldNot(BeNil())
+			Expect(foreignPod.Labels[LiqoOriginClusterID]).Should(Equal("foreign-id"))
+
+		})
+
+	})
+
+})

--- a/pkg/virtualKubelet/forge/meta.go
+++ b/pkg/virtualKubelet/forge/meta.go
@@ -3,7 +3,11 @@ package forge
 import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 const (
+	// LiqoOutgoingKey is a label to set on all offloaded resources.
 	LiqoOutgoingKey = "virtualkubelet.liqo.io/outgoing"
+	// LiqoOriginClusterID is a label to set on all offloaded resources to identify the origin cluster.
+	LiqoOriginClusterID = "virtualkubelet.liqo.io/originClusterId"
+	// LiqoIncomingKey is a label for incoming resources.
 	LiqoIncomingKey = "virtualkubelet.liqo.io/incoming"
 )
 
@@ -20,6 +24,7 @@ func (f *apiForger) forgeForeignMeta(homeMeta, foreignMeta *metav1.ObjectMeta, f
 	forgeObjectMeta(homeMeta, foreignMeta)
 
 	foreignMeta.Namespace = foreignNamespace
+	foreignMeta.Labels[LiqoOriginClusterID] = f.offloadClusterID.Value().ToString()
 	foreignMeta.Labels[reflectionType] = LiqoNodeName()
 }
 

--- a/pkg/virtualKubelet/options/types/networking.go
+++ b/pkg/virtualKubelet/options/types/networking.go
@@ -13,6 +13,7 @@ const (
 	LocalRemappedPodCIDR  = "localRemappedPodCIDR"
 	RemoteRemappedPodCIDR = "remoteRemappedPodCIDR"
 	VirtualNodeName       = "virtualNodeName"
+	RemoteClusterID       = "remoteClusterID"
 	LiqoIpamServer        = "liqoIpamServer"
 )
 

--- a/pkg/virtualKubelet/provider/provider.go
+++ b/pkg/virtualKubelet/provider/provider.go
@@ -107,8 +107,9 @@ func NewLiqoProvider(nodeName, foreignClusterID, homeClusterID, internalIP strin
 	localRemappedPodCIDROpt := optTypes.NewNetworkingOption(optTypes.LocalRemappedPodCIDR, "")
 	virtualNodeNameOpt := optTypes.NewNetworkingOption(optTypes.VirtualNodeName, optTypes.NetworkingValue(nodeName))
 	grpcServerNameOpt := optTypes.NewNetworkingOption(optTypes.LiqoIpamServer, optTypes.NetworkingValue(ipamGRPCServer))
+	remoteClusterIDOpt := optTypes.NewNetworkingOption(optTypes.RemoteClusterID, optTypes.NetworkingValue(foreignClusterID))
 
-	forge.InitForger(mapper, remoteRemappedPodCIDROpt, localRemappedPodCIDROpt, virtualNodeNameOpt, grpcServerNameOpt)
+	forge.InitForger(mapper, remoteRemappedPodCIDROpt, localRemappedPodCIDROpt, virtualNodeNameOpt, remoteClusterIDOpt, grpcServerNameOpt)
 
 	opts := forgeOptionsMap(
 		remoteRemappedPodCIDROpt,


### PR DESCRIPTION
This PR adds new label remoteClusterId to offloaded pods. It is useful to get cluster which has offloaded that pod. 