### PR TITLE
Adding privileged mode to docker contairner used to run the tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -267,7 +267,7 @@ jobs:
         options: |
             --mount type=bind,src=${{ github.workspace }},dst=/go/src/liqotech/liqo
             --workdir /go/src/liqotech/liqo
-            --cap-add=NET_ADMIN
+            --privileged=true
         image: liqo/liqo-test${{ needs.configure.outputs.repo-suffix }}:${{ needs.configure.outputs.commit_ref }}
         run: |
           go-acc ./... --ignore liqo/test/e2e


### PR DESCRIPTION

# Description

Liqo network interacts with the operating system in order to create/configure network interfaces hence it needs to have the right permissions to do that. Same requirements are needed also for the unit test of the networking code. This PR enables to run a docker container in privileged modes when launching the tests.

