### PR TITLE
ForeignCluster Operator Refactoring - 1

### DIFF
--- a/apis/discovery/v1alpha1/foreigncluster_methods.go
+++ b/apis/discovery/v1alpha1/foreigncluster_methods.go
@@ -88,5 +88,5 @@ func (fc *ForeignCluster) IsExpired() bool {
 		return true
 	}
 	now := time.Now().Unix()
-	return int64(lu+int(fc.Status.TTL)) < now
+	return int64(lu+fc.Spec.TTL) < now
 }

--- a/cmd/discovery/main.go
+++ b/cmd/discovery/main.go
@@ -8,7 +8,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"

--- a/deployments/liqo/crds/discovery.liqo.io_foreignclusters.yaml
+++ b/deployments/liqo/crds/discovery.liqo.io_foreignclusters.yaml
@@ -17,15 +17,18 @@ spec:
   scope: Cluster
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .status.outgoing.joined
-      name: Outgoing joined
+    - jsonPath: .status.outgoing.joinPhase
+      name: Outgoing peering phase
       type: string
-    - jsonPath: .status.incoming.joined
-      name: Incoming joined
+    - jsonPath: .status.incoming.joinPhase
+      name: Incoming peering phase
       type: string
     - jsonPath: .status.authStatus
       name: Authentication status
       type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     name: v1alpha1
     schema:
       openAPIV3Schema:
@@ -76,7 +79,7 @@ spec:
                 description: Enable join process to foreign cluster.
                 type: boolean
               namespace:
-                description: Namespace where Liqo is deployed.
+                description: Namespace where Liqo is deployed. (Deprecated)
                 type: string
               trustMode:
                 default: Unknown
@@ -86,6 +89,12 @@ spec:
                 - Trusted
                 - Untrusted
                 type: string
+              ttl:
+                description: If discoveryType is LAN or WAN and this indicates the
+                  number of seconds after that this ForeignCluster will be removed
+                  if no updates have been received.
+                minimum: 0
+                type: integer
             required:
             - authUrl
             type: object
@@ -106,12 +115,13 @@ spec:
                 properties:
                   advertisementStatus:
                     description: Status of Advertisement created from this PeeringRequest.
+                      (Deprecated)
                     type: string
                   availableIdentity:
-                    description: Indicates if related identity is available.
+                    description: Indicates if related identity is available. (Deprecated)
                     type: boolean
                   identityRef:
-                    description: Object reference to related identity.
+                    description: Object reference to related identity. (Deprecated)
                     properties:
                       apiVersion:
                         description: API version of the referent.
@@ -146,12 +156,18 @@ spec:
                         description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                         type: string
                     type: object
-                  joined:
+                  joinPhase:
+                    default: None
                     description: Indicates if peering request has been created and
                       this remote cluster is using our local resources.
-                    type: boolean
+                    enum:
+                    - None
+                    - Pending
+                    - Established
+                    - Disconnecting
+                    type: string
                   peeringRequest:
-                    description: Object Reference to created PeeringRequest CR.
+                    description: Object Reference to created PeeringRequest CR. (Deprecated)
                     properties:
                       apiVersion:
                         description: API version of the referent.
@@ -186,8 +202,6 @@ spec:
                         description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                         type: string
                     type: object
-                required:
-                - joined
                 type: object
               network:
                 description: It stores most important network statuses.
@@ -330,16 +344,12 @@ spec:
                     required:
                     - available
                     type: object
-                required:
-                - localNetworkConfig
-                - remoteNetworkConfig
-                - tunnelEndpoint
                 type: object
               outgoing:
                 description: Outgoing contains the status of the outgoing peering.
                 properties:
                   advertisement:
-                    description: Object Reference to created Advertisement CR.
+                    description: Object Reference to created Advertisement CR. (Deprecated)
                     properties:
                       apiVersion:
                         description: API version of the referent.
@@ -375,13 +385,13 @@ spec:
                         type: string
                     type: object
                   advertisementStatus:
-                    description: Advertisement status.
+                    description: Advertisement status. (Deprecated)
                     type: string
                   availableIdentity:
-                    description: Indicates if related identity is available.
+                    description: Indicates if related identity is available. (Deprecated)
                     type: boolean
                   identityRef:
-                    description: Object reference to related identity.
+                    description: Object reference to related identity. (Deprecated)
                     properties:
                       apiVersion:
                         description: API version of the referent.
@@ -416,15 +426,19 @@ spec:
                         description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                         type: string
                     type: object
-                  joined:
+                  joinPhase:
+                    default: None
                     description: Indicates if peering request has been created and
                       this remote cluster is sharing its resources to us.
-                    type: boolean
-                  remote-peering-request-name:
-                    description: Name of created PR.
+                    enum:
+                    - None
+                    - Pending
+                    - Established
+                    - Disconnecting
                     type: string
-                required:
-                - joined
+                  remote-peering-request-name:
+                    description: Name of created PR. (Deprecated)
+                    type: string
                 type: object
               tenantControlNamespace:
                 description: TenantControlNamespaces names in the peered clusters
@@ -436,16 +450,12 @@ spec:
                     description: remote TenantNamespace name
                     type: string
                 type: object
-              ttl:
-                description: If discoveryType is LAN and this counter reach 0 value,
-                  this FC will be removed.
-                format: int32
-                type: integer
             type: object
         type: object
     served: true
     storage: true
-    subresources: {}
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/deployments/liqo/files/liqo-discovery-ClusterRole.yaml
+++ b/deployments/liqo/files/liqo-discovery-ClusterRole.yaml
@@ -48,6 +48,18 @@ rules:
 - apiGroups:
   - discovery.liqo.io
   resources:
+  - foreignclusters/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - discovery.liqo.io
+  resources:
   - peeringrequests
   verbs:
   - get
@@ -60,6 +72,7 @@ rules:
   verbs:
   - create
   - delete
+  - deletecollection
   - get
   - list
   - patch

--- a/deployments/liqo/files/liqo-peering-request-ClusterRole.yaml
+++ b/deployments/liqo/files/liqo-peering-request-ClusterRole.yaml
@@ -25,6 +25,7 @@ rules:
   - discovery.liqo.io
   resources:
   - foreignclusters
