### PR TITLE
Enabled traffic toward ExternalCIDR

### DIFF
--- a/pkg/consts/liqonet.go
+++ b/pkg/consts/liqonet.go
@@ -58,6 +58,8 @@ const (
 	OverlayNetworkMask = "/8"
 	// PodCIDR is a field of the TunnelEndpoint resource.
 	PodCIDR = "PodCIDR"
+	// ExternalCIDR is a field of the TunnelEndpoint resource.
+	ExternalCIDR = "ExternalCIDR"
 	// LocalPodCIDR is a field of the TunnelEndpoint resource.
 	LocalPodCIDR = "LocalPodCIDR"
 	// LocalExternalCIDR is a field of the TunnelEndpoint resource.
@@ -68,4 +70,6 @@ const (
 	LocalNATExternalCIDR = "LocalNATExternalCIDR"
 	// RemoteNATPodCIDR is a field of the TunnelEndpoint resource.
 	RemoteNATPodCIDR = "RemoteNATPodCIDR"
+	// RemoteNATExternalCIDR is a field of the TunnelEndpoint resource.
+	RemoteNATExternalCIDR = "RemoteNATExternalCIDR"
 )

--- a/pkg/liqonet/routing/common.go
+++ b/pkg/liqonet/routing/common.go
@@ -210,8 +210,9 @@ func flushRulesForRoutingTable(routingTableID int) error {
 	return nil
 }
 
-func getRouteConfig(tep *v1alpha1.TunnelEndpoint, podIP string) (dstNet, gatewayIP string, iFaceIndex int, err error) {
-	_, dstNet = utils.GetPodCIDRS(tep)
+func getRouteConfig(tep *v1alpha1.TunnelEndpoint, podIP string) (dstPodCIDRNet, dstExternalCIDRNet, gatewayIP string, iFaceIndex int, err error) {
+	_, dstPodCIDRNet = utils.GetPodCIDRS(tep)
+	_, dstExternalCIDRNet = utils.GetExternalCIDRS(tep)
 	// Check if we are running on the same host as the gateway pod.
 	if tep.Status.GatewayIP != podIP {
 		// If the pod is not running on the same host then set the IP address of the Gateway as next hop.
@@ -219,13 +220,13 @@ func getRouteConfig(tep *v1alpha1.TunnelEndpoint, podIP string) (dstNet, gateway
 		// Get the iFace index for the IP address of the Gateway pod.
 		iFaceIndex, err = getIFaceIndexForIP(gatewayIP)
 		if err != nil {
-			return dstNet, gatewayIP, iFaceIndex, err
+			return dstPodCIDRNet, dstExternalCIDRNet, gatewayIP, iFaceIndex, err
 		}
 	} else {
 		// Running on the same host as the Gateway then set the index of the veth device living on the same network namespace.
 		iFaceIndex = tep.Status.VethIFaceIndex
 	}
-	return dstNet, gatewayIP, iFaceIndex, err
+	return dstPodCIDRNet, dstExternalCIDRNet, gatewayIP, iFaceIndex, err
 }
 
 func getIFaceIndexForIP(ipAddress string) (int, error) {

--- a/pkg/liqonet/routing/common_test.go
+++ b/pkg/liqonet/routing/common_test.go
@@ -470,9 +470,10 @@ var _ = Describe("Common", func() {
 
 		Context("when the the operator has same IP address as the Gateway pod", func() {
 			It("should return no error", func() {
-				dstNet, gwIP, iFaceIndex, err := getRouteConfig(&tep, ipAddress2NoSubnet)
+				dstPodCIDRNet, dstExternalCIDRNet, gwIP, iFaceIndex, err := getRouteConfig(&tep, ipAddress2NoSubnet)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(dstNet).Should(Equal(tep.Status.RemoteNATPodCIDR))
+				Expect(dstPodCIDRNet).Should(Equal(tep.Status.RemoteNATPodCIDR))
+				Expect(dstExternalCIDRNet).Should(Equal(tep.Status.RemoteNATExternalCIDR))
 				Expect(gwIP).Should(Equal(""))
 				Expect(iFaceIndex).Should(BeNumerically("==", tep.Status.VethIFaceIndex))
 			})
@@ -480,9 +481,10 @@ var _ = Describe("Common", func() {
 
 		Context("when the the operator is not running on same node as the Gateway pod", func() {
 			It("should return nil and a link index of the interface through which the Gateway is reachable", func() {
-				dstNet, gwIP, iFaceIndex, err := getRouteConfig(&tep, notReachableIP)
+				dstPodCIDRNet, dstExternalCIDRNet, gwIP, iFaceIndex, err := getRouteConfig(&tep, notReachableIP)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(dstNet).Should(Equal(tep.Status.RemoteNATPodCIDR))
+				Expect(dstPodCIDRNet).Should(Equal(tep.Status.RemoteNATPodCIDR))
+				Expect(dstExternalCIDRNet).Should(Equal(tep.Status.RemoteNATExternalCIDR))
 				Expect(gwIP).Should(Equal(ipAddress2NoSubnet))
 				Expect(iFaceIndex).Should(BeNumerically("==", dummylink1.Attrs().Index))
 			})
@@ -492,7 +494,7 @@ var _ = Describe("Common", func() {
 			It("should return error", func() {
 				tepCopy := tep
 				tepCopy.Status.GatewayIP = notReachableIP
-				_, _, _, err := getRouteConfig(&tepCopy, gwIPCorrect)
+				_, _, _, _, err := getRouteConfig(&tepCopy, gwIPCorrect)
 				Expect(err).To(HaveOccurred())
 				Expect(err).Should(Equal(&errors.NoRouteFound{IPAddress: tepCopy.Status.GatewayIP}))
 			})

--- a/pkg/liqonet/routing/routing_suite_test.go
+++ b/pkg/liqonet/routing/routing_suite_test.go
@@ -50,11 +50,15 @@ var _ = BeforeSuite(func() {
 	Expect(err).Should(BeNil())
 	Expect(drm).NotTo(BeNil())
 	tep = netv1alpha1.TunnelEndpoint{
+		Spec: netv1alpha1.TunnelEndpointSpec{
+			ExternalCIDR: "10.151.0.0/16",
+		},
 		Status: netv1alpha1.TunnelEndpointStatus{
-			LocalNATPodCIDR:  "10.150.0.0/16",
-			RemoteNATPodCIDR: "10.250.0.0/16",
-			VethIFaceIndex:   12345,
-			GatewayIP:        ipAddress2NoSubnet,
+			LocalNATPodCIDR:       "10.150.0.0/16",
+			RemoteNATPodCIDR:      "10.250.0.0/16",
+			RemoteNATExternalCIDR: "10.251.0.0/16",
+			VethIFaceIndex:        12345,
+			GatewayIP:             ipAddress2NoSubnet,
 		}}
 
 	// Create vxlan device for Vxlan Routing manager tests.

--- a/pkg/liqonet/utils/utils.go
+++ b/pkg/liqonet/utils/utils.go
@@ -196,13 +196,18 @@ func GetPodCIDRS(tep *netv1alpha1.TunnelEndpoint) (localRemappedPodCIDR, remoteP
 	return localRemappedPodCIDR, remotePodCIDR
 }
 
-// GetExternalCIDR for a given tep the function retrieves the ExternalCIDR used in remote cluster for
-// local resources. Its value depend if the NAT is required or not.
-func GetExternalCIDR(tep *netv1alpha1.TunnelEndpoint) (localRemappedExternalCIDR string) {
+// GetExternalCIDRS for a given tep the function retrieves the values for localExternalCIDR and remoteExternalCIDR.
+// Their values depend if the NAT is required or not.
+func GetExternalCIDRS(tep *netv1alpha1.TunnelEndpoint) (localExternalCIDR, remoteExternalCIDR string) {
 	if tep.Status.LocalNATExternalCIDR != consts.DefaultCIDRValue {
-		localRemappedExternalCIDR = tep.Status.LocalNATExternalCIDR
+		localExternalCIDR = tep.Status.LocalNATExternalCIDR
 	} else {
-		localRemappedExternalCIDR = tep.Status.LocalExternalCIDR
+		localExternalCIDR = tep.Status.LocalExternalCIDR
+	}
+	if tep.Status.RemoteNATExternalCIDR != consts.DefaultCIDRValue {
+		remoteExternalCIDR = tep.Status.RemoteNATExternalCIDR
+	} else {
+		remoteExternalCIDR = tep.Spec.ExternalCIDR
 	}
 	return
 }
@@ -273,6 +278,12 @@ func CheckTep(tep *netv1alpha1.TunnelEndpoint) error {
 			Reason:    liqoneterrors.ValidCIDR,
 		}
 	}
+	if err := IsValidCIDR(tep.Spec.ExternalCIDR); err != nil {
+		return &liqoneterrors.WrongParameter{
+			Parameter: consts.ExternalCIDR,
+			Reason:    liqoneterrors.ValidCIDR,
+		}
+	}
 	if err := IsValidCIDR(tep.Status.LocalPodCIDR); err != nil {
 		return &liqoneterrors.WrongParameter{
 			Parameter: consts.LocalPodCIDR,
@@ -303,6 +314,13 @@ func CheckTep(tep *netv1alpha1.TunnelEndpoint) error {
 		err != nil {
 		return &liqoneterrors.WrongParameter{
 			Parameter: consts.RemoteNATPodCIDR,
+			Reason:    liqoneterrors.ValidCIDR,
+		}
+	}
+	if err := IsValidCIDR(tep.Status.RemoteNATExternalCIDR); tep.Status.RemoteNATExternalCIDR != consts.DefaultCIDRValue &&
+		err != nil {
+		return &liqoneterrors.WrongParameter{
+			Parameter: consts.RemoteNATExternalCIDR,
 			Reason:    liqoneterrors.ValidCIDR,
 		}
 	}


### PR DESCRIPTION
# Description
This PR enables peered clusters to exchange traffic toward ExternalCIDR, as they already do with PodCIDR. To solve this problem, routing drives supported by Liqo have been modified in such a way that now routing tables hold not only PodCIDR destinations but also ExternalCIDR destinations. SNAT iptables rule for traffic toward ExternalCIDR was added as well.