### PR TITLE
Improve PeeringPhase-Based Replication

### DIFF
--- a/apis/config/v1alpha1/clusterconfig_types.go
+++ b/apis/config/v1alpha1/clusterconfig_types.go
@@ -206,10 +206,14 @@ type LiqonetConfig struct {
 type Resource struct {
 	// GroupVersionResource contains the GVR of the resource to replicate.
 	GroupVersionResource metav1.GroupVersionResource `json:"groupVersionResource"`
-
+	// PeeringPhase contains the peering phase when this resource should be replicated.
 	// +kubebuilder:validation:Enum="None";"All";"Established";"Incoming";"Outgoing";"Bidirectional"
 	// +kubebuilder:default="All"
 	PeeringPhase consts.PeeringPhase `json:"peeringPhase,omitempty"`
+	// Ownership indicates the ownership over this resource.
+	// +kubebuilder:validation:Enum="Local";"Shared"
+	// +kubebuilder:default="Shared"
+	Ownership consts.OwnershipType `json:"ownership,omitempty"`
 }
 
 // DispatcherConfig defines the configuration of the CRDReplicator.

--- a/cmd/crd-replicator/main.go
+++ b/cmd/crd-replicator/main.go
@@ -101,8 +101,10 @@ func main() {
 		NamespaceManager:               namespaceManager,
 		IdentityManager: identitymanager.NewCertificateIdentityManager(
 			k8sClient, clusterIDInterface, namespaceManager),
-		LocalToRemoteNamespaceMapper: map[string]string{},
-		RemoteToLocalNamespaceMapper: map[string]string{},
+		LocalToRemoteNamespaceMapper:     map[string]string{},
+		RemoteToLocalNamespaceMapper:     map[string]string{},
+		ClusterIDToLocalNamespaceMapper:  map[string]string{},
+		ClusterIDToRemoteNamespaceMapper: map[string]string{},
 	}
 	if err = d.SetupWithManager(mgr); err != nil {
 		klog.Error(err, "unable to setup the crdreplicator-operator")

--- a/deployments/liqo/crds/config.liqo.io_clusterconfigs.yaml
+++ b/deployments/liqo/crds/config.liqo.io_clusterconfigs.yaml
@@ -290,10 +290,18 @@ spec:
                           - resource
                           - version
                           type: object
+                        ownership:
+                          default: Shared
+                          description: Ownership indicates the ownership over this
+                            resource.
+                          enum:
+                          - Local
+                          - Shared
+                          type: string
                         peeringPhase:
                           default: All
-                          description: PeeringPhase contains the status of the peering
-                            with a remote cluster.
+                          description: PeeringPhase contains the peering phase when
+                            this resource should be replicated.
                           enum:
                           - None
                           - All

--- a/deployments/liqo/files/liqo-remote-peering-basic-ClusterRole.yaml
+++ b/deployments/liqo/files/liqo-remote-peering-basic-ClusterRole.yaml
@@ -6,6 +6,7 @@ rules:
   verbs:
   - create
   - delete
+  - deletecollection
   - get
   - list
   - patch
@@ -18,6 +19,7 @@ rules:
   verbs:
   - create
   - delete
+  - deletecollection
   - get
   - list
   - patch

--- a/deployments/liqo/files/liqo-remote-peering-incoming-ClusterRole.yaml
+++ b/deployments/liqo/files/liqo-remote-peering-incoming-ClusterRole.yaml
@@ -6,6 +6,7 @@ rules:
   verbs:
   - create
   - delete
+  - deletecollection
   - get
   - list
   - patch
@@ -18,6 +19,7 @@ rules:
   verbs:
   - create
   - delete
+  - deletecollection
   - get
   - list
   - patch

--- a/deployments/liqo/files/liqo-remote-peering-outgoing-ClusterRole.yaml
+++ b/deployments/liqo/files/liqo-remote-peering-outgoing-ClusterRole.yaml
@@ -6,6 +6,7 @@ rules:
   verbs:
   - create
   - delete
+  - deletecollection
   - get
   - list
   - patch
@@ -18,6 +19,7 @@ rules:
   verbs:
   - create
   - delete
+  - deletecollection
   - get
   - list
   - patch
@@ -30,6 +32,7 @@ rules:
   verbs:
   - create
   - delete
+  - deletecollection
   - get
   - list
   - patch
@@ -42,6 +45,7 @@ rules:
   verbs:
   - create
   - delete
+  - deletecollection
   - get
   - list
   - patch

--- a/internal/crdReplicator/crdReplicator-config.go
+++ b/internal/crdReplicator/crdReplicator-config.go
@@ -3,6 +3,7 @@ package crdreplicator
 import (
 	"reflect"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
@@ -46,17 +47,17 @@ func (c *Controller) getConfig(cfg *configv1alpha1.ClusterConfig) []configv1alph
 	return config
 }
 
-func (c *Controller) getRemovedResources(resources []configv1alpha1.Resource) []string {
-	oldRes := []string{}
-	diffRes := []string{}
-	newRes := []string{}
+func (c *Controller) getRemovedResources(resources []configv1alpha1.Resource) []metav1.GroupVersionResource {
+	oldRes := []metav1.GroupVersionResource{}
+	diffRes := []metav1.GroupVersionResource{}
+	newRes := []metav1.GroupVersionResource{}
 	//save the resources as strings in 'newRes'
 	for _, r := range resources {
-		newRes = append(newRes, r.GroupVersionResource.String())
+		newRes = append(newRes, r.GroupVersionResource)
 	}
 	//get the old resources
 	for _, r := range c.RegisteredResources {
-		oldRes = append(oldRes, r.GroupVersionResource.String())
+		oldRes = append(oldRes, r.GroupVersionResource)
 	}
 	//save in diffRes all the resources that appears in oldRes but not in newRes
 	flag := false

--- a/internal/crdReplicator/namespaceTranslation.go
+++ b/internal/crdReplicator/namespaceTranslation.go
@@ -1,6 +1,8 @@
 package crdreplicator
 
 import (
+	"fmt"
+
 	"k8s.io/klog/v2"
 )
 
@@ -28,4 +30,22 @@ func (c *Controller) remoteToLocalNamespace(namespace string) string {
 	}
 	klog.V(5).Infof("remote namespace %v translation not found, returning the original namespace", namespace)
 	return namespace
+}
+
+func (c *Controller) clusterIDToRemoteNamespace(clusterID string) (string, error) {
+	if ns, ok := c.ClusterIDToRemoteNamespaceMapper[clusterID]; ok {
+		return ns, nil
+	}
+	err := fmt.Errorf("clusterID %v translation not found", clusterID)
+	klog.Error(err)
+	return "", err
+}
+
+func (c *Controller) clusterIDToLocalNamespace(clusterID string) (string, error) {
+	if ns, ok := c.ClusterIDToLocalNamespaceMapper[clusterID]; ok {
+		return ns, nil
+	}
+	err := fmt.Errorf("clusterID %v translation not found", clusterID)
+	klog.Error(err)
+	return "", err
 }

--- a/internal/crdReplicator/peeringPhase.go
+++ b/internal/crdReplicator/peeringPhase.go
@@ -1,6 +1,11 @@
 package crdreplicator
 
 import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/klog/v2"
 
 	configv1alpha1 "github.com/liqotech/liqo/apis/config/v1alpha1"
@@ -8,6 +13,60 @@ import (
 	"github.com/liqotech/liqo/pkg/consts"
 	foreigncluster "github.com/liqotech/liqo/pkg/utils/foreignCluster"
 )
+
+// checkResourcesOnPeeringPhaseChange checks if some of the replicated resources
+// need to start replication of this specific ForeignCluster on this phase change.
+// If some of the replicated resources need to start replication, it lists all the
+// instances already that are already present in the local cluster and calls the
+// AddHandler on them.
+func (c *Controller) checkResourcesOnPeeringPhaseChange(ctx context.Context,
+	remoteClusterID string, currentPhase, oldPhase consts.PeeringPhase) {
+	for i := range c.RegisteredResources {
+		res := &c.RegisteredResources[i]
+		if !isReplicationEnabled(oldPhase, res) && isReplicationEnabled(currentPhase, res) {
+			// this change has triggered the replication on this resource
+			klog.Infof("phase from %v to %v triggers replication on resource %v",
+				oldPhase, currentPhase, res.GroupVersionResource)
+			if err := c.startResourceReplicationHandler(ctx, remoteClusterID, res); err != nil {
+				klog.Error(err)
+				continue
+			}
+		}
+	}
+}
+
+// startResourceReplicationHandler lists all the instances already that are already present
+// in the local cluster and calls the AddHandler on them.
+func (c *Controller) startResourceReplicationHandler(ctx context.Context,
+	remoteClusterID string, res *configv1alpha1.Resource) error {
+	localNamespace, err := c.clusterIDToLocalNamespace(remoteClusterID)
+	if err != nil {
+		klog.Error(err)
+		return err
+	}
+
+	listOptions := metav1.ListOptions{}
+	SetLabelsForLocalResources(&listOptions)
+
+	// this change has triggered the replication on this resource
+	resources, err := c.LocalDynClient.Resource(convertGVR(res.GroupVersionResource)).
+		Namespace(localNamespace).List(ctx, listOptions)
+	if err != nil {
+		klog.Error(err)
+		return err
+	}
+	c.addListHandler(resources, convertGVR(res.GroupVersionResource))
+	return nil
+}
+
+// addListHandler calls the AddHandler on a list of resources.
+func (c *Controller) addListHandler(list *unstructured.UnstructuredList, gvr schema.GroupVersionResource) {
+	for i := range list.Items {
+		item := &list.Items[i]
+		klog.V(4).Infof("replicating %v %v/%v", item.GetKind(), item.GetNamespace(), item.GetName())
+		c.AddedHandler(item, gvr)
+	}
+}
 
 // getPeeringPhase returns the peering phase for a cluster given its clusterID.
 func (c *Controller) getPeeringPhase(clusterID string) consts.PeeringPhase {
@@ -50,7 +109,7 @@ func getPeeringPhase(fc *discoveryv1alpha1.ForeignCluster) consts.PeeringPhase {
 
 // isReplicationEnabled indicates if the replication has to be enabled for a given peeringPhase
 // and a given CRD.
-func isReplicationEnabled(peeringPhase consts.PeeringPhase, resource configv1alpha1.Resource) bool {
+func isReplicationEnabled(peeringPhase consts.PeeringPhase, resource *configv1alpha1.Resource) bool {
 	switch resource.PeeringPhase {
 	case consts.PeeringPhaseNone:
 		return false

--- a/internal/crdReplicator/peeringPhase_test.go
+++ b/internal/crdReplicator/peeringPhase_test.go
@@ -1,20 +1,45 @@
 package crdreplicator
 
 import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/types"
+	v1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/dynamic/dynamicinformer"
+	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 
+	configv1alpha1 "github.com/liqotech/liqo/apis/config/v1alpha1"
 	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
+	netv1alpha1 "github.com/liqotech/liqo/apis/net/v1alpha1"
+	"github.com/liqotech/liqo/pkg/clusterid"
 	"github.com/liqotech/liqo/pkg/consts"
+	identitymanager "github.com/liqotech/liqo/pkg/identityManager"
+	tenantcontrolnamespace "github.com/liqotech/liqo/pkg/tenantControlNamespace"
+	testUtils "github.com/liqotech/liqo/pkg/utils/testUtils"
 )
 
-func TestDiscovery(t *testing.T) {
+func TestPeeringPhase(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "PeeringPhase")
 }
+
+const (
+	timeout  = time.Second * 30
+	interval = time.Millisecond * 250
+)
 
 var _ = Describe("PeeringPhase", func() {
 
@@ -86,6 +111,204 @@ var _ = Describe("PeeringPhase", func() {
 				expectedPhase: consts.PeeringPhaseNone,
 			}),
 		)
+	})
+
+})
+
+var _ = Describe("PeeringPhase-Based Replication", func() {
+
+	var (
+		cluster    testUtils.Cluster
+		controller Controller
+		mgr        manager.Manager
+		ctx        context.Context
+		cancel     context.CancelFunc
+	)
+
+	BeforeEach(func() {
+		ctx, cancel = context.WithCancel(context.Background())
+
+		var err error
+		cluster, mgr, err = testUtils.NewTestCluster([]string{filepath.Join("..", "..", "deployments", "liqo", "crds")})
+		if err != nil {
+			By(err.Error())
+			os.Exit(1)
+		}
+
+		k8sclient = kubernetes.NewForConfigOrDie(mgr.GetConfig())
+
+		tenantmanager := tenantcontrolnamespace.NewTenantControlNamespaceManager(k8sclient)
+		clusterIDInterface := clusterid.NewStaticClusterID(localClusterID)
+
+		dynClient := dynamic.NewForConfigOrDie(mgr.GetConfig())
+		dynFac := dynamicinformer.NewFilteredDynamicSharedInformerFactory(dynClient, ResyncPeriod, metav1.NamespaceAll, func(options *metav1.ListOptions) {
+			//we want to watch only the resources that have been created by us on the remote cluster
+			if options.LabelSelector == "" {
+				newLabelSelector := []string{RemoteLabelSelector, "=", localClusterID}
+				options.LabelSelector = strings.Join(newLabelSelector, "")
+			} else {
+				newLabelSelector := []string{options.LabelSelector, RemoteLabelSelector, "=", localClusterID}
+				options.LabelSelector = strings.Join(newLabelSelector, "")
+			}
+		})
+
+		localDynFac := dynamicinformer.NewFilteredDynamicSharedInformerFactory(dynClient, ResyncPeriod, metav1.NamespaceAll, nil)
+
+		controller = Controller{
+			Scheme:                         mgr.GetScheme(),
+			Client:                         mgr.GetClient(),
+			ClusterID:                      localClusterID,
+			RemoteDynClients:               map[string]dynamic.Interface{remoteClusterID: dynClient},
+			RemoteDynSharedInformerFactory: map[string]dynamicinformer.DynamicSharedInformerFactory{remoteClusterID: dynFac},
+			RegisteredResources:            nil,
+			UnregisteredResources:          nil,
+			RemoteWatchers:                 map[string]map[string]chan struct{}{},
+			LocalDynClient:                 dynClient,
+			LocalDynSharedInformerFactory:  localDynFac,
+			LocalWatchers:                  map[string]chan struct{}{},
+
+			UseNewAuth:                       false,
+			NamespaceManager:                 tenantmanager,
+			IdentityManager:                  identitymanager.NewCertificateIdentityManager(k8sclient, clusterIDInterface, tenantmanager),
+			LocalToRemoteNamespaceMapper:     map[string]string{},
+			RemoteToLocalNamespaceMapper:     map[string]string{},
+			ClusterIDToLocalNamespaceMapper:  map[string]string{},
+			ClusterIDToRemoteNamespaceMapper: map[string]string{},
+		}
+
+		go mgr.GetCache().Start(ctx)
+	})
+
+	AfterEach(func() {
+		cancel()
+
+		err := cluster.GetEnv().Stop()
+		if err != nil {
+			By(err.Error())
+			os.Exit(1)
+		}
+	})
+
+	Context("Outgoing Resource Replication", func() {
+
+		type outgoingReplicationTestcase struct {
+			resource            *unstructured.Unstructured
+			registeredResources []configv1alpha1.Resource
+			peeringPhases       map[string]consts.PeeringPhase
+			expectedError       types.GomegaMatcher
+		}
+
+		DescribeTable("Filter resources to replicate to the remote cluster",
+			func(c outgoingReplicationTestcase) {
+				controller.RegisteredResources = c.registeredResources
+				controller.peeringPhases = c.peeringPhases
+
+				controller.AddedHandler(c.resource, gvr)
+
+				_, err := controller.LocalDynClient.Resource(gvr).
+					Get(context.TODO(), c.resource.GetName(), metav1.GetOptions{})
+				Expect(err).To(c.expectedError)
+			},
+
+			Entry("replicated resource", outgoingReplicationTestcase{
+				resource: getObj(),
+				registeredResources: []configv1alpha1.Resource{
+					{
+						GroupVersionResource: metav1.GroupVersionResource(
+							netv1alpha1.NetworkConfigGroupVersionResource),
+						PeeringPhase: consts.PeeringPhaseAll,
+					},
+				},
+				peeringPhases: map[string]consts.PeeringPhase{
+					remoteClusterID: consts.PeeringPhaseEstablished,
+				},
+				expectedError: BeNil(),
+			}),
+
+			Entry("not replicated resource (phase not enabled)", outgoingReplicationTestcase{
+				resource: getObj(),
+				registeredResources: []configv1alpha1.Resource{
+					{
+						GroupVersionResource: metav1.GroupVersionResource(
+							netv1alpha1.NetworkConfigGroupVersionResource),
+						PeeringPhase: consts.PeeringPhaseOutgoing,
+					},
+				},
+				peeringPhases: map[string]consts.PeeringPhase{
+					remoteClusterID: consts.PeeringPhaseIncoming,
+				},
+				expectedError: Not(BeNil()),
+			}),
+
+			Entry("not replicated resource (peering not established)", outgoingReplicationTestcase{
+				resource: getObj(),
+				registeredResources: []configv1alpha1.Resource{
+					{
+						GroupVersionResource: metav1.GroupVersionResource(
+							netv1alpha1.NetworkConfigGroupVersionResource),
+						PeeringPhase: consts.PeeringPhaseEstablished,
+					},
+				},
+				peeringPhases: map[string]consts.PeeringPhase{
+					remoteClusterID: consts.PeeringPhaseNone,
+				},
+				expectedError: Not(BeNil()),
+			}),
+		)
+
+	})
+
+	Context("Enable Outgoing Replication", func() {
+
+		It("Enable Outgoing Replication", func() {
+
+			gvr := discoveryv1alpha1.GroupVersion.WithResource("resourcerequests")
+
+			controller.RegisteredResources = []configv1alpha1.Resource{
+				{
+					GroupVersionResource: metav1.GroupVersionResource(gvr),
+					PeeringPhase:         consts.PeeringPhaseEstablished,
+				},
+			}
+			controller.peeringPhases = map[string]consts.PeeringPhase{
+				remoteClusterID: consts.PeeringPhaseNone,
+			}
+			controller.ClusterIDToLocalNamespaceMapper[remoteClusterID] = "default"
+			controller.LocalToRemoteNamespaceMapper["default"] = "remote-1"
+			controller.ClusterIDToRemoteNamespaceMapper[remoteClusterID] = "remote-1"
+
+			// this namespace will be used as a remote cluster namespace
+			_, err := k8sclient.CoreV1().Namespaces().Create(ctx, &v1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "remote-1",
+				},
+			}, metav1.CreateOptions{})
+			Expect(err).To(BeNil())
+
+			obj := getObjNamespaced()
+			obj, err = controller.LocalDynClient.Resource(gvr).Namespace("default").
+				Create(ctx, obj, metav1.CreateOptions{})
+			Expect(err).To(BeNil())
+
+			controller.checkResourcesOnPeeringPhaseChange(ctx, remoteClusterID,
+				consts.PeeringPhaseNone, consts.PeeringPhaseNone)
+
+			_, err = controller.LocalDynClient.Resource(gvr).Namespace("remote-1").
+				Get(context.TODO(), obj.GetName(), metav1.GetOptions{})
+			Expect(kerrors.IsNotFound(err)).To(BeTrue())
+
+			// change peering phase
+			controller.peeringPhases[remoteClusterID] = consts.PeeringPhaseOutgoing
+			controller.checkResourcesOnPeeringPhaseChange(ctx, remoteClusterID,
+				consts.PeeringPhaseOutgoing, consts.PeeringPhaseNone)
+
+			Eventually(func() error {
+				_, err = controller.LocalDynClient.Resource(gvr).Namespace("remote-1").
+					Get(context.TODO(), obj.GetName(), metav1.GetOptions{})
+				return err
+			}, timeout, interval).Should(BeNil())
+		})
+
 	})
 
 })

--- a/internal/discovery/discovery-config.go
+++ b/internal/discovery/discovery-config.go
@@ -118,7 +118,7 @@ func (discovery *Controller) handleDispatcherConfig(config *configv1alpha1.Dispa
 	rules := []rbacv1.PolicyRule{}
 	for _, res := range config.ResourcesToReplicate {
 		rules = append(rules, rbacv1.PolicyRule{
-			Verbs:     []string{"get", "update", "patch", "list", "watch", "delete", "create"},
+			Verbs:     []string{"get", "update", "patch", "list", "watch", "delete", "create", "deletecollection"},
 			APIGroups: []string{res.GroupVersionResource.Group},
 			Resources: []string{res.GroupVersionResource.Resource, res.GroupVersionResource.Resource + "/status"},
 		})

--- a/pkg/consts/replication.go
+++ b/pkg/consts/replication.go
@@ -1,0 +1,14 @@
+package consts
+
+// OwnershipType indicates the type of ownership over a resource.
+type OwnershipType string
+
+const (
+	// OwnershipLocal indicates that the resource is owned by the local cluster.
+	OwnershipLocal OwnershipType = "Local"
+	// OwnershipShared indicates that the ownership over the resource is shared between the two clusters.
+	// In particular:
+	// - the spec of the resource is owned by the local cluster.
+	// - the status by the remote cluster.
+	OwnershipShared OwnershipType = "Shared"
+)

--- a/pkg/liqonet/routing/routing_suite_test.go
+++ b/pkg/liqonet/routing/routing_suite_test.go
@@ -68,7 +68,7 @@ var _ = BeforeSuite(func() {
 
 	//*** Gateway Route Manager Configuration ***/
 	// Create a dummy interface used as tunnel device.
-	link = &netlink.Dummy{netlink.LinkAttrs{Name: "dummy-tunnel"}}
+	link = &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: "dummy-tunnel"}}
 	Expect(netlink.LinkAdd(link)).To(BeNil())
 	tunnelDevice, err = netlink.LinkByName("dummy-tunnel")
 	Expect(err).To(BeNil())

--- a/pkg/peering-roles/basic/basic.go
+++ b/pkg/peering-roles/basic/basic.go
@@ -3,5 +3,5 @@
 // this ClusterRole has the basic permissions to give to a remote cluster
 package basic
 
-// +kubebuilder:rbac:groups=discovery.liqo.io,resources=resourcerequests,verbs=get;update;patch;list;watch;delete;create
-// +kubebuilder:rbac:groups=discovery.liqo.io,resources=resourcerequests/status,verbs=get;update;patch;list;watch;delete;create
+// +kubebuilder:rbac:groups=discovery.liqo.io,resources=resourcerequests,verbs=get;update;patch;list;watch;delete;create;deletecollection
+// +kubebuilder:rbac:groups=discovery.liqo.io,resources=resourcerequests/status,verbs=get;update;patch;list;watch;delete;create;deletecollection

--- a/pkg/peering-roles/incoming/incoming.go
+++ b/pkg/peering-roles/incoming/incoming.go
@@ -4,5 +4,5 @@
 // when the Pods will be offloaded to the local cluster
 package incoming
 
-// +kubebuilder:rbac:groups=net.liqo.io,resources=networkconfigs,verbs=get;update;patch;list;watch;delete;create
-// +kubebuilder:rbac:groups=net.liqo.io,resources=networkconfigs/status,verbs=get;update;patch;list;watch;delete;create
+// +kubebuilder:rbac:groups=net.liqo.io,resources=networkconfigs,verbs=get;update;patch;list;watch;delete;create;deletecollection
+// +kubebuilder:rbac:groups=net.liqo.io,resources=networkconfigs/status,verbs=get;update;patch;list;watch;delete;create;deletecollection

--- a/pkg/peering-roles/outgoing/outgoing.go
+++ b/pkg/peering-roles/outgoing/outgoing.go
@@ -4,8 +4,8 @@
 // when the Pods will be offloaded from the local cluster
 package outgoing
 
-// +kubebuilder:rbac:groups=net.liqo.io,resources=networkconfigs,verbs=get;update;patch;list;watch;delete;create
-// +kubebuilder:rbac:groups=net.liqo.io,resources=networkconfigs/status,verbs=get;update;patch;list;watch;delete;create
+// +kubebuilder:rbac:groups=net.liqo.io,resources=networkconfigs,verbs=get;update;patch;list;watch;delete;create;deletecollection
+// +kubebuilder:rbac:groups=net.liqo.io,resources=networkconfigs/status,verbs=get;update;patch;list;watch;delete;create;deletecollection
 
-// +kubebuilder:rbac:groups=sharing.liqo.io,resources=resourceoffers,verbs=get;update;patch;list;watch;delete;create
-// +kubebuilder:rbac:groups=sharing.liqo.io,resources=resourceoffers/status,verbs=get;update;patch;list;watch;delete;create
+// +kubebuilder:rbac:groups=sharing.liqo.io,resources=resourceoffers,verbs=get;update;patch;list;watch;delete;create;deletecollection
+// +kubebuilder:rbac:groups=sharing.liqo.io,resources=resourceoffers/status,verbs=get;update;patch;list;watch;delete;create;deletecollection

--- a/test/unit/crdReplicator/crdReplicator-operator_test.go
+++ b/test/unit/crdReplicator/crdReplicator-operator_test.go
@@ -18,6 +18,7 @@ import (
 
 	netv1alpha1 "github.com/liqotech/liqo/apis/net/v1alpha1"
 	crdreplicator "github.com/liqotech/liqo/internal/crdReplicator"
+	"github.com/liqotech/liqo/pkg/consts"
 )
 
 var (
@@ -184,6 +185,7 @@ func TestReplication2(t *testing.T) {
 // we label it to be replicated on all the three clusters, so we expect to find it on the remote clusters
 // we update the status on the peering clusters and expect it to be replicated on the local cluster as well
 func TestReplication4(t *testing.T) {
+	updateOwnership(consts.OwnershipShared)
 	time.Sleep(10 * time.Second)
 	localResources := map[string]*netv1alpha1.TunnelEndpoint{}
 	// we create the resource on the localcluster to be replicated on all the peeringClusters
@@ -243,6 +245,7 @@ func TestReplication4(t *testing.T) {
 
 	// err = dOperator.LocalDynClient.Resource(fcGVR).Delete(context.TODO(), newFc.GetName(), metav1.DeleteOptions{})
 	time.Sleep(3 * time.Second)
+	updateOwnership(consts.OwnershipLocal)
 }
 
 // we create a resource which type has been registered for the replication


### PR DESCRIPTION
# Description

This pr includes:
* the logic to delete the replicated resources when the GroupVersionResource has no longer to be replicated
* a filter in the add and update handlers to avoid the replication of local resource to the remote cluster when the replication is not enabled for that Cluster-GroupVersionResource pair
* a handler that is triggered when the replication has to start for a remote cluster. This handler lists the local resources and passes them to the AddHandler

Fixes #573

# How Has This Been Tested?

- [x] locally on KinD
- [x] add unit test
