### PR TITLE
test: fix deletepod testcase

### DIFF
--- a/pkg/virtualKubelet/provider/pods_test.go
+++ b/pkg/virtualKubelet/provider/pods_test.go
@@ -133,8 +133,8 @@ var _ = Describe("Pods", func() {
 		})
 
 		It("delete pod", func() {
-			err := provider.CreatePod(context.TODO(), nil)
-			Expect(err).NotTo(HaveOccurred())
+			err := provider.DeletePod(context.TODO(), nil)
+			Expect(err).To(HaveOccurred())
 		})
 	})
 })


### PR DESCRIPTION
Trigger the function that was intended to be tested, ie. DeletePod.
We are not sure what is the behaviour we want when a nil pod reaches
this function, if that's possible at all. Further analysis and work is
needed.

Also, note that Create and Update functions show a different behaviour
introduced as quick fix to race condition:
https://github.com/liqotech/liqo/issues/598#issuecomment-867572624. 
To re-evaluate.