### PR TITLE
Symmetric Routing for vxlan overlay

### DIFF
--- a/internal/liqonet/route-operator/overlayOperator.go
+++ b/internal/liqonet/route-operator/overlayOperator.go
@@ -63,7 +63,7 @@ func (ovc *OverlayController) Reconcile(ctx context.Context, req ctrl.Request) (
 	var err error
 	err = ovc.Get(ctx, req.NamespacedName, &pod)
 	if err != nil && !k8sApiErrors.IsNotFound(err) {
-		klog.Errorf("an error occurred while getting pod %s: %v", req.NamespacedName, err)
+		klog.Errorf("an error occurred while getting pod {%s}: %v", req.NamespacedName, err)
 		return ctrl.Result{}, err
 	}
 	if k8sApiErrors.IsNotFound(err) {
@@ -73,7 +73,7 @@ func (ovc *OverlayController) Reconcile(ctx context.Context, req ctrl.Request) (
 			return ctrl.Result{}, err
 		}
 		if deleted {
-			klog.Infof("successfully removed peer %s from vxlan overlay network", req.String())
+			klog.Infof("successfully removed peer {%s} from vxlan overlay network", req.String())
 		}
 		return ctrl.Result{}, nil
 	}
@@ -81,10 +81,10 @@ func (ovc *OverlayController) Reconcile(ctx context.Context, req ctrl.Request) (
 	if ovc.podIP == pod.Status.PodIP {
 		if ovc.addAnnotation(&pod, vxlanMACAddressKey, ovc.vxlanDev.Link.HardwareAddr.String()) {
 			if err := ovc.Update(ctx, &pod); err != nil {
-				klog.Errorf("an error occurred while adding mac address annotation to pod %s: %v", req.String(), err)
+				klog.Errorf("an error occurred while adding mac address annotation to pod {%s}: %v", req.String(), err)
 				return ctrl.Result{}, err
 			}
-			klog.Infof("successfully annotated pod %s with mac address %s", req.String(), ovc.vxlanDev.Link.HardwareAddr.String())
+			klog.Infof("successfully annotated pod {%s} with mac address {%s}", req.String(), ovc.vxlanDev.Link.HardwareAddr.String())
 		}
 		return ctrl.Result{}, nil
 	}
@@ -92,12 +92,12 @@ func (ovc *OverlayController) Reconcile(ctx context.Context, req ctrl.Request) (
 	// If it is not our pod, then add peer to the vxlan network.
 	added, err := ovc.addPeer(req, &pod)
 	if err != nil {
-		klog.Errorf("an error occurred while adding peer %s with IP address %s and MAC address %s to the vxlan overlay network: %v",
+		klog.Errorf("an error occurred while adding peer {%s} with IP address {%s} and MAC address {%s} to the vxlan overlay network: %v",
 			req.String(), pod.Status.PodIP, ovc.getAnnotationValue(&pod, vxlanMACAddressKey), err)
 		return ctrl.Result{}, err
 	}
 	if added {
-		klog.Errorf("successfully added peer %s with IP address %s and MAC address %s to the vxlan overlay network",
+		klog.Errorf("successfully added peer {%s} with IP address {%s} and MAC address {%s} to the vxlan overlay network",
 			req.String(), pod.Status.PodIP, ovc.getAnnotationValue(&pod, vxlanMACAddressKey))
 	}
 	return ctrl.Result{}, nil
@@ -198,7 +198,7 @@ func (ovc *OverlayController) podFilter(obj client.Object) bool {
 	// Check if the object is a pod.
 	p, ok := obj.(*corev1.Pod)
 	if !ok {
-		klog.Infof("object %s is not of type corev1.Pod", obj.GetName())
+		klog.Infof("object {%s} is not of type corev1.Pod", obj.GetName())
 		return false
 	}
 	// Filter by labels.

--- a/internal/liqonet/route-operator/symmetricRoutingOperator.go
+++ b/internal/liqonet/route-operator/symmetricRoutingOperator.go
@@ -1,0 +1,162 @@
+package routeoperator
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+
+	"golang.org/x/sys/unix"
+	corev1 "k8s.io/api/core/v1"
+	k8sApiErrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/klog/v2"
+	"k8s.io/kubernetes/pkg/api/v1/pod"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	liqoerrors "github.com/liqotech/liqo/pkg/liqonet/errors"
+	"github.com/liqotech/liqo/pkg/liqonet/overlay"
+	"github.com/liqotech/liqo/pkg/liqonet/routing"
+)
+
+// SymmetricRoutingController reconciles pods objects, in our case all the existing pods.
+type SymmetricRoutingController struct {
+	client.Client
+	vxlanDev       overlay.VxlanDevice
+	nodeName       string
+	routingTableID int
+	nodesLock      *sync.RWMutex
+	vxlanNodes     map[string]string
+	routes         map[string]string
+}
+
+// Reconcile for a given pod, based on the node where the pod is running, configures a route to send the traffic
+// through the overlay network. The route is used only for the traffic generated on remote clusters with
+// destination address a pod running on the local cluster. The traffic for local pods should be handled by
+// the local CNI but if the reverse path filtering is in strict mode (default) the traffic coming from a
+// network interface where the source address is not routable by the same interface is dropped. To solve the
+// issue it requires to set the reverse path filtering to loose mode, but some times it is not possible. To
+// overcome the problem all the traffic sent to or coming from a peering cluster has to be routed using the
+// overlay network.
+func (src *SymmetricRoutingController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	var p corev1.Pod
+	var err error
+	err = src.Get(ctx, req.NamespacedName, &p)
+	if err != nil && !k8sApiErrors.IsNotFound(err) {
+		klog.Errorf("an error occurred while getting pod {%s}: %v", req.NamespacedName, err)
+		return ctrl.Result{}, err
+	}
+	if k8sApiErrors.IsNotFound(err) {
+		// Remove the peer.
+		deleted, err := src.delRoute(req)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+		if deleted {
+			klog.Infof("successfully removed route for pod {%s} from vxlan overlay network", req.String())
+		}
+		return ctrl.Result{}, nil
+	}
+	added, err := src.addRoute(req, &p)
+	if err != nil {
+		klog.Errorf("an error occurred while adding route for pod {%s} with IP address {{%s}} to the vxlan overlay network: %v",
+			req.String(), p.Status.PodIP, err)
+		return ctrl.Result{}, err
+	}
+	if added {
+		klog.Errorf("successfully added route for pod {%s} with IP address {%s} to the vxlan overlay network: %v",
+			req.String(), p.Status.PodIP)
+	}
+	return ctrl.Result{}, nil
+}
+
+// NewSymmetricRoutingOperator returns a new controller ready to be setup and started with the controller manager.
+func NewSymmetricRoutingOperator(nodeName string, routingTableID int, vxlanDevice overlay.VxlanDevice,
+	nodesLock *sync.RWMutex, vxlanNodes map[string]string, cl client.Client) (*SymmetricRoutingController, error) {
+	// Check the validity of input parameters.
+	if routingTableID > unix.RT_TABLE_MAX {
+		return nil, &liqoerrors.WrongParameter{Parameter: "routingTableID", Reason: liqoerrors.MinorOrEqual + strconv.Itoa(unix.RT_TABLE_MAX)}
+	}
+	if routingTableID < 0 {
+		return nil, &liqoerrors.WrongParameter{Parameter: "routingTableID", Reason: liqoerrors.GreaterOrEqual + strconv.Itoa(0)}
+	}
+	if vxlanDevice.Link == nil {
+		return nil, &liqoerrors.WrongParameter{Parameter: "vxlanDevice.Link", Reason: liqoerrors.NotNil}
+	}
+	return &SymmetricRoutingController{
+		Client:         cl,
+		vxlanDev:       vxlanDevice,
+		nodeName:       nodeName,
+		routingTableID: routingTableID,
+		nodesLock:      nodesLock,
+		vxlanNodes:     vxlanNodes,
+		routes:         map[string]string{},
+	}, nil
+}
+
+// addPeer adds route for the given pod. It return true when the route dose not exists
+// and is added, false if the route does already exist. An error is return if something
+// goes wrong.
+func (src *SymmetricRoutingController) addRoute(req ctrl.Request, p *corev1.Pod) (bool, error) {
+	src.nodesLock.RLock()
+	defer src.nodesLock.RUnlock()
+	nodeIP, ok := src.vxlanNodes[p.Spec.NodeName]
+	if !ok {
+		return false, fmt.Errorf("ip for node {%s} has not been set yet", p.Spec.NodeName)
+	}
+	gwIP := overlay.GetOverlayIP(nodeIP)
+	dstNet := strings.Join([]string{p.Status.PodIP, "32"}, "/")
+	added, err := routing.AddRoute(dstNet, gwIP, src.vxlanDev.Link.Attrs().Index, src.routingTableID)
+	if err != nil {
+		return added, err
+	}
+	src.routes[req.String()] = dstNet
+	return added, err
+}
+
+// delRoute removes route for the given pod. It returns true when the route exists
+// and is removed. False if the route does not exist. An error if something goes
+// wrong.
+func (src *SymmetricRoutingController) delRoute(req ctrl.Request) (bool, error) {
+	dstNet, ok := src.routes[req.String()]
+	if !ok {
+		return false, nil
+	}
+	deleted, err := routing.DelRoute(dstNet, "", src.vxlanDev.Link.Attrs().Index, src.routingTableID)
+	if err != nil {
+		return deleted, err
+	}
+	delete(src.routes, req.String())
+	return deleted, nil
+}
+
+// podFilter used to filter out all the pods that are running on the same node
+// as the operator or pods that are not ready. We do not need to configure routes
+// for pods running on same node.
+func (src *SymmetricRoutingController) podFilter(obj client.Object) bool {
+	// Check if the object is a pod.
+	p, ok := obj.(*corev1.Pod)
+	if !ok {
+		klog.Infof("object {%s} is not of type corev1.Pod", obj.GetName())
+		return false
+	}
+	// Check if pod is running on same node as the operator.
+	if p.Spec.NodeName == src.nodeName {
+		klog.V(4).Infof("skipping pod {%s} running on our same node {%s}", p.Name, p.Spec.NodeName)
+		return false
+	}
+	// If pod is not ready return false.
+	if !pod.IsPodReady(p) {
+		return false
+	}
+	return true
+}
+
+// SetupWithManager used to set up the controller with a given manager.
+func (src *SymmetricRoutingController) SetupWithManager(mgr ctrl.Manager) error {
+	p := predicate.NewPredicateFuncs(src.podFilter)
+	return ctrl.NewControllerManagedBy(mgr).For(&corev1.Pod{}).WithEventFilter(p).
+		Complete(src)
+}

--- a/internal/liqonet/route-operator/symmetricRoutingOperator_test.go
+++ b/internal/liqonet/route-operator/symmetricRoutingOperator_test.go
@@ -1,0 +1,325 @@
+package routeoperator
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+	"sync"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	liqoerrors "github.com/liqotech/liqo/pkg/liqonet/errors"
+	"github.com/liqotech/liqo/pkg/liqonet/overlay"
+)
+
+var (
+	srcRoutingTableID = 1000
+	// Name of the node where the operator is running.
+	srcNodeName = "src-operator-node"
+	srcNodeIP   = "10.200.1.2"
+	// Name of the node where the test pod is running.
+	srcPodNodeName = "src-pod-node"
+	srcPodName     = "src-test-pod"
+	srcPodIP       = "10.234.0.1"
+	srcNamespace   = "src-namespace"
+	srcRouteDst    = "10.245.0.1/32"
+
+	srcTestPod *corev1.Pod
+	srcReq     ctrl.Request
+	srcRoute   *netlink.Route
+	src        *SymmetricRoutingController
+	srcClient  client.Client
+)
+
+var _ = Describe("SymmetricRoutingOperator", func() {
+	JustBeforeEach(func() {
+		srcReq = ctrl.Request{
+			NamespacedName: types.NamespacedName{
+				Namespace: srcNamespace,
+				Name:      srcPodName,
+			},
+		}
+		// Reset the test pod to the default values.
+		srcTestPod = &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      srcReq.Name,
+				Namespace: srcReq.Namespace,
+			},
+			Spec: corev1.PodSpec{
+				NodeName: srcPodNodeName,
+				Containers: []corev1.Container{
+					{
+						Name:            "busybox",
+						Image:           "busybox",
+						ImagePullPolicy: corev1.PullIfNotPresent,
+						Command: []string{
+							"sleep",
+							"3600",
+						},
+					},
+				},
+			},
+		}
+		gw := net.ParseIP(overlay.GetOverlayIP(srcNodeIP))
+		Expect(gw).NotTo(BeNil())
+		_, dst, err := net.ParseCIDR(srcRouteDst)
+		Expect(err).To(BeNil())
+		srcRoute = &netlink.Route{
+			LinkIndex: vxlanDevice.Link.Attrs().Index,
+			Dst:       dst,
+			Gw:        gw,
+			Table:     srcRoutingTableID,
+		}
+		// Add route.
+		err = netlink.RouteAdd(srcRoute)
+		Expect(err).To(BeNil())
+
+		// Create the symmetric routing operator.
+		src = &SymmetricRoutingController{
+			Client:         k8sClient,
+			vxlanDev:       vxlanDevice,
+			nodeName:       srcNodeName,
+			routingTableID: srcRoutingTableID,
+			nodesLock:      &sync.RWMutex{},
+			vxlanNodes:     map[string]string{srcNodeName: srcNodeIP},
+			routes:         map[string]string{},
+		}
+	})
+	JustAfterEach(func() {
+		err := netlink.RouteDel(srcRoute)
+		if err != nil && !errors.Is(err, unix.ESRCH) {
+			Expect(err).Should(BeNil())
+		}
+
+	})
+	Describe("testing NewSymmetricRoutingOperator function", func() {
+		Context("when input parameters are not correct", func() {
+			It("vxlan device is not correct, should return nil and error", func() {
+				src, err := NewSymmetricRoutingOperator(srcNodeName, srcRoutingTableID, overlay.VxlanDevice{Link: nil}, &sync.RWMutex{}, nil, k8sClient)
+				Expect(err).Should(MatchError(&liqoerrors.WrongParameter{Parameter: "vxlanDevice.Link", Reason: liqoerrors.NotNil}))
+				Expect(src).Should(BeNil())
+			})
+
+			It("routingTableID parameter out of range: a negative number", func() {
+				src, err := NewSymmetricRoutingOperator(srcNodeName, -244, vxlanDevice, &sync.RWMutex{}, nil, k8sClient)
+				Expect(err).Should(Equal(&liqoerrors.WrongParameter{Parameter: "routingTableID", Reason: liqoerrors.GreaterOrEqual + strconv.Itoa(0)}))
+				Expect(src).Should(BeNil())
+			})
+
+			It("routingTableID parameter out of range: superior to max value ", func() {
+				src, err := NewSymmetricRoutingOperator(srcNodeName, unix.RT_TABLE_MAX+1, vxlanDevice, &sync.RWMutex{}, nil, k8sClient)
+				Expect(err).Should(Equal(&liqoerrors.WrongParameter{Parameter: "routingTableID", Reason: liqoerrors.MinorOrEqual + strconv.Itoa(unix.RT_TABLE_MAX)}))
+				Expect(src).Should(BeNil())
+			})
+		})
+
+		Context("when input parameters are correct", func() {
+			It("should return symmetrinc routing controller and nil", func() {
+				src, err := NewSymmetricRoutingOperator(srcNodeName, srcRoutingTableID, vxlanDevice, &sync.RWMutex{}, nil, k8sClient)
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(src).ShouldNot(BeNil())
+			})
+		})
+	})
+
+	Describe("testing reconcile function", func() {
+		Context("adding route for new pod", func() {
+			It("ip for destination node has not been set, should return error", func() {
+				srcTestPod.Name = "add-route-no-gw-existing"
+				srcReq.Name = "add-route-no-gw-existing"
+				Eventually(func() error { return k8sClient.Create(context.TODO(), srcTestPod) }).Should(BeNil())
+				newPod := &corev1.Pod{}
+				Eventually(func() error { return k8sClient.Get(context.TODO(), srcReq.NamespacedName, newPod) }).Should(BeNil())
+				newPod.Status.PodIP = "10.1.11.1"
+				Eventually(func() error { return k8sClient.Status().Update(context.TODO(), newPod) }).Should(BeNil())
+				// Make sure that the field has already been updated on the testing api-server.
+				Eventually(func() error {
+					err := k8sClient.Get(context.TODO(), srcReq.NamespacedName, newPod)
+					if err != nil {
+						return err
+					}
+					if newPod.Status.PodIP != "10.1.11.1" {
+						return fmt.Errorf("pod ip has not been updated yet on the testing api-server")
+					}
+					return nil
+				}).Should(BeNil())
+				Eventually(func() error { _, err := src.Reconcile(context.TODO(), srcReq); return err }).Should(MatchError("ip for node {src-pod-node} has not been set yet"))
+				_, ok := src.routes[srcReq.String()]
+				Expect(ok).Should(BeFalse())
+			})
+
+			It("route does not exist, should add it and return nil", func() {
+				srcTestPod.Name = "add-route-no-existing"
+				srcTestPod.Spec.NodeName = srcNodeName
+				srcReq.Name = "add-route-no-existing"
+				Eventually(func() error { return k8sClient.Create(context.TODO(), srcTestPod) }).Should(BeNil())
+				newPod := &corev1.Pod{}
+				Eventually(func() error { return k8sClient.Get(context.TODO(), srcReq.NamespacedName, newPod) }).Should(BeNil())
+				newPod.Status.PodIP = "10.1.11.1"
+				Eventually(func() error { return k8sClient.Status().Update(context.TODO(), newPod) }).Should(BeNil())
+				// Make sure that the field has already been updated on the testing api-server.
+				Eventually(func() error {
+					err := k8sClient.Get(context.TODO(), srcReq.NamespacedName, newPod)
+					if err != nil {
+						return err
+					}
+					if newPod.Status.PodIP != "10.1.11.1" {
+						return fmt.Errorf("pod ip has not been updated yet on the testing api-server")
+					}
+					return nil
+				}).Should(BeNil())
+				Eventually(func() error { _, err := src.Reconcile(context.TODO(), srcReq); return err }).Should(BeNil())
+				_, ok := src.routes[srcReq.String()]
+				Expect(ok).Should(BeTrue())
+			})
+		})
+
+		Context("removing route for a deleted pod", func() {
+			It("route does not exist", func() {
+				srcTestPod.Name = "del-route-no-existing"
+				srcReq.Name = "del-route-no-existing"
+				Eventually(func() error { _, err := src.Reconcile(context.TODO(), srcReq); return err }).Should(BeNil())
+			})
+
+			It("route does exist", func() {
+				srcTestPod.Name = "del-route-existing"
+				srcReq.Name = "del-route-existing"
+				src.routes[srcReq.String()] = srcRouteDst
+				Eventually(func() error { _, err := src.Reconcile(context.TODO(), srcReq); return err }).Should(BeNil())
+				_, ok := src.routes[srcReq.String()]
+				Expect(ok).Should(BeFalse())
+			})
+		})
+	})
+
+	Describe("testing addRoute function", func() {
+		Context("when ip of the node where the pod runs has not been set", func() {
+			It("should return false and error", func() {
+				added, err := src.addRoute(srcReq, srcTestPod)
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError("ip for node {" + srcPodNodeName + "} has not been set yet"))
+				Expect(added).Should(BeFalse())
+			})
+		})
+
+		Context("when route does not exist", func() {
+			It("should insert the route, return true and nil", func() {
+				// Prepare pod with the right values.
+				srcTestPod.Status.PodIP = srcPodIP
+				// Insert node ip of the node where the testing pod is running.
+				src.vxlanNodes[srcPodNodeName] = srcNodeIP
+				// Add route.
+				added, err := src.addRoute(srcReq, srcTestPod)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(added).Should(BeTrue())
+				_, ok := src.routes[srcReq.String()]
+				Expect(ok).Should(BeTrue())
+				_, dstNet, err := net.ParseCIDR(srcPodIP + "/32")
+				Expect(err).To(BeNil())
+				// List rules wit destination net the one of the pod.
+				routes, err := netlink.RouteListFiltered(netlink.FAMILY_V4, &netlink.Route{Table: srcRoutingTableID, Dst: dstNet}, netlink.RT_FILTER_TABLE|netlink.RT_FILTER_DST)
+				Expect(err).Should(BeNil())
+				Expect(len(routes)).Should(BeNumerically("==", 1))
+				Expect(routes[0].Dst.String()).Should(Equal(dstNet.String()))
+				Expect(routes[0].Gw.String()).Should(Equal(overlay.GetOverlayIP(srcNodeIP)))
+			})
+		})
+
+		Context("when route does exist", func() {
+			It("route remains the same, return false and nil", func() {
+				// Prepare pod with the right values.
+				tmpTokens := strings.Split(srcRouteDst, "/")
+				srcTestPod.Status.PodIP = tmpTokens[0]
+				// Insert node ip of the node where the testing pod is running.
+				src.vxlanNodes[srcPodNodeName] = srcNodeIP
+				// Add route.
+				added, err := src.addRoute(srcReq, srcTestPod)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(added).Should(BeFalse())
+				_, ok := src.routes[srcReq.String()]
+				Expect(ok).Should(BeTrue())
+				// List rules wit destination net the one of the pod.
+				routes, err := netlink.RouteListFiltered(netlink.FAMILY_V4, srcRoute, netlink.RT_FILTER_TABLE|netlink.RT_FILTER_DST)
+				Expect(err).Should(BeNil())
+				Expect(len(routes)).Should(BeNumerically("==", 1))
+				Expect(routes[0].Dst.String()).Should(Equal(srcRouteDst))
+				Expect(routes[0].Gw.String()).Should(Equal(overlay.GetOverlayIP(srcNodeIP)))
+
+			})
+		})
+	})
+
+	Describe("testing delRoute function", func() {
+		Context("when route does not exist", func() {
+			It("should return false and nil", func() {
+				deleted, err := src.delRoute(srcReq)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(deleted).Should(BeFalse())
+				_, ok := src.routes[srcReq.String()]
+				Expect(ok).Should(BeFalse())
+			})
+		})
+
+		Context("when route does exist", func() {
+			It("should remove the route and return true and nil", func() {
+				src.routes[srcReq.String()] = srcRouteDst
+				deleted, err := src.delRoute(srcReq)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(deleted).Should(BeTrue())
+				_, ok := src.routes[srcReq.String()]
+				Expect(ok).Should(BeFalse())
+				routes, err := netlink.RouteListFiltered(netlink.FAMILY_V4, srcRoute, netlink.RT_FILTER_TABLE|netlink.RT_FILTER_DST)
+				Expect(err).Should(BeNil())
+				Expect(len(routes)).Should(BeNumerically("==", 0))
+			})
+		})
+	})
+
+	Describe("testing podFilter function", func() {
+		Context("when object is not a pod", func() {
+			It("should return false", func() {
+				// Create a service object
+				s := corev1.Service{}
+				ok := src.podFilter(&s)
+				Expect(ok).Should(BeFalse())
+			})
+		})
+
+		Context("when pod is running on same node as the operator", func() {
+			It("should return false", func() {
+				// Set the same node name.
+				srcTestPod.Spec.NodeName = srcNodeName
+				ok := src.podFilter(srcTestPod)
+				Expect(ok).Should(BeFalse())
+			})
+		})
+
+		Context("when pod is running on different node than operator", func() {
+			It("pod is not ready, should return false", func() {
+				ok := src.podFilter(srcTestPod)
+				Expect(ok).Should(BeFalse())
+			})
+
+			It("pod is ready, should return true", func() {
+				srcTestPod.Status.Conditions = []corev1.PodCondition{
+					{Type: corev1.PodReady,
+						Status: corev1.ConditionTrue,
+					},
+				}
+				ok := src.podFilter(srcTestPod)
+				Expect(ok).Should(BeTrue())
+			})
+		})
+	})
+})

--- a/pkg/liqonet/routing/common.go
+++ b/pkg/liqonet/routing/common.go
@@ -68,7 +68,8 @@ func AddRoute(dstNet, gwIP string, iFaceIndex, tableID int) (bool, error) {
 	return true, nil
 }
 
-func delRoute(dstNet, gwIP string, iFaceIndex, tableID int) (bool, error) {
+// DelRoute removes a route described by the given parameters.
+func DelRoute(dstNet, gwIP string, iFaceIndex, tableID int) (bool, error) {
 	var route *netlink.Route
 	var gatewayIP net.IP
 	// Convert destination in *net.IPNet.

--- a/pkg/liqonet/routing/common_test.go
+++ b/pkg/liqonet/routing/common_test.go
@@ -168,13 +168,13 @@ var _ = Describe("Common", func() {
 	Describe("deleting an existing route", func() {
 		Context("when input parameters are not in the correct format", func() {
 			It("should return error on wrong destination net", func() {
-				removed, err := delRoute(dstNetWrong, gwIPCorrect, dummylink1.Attrs().Index, routingTableID)
+				removed, err := DelRoute(dstNetWrong, gwIPCorrect, dummylink1.Attrs().Index, routingTableID)
 				Expect(removed).Should(Equal(false))
 				Expect(err).Should(Equal(&net.ParseError{Type: "CIDR address", Text: dstNetWrong}))
 			})
 
 			It("should return error on wrong gateway IP address", func() {
-				removed, err := delRoute(dstNetCorrect, gwIPWrong, dummylink1.Attrs().Index, routingTableID)
+				removed, err := DelRoute(dstNetCorrect, gwIPWrong, dummylink1.Attrs().Index, routingTableID)
 				Expect(removed).Should(Equal(false))
 				Expect(err).Should(Equal(&errors.ParseIPError{IPToBeParsed: gwIPWrong}))
 			})
@@ -182,7 +182,7 @@ var _ = Describe("Common", func() {
 
 		Context("when an error occurred while deleting a route", func() {
 			It("should return an error on non existing link", func() {
-				added, err := delRoute(dstNetCorrect, gwIPWrong, 0, routingTableID)
+				added, err := DelRoute(dstNetCorrect, gwIPWrong, 0, routingTableID)
 				Expect(added).Should(Equal(false))
 				Expect(err).To(HaveOccurred())
 			})
@@ -190,13 +190,13 @@ var _ = Describe("Common", func() {
 
 		Context("when route does not exist and we want to delete it", func() {
 			It("no gatewayIP, should return false and nil", func() {
-				removed, err := delRoute(dstNetCorrect, "", dummylink1.Attrs().Index, routingTableID)
+				removed, err := DelRoute(dstNetCorrect, "", dummylink1.Attrs().Index, routingTableID)
 				Expect(removed).Should(Equal(false))
 				Expect(err).NotTo(HaveOccurred())
 			})
 
 			It("with gatewayIP, should return false and nil", func() {
-				removed, err := delRoute(dstNetCorrect, gwIPCorrect, dummylink1.Attrs().Index, routingTableID)
+				removed, err := DelRoute(dstNetCorrect, gwIPCorrect, dummylink1.Attrs().Index, routingTableID)
 				Expect(removed).Should(Equal(false))
 				Expect(err).NotTo(HaveOccurred())
 			})
@@ -213,7 +213,7 @@ var _ = Describe("Common", func() {
 
 			It("with gateway, should return true and nil", func() {
 				// Delete existing route with GW.
-				removed, err := delRoute(existingRoutesCM[0].Dst.String(), existingRoutesCM[0].Gw.String(), existingRoutesCM[0].LinkIndex, existingRoutesCM[0].Table)
+				removed, err := DelRoute(existingRoutesCM[0].Dst.String(), existingRoutesCM[0].Gw.String(), existingRoutesCM[0].LinkIndex, existingRoutesCM[0].Table)
 				Expect(removed).Should(Equal(true))
 				Expect(err).NotTo(HaveOccurred())
 				// Expecting no routes exist for the given destination.
@@ -224,7 +224,7 @@ var _ = Describe("Common", func() {
 
 			It("without gateway, should return true and nil", func() {
 				// Del existing route without GW.
-				removed, err := delRoute(existingRoutesCM[1].Dst.String(), "", existingRoutesCM[1].LinkIndex, existingRoutesCM[1].Table)
+				removed, err := DelRoute(existingRoutesCM[1].Dst.String(), "", existingRoutesCM[1].LinkIndex, existingRoutesCM[1].Table)
 				Expect(removed).Should(Equal(true))
 				Expect(err).NotTo(HaveOccurred())
 				// Expecting no routes exist for the given destination.

--- a/pkg/liqonet/routing/directRouting.go
+++ b/pkg/liqonet/routing/directRouting.go
@@ -92,7 +92,7 @@ func (drm *DirectRoutingManager) RemoveRoutesPerCluster(tep *netv1alpha1.TunnelE
 	// Delete route for the given cluster.
 	klog.Infof("%s -> deleting route for destination {%s} with gateway {%s} in routing table with ID {%d}",
 		clusterID, dstNet, gatewayIP, drm.routingTableID)
-	routeDel, err = delRoute(dstNet, gatewayIP, iFaceIndex, drm.routingTableID)
+	routeDel, err = DelRoute(dstNet, gatewayIP, iFaceIndex, drm.routingTableID)
 	if err != nil {
 		return routeDel, err
 	}

--- a/pkg/liqonet/routing/gatewayRouting.go
+++ b/pkg/liqonet/routing/gatewayRouting.go
@@ -66,7 +66,7 @@ func (grm *GatewayRoutingManager) RemoveRoutesPerCluster(tep *netv1alpha1.Tunnel
 	// Extract and save route information from the given tep.
 	_, dstNet := utils.GetPodCIDRS(tep)
 	// Delete route for the given cluster.
-	routeDel, err = delRoute(dstNet, "", grm.tunnelDevice.Attrs().Index, grm.routingTableID)
+	routeDel, err = DelRoute(dstNet, "", grm.tunnelDevice.Attrs().Index, grm.routingTableID)
 	if err != nil {
 		return routeDel, err
 	}

--- a/pkg/liqonet/routing/vxlanRouting.go
+++ b/pkg/liqonet/routing/vxlanRouting.go
@@ -128,7 +128,7 @@ func (vrm *VxlanRoutingManager) RemoveRoutesPerCluster(tep *netv1alpha1.TunnelEn
 	// Delete route for the given cluster.
 	klog.Infof("%s -> deleting route for destination {%s} with gateway {%s} in routing table with ID {%d}",
 		clusterID, dstNet, gatewayIP, vrm.routingTableID)
-	routeDel, err = delRoute(dstNet, gatewayIP, iFaceIndex, vrm.routingTableID)
+	routeDel, err = DelRoute(dstNet, gatewayIP, iFaceIndex, vrm.routingTableID)
 	if err != nil {
 		return routeDel, err
 	}


### PR DESCRIPTION
# Description
The operator for a given pod, based on the node where the pod is running, configures a route to send the traffic through the overlay network. The route is used only for the traffic generated on remote clusters with destination address a pod running on the local cluster. Those route are configured only on the node where the `gateway` pod is running. The traffic for local pods should be handled by the local CNI but if the reverse path filtering is in strict mode (default) the traffic coming from a network interface where the source address is not routable by the same interface is dropped. To solve the issue it requires to set the reverse path filtering to loose mode, but some times it is not possible. To overcome the problem all the traffic sent to or coming from a peering cluster has to be routed using the overlay network.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.
Unit test for each function.
