### PR TITLE
Disable Linting on branch master and releases

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,10 +1,5 @@
 name: Linting
 on:
-  push:
-    tags:
-      - v*
-    branches:
-      - master
   pull_request:
 jobs:
   golangci:


### PR DESCRIPTION
# Description

We recently introduced a stricter linter on the Liqo code. The intention is to gradually improve the average quality and uniform the style of the repository. 

Since we decided to have a gradual approach, this check is always broken on the main branch bringing a "broken window" effect on the repository status.

This PR drops the execution of such check on the main branch and releases, leaving it only for PRs.

# How Has This Been Tested?

This PR introduces no functional changes to the code.