### PR TITLE
Fix race condition causing netns tests to fail

### DIFF
--- a/pkg/liqonet/netns/netns_suite_test.go
+++ b/pkg/liqonet/netns/netns_suite_test.go
@@ -1,6 +1,7 @@
 package netns
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/containernetworking/plugins/pkg/ns"
@@ -47,11 +48,18 @@ func setUpNetns(name string) {
 	defer newNs.Close()
 }
 
-func tearDownNetns(name string) {
-	err := netns.DeleteNamed(name)
-	if err != nil {
-		Expect(err).Should(Equal(unix.ENOENT))
-		return
+func cleanUpEnv() error {
+	err := netns.DeleteNamed(netnsName)
+	if err != nil && !errors.Is(err, unix.ENOENT) {
+		return err
 	}
-	Expect(err).ShouldNot(HaveOccurred())
+	// Get the veth dev living in host network.
+	veth, err := netlink.LinkByName(hostVeth)
+	if err != nil && err.Error() != "Link not found" {
+		return err
+	}
+	if veth != nil {
+		return netlink.LinkDel(veth)
+	}
+	return nil
 }


### PR DESCRIPTION
# Description

Some times `netns` tests fails due to a race conditions causing the clean up function to fail.

Fixes #(issue)
Fix race condition causing unit tests of the `netns` package to fail.