+  - foreignclusters/status
   verbs:
   - create
   - list

--- a/internal/crdReplicator/crdReplicator-operator.go
+++ b/internal/crdReplicator/crdReplicator-operator.go
@@ -34,6 +34,7 @@ import (
 	identitymanager "github.com/liqotech/liqo/pkg/identityManager"
 	"github.com/liqotech/liqo/pkg/liqonet/utils"
 	tenantcontrolnamespace "github.com/liqotech/liqo/pkg/tenantControlNamespace"
+	foreigncluster "github.com/liqotech/liqo/pkg/utils/foreignCluster"
 )
 
 var (
@@ -130,7 +131,7 @@ func (c *Controller) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	// examine DeletionTimestamp to determine if object is under deletion
 	if fc.ObjectMeta.DeletionTimestamp.IsZero() {
 		// the finalizer is added only if a join is active with the remote cluster
-		if !fc.Status.Incoming.Joined && !fc.Status.Outgoing.Joined {
+		if !foreigncluster.IsIncomingEnabled(&fc) && !foreigncluster.IsOutgoingEnabled(&fc) {
 			if utils.ContainsString(fc.ObjectMeta.Finalizers, finalizer) {
 				fc.Finalizers = utils.RemoveString(fc.Finalizers, finalizer)
 				if err := c.Update(ctx, &fc); err != nil {

--- a/internal/crdReplicator/peeringPhase.go
+++ b/internal/crdReplicator/peeringPhase.go
@@ -6,6 +6,7 @@ import (
 	configv1alpha1 "github.com/liqotech/liqo/apis/config/v1alpha1"
 	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
 	"github.com/liqotech/liqo/pkg/consts"
+	foreigncluster "github.com/liqotech/liqo/pkg/utils/foreignCluster"
 )
 
 // getPeeringPhase returns the peering phase for a cluster given its clusterID.
@@ -33,13 +34,15 @@ func (c *Controller) setPeeringPhase(clusterID string, phase consts.PeeringPhase
 
 // getPeeringPhase returns the peering phase for a fiver ForignCluster CR.
 func getPeeringPhase(fc *discoveryv1alpha1.ForeignCluster) consts.PeeringPhase {
-	if fc.Status.Incoming.Joined && fc.Status.Outgoing.Joined {
+	incoming := foreigncluster.IsIncomingEnabled(fc)
+	outgoing := foreigncluster.IsOutgoingEnabled(fc)
+	if incoming && outgoing {
 		return consts.PeeringPhaseBidirectional
 	}
-	if fc.Status.Incoming.Joined {
+	if incoming {
 		return consts.PeeringPhaseIncoming
 	}
-	if fc.Status.Outgoing.Joined {
+	if outgoing {
 		return consts.PeeringPhaseOutgoing
 	}
 	return consts.PeeringPhaseNone

--- a/internal/crdReplicator/peeringPhase_test.go
+++ b/internal/crdReplicator/peeringPhase_test.go
@@ -34,10 +34,10 @@ var _ = Describe("PeeringPhase", func() {
 				foreignCluster: &discoveryv1alpha1.ForeignCluster{
 					Status: discoveryv1alpha1.ForeignClusterStatus{
 						Incoming: discoveryv1alpha1.Incoming{
-							Joined: true,
+							PeeringPhase: discoveryv1alpha1.PeeringPhaseEstablished,
 						},
 						Outgoing: discoveryv1alpha1.Outgoing{
-							Joined: true,
+							PeeringPhase: discoveryv1alpha1.PeeringPhaseEstablished,
 						},
 					},
 				},
@@ -48,10 +48,10 @@ var _ = Describe("PeeringPhase", func() {
 				foreignCluster: &discoveryv1alpha1.ForeignCluster{
 					Status: discoveryv1alpha1.ForeignClusterStatus{
 						Incoming: discoveryv1alpha1.Incoming{
-							Joined: true,
+							PeeringPhase: discoveryv1alpha1.PeeringPhaseEstablished,
 						},
 						Outgoing: discoveryv1alpha1.Outgoing{
-							Joined: false,
+							PeeringPhase: discoveryv1alpha1.PeeringPhaseNone,
 						},
 					},
 				},
@@ -62,10 +62,10 @@ var _ = Describe("PeeringPhase", func() {
 				foreignCluster: &discoveryv1alpha1.ForeignCluster{
 					Status: discoveryv1alpha1.ForeignClusterStatus{
 						Incoming: discoveryv1alpha1.Incoming{
-							Joined: false,
+							PeeringPhase: discoveryv1alpha1.PeeringPhaseNone,
 						},
 						Outgoing: discoveryv1alpha1.Outgoing{
-							Joined: true,
+							PeeringPhase: discoveryv1alpha1.PeeringPhaseEstablished,
 						},
 					},
 				},
@@ -76,10 +76,10 @@ var _ = Describe("PeeringPhase", func() {
 				foreignCluster: &discoveryv1alpha1.ForeignCluster{
 					Status: discoveryv1alpha1.ForeignClusterStatus{
 						Incoming: discoveryv1alpha1.Incoming{
-							Joined: false,
+							PeeringPhase: discoveryv1alpha1.PeeringPhaseNone,
 						},
 						Outgoing: discoveryv1alpha1.Outgoing{
-							Joined: false,
+							PeeringPhase: discoveryv1alpha1.PeeringPhaseNone,
 						},
 					},
 				},

--- a/internal/discovery/discovery_test.go
+++ b/internal/discovery/discovery_test.go
@@ -703,9 +703,7 @@ var _ = Describe("Discovery", func() {
 								DiscoveryType: discovery.LanDiscovery,
 								AuthURL:       "",
 								TrustMode:     discovery.TrustModeUntrusted,
-							},
-							Status: v1alpha12.ForeignClusterStatus{
-								TTL: 300,
+								TTL:           300,
 							},
 						},
 
@@ -733,9 +731,7 @@ var _ = Describe("Discovery", func() {
 								DiscoveryType: discovery.LanDiscovery,
 								AuthURL:       "",
 								TrustMode:     discovery.TrustModeUntrusted,
-							},
-							Status: v1alpha12.ForeignClusterStatus{
-								TTL: 300,
+								TTL:           300,
 							},
 						},
 
@@ -763,9 +759,7 @@ var _ = Describe("Discovery", func() {
 								DiscoveryType: discovery.ManualDiscovery,
 								AuthURL:       "",
 								TrustMode:     discovery.TrustModeUntrusted,
-							},
-							Status: v1alpha12.ForeignClusterStatus{
-								TTL: 300,
+								TTL:           300,
 							},
 						},
 

--- a/internal/discovery/foreign-cluster-operator/clusterIdentityDefaulting.go
+++ b/internal/discovery/foreign-cluster-operator/clusterIdentityDefaulting.go
@@ -2,7 +2,7 @@ package foreignclusteroperator
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 
 	"github.com/liqotech/liqo/apis/discovery/v1alpha1"
 	"github.com/liqotech/liqo/internal/discovery/utils"

--- a/internal/discovery/foreign-cluster-operator/oldReconcile.go
+++ b/internal/discovery/foreign-cluster-operator/oldReconcile.go
@@ -1,0 +1,244 @@
+package foreignclusteroperator
+
+import (
+	"context"
+	goerrors "errors"
+	"fmt"
+	"reflect"
+
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+	"k8s.io/kubernetes/pkg/util/slice"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
+	advtypes "github.com/liqotech/liqo/apis/sharing/v1alpha1"
+	"github.com/liqotech/liqo/pkg/discovery"
+	foreigncluster "github.com/liqotech/liqo/pkg/utils/foreignCluster"
+)
+
+// nolint:gocyclo // (aleoli): Suppressing for now, it will be deleted.
+func (r *ForeignClusterReconciler) oldReconcile(ctx context.Context, foreignCluster *discoveryv1alpha1.ForeignCluster) (ctrl.Result, error) {
+	oldStatus := foreignCluster.Status.DeepCopy()
+
+	// check for NetworkConfigs
+	if err := r.checkNetwork(ctx, foreignCluster); err != nil {
+		klog.Error(err)
+		return ctrl.Result{}, err
+	}
+
+	// check for TunnelEndpoints
+	if err := r.checkTEP(ctx, foreignCluster); err != nil {
+		klog.Error(err)
+		return ctrl.Result{}, err
+	}
+
+	// TODO: to be removed
+	// check if linked advertisement exists
+	if foreigncluster.IsOutgoingEnabled(foreignCluster) {
+		requireUpdate := false
+		requireSpecUpdate := false
+		tmp, err := r.advertisementClient.Resource("advertisements").
+			Get(fmt.Sprintf("advertisement-%s", foreignCluster.Spec.ClusterIdentity.ClusterID), &metav1.GetOptions{})
+		if errors.IsNotFound(err) && foreignCluster.Status.Outgoing.AvailableIdentity {
+			foreignCluster.Status.Outgoing.Advertisement = nil
+			foreignCluster.Status.Outgoing.AvailableIdentity = false
+			foreignCluster.Status.Outgoing.IdentityRef = nil
+			foreignCluster.Status.Outgoing.AdvertisementStatus = ""
+			foreignCluster.Status.Outgoing.PeeringPhase = discoveryv1alpha1.PeeringPhaseNone
+			foreignCluster.Status.Outgoing.RemotePeeringRequestName = ""
+			foreignCluster.Spec.Join = false
+			requireUpdate = true
+			requireSpecUpdate = true
+		} else if err == nil {
+			// check if kubeconfig secret exists
+			adv, ok := tmp.(*advtypes.Advertisement)
+			if !ok {
+				err = goerrors.New("retrieved object is not an Advertisement")
+				klog.Error(err)
+				return ctrl.Result{
+					Requeue:      true,
+					RequeueAfter: r.RequeueAfter,
+				}, err
+			}
+			if adv.Spec.KubeConfigRef.Name != "" && adv.Spec.KubeConfigRef.Namespace != "" {
+				_, err = r.crdClient.Client().CoreV1().Secrets(
+					adv.Spec.KubeConfigRef.Namespace).Get(
+					context.TODO(), adv.Spec.KubeConfigRef.Name, metav1.GetOptions{})
+				available := err == nil
+				if foreignCluster.Status.Outgoing.AvailableIdentity != available {
+					foreignCluster.Status.Outgoing.AvailableIdentity = available
+					if available {
+						foreignCluster.Status.Outgoing.IdentityRef = &apiv1.ObjectReference{
+							Kind:       "Secret",
+							Namespace:  adv.Spec.KubeConfigRef.Namespace,
+							Name:       adv.Spec.KubeConfigRef.Name,
+							APIVersion: "v1",
+						}
+					}
+					requireUpdate = true
+				}
+			}
+
+			// update advertisement status
+			status := adv.Status.AdvertisementStatus
+			if status != foreignCluster.Status.Outgoing.AdvertisementStatus {
+				foreignCluster.Status.Outgoing.AdvertisementStatus = status
+				requireUpdate = true
+			}
+		}
+
+		if requireSpecUpdate {
+			status := foreignCluster.Status.DeepCopy()
+			if foreignCluster, err = r.update(foreignCluster); err != nil {
+				klog.Error(err)
+				return ctrl.Result{}, err
+			}
+			foreignCluster.Status = *status
+		}
+
+		if requireUpdate {
+			return r.updateStatus(ctx, foreignCluster)
+		}
+	}
+
+	// TODO: to be removed
+	// check if linked peeringRequest exists
+	if foreignCluster.Status.Incoming.PeeringRequest != nil {
+		requireUpdate := false
+		tmp, err := r.crdClient.Resource("peeringrequests").Get(foreignCluster.Status.Incoming.PeeringRequest.Name, &metav1.GetOptions{})
+		if errors.IsNotFound(err) {
+			foreignCluster.Status.Incoming.PeeringRequest = nil
+			foreignCluster.Status.Incoming.AvailableIdentity = false
+			foreignCluster.Status.Incoming.IdentityRef = nil
+			foreignCluster.Status.Incoming.AdvertisementStatus = ""
+			foreignCluster.Status.Incoming.PeeringPhase = discoveryv1alpha1.PeeringPhaseNone
+			requireUpdate = true
+		} else if err == nil {
+			pr, ok := tmp.(*discoveryv1alpha1.PeeringRequest)
+			if !ok {
+				err = goerrors.New("retrieved object is not a PeeringRequest")
+				klog.Error(err)
+				return ctrl.Result{
+					Requeue:      true,
+					RequeueAfter: r.RequeueAfter,
+				}, err
+			}
+
+			if !foreigncluster.IsIncomingJoined(foreignCluster) {
+				// PeeringRequest exists, set flag to true
+				foreignCluster.Status.Incoming.PeeringPhase = discoveryv1alpha1.PeeringPhaseEstablished
+				requireUpdate = true
+			}
+
+			// check if kubeconfig secret exists
+			if pr.Spec.KubeConfigRef != nil && pr.Spec.KubeConfigRef.Name != "" && pr.Spec.KubeConfigRef.Namespace != "" {
+				_, err = r.crdClient.Client().CoreV1().Secrets(
+					pr.Spec.KubeConfigRef.Namespace).Get(context.TODO(), pr.Spec.KubeConfigRef.Name, metav1.GetOptions{})
+				available := err == nil
+				if foreignCluster.Status.Incoming.AvailableIdentity != available {
+					foreignCluster.Status.Incoming.AvailableIdentity = available
+					if available {
+						foreignCluster.Status.Incoming.IdentityRef = pr.Spec.KubeConfigRef
+					}
+					requireUpdate = true
+				}
+			}
+
+			// update advertisement status
+			status := pr.Status.AdvertisementStatus
+			if status != foreignCluster.Status.Incoming.AdvertisementStatus {
+				foreignCluster.Status.Incoming.AdvertisementStatus = status
+				requireUpdate = true
+			}
+		}
+
+		if requireUpdate {
+			return r.updateStatus(ctx, foreignCluster)
+		}
+	}
+
+	// if it has been discovered thanks to incoming peeringRequest and it has no active connections, delete it
+	isIncomingDiscovery := foreignCluster.Spec.DiscoveryType == discovery.IncomingPeeringDiscovery
+	isNotDeleting := foreignCluster.DeletionTimestamp.IsZero()
+	hasPeering := foreigncluster.IsIncomingEnabled(foreignCluster) || foreigncluster.IsOutgoingEnabled(foreignCluster)
+	if isIncomingDiscovery && isNotDeleting && !hasPeering {
+		klog.Infof("%s deleted, discovery type %s has no active connections", foreignCluster.Name, foreignCluster.Spec.DiscoveryType)
+		if err := r.deleteForeignCluster(ctx, foreignCluster); err != nil {
+			klog.Error(err)
+			return ctrl.Result{}, err
+		}
+		klog.V(4).Infof("ForeignCluster %s successfully reconciled", foreignCluster.Name)
+		return ctrl.Result{}, nil
+	}
+
+	foreignDiscoveryClient, err := r.getRemoteClient(foreignCluster, &discoveryv1alpha1.GroupVersion)
+	if err != nil {
+		klog.Error(err)
+		return ctrl.Result{
+			Requeue:      true,
+			RequeueAfter: r.RequeueAfter,
+		}, nil
+	} else if foreignDiscoveryClient == nil {
+		return r.updateStatus(ctx, foreignCluster)
+	}
+
+	if foreignDiscoveryClient != nil && foreignCluster.Spec.Join && !foreigncluster.IsOutgoingEnabled(foreignCluster) {
+		fc, err := r.Peer(foreignCluster, foreignDiscoveryClient)
+		if err != nil {
+			return ctrl.Result{
+				Requeue:      true,
+				RequeueAfter: r.RequeueAfter,
+			}, err
+		}
+		return r.updateStatus(ctx, fc)
+	}
+
+	if foreignDiscoveryClient != nil && (!foreignCluster.Spec.Join || !foreignCluster.DeletionTimestamp.
+		IsZero()) && foreigncluster.IsOutgoingEnabled(foreignCluster) {
+		fc, err := r.Unpeer(foreignCluster, foreignDiscoveryClient)
+		if err != nil {
+			return ctrl.Result{
+				Requeue:      true,
+				RequeueAfter: r.RequeueAfter,
+			}, err
+		}
+		return r.updateStatus(ctx, fc)
+	}
+
+	if !foreignCluster.Spec.Join && !foreigncluster.
+		IsOutgoingEnabled(foreignCluster) && slice.
+		ContainsString(foreignCluster.Finalizers, FinalizerString, nil) {
+		if result, err := r.removeFinalizer(ctx, foreignCluster); err != nil {
+			klog.Error(err)
+			return ctrl.Result{}, err
+		} else if result != controllerutil.OperationResultNone {
+			return ctrl.Result{}, nil
+		}
+	}
+
+	// check if peering request really exists on foreign cluster
+	if foreignDiscoveryClient != nil && foreignCluster.Spec.Join && foreigncluster.IsOutgoingEnabled(foreignCluster) {
+		_, err = r.checkJoined(foreignCluster, foreignDiscoveryClient)
+		if err != nil {
+			klog.Error(err, err.Error())
+			return ctrl.Result{
+				Requeue:      true,
+				RequeueAfter: r.RequeueAfter,
+			}, err
+		}
+	}
+
+	if !reflect.DeepEqual(&foreignCluster.Status, oldStatus) {
+		return r.updateStatus(ctx, foreignCluster)
+	}
+
+	klog.V(4).Infof("ForeignCluster %s successfully reconciled", foreignCluster.Name)
+	return ctrl.Result{
+		Requeue:      true,
+		RequeueAfter: r.RequeueAfter,
+	}, nil
+}

--- a/internal/discovery/foreign-cluster-operator/peeringPolicy.go
+++ b/internal/discovery/foreign-cluster-operator/peeringPolicy.go
@@ -1,0 +1,21 @@
+package foreignclusteroperator
+
+import (
+	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
+)
+
+type desiredPeeringPhase string
+
+const (
+	desiredPeeringPhasePeering   desiredPeeringPhase = "Peering"
+	desiredPeeringPhaseUnpeering desiredPeeringPhase = "Unpeering"
+)
+
+// getDesiredOutgoingPeeringState returns the desired state for the outgoing peering basing on the ForeignCluster resource.
+func (r *ForeignClusterReconciler) getDesiredOutgoingPeeringState(foreignCluster *discoveryv1alpha1.ForeignCluster) desiredPeeringPhase {
+	remoteNamespace := foreignCluster.Status.TenantControlNamespace.Remote
+	if remoteNamespace != "" && foreignCluster.Spec.Join {
+		return desiredPeeringPhasePeering
+	}
+	return desiredPeeringPhaseUnpeering
+}

--- a/internal/discovery/foreign-cluster-operator/resourceRequest.go
+++ b/internal/discovery/foreign-cluster-operator/resourceRequest.go
@@ -1,86 +1,90 @@
 package foreignclusteroperator
 
 import (
-	goerrors "errors"
-	"fmt"
+	"context"
 
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
 	crdreplicator "github.com/liqotech/liqo/internal/crdReplicator"
 )
 
 // createResourceRequest creates a resource request to be sent to the specified ForeignCluster.
-func (r *ForeignClusterReconciler) createResourceRequest(
-	foreignCluster *discoveryv1alpha1.ForeignCluster) (*discoveryv1alpha1.ResourceRequest, error) {
+func (r *ForeignClusterReconciler) createResourceRequest(ctx context.Context,
+	foreignCluster *discoveryv1alpha1.ForeignCluster) (controllerutil.OperationResult, error) {
+	klog.Infof("[%v] ensuring ResourceRequest existence", foreignCluster.Spec.ClusterIdentity.ClusterID)
+
 	localClusterID := r.clusterID.GetClusterID()
 	remoteClusterID := foreignCluster.Spec.ClusterIdentity.ClusterID
 	localNamespace := foreignCluster.Status.TenantControlNamespace.Local
 
-	// check if a peering request with our cluster id already exists on remote cluster
-	tmp, err := r.crdClient.Resource("resourcerequests").Namespace(localNamespace).Get(localClusterID, &metav1.GetOptions{})
-	if err != nil && !errors.IsNotFound(err) {
-		return nil, err
+	authURL, err := r.getHomeAuthURL()
+	if err != nil {
+		return controllerutil.OperationResultNone, err
 	}
-	resourceRequest, ok := tmp.(*discoveryv1alpha1.ResourceRequest)
-	// if resource request does not exists
-	if errors.IsNotFound(err) || !ok {
-		if _, err = r.namespaceManager.BindClusterRoles(remoteClusterID, r.peeringPermission.Outgoing...); err != nil {
-			klog.Error(err)
-			return nil, err
+
+	if _, err = r.namespaceManager.BindClusterRoles(remoteClusterID, r.peeringPermission.Outgoing...); err != nil {
+		klog.Error(err)
+		return controllerutil.OperationResultNone, err
+	}
+
+	resourceRequest := &discoveryv1alpha1.ResourceRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      localClusterID,
+			Namespace: localNamespace,
+		},
+	}
+
+	result, err := controllerutil.CreateOrUpdate(ctx, r.Client, resourceRequest, func() error {
+		labels := resourceRequest.GetLabels()
+		requiredLabels := resourceRequestLabels(remoteClusterID)
+		if labels == nil {
+			labels = requiredLabels
+		} else {
+			for k, v := range requiredLabels {
+				labels[k] = v
+			}
+		}
+		resourceRequest.SetLabels(labels)
+
+		resourceRequest.Spec = discoveryv1alpha1.ResourceRequestSpec{
+			ClusterIdentity: discoveryv1alpha1.ClusterIdentity{
+				ClusterID:   localClusterID,
+				ClusterName: r.ConfigProvider.GetConfig().ClusterName,
+			},
+			AuthURL: authURL,
 		}
 
-		// does not exist -> create new resource request
-		authURL, err := r.getHomeAuthURL()
-		if err != nil {
-			return nil, err
-		}
-		resourceRequest = &discoveryv1alpha1.ResourceRequest{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: localClusterID,
-				OwnerReferences: []metav1.OwnerReference{
-					{
-						APIVersion: fmt.Sprintf(
-							"%s/%s",
-							discoveryv1alpha1.GroupVersion.Group, discoveryv1alpha1.GroupVersion.Version),
-						Kind: "ForeignCluster",
-						Name: foreignCluster.Name,
-						UID:  foreignCluster.UID,
-					},
-				},
-				Labels: map[string]string{
-					crdreplicator.LocalLabelSelector: "true",
-					crdreplicator.DestinationLabel:   remoteClusterID,
-				},
-			},
-			Spec: discoveryv1alpha1.ResourceRequestSpec{
-				ClusterIdentity: discoveryv1alpha1.ClusterIdentity{
-					ClusterID:   localClusterID,
-					ClusterName: r.ConfigProvider.GetConfig().ClusterName,
-				},
-				AuthURL: authURL,
-			},
-		}
-		tmp, err = r.crdClient.Resource("resourcerequests").Namespace(
-			localNamespace).Create(resourceRequest, &metav1.CreateOptions{})
-		if err != nil {
-			return nil, err
-		}
-		var ok bool
-		resourceRequest, ok = tmp.(*discoveryv1alpha1.ResourceRequest)
-		if !ok {
-			return nil, goerrors.New("created object is not a ResourceRequest")
-		}
+		return controllerutil.SetControllerReference(foreignCluster, resourceRequest, r.Scheme)
+	})
+	if err != nil {
+		klog.Error(err)
+		return controllerutil.OperationResultNone, err
 	}
-	// already exists
-	return resourceRequest, nil
+	klog.Infof("[%v] ensured the existence of ResourceRequest (with %v operation)", remoteClusterID, result)
+
+	return result, nil
 }
 
 // deleteResourceRequest deletes a resource request related to the specified ForeignCluster.
-func (r *ForeignClusterReconciler) deleteResourceRequest(fc *discoveryv1alpha1.ForeignCluster) error {
-	localClusterID := r.clusterID.GetClusterID()
-	return r.crdClient.Resource("resourcerequests").Namespace(
-		fc.Status.TenantControlNamespace.Local).Delete(localClusterID, &metav1.DeleteOptions{})
+func (r *ForeignClusterReconciler) deleteResourceRequest(ctx context.Context, foreignCluster *discoveryv1alpha1.ForeignCluster) error {
+	klog.Infof("[%v] ensuring that the ResourceRequest does not exist", foreignCluster.Spec.ClusterIdentity.ClusterID)
+	if err := r.Client.DeleteAllOf(ctx,
+		&discoveryv1alpha1.ResourceRequest{}, client.MatchingLabels(resourceRequestLabels(foreignCluster.Spec.ClusterIdentity.ClusterID)),
+		client.InNamespace(foreignCluster.Status.TenantControlNamespace.Local)); err != nil {
+		klog.Error(err)
+		return err
+	}
+	klog.Infof("[%v] ensured that the ResourceRequest does not exist", foreignCluster.Spec.ClusterIdentity.ClusterID)
+	return nil
+}
+
+func resourceRequestLabels(remoteClusterID string) map[string]string {
+	return map[string]string{
+		crdreplicator.LocalLabelSelector: "true",
+		crdreplicator.DestinationLabel:   remoteClusterID,
+	}
 }

--- a/internal/discovery/foreign-cluster-operator/setup.go
+++ b/internal/discovery/foreign-cluster-operator/setup.go
@@ -6,7 +6,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
@@ -66,8 +66,8 @@ func StartOperator(
 	namespaceManager := tenantcontrolnamespace.NewTenantControlNamespaceManager(discoveryClient.Client())
 	idManager := identitymanager.NewCertificateIdentityManager(discoveryClient.Client(), localClusterID, namespaceManager)
 
-	if err = (getFCReconciler(
-		mgr.GetScheme(),
+	if err = (getForeignClusterReconciler(
+		mgr,
 		namespace,
 		discoveryClient,
 		advClient,
@@ -85,7 +85,7 @@ func StartOperator(
 	}
 }
 
-func getFCReconciler(scheme *runtime.Scheme,
+func getForeignClusterReconciler(mgr manager.Manager,
 	namespace string,
 	client, advertisementClient, networkClient *crdclient.CRDClient,
 	localClusterID clusterid.ClusterID,
@@ -96,7 +96,8 @@ func getFCReconciler(scheme *runtime.Scheme,
 	idManager identitymanager.IdentityManager,
 	useNewAuth bool) *ForeignClusterReconciler {
 	reconciler := &ForeignClusterReconciler{
-		Scheme:              scheme,
+		Client:              mgr.GetClient(),
+		Scheme:              mgr.GetScheme(),
 		Namespace:           namespace,
 		crdClient:           client,
 		advertisementClient: advertisementClient,

--- a/internal/discovery/foreign-cluster-operator/tenantControlNamespace.go
+++ b/internal/discovery/foreign-cluster-operator/tenantControlNamespace.go
@@ -1,27 +1,22 @@
 package foreignclusteroperator
 
 import (
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/klog"
+	"context"
+
+	"k8s.io/klog/v2"
 
 	"github.com/liqotech/liqo/apis/discovery/v1alpha1"
 )
 
-// createLocalTenantControlNamespace creates the LocalTenantControlNamespace for the given ForeignCluster, if it is not yet present.
-// It returns a boolean indicating if the ForeignCluster requires an update.
-func (r *ForeignClusterReconciler) createLocalTenantControlNamespace(foreignCluster *v1alpha1.ForeignCluster) (requireUpdate bool, err error) {
-	var namespace *v1.Namespace
-	namespace, err = r.namespaceManager.CreateNamespace(foreignCluster.Spec.ClusterIdentity.ClusterID)
+// ensureLocalTenantNamespace creates the LocalTenantControlNamespace for the given ForeignCluster, if it is not yet present.
+func (r *ForeignClusterReconciler) ensureLocalTenantNamespace(
+	ctx context.Context, foreignCluster *v1alpha1.ForeignCluster) error {
+	namespace, err := r.namespaceManager.CreateNamespace(foreignCluster.Spec.ClusterIdentity.ClusterID)
 	if err != nil {
 		klog.Error(err)
-		return false, err
+		return err
 	}
 
-	requireUpdate = false
-	if foreignCluster.Status.TenantControlNamespace.Local != namespace.Name {
-		foreignCluster.Status.TenantControlNamespace.Local = namespace.Name
-		requireUpdate = true
-	}
-
-	return requireUpdate, nil
+	foreignCluster.Status.TenantControlNamespace.Local = namespace.Name
+	return nil
 }

--- a/internal/discovery/foreign-cluster-operator/validator.go
+++ b/internal/discovery/foreign-cluster-operator/validator.go
@@ -1,0 +1,97 @@
+package foreignclusteroperator
+
+import (
+	"context"
+
+	"k8s.io/klog/v2"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
+	"github.com/liqotech/liqo/pkg/discovery"
+)
+
+// validateForeignCluster contains the logic that validates and defaults labels and spec fields.
+// TODO: this function will be refactored in a future pr.
+func (r *ForeignClusterReconciler) validateForeignCluster(ctx context.Context,
+	foreignCluster *discoveryv1alpha1.ForeignCluster) (cont bool, res ctrl.Result, err error) {
+	requireUpdate := false
+
+	if r.needsClusterIdentityDefaulting(foreignCluster) {
+		// this ForeignCluster has not all the required fields, probably it has been added manually, so default to exposed values
+		if err := r.clusterIdentityDefaulting(foreignCluster); err != nil {
+			klog.Error(err)
+			return false, ctrl.Result{
+				Requeue:      true,
+				RequeueAfter: r.RequeueAfter,
+			}, err
+		}
+		// the resource has been updated, no need to requeue
+		return false, ctrl.Result{}, nil
+	}
+
+	// set trust property
+	// This will only be executed in the ForeignCluster CR has been added in a manual way,
+	// if it was discovered this field is set by the discovery process.
+	if foreignCluster.Spec.TrustMode == discovery.TrustModeUnknown || foreignCluster.Spec.TrustMode == "" {
+		trust, err := foreignCluster.CheckTrusted()
+		if err != nil {
+			klog.Error(err)
+			return false, ctrl.Result{
+				Requeue:      true,
+				RequeueAfter: r.RequeueAfter,
+			}, err
+		}
+		if trust {
+			foreignCluster.Spec.TrustMode = discovery.TrustModeTrusted
+		} else {
+			foreignCluster.Spec.TrustMode = discovery.TrustModeUntrusted
+		}
+		// set join flag
+		// if it was discovery with WAN discovery, this value is overwritten by SearchDomain value
+		isWan := foreignCluster.Spec.DiscoveryType == discovery.WanDiscovery
+		isIncoming := foreignCluster.Spec.DiscoveryType == discovery.IncomingPeeringDiscovery
+		isManual := foreignCluster.Spec.DiscoveryType == discovery.ManualDiscovery
+		if !isWan && !isIncoming && !isManual {
+			joinTrusted := r.getAutoJoin(foreignCluster) && foreignCluster.Spec.TrustMode == discovery.TrustModeTrusted
+			joinUntrusted := r.getAutoJoinUntrusted(foreignCluster) && foreignCluster.Spec.TrustMode == discovery.TrustModeUntrusted
+			foreignCluster.Spec.Join = joinTrusted || joinUntrusted
+		}
+
+		requireUpdate = true
+	}
+
+	// if it has no discovery type label, add it
+	if foreignCluster.ObjectMeta.Labels == nil {
+		foreignCluster.ObjectMeta.Labels = map[string]string{}
+	}
+	noLabel := foreignCluster.ObjectMeta.Labels[discovery.DiscoveryTypeLabel] == ""
+	differentLabel := foreignCluster.ObjectMeta.Labels[discovery.DiscoveryTypeLabel] != string(foreignCluster.Spec.DiscoveryType)
+	if noLabel || differentLabel {
+		foreignCluster.ObjectMeta.Labels[discovery.DiscoveryTypeLabel] = string(foreignCluster.Spec.DiscoveryType)
+		requireUpdate = true
+	}
+	// set cluster-id label to easy retrieve ForeignClusters by ClusterId,
+	// if it is added manually, the name maybe not coincide with ClusterId
+	if foreignCluster.ObjectMeta.Labels[discovery.ClusterIDLabel] == "" {
+		foreignCluster.ObjectMeta.Labels[discovery.ClusterIDLabel] = foreignCluster.Spec.ClusterIdentity.ClusterID
+		requireUpdate = true
+	}
+
+	if requireUpdate {
+		_, err := r.update(foreignCluster)
+		if err != nil {
+			klog.Error(err, err.Error())
+			return false, ctrl.Result{
+				Requeue:      true,
+				RequeueAfter: r.RequeueAfter,
+			}, err
+		}
+		klog.V(4).Infof("ForeignCluster %s successfully reconciled", foreignCluster.Name)
+		return false, ctrl.Result{
+			Requeue:      true,
+			RequeueAfter: r.RequeueAfter,
+		}, nil
+	}
+
+	return true, ctrl.Result{}, nil
+}

--- a/internal/discovery/foreign.go
+++ b/internal/discovery/foreign.go
@@ -162,7 +162,7 @@ func (discovery *Controller) createForeign(
 		fc.Labels[discoveryPkg.SearchDomainLabel] = sd.Name
 	}
 	// set TTL
-	fc.Status.TTL = data.AuthData.ttl
+	fc.Spec.TTL = int(data.AuthData.ttl)
 	tmp, err := discovery.crdClient.Resource("foreignclusters").Create(fc, &metav1.CreateOptions{})
 	if err != nil {
 		klog.Error(err)
@@ -196,10 +196,10 @@ func (discovery *Controller) checkUpdate(
 			joinTrusted := fc.Spec.TrustMode == discoveryPkg.TrustModeTrusted && discovery.Config.AutoJoin
 			joinUntrusted := fc.Spec.TrustMode == discoveryPkg.TrustModeUntrusted && discovery.Config.AutoJoinUntrusted
 			fc.Spec.Join = joinTrusted || joinUntrusted
-			fc.Status.TTL = data.AuthData.ttl
+			fc.Spec.TTL = int(data.AuthData.ttl)
 		} else if searchDomain != nil && discoveryType == discoveryPkg.WanDiscovery {
 			fc.Spec.Join = searchDomain.Spec.AutoJoin
-			fc.Status.TTL = data.AuthData.ttl
+			fc.Spec.TTL = int(data.AuthData.ttl)
 		}
 		fc.LastUpdateNow()
 		tmp, err := discovery.crdClient.Resource("foreignclusters").Update(fc.Name, fc, &metav1.UpdateOptions{})

--- a/internal/discovery/foreignClusterGarbageCollector.go
+++ b/internal/discovery/foreignClusterGarbageCollector.go
@@ -46,6 +46,7 @@ func (discovery *Controller) collectGarbage() error {
 	for i := range fcs.Items {
 		if fcs.Items[i].IsExpired() {
 			klog.V(4).Infof("delete foreignCluster %v (TTL expired)", fcs.Items[i].Name)
+			klog.Infof("delete foreignCluster %v", fcs.Items[i].Name)
 			err = discovery.crdClient.Resource("foreignclusters").Delete(fcs.Items[i].Name, &metav1.DeleteOptions{})
 			if err != nil {
 				klog.Error(err)

--- a/internal/liqonet/tunnelEndpointCreator/foreignclusterWatcher.go
+++ b/internal/liqonet/tunnelEndpointCreator/foreignclusterWatcher.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/klog/v2"
 
 	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
+	foreigncluster "github.com/liqotech/liqo/pkg/utils/foreignCluster"
 )
 
 func (tec *TunnelEndpointCreator) StartForeignClusterWatcher() {
@@ -44,9 +45,9 @@ func (tec *TunnelEndpointCreator) ForeignClusterHandlerAdd(obj interface{}) {
 		klog.Errorf("an error occurred while converting resource %s of type %s to typed object: %s", objUnstruct.GetName(), objUnstruct.GetKind(), err)
 		return
 	}
-	if fc.Status.Incoming.Joined || fc.Status.Outgoing.Joined {
+	if foreigncluster.IsIncomingJoined(fc) || foreigncluster.IsOutgoingJoined(fc) {
 		_ = tec.createNetConfig(fc)
-	} else if !fc.Status.Incoming.Joined && !fc.Status.Outgoing.Joined {
+	} else if !foreigncluster.IsIncomingJoined(fc) && !foreigncluster.IsOutgoingJoined(fc) {
 		_ = tec.deleteNetConfig(fc)
 	}
 }

--- a/internal/peering-request-operator/foreign-cluster.go
+++ b/internal/peering-request-operator/foreign-cluster.go
@@ -52,7 +52,7 @@ func (r *PeeringRequestReconciler) UpdateForeignCluster(pr *v1alpha1.PeeringRequ
 			UID:        pr.UID,
 			APIVersion: pr.APIVersion,
 		}
-		_, err = r.crdClient.Resource("foreignclusters").Update(fc.Name, fc, &metav1.UpdateOptions{})
+		_, err = r.crdClient.Resource("foreignclusters").UpdateStatus(fc.Name, fc, &metav1.UpdateOptions{})
 		if err != nil {
 			klog.Error(err, err.Error())
 			return err

--- a/internal/peering-request-operator/peering-request-controller.go
+++ b/internal/peering-request-operator/peering-request-controller.go
@@ -53,7 +53,7 @@ type PeeringRequestReconciler struct {
 
 // +kubebuilder:rbac:groups=discovery.liqo.io,resources=peeringrequests,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=discovery.liqo.io,resources=peeringrequests/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=discovery.liqo.io,resources=foreignclusters,verbs=list;update;create
+// +kubebuilder:rbac:groups=discovery.liqo.io,resources=foreignclusters;foreignclusters/status,verbs=list;update;create
 // +kubebuilder:rbac:groups=certificates.k8s.io,resources=certificatesigningrequests,verbs=get;list;watch;create;update;create;patch
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;create;patch
 // role

--- a/pkg/uninstaller/helpers.go
+++ b/pkg/uninstaller/helpers.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/klog/v2"
 
 	discoveryV1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
+	foreigncluster "github.com/liqotech/liqo/pkg/utils/foreignCluster"
 )
 
 // getForeignList retrieve the list of available ForeignCluster and return it as a ForeignClusterList object.
@@ -30,9 +31,11 @@ func getForeignList(client dynamic.Interface) (*discoveryV1alpha1.ForeignCluster
 // checkPeeringsStatus verifies if all clusters have not active peerings.
 func checkPeeringsStatus(foreign *discoveryV1alpha1.ForeignClusterList) bool {
 	var returnValue = true
-	for _, item := range foreign.Items {
-		if item.Status.Incoming.Joined || item.Status.Outgoing.Joined {
-			klog.Infof("Cluster %s still has a valid peering: (Incoming: %s, Outgoing: %s", item.Name, item.Status.Incoming.Joined, item.Status.Outgoing.Joined)
+	for i := range foreign.Items {
+		item := &foreign.Items[i]
+		if foreigncluster.IsIncomingEnabled(item) || foreigncluster.IsOutgoingEnabled(item) {
+			klog.Infof("Cluster %s still has a valid peering: (Incoming: %s, Outgoing: %s",
+				item.Name, item.Status.Incoming.PeeringPhase, item.Status.Outgoing.PeeringPhase)
 			returnValue = false
 		}
 	}

--- a/pkg/utils/foreignCluster/garbageCollection.go
+++ b/pkg/utils/foreignCluster/garbageCollection.go
@@ -1,0 +1,13 @@
+package foreigncluster
+
+import (
+	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
+	"github.com/liqotech/liqo/pkg/discovery"
+)
+
+// HasToBeRemoved indicates if a ForeignCluster CR has to be removed.
+func HasToBeRemoved(foreignCluster *discoveryv1alpha1.ForeignCluster) bool {
+	isIncomingDiscovery := foreignCluster.Spec.DiscoveryType == discovery.IncomingPeeringDiscovery
+	hasPeering := IsIncomingEnabled(foreignCluster) || IsOutgoingEnabled(foreignCluster)
+	return isIncomingDiscovery && !hasPeering
+}

--- a/pkg/utils/foreignCluster/peeringStatus.go
+++ b/pkg/utils/foreignCluster/peeringStatus.go
@@ -1,0 +1,25 @@
+package foreigncluster
+
+import (
+	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
+)
+
+// IsIncomingJoined checks if the incoming peering has been completely established.
+func IsIncomingJoined(foreignCluster *discoveryv1alpha1.ForeignCluster) bool {
+	return foreignCluster.Status.Incoming.PeeringPhase == discoveryv1alpha1.PeeringPhaseEstablished
+}
+
+// IsOutgoingJoined checks if the outgoing peering has been completely established.
+func IsOutgoingJoined(foreignCluster *discoveryv1alpha1.ForeignCluster) bool {
+	return foreignCluster.Status.Outgoing.PeeringPhase == discoveryv1alpha1.PeeringPhaseEstablished
+}
+
+// IsIncomingEnabled checks if the incoming peering is enabled (i.e. Pending, Established or Deleting).
+func IsIncomingEnabled(foreignCluster *discoveryv1alpha1.ForeignCluster) bool {
+	return foreignCluster.Status.Incoming.PeeringPhase != discoveryv1alpha1.PeeringPhaseNone && foreignCluster.Status.Incoming.PeeringPhase != ""
+}
+
+// IsOutgoingEnabled checks if the outgoing peering is enabled (i.e. Pending, Established or Deleting).
+func IsOutgoingEnabled(foreignCluster *discoveryv1alpha1.ForeignCluster) bool {
+	return foreignCluster.Status.Outgoing.PeeringPhase != discoveryv1alpha1.PeeringPhaseNone && foreignCluster.Status.Outgoing.PeeringPhase != ""
+}


### PR DESCRIPTION
# Description

This pr starts the refactoring of the ForeignCluster Operator to improve readability and stability.

In particular:
* some functions have been moved away and will be moved to a ForeignCluster webhook in a future pr
* some fields in the ForeignCluster resource are now deprecated, since no more need with the new authentication mechanism
* the reconcile function has been refactored to use the controller runtime client and to be more readable

# How Has This Been Tested?

- [x] locally on KinD
- [x] add unit test
- [ ] other unit test will be added in a future dedicated pr
