### PR TITLE
Fix Update Lease Conflict

### DIFF
--- a/deployments/liqo/files/liqo-virtual-kubelet-local-ClusterRole.yaml
+++ b/deployments/liqo/files/liqo-virtual-kubelet-local-ClusterRole.yaml
@@ -74,6 +74,7 @@ rules:
   verbs:
   - create
   - delete
+  - get
   - update
 - apiGroups:
   - discovery.k8s.io

--- a/pkg/virtualKubelet/node/module/node.go
+++ b/pkg/virtualKubelet/node/module/node.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	coordinationv1 "k8s.io/client-go/kubernetes/typed/coordination/v1"
 	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
 )
 
@@ -376,22 +377,40 @@ func ensureLease(ctx context.Context, leases coordinationv1.LeaseInterface, leas
 // If this function returns an errors.IsNotFound(err) error, this likely means
 // that node leases are not supported, if this is the case, call updateNodeStatus
 // instead.
+//
+// NOTE: this code has been modified to fix a bug already addressed in the upstream
+// virtual kubelet repository. It can be dropped when upgrading the kubelet code.
 func updateNodeLease(ctx context.Context, leases coordinationv1.LeaseInterface, lease *coord.Lease) (*coord.Lease, error) {
-	l, err := leases.Update(context.TODO(), lease, metav1.UpdateOptions{})
-	if err != nil {
-		if errors.IsNotFound(err) {
-			klog.V(4).Infof("lease %s/%s not found", lease.Namespace, lease.Name)
-			l, err = ensureLease(ctx, leases, lease)
-		}
+	var l *coord.Lease
+	var err error
+	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		l, err = leases.Update(ctx, lease, metav1.UpdateOptions{})
 		if err != nil {
-			return nil, err
+			if errors.IsNotFound(err) {
+				klog.V(4).Infof("lease %s/%s not found", lease.Namespace, lease.Name)
+				l, err = ensureLease(ctx, leases, lease)
+			}
+			if errors.IsConflict(err) {
+				klog.V(4).Infof("conflict, get lease %s/%s", lease.Namespace, lease.Name)
+				var newErr error
+				lease, newErr = leases.Get(ctx, lease.GetName(), metav1.GetOptions{})
+				if newErr != nil {
+					klog.Error(newErr)
+					return newErr
+				}
+				return err
+			}
+			if err != nil {
+				return err
+			}
+			klog.V(4).Infof("created new lease %s%s", lease.Namespace, lease.Name)
+		} else {
+			klog.V(4).Infof("updated lease %s/%s", lease.Namespace, lease.Name)
 		}
-		klog.V(4).Infof("created new lease %s%s", lease.Namespace, lease.Name)
-	} else {
-		klog.V(4).Infof("updated lease %s/%s", lease.Namespace, lease.Name)
-	}
 
-	return l, nil
+		return nil
+	})
+	return l, err
 }
 
 // just so we don't have to allocate this on every get request.

--- a/pkg/virtualKubelet/roles/role.go
+++ b/pkg/virtualKubelet/roles/role.go
@@ -15,4 +15,4 @@ package roles
 // +kubebuilder:rbac:groups=net.liqo.io,resources=tunnelendpoints,verbs=get;list;watch
 // +kubebuilder:rbac:groups=sharing.liqo.io,resources=advertisements,verbs=get;list;watch;update;delete
 
-// +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=create;update;delete
+// +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;create;update;delete


### PR DESCRIPTION
# Description

This pr fixes a bug already addressed in the upstream virtual kubelet repository. It can be dropped when upgrading the kubelet code.

This bug prevents the node lease to be correctly updated by the node provider after a transitory API server issue.

That is the log of the virtual kubelet in that case:
```txt
I0624 14:28:48.845622       1 namespaceMapper.go:72] namespaceNattingTable cache initialized
I0624 14:28:48.950864       1 root.go:287] advertisement not found, setting empty owner reference
I0624 14:28:49.046036       1 root.go:277] setup ended
I0624 14:28:49.046061       1 resourceWatcher.go:59] Liqo informers started
I0624 14:28:49.049781       1 reconciler.go:79] node correctly updated from resourceOffer
I0624 14:28:49.060621       1 reconciler.go:194] correctly set pod CIDR from tunnel endpoint
I0624 14:28:49.062189       1 podcontroller.go:282] Pod cache in-sync
I0624 14:28:49.062452       1 podcontroller.go:324] starting workers
I0624 14:28:49.062464       1 podcontroller.go:338] started workers
I0624 14:28:49.269875       1 reconciler.go:79] node correctly updated from resourceOffer
I0625 00:00:42.694839       1 reconciler.go:79] node correctly updated from resourceOffer
I0625 00:25:04.211517       1 reconciler.go:79] node correctly updated from resourceOffer
I0625 00:25:04.258284       1 reconciler.go:79] node correctly updated from resourceOffer
E0625 01:57:58.216709       1 node.go:294] etcdserver: request timed out - Error while handling node ping
E0625 01:58:09.602193       1 node.go:294] Operation cannot be fulfilled on leases.coordination.k8s.io "liqo-2aac7bf5-0349-47db-836a-13df66cec619": the object has been modified; please apply your changes to the latest version and try again - Error while handling node ping
E0625 01:58:20.514292       1 node.go:294] Operation cannot be fulfilled on leases.coordination.k8s.io "liqo-2aac7bf5-0349-47db-836a-13df66cec619": the object has been modified; please apply your changes to the latest version and try again - Error while handling node ping
E0625 01:58:32.150979       1 node.go:294] Operation cannot be fulfilled on leases.coordination.k8s.io "liqo-2aac7bf5-0349-47db-836a-13df66cec619": the object has been modified; please apply your changes to the latest version and try again - Error while handling node ping
E0625 01:58:42.153110       1 node.go:294] Operation cannot be fulfilled on leases.coordination.k8s.io "liqo-2aac7bf5-0349-47db-836a-13df66cec619": the object has been modified; please apply your changes to the latest version and try again - Error while handling node ping
E0625 01:58:52.212428       1 node.go:294] Operation cannot be fulfilled on leases.coordination.k8s.io "liqo-2aac7bf5-0349-47db-836a-13df66cec619": the object has been modified; please apply your changes to the latest version and try again - Error while handling node ping
...
```
