### PR TITLE
Updated BeforeEach logic in package Liqonet

### DIFF
--- a/pkg/liqonet/ipam_test.go
+++ b/pkg/liqonet/ipam_test.go
@@ -105,6 +105,13 @@ func setDynClient() error {
 	if err != nil {
 		return err
 	}
+	// The following loop guarrantees resource have different names.
+	for nm2.GetName() == nm1.GetName() {
+		nm2, err = natmappinginflater.ForgeNatMapping(clusterID2, remotePodCIDR, localNATExternalCIDR, make(map[string]string))
+		if err != nil {
+			return err
+		}
+	}
 
 	dynClient = fake.NewSimpleDynamicClientWithCustomListKinds(scheme, m, nm1, nm2)
 	return nil

--- a/pkg/liqonet/natmappinginflater/natMappingInflater_test.go
+++ b/pkg/liqonet/natmappinginflater/natMappingInflater_test.go
@@ -64,13 +64,21 @@ func setDynClient() error {
 
 	// Init fake dynamic client with objects in order to avoid errors in InitNatMappings func
 	// due to the lack of support of fake.dynamicClient for creation of more than 2 resources of the same Kind.
-	nm1, err := ForgeNatMapping(clusterID1, "10.0.0.0/24", "10.0.1.0/24", make(map[string]string))
+	nm1, err := ForgeNatMapping(clusterID1, podCIDR, externalCIDR, make(map[string]string))
 	if err != nil {
 		return err
 	}
-	nm2, err := ForgeNatMapping(clusterID2, "10.0.0.0/24", "10.0.1.0/24", map[string]string{})
+	nm2, err := ForgeNatMapping(clusterID2, podCIDR, externalCIDR, map[string]string{})
 	if err != nil {
 		return err
+	}
+
+	// The following loop guarrantees resource have different names.
+	for nm2.GetName() == nm1.GetName() {
+		nm2, err = ForgeNatMapping(clusterID2, podCIDR, externalCIDR, make(map[string]string))
+		if err != nil {
+			return err
+		}
 	}
 
 	dynClient = fake.NewSimpleDynamicClientWithCustomListKinds(scheme, m, nm1, nm2)

--- a/pkg/liqonet/natmappinginflater/test_utils.go
+++ b/pkg/liqonet/natmappinginflater/test_utils.go
@@ -15,7 +15,7 @@ import (
 
 // ForgeNatMapping forges a NatMapping resource for a cluster received as parameter.
 func ForgeNatMapping(clusterID, podCIDR, externalCIDR string, mappings map[string]string) (*unstructured.Unstructured, error) {
-	n, err := rand.Int(rand.Reader, big.NewInt(5000))
+	n, err := rand.Int(rand.Reader, big.NewInt(10000))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Currently function setDynClient forges 2 natmapping resources and create a dynamic client using those resource as starting object. It may happen that function ForgeNatMapping defines resource with the same name, resulting in an error during the initialization of the client. This behavior has been fixed by checking equality of resource names before creating the client.