### PR TITLE
NAT rules for ExternalCIDR (4/4)

### DIFF
--- a/deployments/liqo/files/liqo-gateway-ClusterRole.yaml
+++ b/deployments/liqo/files/liqo-gateway-ClusterRole.yaml
@@ -24,6 +24,18 @@ rules:
 - apiGroups:
   - net.liqo.io
   resources:
+  - natmappings
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - net.liqo.io
+  resources:
   - tunnelendpoints
   verbs:
   - create

--- a/internal/liqonet/tunnel-operator/doc.go
+++ b/internal/liqonet/tunnel-operator/doc.go
@@ -1,3 +1,4 @@
 // Package tunneloperator contains the tunnel controller which configures the vpn tunnels, natting rules and
-// routes in order to comunicate with the remote peering clusters.
+// routes in order to comunicate with the remote peering clusters and also the natmapping controller
+// that configures nat rules for ExternalCIDR.
 package tunneloperator

--- a/internal/liqonet/tunnel-operator/natmapping-operator.go
+++ b/internal/liqonet/tunnel-operator/natmapping-operator.go
@@ -1,0 +1,82 @@
+package tunneloperator
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/containernetworking/plugins/pkg/ns"
+	"k8s.io/klog/v2"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	netv1alpha1 "github.com/liqotech/liqo/apis/net/v1alpha1"
+	"github.com/liqotech/liqo/pkg/liqonet/iptables"
+)
+
+// NatMappingController reconciles a NatMapping object.
+type NatMappingController struct {
+	client.Client
+	iptables.IPTHandler
+	readyClustersMutex *sync.Mutex
+	readyClusters      map[string]struct{}
+	gatewayNetns       ns.NetNS
+}
+
+//+kubebuilder:rbac:groups=net.liqo.io,resources=natmappings,verbs=get;list;watch;create;update;patch;delete
+
+// Reconcile function handles requests made on NatMapping resource
+// by guaranteeing the proper set of DNAT rules are updated.
+func (npc *NatMappingController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	var nm netv1alpha1.NatMapping
+
+	if err := npc.Get(ctx, req.NamespacedName, &nm); err != nil {
+		return result, client.IgnoreNotFound(err)
+	}
+	// There's no need of a pre-delete logic since IPTables rules for cluster are removed by the
+	// tunnel-operator after the un-peer.
+
+	// The following logic has to be executed in the custom network namespace,
+	// and not on the root namespace. Therefore it must be defined in a closure
+	// and then used as parameter of method Do of netNs
+	if err := npc.gatewayNetns.Do(func(netNamespace ns.NetNS) error {
+		// Is the remote cluster tunnel ready? If not, do nothing
+		npc.readyClustersMutex.Lock()
+		defer npc.readyClustersMutex.Unlock()
+		if _, ready := npc.readyClusters[nm.Spec.ClusterID]; !ready {
+			return fmt.Errorf("tunnel for cluster {%s} is not ready", nm.Spec.ClusterID)
+		}
+		if err := npc.IPTHandler.EnsurePreroutingRulesPerNatMapping(&nm); err != nil {
+			klog.Errorf("unable to ensure prerouting rules for cluster {%s}: %s",
+				nm.Spec.ClusterID, err.Error())
+			return err
+		}
+		return nil
+	}); err != nil {
+		return result, err
+	}
+	return result, nil
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (npc *NatMappingController) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&netv1alpha1.NatMapping{}).
+		Complete(npc)
+}
+
+// NewNatMappingController returns a NAT mapping controller istance.
+func NewNatMappingController(cl client.Client, readyClustersMutex *sync.Mutex,
+	readyClusters map[string]struct{}, gatewayNetns ns.NetNS) (*NatMappingController, error) {
+	iptablesHandler, err := iptables.NewIPTHandler()
+	if err != nil {
+		return nil, err
+	}
+	return &NatMappingController{
+		Client:             cl,
+		IPTHandler:         iptablesHandler,
+		readyClustersMutex: readyClustersMutex,
+		readyClusters:      readyClusters,
+		gatewayNetns:       gatewayNetns,
+	}, nil
+}

