### PR TITLE
Introduce the gci linter (imports determinism) and fix issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -65,6 +65,7 @@ linters:
   # - gochecknoglobals
   # - gochecknoinits
   # - gocognit
+    - gci
     - goconst
     - gocritic
     - gocyclo

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,7 +2,6 @@ run:
   timeout: 10m
   skip-files:
     - "zz_generated.*.go"
-    - ".*_test.go"
 
 linters-settings:
   exhaustive:
@@ -124,3 +123,8 @@ issues:
       # Disable the check to test that HTTP clients are not using an insecure TLS connection.
       # We need it to contact the remote authentication services exposing a self-signed certificate
       text: TLS InsecureSkipVerify set true.
+
+    # Exclude the following linters from running on tests files.
+    - path: _test\.go
+      linters:
+        - whitespace

--- a/cmd/advertisement-broadcaster/main.go
+++ b/cmd/advertisement-broadcaster/main.go
@@ -4,9 +4,9 @@ import (
 	"flag"
 	"os"
 
-	"github.com/liqotech/liqo/internal/advertisementoperator/broadcaster"
-
 	"k8s.io/klog/v2"
+
+	"github.com/liqotech/liqo/internal/advertisementoperator/broadcaster"
 )
 
 func main() {

--- a/cmd/advertisement-operator/main.go
+++ b/cmd/advertisement-operator/main.go
@@ -40,7 +40,6 @@ import (
 	"github.com/liqotech/liqo/pkg/mapperUtils"
 	"github.com/liqotech/liqo/pkg/vkMachinery"
 	"github.com/liqotech/liqo/pkg/vkMachinery/csr"
-	// +kubebuilder:scaffold:imports
 )
 
 const (

--- a/cmd/virtual-kubelet/main.go
+++ b/cmd/virtual-kubelet/main.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 	"syscall"
 
+	"github.com/spf13/cobra"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -30,8 +31,6 @@ import (
 
 	"github.com/liqotech/liqo/cmd/virtual-kubelet/provider"
 	"github.com/liqotech/liqo/cmd/virtual-kubelet/root"
-
-	"github.com/spf13/cobra"
 )
 
 var (

--- a/cmd/virtual-kubelet/provider/provider.go
+++ b/cmd/virtual-kubelet/provider/provider.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"io"
 
-	"github.com/liqotech/liqo/pkg/virtualKubelet/node/module"
-	"github.com/liqotech/liqo/pkg/virtualKubelet/node/module/api"
-
 	v1 "k8s.io/api/core/v1"
 	stats "k8s.io/kubelet/pkg/apis/stats/v1alpha1"
+
+	"github.com/liqotech/liqo/pkg/virtualKubelet/node/module"
+	"github.com/liqotech/liqo/pkg/virtualKubelet/node/module/api"
 )
 
 // Provider contains the methods required to implement a virtual-kubelet provider.

--- a/cmd/virtual-kubelet/root/http.go
+++ b/cmd/virtual-kubelet/root/http.go
@@ -24,12 +24,11 @@ import (
 	"os"
 	"time"
 
+	"github.com/pkg/errors"
 	"k8s.io/klog"
 
 	"github.com/liqotech/liqo/cmd/virtual-kubelet/provider"
 	"github.com/liqotech/liqo/pkg/virtualKubelet/node/module/api"
-
-	"github.com/pkg/errors"
 )
 
 // AcceptedCiphers is the list of accepted TLS ciphers, with known weak ciphers elided

--- a/internal/crdReplicator/env_test.go
+++ b/internal/crdReplicator/env_test.go
@@ -1,7 +1,10 @@
 package crdreplicator
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
+	"testing"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -9,17 +12,12 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/dynamic/dynamicinformer"
 	"k8s.io/client-go/kubernetes"
-
-	netv1alpha1 "github.com/liqotech/liqo/apis/net/v1alpha1"
-
-	"os"
-	"path/filepath"
-	"testing"
-
 	"k8s.io/klog/v2"
 	"k8s.io/kubectl/pkg/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
+
+	netv1alpha1 "github.com/liqotech/liqo/apis/net/v1alpha1"
 )
 
 var (

--- a/pkg/liqo-controller-manager/namespace-controller/suite_test.go
+++ b/pkg/liqo-controller-manager/namespace-controller/suite_test.go
@@ -33,7 +33,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
 
 	offv1alpha1 "github.com/liqotech/liqo/apis/offloading/v1alpha1"
-	// +kubebuilder:scaffold:imports
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to

--- a/pkg/liqo-controller-manager/namespaceMap-controller/namespaceMap_controller_test.go
+++ b/pkg/liqo-controller-manager/namespaceMap-controller/namespaceMap_controller_test.go
@@ -21,14 +21,13 @@ import (
 	"fmt"
 	"time"
 
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	ctrlutils "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlutils "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	mapsv1alpha1 "github.com/liqotech/liqo/apis/virtualKubelet/v1alpha1"
 	liqoconst "github.com/liqotech/liqo/pkg/consts"

--- a/pkg/liqo-controller-manager/namespaceMap-controller/suite_test.go
+++ b/pkg/liqo-controller-manager/namespaceMap-controller/suite_test.go
@@ -34,7 +34,6 @@ import (
 	offv1alpha1 "github.com/liqotech/liqo/apis/offloading/v1alpha1"
 	mapsv1alpha1 "github.com/liqotech/liqo/apis/virtualKubelet/v1alpha1"
 	liqoconst "github.com/liqotech/liqo/pkg/consts"
-	// +kubebuilder:scaffold:imports
 )
 
 const (

--- a/pkg/liqo-controller-manager/namespaceOffloading-controller/namespaceoffloading_controller.go
+++ b/pkg/liqo-controller-manager/namespaceOffloading-controller/namespaceoffloading_controller.go
@@ -18,7 +18,6 @@ import (
 	"context"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog"

--- a/pkg/liqo-controller-manager/namespaceOffloading-controller/suite_test.go
+++ b/pkg/liqo-controller-manager/namespaceOffloading-controller/suite_test.go
@@ -34,7 +34,6 @@ import (
 	offv1alpha1 "github.com/liqotech/liqo/apis/offloading/v1alpha1"
 	mapsv1alpha1 "github.com/liqotech/liqo/apis/virtualKubelet/v1alpha1"
 	liqoconst "github.com/liqotech/liqo/pkg/consts"
-	// +kubebuilder:scaffold:imports
 )
 
 const (

--- a/pkg/liqo-controller-manager/offloadingStatus-controller/suite_test.go
+++ b/pkg/liqo-controller-manager/offloadingStatus-controller/suite_test.go
@@ -35,7 +35,6 @@ import (
 	offv1alpha1 "github.com/liqotech/liqo/apis/offloading/v1alpha1"
 	mapsv1alpha1 "github.com/liqotech/liqo/apis/virtualKubelet/v1alpha1"
 	liqoconst "github.com/liqotech/liqo/pkg/consts"
-	// +kubebuilder:scaffold:imports
 )
 
 const (

--- a/pkg/liqo-controller-manager/virtualNode-controller/suite_test.go
+++ b/pkg/liqo-controller-manager/virtualNode-controller/suite_test.go
@@ -36,7 +36,6 @@ import (
 
 	mapsv1alpha1 "github.com/liqotech/liqo/apis/virtualKubelet/v1alpha1"
 	liqoconst "github.com/liqotech/liqo/pkg/consts"
-	// +kubebuilder:scaffold:imports
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to

--- a/pkg/liqonet/natmappinginflater/natMappingInflater_test.go
+++ b/pkg/liqonet/natmappinginflater/natMappingInflater_test.go
@@ -13,7 +13,6 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/dynamic/fake"
 
-	liqonetapi "github.com/liqotech/liqo/apis/net/v1alpha1"
 	netv1alpha1 "github.com/liqotech/liqo/apis/net/v1alpha1"
 	"github.com/liqotech/liqo/pkg/consts"
 	liqoneterrors "github.com/liqotech/liqo/pkg/liqonet/errors"
@@ -46,7 +45,7 @@ func setDynClient() error {
 		Group:   "net.liqo.io",
 		Version: "v1alpha1",
 		Kind:    "natmappings",
-	}, &liqonetapi.NatMapping{})
+	}, &netv1alpha1.NatMapping{})
 
 	var m = make(map[schema.GroupVersionResource]string)
 
@@ -134,7 +133,7 @@ var _ = Describe("NatMappingInflater", func() {
 					Group:   "net.liqo.io",
 					Version: "v1alpha1",
 					Kind:    "natmappings",
-				}, &liqonetapi.NatMapping{})
+				}, &netv1alpha1.NatMapping{})
 				var m = make(map[schema.GroupVersionResource]string)
 				m[schema.GroupVersionResource{
 					Group:    "net.liqo.io",
@@ -163,7 +162,7 @@ var _ = Describe("NatMappingInflater", func() {
 					Group:   "net.liqo.io",
 					Version: "v1alpha1",
 					Kind:    "natmappings",
-				}, &liqonetapi.NatMapping{})
+				}, &netv1alpha1.NatMapping{})
 				var m = make(map[schema.GroupVersionResource]string)
 				m[schema.GroupVersionResource{
 					Group:    "net.liqo.io",
@@ -242,7 +241,7 @@ var _ = Describe("NatMappingInflater", func() {
 					Group:   "net.liqo.io",
 					Version: "v1alpha1",
 					Kind:    "natmappings",
-				}, &liqonetapi.NatMapping{})
+				}, &netv1alpha1.NatMapping{})
 				var m = make(map[schema.GroupVersionResource]string)
 				m[schema.GroupVersionResource{
 					Group:    "net.liqo.io",

--- a/pkg/liqonet/netns/netns_suite_test.go
+++ b/pkg/liqonet/netns/netns_suite_test.go
@@ -4,12 +4,11 @@ import (
 	"testing"
 
 	"github.com/containernetworking/plugins/pkg/ns"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netns"
 	"golang.org/x/sys/unix"
-
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 )
 
 var (

--- a/pkg/liqonet/overlay/overlay_suite_test.go
+++ b/pkg/liqonet/overlay/overlay_suite_test.go
@@ -5,10 +5,9 @@ import (
 	"net"
 	"testing"
 
-	"github.com/vishvananda/netlink"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/vishvananda/netlink"
 )
 
 var (

--- a/pkg/liqonet/utils/utils_test.go
+++ b/pkg/liqonet/utils/utils_test.go
@@ -7,7 +7,6 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
-	"github.com/onsi/gomega"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -27,11 +26,11 @@ var _ = Describe("Liqonet", func() {
 		func(oldIp, newPodCidr, expectedIP string, expectedErr string) {
 			ip, err := utils.MapIPToNetwork(oldIp, newPodCidr)
 			if expectedErr != "" {
-				gomega.Expect(err.Error()).To(gomega.Equal(expectedErr))
+				Expect(err.Error()).To(Equal(expectedErr))
 			} else {
-				gomega.Expect(err).ToNot(gomega.HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 			}
-			gomega.Expect(ip).To(gomega.Equal(expectedIP))
+			Expect(ip).To(Equal(expectedIP))
 		},
 		Entry("Mapping 10.2.1.3 to 10.0.4.0/24", "10.0.4.0/24", "10.2.1.3", "10.0.4.3", ""),
 		Entry("Mapping 10.2.1.128 to 10.0.4.0/24", "10.0.4.0/24", "10.2.1.128", "10.0.4.128", ""),
@@ -47,11 +46,11 @@ var _ = Describe("Liqonet", func() {
 		func(network, expectedIP string, expectedErr *net.ParseError) {
 			ip, err := utils.GetFirstIP(network)
 			if expectedErr != nil {
-				gomega.Expect(err).To(MatchError(expectedErr))
+				Expect(err).To(MatchError(expectedErr))
 			} else {
-				gomega.Expect(err).ToNot(gomega.HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 			}
-			gomega.Expect(ip).To(gomega.Equal(expectedIP))
+			Expect(ip).To(Equal(expectedIP))
 		},
 		Entry("Passing an invalid network", invalidValue, "", &net.ParseError{Type: CIDRAddressNetErr, Text: invalidValue}),
 		Entry("Passing an empty network", "", "", &net.ParseError{Type: CIDRAddressNetErr, Text: ""}),

--- a/pkg/liqonet/wireguard/wireguard_suite_test.go
+++ b/pkg/liqonet/wireguard/wireguard_suite_test.go
@@ -4,15 +4,14 @@ import (
 	"testing"
 	"time"
 
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	wg "github.com/liqotech/liqo/pkg/liqonet/tunnel/wireguard"
 	"github.com/liqotech/liqo/pkg/liqonet/wireguard"
-
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 )
 
 var (

--- a/pkg/liqonet/wireguard/wireguard_test.go
+++ b/pkg/liqonet/wireguard/wireguard_test.go
@@ -2,10 +2,6 @@ package wireguard_test
 
 import (
 	"context"
-
-	wg "github.com/liqotech/liqo/pkg/liqonet/tunnel/wireguard"
-
-	//wg "github.com/liqotech/liqo/pkg/liqonet/tunnel/wireguard"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -16,6 +12,7 @@ import (
 	k8s "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 
+	wg "github.com/liqotech/liqo/pkg/liqonet/tunnel/wireguard"
 	"github.com/liqotech/liqo/pkg/liqonet/wireguard"
 )
 

--- a/pkg/virtualKubelet/forge/forge_test.go
+++ b/pkg/virtualKubelet/forge/forge_test.go
@@ -3,7 +3,6 @@ package forge
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/liqotech/liqo/pkg/virtualKubelet/namespacesMapping/test"

--- a/pkg/virtualKubelet/node/module/api/logs.go
+++ b/pkg/virtualKubelet/node/module/api/logs.go
@@ -22,11 +22,10 @@ import (
 	"strconv"
 	"time"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/klog"
-
 	"github.com/gorilla/mux"
 	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog"
 
 	"github.com/liqotech/liqo/internal/utils/errdefs"
 )

--- a/pkg/virtualKubelet/node/module/env.go
+++ b/pkg/virtualKubelet/node/module/env.go
@@ -20,12 +20,11 @@ import (
 	"sort"
 	"strings"
 
-	"k8s.io/klog/v2"
-
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	apivalidation "k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/klog/v2"
 	podshelper "k8s.io/kubernetes/pkg/apis/core/pods"
 	fieldpath "k8s.io/kubernetes/pkg/fieldpath"
 	"k8s.io/kubernetes/third_party/forked/golang/expansion"

--- a/pkg/virtualKubelet/node/module/mock_test.go
+++ b/pkg/virtualKubelet/node/module/mock_test.go
@@ -6,14 +6,13 @@ import (
 	"sync"
 	"time"
 
-	"github.com/liqotech/liqo/pkg/virtualKubelet/apiReflection/controller"
-	"github.com/liqotech/liqo/pkg/virtualKubelet/namespacesMapping"
-
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/liqotech/liqo/internal/utils/errdefs"
 	"github.com/liqotech/liqo/internal/utils/log"
+	"github.com/liqotech/liqo/pkg/virtualKubelet/apiReflection/controller"
+	"github.com/liqotech/liqo/pkg/virtualKubelet/namespacesMapping"
 )
 
 const (

--- a/pkg/virtualKubelet/node/module/node.go
+++ b/pkg/virtualKubelet/node/module/node.go
@@ -21,8 +21,6 @@ import (
 	"sync"
 	"time"
 
-	"k8s.io/klog/v2"
-
 	pkgerrors "github.com/pkg/errors"
 	coord "k8s.io/api/coordination/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -32,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	coordinationv1 "k8s.io/client-go/kubernetes/typed/coordination/v1"
 	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/klog/v2"
 )
 
 // NodeProvider is the interface used for registering a node and updating its

--- a/pkg/virtualKubelet/node/module/sync.go
+++ b/pkg/virtualKubelet/node/module/sync.go
@@ -5,14 +5,13 @@ import (
 	"sync"
 	"time"
 
-	"k8s.io/klog/v2"
-
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
 
 	"github.com/liqotech/liqo/internal/utils/errdefs"
 )

--- a/pkg/virtualKubelet/node/provider/node.go
+++ b/pkg/virtualKubelet/node/provider/node.go
@@ -19,11 +19,10 @@ import (
 	"os"
 	"strings"
 
-	"github.com/liqotech/liqo/cmd/virtual-kubelet/provider"
-
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/liqotech/liqo/cmd/virtual-kubelet/provider"
 	"github.com/liqotech/liqo/internal/utils/errdefs"
 )
 

--- a/pkg/virtualKubelet/test/e2e/main_test.go
+++ b/pkg/virtualKubelet/test/e2e/main_test.go
@@ -7,9 +7,9 @@ import (
 	"fmt"
 	"testing"
 
-	vke2e "github.com/liqotech/liqo/test/e2e"
-
 	v1 "k8s.io/api/core/v1"
+
+	vke2e "github.com/liqotech/liqo/test/e2e"
 )
 
 const (

--- a/pkg/vkMachinery/csr/approve.go
+++ b/pkg/vkMachinery/csr/approve.go
@@ -5,11 +5,10 @@ import (
 	"sync"
 	"time"
 
-	"k8s.io/apimachinery/pkg/labels"
-
 	certificatesv1 "k8s.io/api/certificates/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/informers"
 	k8s "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"

--- a/test/e2e/deploy_app_test.go
+++ b/test/e2e/deploy_app_test.go
@@ -7,12 +7,11 @@ import (
 	"testing"
 	"time"
 
+	http_helper "github.com/gruntwork-io/terratest/modules/http-helper"
+	"github.com/gruntwork-io/terratest/modules/k8s"
 	"gotest.tools/assert"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	http_helper "github.com/gruntwork-io/terratest/modules/http-helper"
-	"github.com/gruntwork-io/terratest/modules/k8s"
 
 	liqoconst "github.com/liqotech/liqo/pkg/consts"
 )

--- a/test/e2e/net_test.go
+++ b/test/e2e/net_test.go
@@ -4,9 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-
-	liqoconst "github.com/liqotech/liqo/pkg/consts"
-
 	"os/exec"
 	"strconv"
 	"testing"
@@ -17,6 +14,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog"
 
+	liqoconst "github.com/liqotech/liqo/pkg/consts"
 	"github.com/liqotech/liqo/pkg/virtualKubelet"
 	"github.com/liqotech/liqo/test/e2e/util"
 )

--- a/test/unit/advertisement-operator/broadcaster_test.go
+++ b/test/unit/advertisement-operator/broadcaster_test.go
@@ -3,15 +3,6 @@ package advertisement_operator
 import (
 	"context"
 	"fmt"
-
-	configv1alpha1 "github.com/liqotech/liqo/apis/config/v1alpha1"
-	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
-	advtypes "github.com/liqotech/liqo/apis/sharing/v1alpha1"
-	advop "github.com/liqotech/liqo/internal/advertisementoperator"
-	"github.com/liqotech/liqo/internal/advertisementoperator/broadcaster"
-	liqoconst "github.com/liqotech/liqo/pkg/consts"
-	crdclient "github.com/liqotech/liqo/pkg/crdClient"
-
 	"strconv"
 	"testing"
 	"time"
@@ -22,6 +13,13 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	configv1alpha1 "github.com/liqotech/liqo/apis/config/v1alpha1"
+	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
+	advtypes "github.com/liqotech/liqo/apis/sharing/v1alpha1"
+	advop "github.com/liqotech/liqo/internal/advertisementoperator"
+	"github.com/liqotech/liqo/internal/advertisementoperator/broadcaster"
+	liqoconst "github.com/liqotech/liqo/pkg/consts"
+	crdclient "github.com/liqotech/liqo/pkg/crdClient"
 	"github.com/liqotech/liqo/pkg/utils"
 	pkg "github.com/liqotech/liqo/pkg/virtualKubelet"
 	"github.com/liqotech/liqo/pkg/virtualKubelet/provider/test"

--- a/test/unit/advertisement-operator/config-watcher_test.go
+++ b/test/unit/advertisement-operator/config-watcher_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/klog"
@@ -22,7 +21,7 @@ import (
 
 func createFakeClusterConfig() configv1alpha1.ClusterConfig {
 	return configv1alpha1.ClusterConfig{
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name: "fake-configuration",
 		},
 		Spec: configv1alpha1.ClusterConfigSpec{
@@ -71,7 +70,7 @@ func testModifySharingPercentage(t *testing.T) {
 		t.Fatal(err)
 	}
 	// launch watcher over cluster config
-	_, err = configClient.Resource("clusterconfigs").Create(&clusterConfig, &v1.CreateOptions{})
+	_, err = configClient.Resource("clusterconfigs").Create(&clusterConfig, &metav1.CreateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -81,7 +80,7 @@ func testModifySharingPercentage(t *testing.T) {
 	}
 	// create advertisement on foreign cluster
 	adv := prepareAdv(&b)
-	_, err = b.RemoteClient.Resource("advertisements").Create(&adv, &v1.CreateOptions{})
+	_, err = b.RemoteClient.Resource("advertisements").Create(&adv, &metav1.CreateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -94,7 +93,7 @@ func testModifySharingPercentage(t *testing.T) {
 	mem := adv.Spec.ResourceQuota.Hard.Memory().Value()
 	// modify sharing percentage
 	clusterConfig.Spec.AdvertisementConfig.OutgoingConfig.ResourceSharingPercentage = int32(30)
-	_, err = configClient.Resource("clusterconfigs").Update(clusterConfig.Name, &clusterConfig, &v1.UpdateOptions{})
+	_, err = configClient.Resource("clusterconfigs").Update(clusterConfig.Name, &clusterConfig, &metav1.UpdateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -103,7 +102,7 @@ func testModifySharingPercentage(t *testing.T) {
 		t.Fatal(err)
 	}
 	// get the new adv
-	tmp, err := b.RemoteClient.Resource("advertisements").Get(adv.Name, &v1.GetOptions{})
+	tmp, err := b.RemoteClient.Resource("advertisements").Get(adv.Name, &metav1.GetOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -132,7 +131,7 @@ func testDisableBroadcaster(t *testing.T) {
 			time.Sleep(500 * time.Millisecond)
 		}
 	}
-	_, err = configClient.Resource("clusterconfigs").Create(&clusterConfig, &v1.CreateOptions{})
+	_, err = configClient.Resource("clusterconfigs").Create(&clusterConfig, &metav1.CreateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -142,7 +141,7 @@ func testDisableBroadcaster(t *testing.T) {
 	}
 	// create adv on foreign cluster
 	adv := prepareAdv(&b)
-	_, err = b.RemoteClient.Resource("advertisements").Create(&adv, &v1.CreateOptions{})
+	_, err = b.RemoteClient.Resource("advertisements").Create(&adv, &metav1.CreateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -152,7 +151,7 @@ func testDisableBroadcaster(t *testing.T) {
 	}
 	// disable advertisement
 	clusterConfig.Spec.AdvertisementConfig.OutgoingConfig.EnableBroadcaster = false
-	_, err = configClient.Resource("clusterconfigs").Update(clusterConfig.Name, &clusterConfig, &v1.UpdateOptions{})
+	_, err = configClient.Resource("clusterconfigs").Update(clusterConfig.Name, &clusterConfig, &metav1.UpdateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -161,13 +160,13 @@ func testDisableBroadcaster(t *testing.T) {
 		t.Fatal(err)
 	}
 	// check adv has been deleted
-	_, err = b.RemoteClient.Resource("advertisements").Get(adv.Name, &v1.GetOptions{})
+	_, err = b.RemoteClient.Resource("advertisements").Get(adv.Name, &metav1.GetOptions{})
 	assert.Equal(t, k8serrors.IsNotFound(err), true, "Advertisement has not been deleted")
 }
 
 func waitEvent(client *crdclient.CRDClient, resourcetype string, name string) error {
 	var timeout int64 = 10
-	watcher, err := client.Resource(resourcetype).Watch(&v1.ListOptions{
+	watcher, err := client.Resource(resourcetype).Watch(&metav1.ListOptions{
 		FieldSelector:  fields.OneTermEqualSelector(metav1.ObjectNameField, name).String(),
 		TimeoutSeconds: &timeout,
 	})

--- a/test/unit/virtualKubelet/reflection/endpointslices_test.go
+++ b/test/unit/virtualKubelet/reflection/endpointslices_test.go
@@ -12,7 +12,6 @@ import (
 	"k8s.io/klog"
 
 	liqonetTest "github.com/liqotech/liqo/pkg/liqonet/test"
-
 	apimgmt "github.com/liqotech/liqo/pkg/virtualKubelet/apiReflection"
 	api "github.com/liqotech/liqo/pkg/virtualKubelet/apiReflection/reflectors"
 	"github.com/liqotech/liqo/pkg/virtualKubelet/apiReflection/reflectors/outgoing"


### PR DESCRIPTION
# Description

This PR introduces the gci linter, to ensure determinism in the imports order. Differently from goimports, gci ensures exactly three groups of imports are present (system, local, remotes). 

Additionally, this PR enables also the linters on test files, arranging proper exceptions in case of annoying ones (others could be added later if necessary)/ 


# How Has This Been Tested?

This PR introduces no functional changes to the code.