### PR TITLE
Bump Lease Api to V1 in the Virtual-Kubelet

### DIFF
--- a/cmd/virtual-kubelet/root/root.go
+++ b/cmd/virtual-kubelet/root/root.go
@@ -30,7 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	kubeinformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/kubernetes/typed/coordination/v1beta1"
+	coordv1 "k8s.io/client-go/kubernetes/typed/coordination/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
@@ -139,9 +139,9 @@ func runRootCommand(ctx context.Context, s *provider.Store, c *Opts) error {
 		return errors.Wrapf(err, "error initializing provider %s", c.Provider)
 	}
 
-	var leaseClient v1beta1.LeaseInterface
+	var leaseClient coordv1.LeaseInterface
 	if c.EnableNodeLease {
-		leaseClient = client.Client().CoordinationV1beta1().Leases(corev1.NamespaceNodeLease)
+		leaseClient = client.Client().CoordinationV1().Leases(corev1.NamespaceNodeLease)
 	}
 
 	advName := strings.Join([]string{virtualKubelet.AdvertisementPrefix, c.ForeignClusterId}, "")
@@ -177,7 +177,7 @@ func runRootCommand(ctx context.Context, s *provider.Store, c *Opts) error {
 		nodeProviderModule,
 		pNode,
 		client.Client().CoreV1().Nodes(),
-		module.WithNodeEnableLeaseV1Beta1(leaseClient, nil),
+		module.WithNodeEnableLeaseV1(leaseClient, nil),
 		module.WithNodeStatusUpdateErrorHandler(
 			func(ctx context.Context, err error) error {
 				klog.Info("node setting up")

--- a/pkg/virtualKubelet/node/module/node_test.go
+++ b/pkg/virtualKubelet/node/module/node_test.go
@@ -22,7 +22,7 @@ import (
 
 	"gotest.tools/assert"
 	"gotest.tools/assert/cmp"
-	coord "k8s.io/api/coordination/v1beta1"
+	coord "k8s.io/api/coordination/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -44,7 +44,7 @@ func testNodeRun(t *testing.T, enableLease bool) {
 	testP := &testNodeProvider{NodeProvider: &NaiveNodeProvider{}}
 
 	nodes := c.CoreV1().Nodes()
-	leases := c.CoordinationV1beta1().Leases(corev1.NamespaceNodeLease)
+	leases := c.CoordinationV1().Leases(corev1.NamespaceNodeLease)
 
 	interval := 1 * time.Millisecond
 	opts := []NodeControllerOpt{
@@ -52,7 +52,7 @@ func testNodeRun(t *testing.T, enableLease bool) {
 		WithNodeStatusUpdateInterval(interval),
 	}
 	if enableLease {
-		opts = append(opts, WithNodeEnableLeaseV1Beta1(leases, nil))
+		opts = append(opts, WithNodeEnableLeaseV1(leases, nil))
 	}
 	testNode := testNode(t)
 	// We have to refer to testNodeCopy during the course of the test. testNode is modified by the node controller
@@ -222,7 +222,7 @@ func TestNodeCustomUpdateStatusErrorHandler(t *testing.T) {
 }
 
 func TestEnsureLease(t *testing.T) {
-	c := testclient.NewSimpleClientset().CoordinationV1beta1().Leases(corev1.NamespaceNodeLease)
+	c := testclient.NewSimpleClientset().CoordinationV1().Leases(corev1.NamespaceNodeLease)
 	n := testNode(t)
 	ctx := context.Background()
 
@@ -280,7 +280,7 @@ func TestUpdateNodeStatus(t *testing.T) {
 }
 
 func TestUpdateNodeLease(t *testing.T) {
-	leases := testclient.NewSimpleClientset().CoordinationV1beta1().Leases(corev1.NamespaceNodeLease)
+	leases := testclient.NewSimpleClientset().CoordinationV1().Leases(corev1.NamespaceNodeLease)
 	lease := newLease(nil)
 	n := testNode(t)
 	setLeaseAttrs(lease, n, 0)


### PR DESCRIPTION
# Description

This PR bumps the version of the Lease API used by the Liqo VirtualKubelet to v1 instead of the deprecated v1beta1

# How Has This Been Tested?

- [x] E2E
- [x] Unit Test