--- a/internal/liqonet/tunnel-operator/natmapping_operator_test.go
+++ b/internal/liqonet/tunnel-operator/natmapping_operator_test.go
@@ -1,0 +1,251 @@
+package tunneloperator
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/containernetworking/plugins/pkg/ns"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/kubernetes/pkg/util/slice"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/liqotech/liqo/apis/net/v1alpha1"
+)
+
+const (
+	oldIP1    = "10.0.1.2"
+	oldIP2    = "10.0.1.5"
+	newIP1    = "10.0.2.4"
+	newIP2    = "10.0.3.7"
+	DNAT      = "DNAT"
+	timeout   = time.Second * 10
+	interval  = time.Millisecond * 250
+	namespace = "test"
+)
+
+var _ = Describe("NatmappingOperator", func() {
+	BeforeEach(func() {
+		request.Namespace = namespace
+		// Names to resources will be given in Its
+		nm1 = &v1alpha1.NatMapping{
+			ObjectMeta: v1.ObjectMeta{
+				Namespace: namespace,
+			},
+			Spec: v1alpha1.NatMappingSpec{
+				ClusterID:       clusterID1,
+				ClusterMappings: make(v1alpha1.Mappings),
+			},
+		}
+		nm2 = &v1alpha1.NatMapping{
+			ObjectMeta: v1.ObjectMeta{
+				Namespace: namespace,
+			},
+			Spec: v1alpha1.NatMappingSpec{
+				ClusterID:       clusterID2,
+				ClusterMappings: make(v1alpha1.Mappings),
+			},
+		}
+	})
+	AfterEach(func() {
+		err := k8sClient.DeleteAllOf(context.Background(), &v1alpha1.NatMapping{}, &client.DeleteAllOfOptions{
+			ListOptions: client.ListOptions{
+				Namespace: namespace,
+			},
+		})
+		Expect(err).To(BeNil())
+	})
+	Context("Reconcile on a resource that does not exist", func() {
+		It("the controller should return no errors", func() {
+			nm2.ObjectMeta.Name = "resource-not-exists"
+			request.Name = nm2.ObjectMeta.Name
+			Consistently(func() error { _, err := controller.Reconcile(context.TODO(), request); return err }).Should(BeNil())
+		})
+	})
+	Context("If the cluster is not ready", func() {
+		It("the controller should do nothing", func() {
+			nm2.ObjectMeta.Name = "cluster-not-ready"
+			request.Name = nm2.ObjectMeta.Name
+			// ClusterID2 is set as non ready in BeforeSuite,
+			// then even if natmapping resource of cluster
+			// contains some mappings, they should not result
+			// in real IPTables rules.
+
+			// Populate resource
+			nm2.Spec.ClusterMappings[oldIP1] = newIP1
+			nm2.Spec.ClusterMappings[oldIP2] = newIP2
+			Eventually(func() error {
+				err := k8sClient.Create(context.Background(), nm2, &client.CreateOptions{})
+				return err
+			}).Should(BeNil())
+
+			Eventually(func() error { _, err := controller.Reconcile(context.TODO(), request); return err }).
+				Should(MatchError(fmt.Sprintf("tunnel for cluster {%s} is not ready", clusterID2)))
+
+			Consistently(func() []string {
+				// Rules should not be present
+				rules, err := ListRulesInChainInCustomNs(getClusterPreRoutingMappingChain(clusterID1))
+				if err != nil {
+					Fail(fmt.Sprintf("failed to list rules in chain %s: %s", getClusterPreRoutingMappingChain(clusterID1), err))
+				}
+				return rules
+			}).Should(BeEmpty())
+		})
+	})
+	Context("If the cluster is ready", func() {
+		It("the controller should insert the right rules", func() {
+			nm1.ObjectMeta.Name = "cluster-ready"
+			request.Name = nm1.ObjectMeta.Name
+			// ClusterID1 is set as ready in BeforeSuite
+
+			// Populate resource
+			nm1.Spec.ClusterMappings[oldIP1] = newIP1
+			nm1.Spec.ClusterMappings[oldIP2] = newIP2
+			Eventually(func() error {
+				err := k8sClient.Create(context.Background(), nm1, &client.CreateOptions{})
+				return err
+			}).Should(BeNil())
+			Consistently(func() error { _, err := controller.Reconcile(context.TODO(), request); return err }).Should(BeNil())
+			Eventually(func() []string {
+				rules, err := ListRulesInChainInCustomNs(getClusterPreRoutingMappingChain(clusterID1))
+				if err != nil {
+					Fail(fmt.Sprintf("failed to list rules in chain %s: %s", getClusterPreRoutingMappingChain(clusterID1), err))
+				}
+				return rules
+			}, timeout, interval).Should(ContainElements(
+				fmt.Sprintf("-d %s -j %s --to-destination %s", newIP1, DNAT, oldIP1),
+				fmt.Sprintf("-d %s -j %s --to-destination %s", newIP2, DNAT, oldIP2),
+			))
+		})
+	})
+	Context("If natmapping resource is updated with deletion and insertion of mappings", func() {
+		It("the controller should update IPTables rules", func() {
+			nm1.ObjectMeta.Name = "update"
+			request.Name = nm1.ObjectMeta.Name
+			// Insert mapping for oldIP1
+			nm1.Spec.ClusterMappings[oldIP1] = newIP1
+			Eventually(func() error {
+				err := k8sClient.Create(context.Background(), nm1, &client.CreateOptions{})
+				return err
+			}).Should(BeNil())
+
+			Consistently(func() error { _, err := controller.Reconcile(context.TODO(), request); return err }).Should(BeNil())
+
+			Eventually(func() []string {
+				rules, err := ListRulesInChainInCustomNs(getClusterPreRoutingMappingChain(clusterID1))
+				if err != nil {
+					Fail(fmt.Sprintf("failed to list rules in chain %s: %s", getClusterPreRoutingMappingChain(clusterID1), err))
+				}
+				return rules
+			}, timeout, interval).Should(ContainElements(
+				fmt.Sprintf("-d %s -j %s --to-destination %s", newIP1, DNAT, oldIP1),
+			))
+
+			Eventually(func() bool {
+				err := k8sClient.Get(context.Background(), types.NamespacedName{Name: nm1.ObjectMeta.Name, Namespace: namespace}, nm1)
+				if err != nil {
+					return false
+				}
+				// Delete mapping for oldIP1
+				delete(nm1.Spec.ClusterMappings, oldIP1)
+				// Insert mapping for oldIP2
+				nm1.Spec.ClusterMappings[oldIP2] = newIP2
+				err = k8sClient.Update(context.Background(), nm1, &client.UpdateOptions{})
+				return err == nil
+			}).Should(BeTrue())
+
+			Consistently(func() error { _, err := controller.Reconcile(context.TODO(), request); return err }).Should(BeNil())
+
+			Eventually(func() bool {
+				rules, err := ListRulesInChainInCustomNs(getClusterPreRoutingMappingChain(clusterID1))
+				if err != nil {
+					Fail(fmt.Sprintf("failed to list rules in chain %s: %s", getClusterPreRoutingMappingChain(clusterID1), err))
+				}
+				// Should contain the rule for oldIP1 but it should not contain the rule for oldIP2
+				if slice.ContainsString(rules, fmt.Sprintf("-d %s -j %s --to-destination %s", newIP2, DNAT, oldIP2), nil) &&
+					!slice.ContainsString(rules, fmt.Sprintf("-d %s -j %s --to-destination %s", newIP1, DNAT, oldIP1), nil) {
+					return true
+				}
+				return false
+			}, timeout, interval).Should(BeTrue())
+		})
+	})
+
+	Context("If mappings for more clusters are active", func() {
+		It("the controller should update IPTables rules independently", func() {
+			nm1.ObjectMeta.Name = "more-clusters-1"
+			request.Name = nm1.ObjectMeta.Name
+			// Set cluster2 as ready
+			readyClustersMutex.Lock()
+			readyClusters[clusterID2] = struct{}{}
+			readyClustersMutex.Unlock()
+			// Insert mapping for oldIP1 in cluster1
+			nm1.Spec.ClusterMappings[oldIP1] = newIP1
+			Eventually(func() error {
+				err := k8sClient.Create(context.Background(), nm1, &client.CreateOptions{})
+				return err
+			}).Should(BeNil())
+
+			Consistently(func() error { _, err := controller.Reconcile(context.TODO(), request); return err }).Should(BeNil())
+
+			// Insert mapping for oldIP2 in cluster2
+			nm2.ObjectMeta.Name = "more-clusters-2"
+			request.Name = nm2.ObjectMeta.Name
+			nm2.Spec.ClusterMappings[oldIP2] = newIP2
+			Eventually(func() error {
+				err := k8sClient.Create(context.Background(), nm2, &client.CreateOptions{})
+				return err
+			}).Should(BeNil())
+
+			Consistently(func() error { _, err := controller.Reconcile(context.TODO(), request); return err }).Should(BeNil())
+
+			Eventually(func() bool {
+				cluster1Rules, err := ListRulesInChainInCustomNs(getClusterPreRoutingMappingChain(clusterID1))
+				if err != nil {
+					Fail(fmt.Sprintf("failed to list rules in chain %s: %s", getClusterPreRoutingMappingChain(clusterID1), err))
+				}
+				// Cluster1 rules should contain the rule for oldIP1 and not contain the rule for oldIP2
+				if !slice.ContainsString(cluster1Rules, fmt.Sprintf("-d %s -j %s --to-destination %s", newIP1, DNAT, oldIP1), nil) ||
+					slice.ContainsString(cluster1Rules, fmt.Sprintf("-d %s -j %s --to-destination %s", newIP2, DNAT, oldIP2), nil) {
+					return false
+				}
+				return true
+			}, timeout, interval).Should(BeTrue())
+
+			Eventually(func() bool {
+				cluster2Rules, err := ListRulesInChainInCustomNs(getClusterPreRoutingMappingChain(clusterID2))
+				if err != nil {
+					Fail(fmt.Sprintf("failed to list rules in chain %s: %s", getClusterPreRoutingMappingChain(clusterID2), err))
+				}
+				// Cluster2 rules should contain the rule for oldIP2 and not contain the rule for oldIP1
+				if !slice.ContainsString(cluster2Rules, fmt.Sprintf("-d %s -j %s --to-destination %s", newIP2, DNAT, oldIP2), nil) ||
+					slice.ContainsString(cluster2Rules, fmt.Sprintf("-d %s -j %s --to-destination %s", newIP1, DNAT, oldIP1), nil) {
+					return false
+				}
+				return true
+			}, timeout, interval).Should(BeTrue())
+		})
+	})
+})
+
+func getClusterPreRoutingMappingChain(clusterID string) string {
+	const liqonetPreRoutingMappingClusterChainPrefix = "LIQO-PRRT-MAP-CLS-"
+	return fmt.Sprintf("%s%s", liqonetPreRoutingMappingClusterChainPrefix, strings.Split(clusterID, "-")[0])
+}
+
+func ListRulesInChainInCustomNs(chain string) ([]string, error) {
+	var rules []string
+	var err error
+	err = iptNetns.Do(func(nn ns.NetNS) error {
+		rules, err = ipt.ListRulesInChain(chain)
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+	return rules, nil
+}

--- a/internal/liqonet/tunnel-operator/tunnel_operator_suite_test.go
+++ b/internal/liqonet/tunnel-operator/tunnel_operator_suite_test.go
@@ -1,17 +1,188 @@
 package tunneloperator
 
 import (
+	"context"
+	"path/filepath"
+	"sync"
 	"testing"
 
+	"github.com/containernetworking/plugins/pkg/ns"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"k8s.io/client-go/kubernetes/scheme"
+	controllerruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	netv1alpha1 "github.com/liqotech/liqo/apis/net/v1alpha1"
+	"github.com/liqotech/liqo/pkg/consts"
+	"github.com/liqotech/liqo/pkg/liqonet/iptables"
+	"github.com/liqotech/liqo/pkg/liqonet/netns"
+)
+
+const (
+	clusterID1   = "cluster1"
+	clusterID2   = "cluster2"
+	iptNetnsName = "iptNetNs"
 )
 
 var (
-	tc = &TunnelController{}
+	envTest            *envtest.Environment
+	ipt                iptables.IPTHandler
+	k8sClient          client.Client
+	controller         *NatMappingController
+	readyClustersMutex sync.Mutex
+	readyClusters      = map[string]struct{}{
+		clusterID1: {},
+	}
+	gatewayNetns ns.NetNS
+	iptNetns     ns.NetNS
+	tep1         = &netv1alpha1.TunnelEndpoint{
+		Spec: netv1alpha1.TunnelEndpointSpec{
+			ClusterID:    clusterID1,
+			PodCIDR:      "10.0.0.0/24",
+			ExternalCIDR: "10.0.1.0/24",
+		},
+		Status: netv1alpha1.TunnelEndpointStatus{
+			LocalPodCIDR:          "192.168.0.0/24",
+			LocalNATPodCIDR:       "192.168.1.0/24",
+			RemoteNATPodCIDR:      "10.0.70.0/24",
+			LocalExternalCIDR:     "192.168.3.0/24",
+			LocalNATExternalCIDR:  "192.168.4.0/24",
+			RemoteNATExternalCIDR: "192.168.5.0/24",
+		},
+	}
+	tep2 = &netv1alpha1.TunnelEndpoint{
+		Spec: netv1alpha1.TunnelEndpointSpec{
+			ClusterID:    clusterID2,
+			PodCIDR:      "10.0.0.0/24",
+			ExternalCIDR: "10.0.1.0/24",
+		},
+		Status: netv1alpha1.TunnelEndpointStatus{
+			LocalPodCIDR:          "192.168.0.0/24",
+			LocalNATPodCIDR:       "192.168.1.0/24",
+			RemoteNATPodCIDR:      "10.0.70.0/24",
+			LocalExternalCIDR:     "192.168.3.0/24",
+			LocalNATExternalCIDR:  "192.168.4.0/24",
+			RemoteNATExternalCIDR: "192.168.5.0/24",
+		},
+	}
+	nm1     *netv1alpha1.NatMapping
+	nm2     *netv1alpha1.NatMapping
+	tc      = &TunnelController{}
+	request = reconcile.Request{}
 )
 
 func TestTunnelOperator(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "TunnelOperator Suite")
+}
+
+var _ = BeforeSuite(func() {
+	var err error
+
+	// Create custom network namespace for tunnel-operator.
+	gatewayNetns, err = netns.CreateNetns(consts.GatewayNetnsName)
+	Expect(err).To(BeNil())
+	tc.gatewayNetns = gatewayNetns
+
+	// Create custom network namespace for natmapping-operator.
+	iptNetns, err = netns.CreateNetns(iptNetnsName)
+	Expect(err).To(BeNil())
+
+	// Config IPTables for remote clusters
+	err = initIPTables()
+	Expect(err).To(BeNil())
+
+	err = netv1alpha1.AddToScheme(scheme.Scheme)
+	Expect(err).To(BeNil())
+	envTest = &envtest.Environment{
+		CRDDirectoryPaths: []string{filepath.Join("..", "..", "..", "deployments", "liqo", "crds")},
+	}
+	config, err := envTest.Start()
+	Expect(err).To(BeNil())
+	mgr, err := controllerruntime.NewManager(config, controllerruntime.Options{
+		Scheme:             scheme.Scheme,
+		MetricsBindAddress: "0",
+	})
+
+	controller, err = NewNatMappingController(mgr.GetClient(), &readyClustersMutex, readyClusters, iptNetns)
+	Expect(err).To(BeNil())
+	go func() {
+		if err = mgr.Start(context.Background()); err != nil {
+			panic(err)
+		}
+	}()
+	k8sClient = mgr.GetClient()
+	// We reconcile on a resource that does not exist with
+	// an Eventually block in order to wait for
+	// cache to start and then begin with unit tests.
+	// If a resource does not exist, Reconcile returns
+	// a nil error.
+	request.Name = "wait-cache"
+	request.Namespace = namespace
+	Eventually(func() error {
+		_, err := controller.Reconcile(context.Background(), request)
+		return err
+	}).Should(BeNil())
+})
+
+var _ = AfterSuite(func() {
+	err := envTest.Stop()
+	Expect(err).To(BeNil())
+	err = terminateIPTables()
+	Expect(err).To(BeNil())
+	err = gatewayNetns.Close()
+	Expect(err).To(BeNil())
+	err = iptNetns.Close()
+	Expect(err).To(BeNil())
+})
+
+func terminateIPTables() error {
+	err := iptNetns.Do(func(nn ns.NetNS) error {
+		var err error
+		err = ipt.RemoveIPTablesConfigurationPerCluster(tep1)
+		if err != nil {
+			return err
+		}
+		err = ipt.RemoveIPTablesConfigurationPerCluster(tep2)
+		if err != nil {
+			return err
+		}
+		err = ipt.Terminate()
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+	return err
+}
+
+func initIPTables() error {
+	err := iptNetns.Do(func(nn ns.NetNS) error {
+		var err error
+		// Allocate new IPTable handler
+		ipt, err = iptables.NewIPTHandler()
+		if err != nil {
+			return err
+		}
+		if err := ipt.Init(); err != nil {
+			return err
+		}
+		if err := ipt.EnsureChainsPerCluster(clusterID1); err != nil {
+			return err
+		}
+		if err := ipt.EnsureChainsPerCluster(clusterID2); err != nil {
+			return err
+		}
+		if err := ipt.EnsureChainRulesPerCluster(tep1); err != nil {
+			return err
+		}
+		if err := ipt.EnsureChainRulesPerCluster(tep2); err != nil {
+			return err
+		}
+		return nil
+	})
+	return err
 }

--- a/internal/liqonet/tunnel-operator/tunnel_operator_test.go
+++ b/internal/liqonet/tunnel-operator/tunnel_operator_test.go
@@ -9,12 +9,11 @@ import (
 	"github.com/vishvananda/netlink"
 
 	liqoconst "github.com/liqotech/liqo/pkg/consts"
-	"github.com/liqotech/liqo/pkg/liqonet/netns"
 )
 
 var _ = Describe("TunnelOperator", func() {
 	Describe("setup gateway namespace", func() {
-		Context("creating a new gateway namespace", func() {
+		Context("configuring the new gateway namespace", func() {
 			JustAfterEach(func() {
 				link, err := netlink.LinkByName(liqoconst.HostVethName)
 				if err != nil {
@@ -26,10 +25,8 @@ var _ = Describe("TunnelOperator", func() {
 				if link != nil {
 					Expect(netlink.LinkDel(link)).ShouldNot(HaveOccurred())
 				}
-				Expect(netns.DeleteNetns(liqoconst.GatewayNetnsName)).ShouldNot(HaveOccurred())
 			})
 			It("should return nil", func() {
-				tc := &TunnelController{}
 				err := tc.setUpGWNetns(liqoconst.GatewayNetnsName, liqoconst.HostVethName, liqoconst.GatewayVethName,
 					"169.254.1.134/32", 1420)
 				Expect(err).ShouldNot(HaveOccurred())
@@ -54,8 +51,6 @@ var _ = Describe("TunnelOperator", func() {
 					return nil
 				})
 				Expect(tc.hostNetns.Close()).ShouldNot(HaveOccurred())
-				Expect(tc.gatewayNetns.Close()).ShouldNot(HaveOccurred())
-
 			})
 
 			It("incorrect name for veth interface, should return error", func() {
@@ -65,7 +60,6 @@ var _ = Describe("TunnelOperator", func() {
 			})
 
 			It("incorrect ip address for veth interface, should return error", func() {
-				tc := &TunnelController{}
 				err := tc.setUpGWNetns(liqoconst.GatewayNetnsName, liqoconst.HostVethName, liqoconst.GatewayVethName, "169.254.1.1.34/24", 1420)
 				Expect(err).Should(HaveOccurred())
 				Expect(err).Should(MatchError(&net.ParseError{Text: "169.254.1.1.34/24", Type: "CIDR address"}))

--- a/pkg/liqonet/errors/errors.go
+++ b/pkg/liqonet/errors/errors.go
@@ -15,7 +15,7 @@ const (
 	// ValidIP used as reason of failure in WrongParameter error.
 	ValidIP = "a valid IP address"
 	// NotNil used as reason of failure in WrongParameter error.
-	NotNil = "have to be not nil"
+	NotNil = "not nil"
 	// ValidCIDR used as reason of failure in WrongParameter error.
 	ValidCIDR = "a valid network CIDR"
 	// StringNotEmpty used as reason of failure in WrongParameter error.

--- a/pkg/liqonet/iptables/iptables.go
+++ b/pkg/liqonet/iptables/iptables.go
@@ -656,7 +656,7 @@ func (h IPTHandler) insertRulesIfNotPresent(table, chain string, rules []IPTable
 			if err := h.ipt.AppendUnique(table, chain, rule...); err != nil {
 				return err
 			}
-			klog.Infof("Inserting rule '%s' in chain %s in table %s", rule, chain, table)
+			klog.Infof("Inserting rule '%s' in chain %s (table %s)", rule, chain, table)
 		}
 	}
 	return nil


### PR DESCRIPTION
# Description
This PR adds a new controller that reconciles the resource NatMapping. It ensures the appropriate set of NAT rules for supporting ExternalCIDR traffic is in place and updated. 