### PR TITLE
docs: fix node selector for hello world example

### DIFF
--- a/docs/examples/hello-world.yaml
+++ b/docs/examples/hello-world.yaml
@@ -17,7 +17,7 @@ spec:
       requiredDuringSchedulingIgnoredDuringExecution:
         nodeSelectorTerms:
           - matchExpressions:
-              - key: type
+              - key: liqo.io/type
                 operator: NotIn
                 values:
                   - virtual-node


### PR DESCRIPTION
Align node selector to label set by the application.

https://github.com/liqotech/liqo/blob/7b1f831874b47367e40204c9e2a4e99a39b840f7/pkg/virtualKubelet/node/provider/node.go#L50-L57

The Pod in the hello-world example cannot be scheduled atm.