### PR TITLE
Add Clastix/Capsule Subchart

### DIFF
--- a/deployments/liqo/Chart.lock
+++ b/deployments/liqo/Chart.lock
@@ -1,3 +1,6 @@
-dependencies: []
-digest: sha256:643d5437104296e21d906ecb15b2c96ad278f20cfc4af53b12bb6069bd853726
-generated: "2021-01-27T18:32:54.7246306+01:00"
+dependencies:
+- name: capsule
+  repository: http://helm.liqo.io/capsule
+  version: v0.1.0-rc2-liqo
+digest: sha256:b2e4d9203115ed1d86313ed9a4c920644cd2b3e7f1d6d07fd51be7ed44703f37
+generated: "2021-06-29T09:01:16.388711445Z"

--- a/deployments/liqo/Chart.yaml
+++ b/deployments/liqo/Chart.yaml
@@ -21,4 +21,9 @@ version: "0.1"
 # AppVersion is commented by default. Uncomment it or add it as extra-args to helm package if you want to release a new Liqo version
 # appVersion:
 
-dependencies: []
+dependencies:
+- name: capsule
+  version: v0.1.0-rc2-liqo
+  # this is a temporary solution waiting for the new version of capsule to be released.
+  repository: http://helm.liqo.io/capsule
+  condition: capsule.install

--- a/deployments/liqo/README.md
+++ b/deployments/liqo/README.md
@@ -24,6 +24,8 @@
 | auth.service.annotations | object | `{}` | auth service annotations |
 | auth.service.type | string | `"NodePort"` | The type of service used to expose the Authentication Service If you are exposing this service with an Ingress consider to change it to ClusterIP, otherwise if you plan to use liqo over the Internet consider to change this field to "LoadBalancer". See https://doc.liqo.io/user/install/pre-install/ for more details. |
 | auth.tls | bool | `true` | Enable TLS for the Authentication Service Pod (using a self-signed certificate). If you are exposing this service with an Ingress consider to disable it or add the appropriate annotations to the Ingress resource. |
+| capsule.fullnameOverride | string | `"capsule"` | override the fullname to fix naming problems |
+| capsule.install | bool | `true` | liqo needs capsule to work properly, but you can use your already deployed capsule installation |
 | crdReplicator.imageName | string | `"liqo/crd-replicator"` | crdReplicator image repository |
 | crdReplicator.pod.annotations | object | `{}` | crdReplicator pod annotations |
 | crdReplicator.pod.labels | object | `{}` | crdReplicator pod labels |

--- a/deployments/liqo/values.yaml
+++ b/deployments/liqo/values.yaml
@@ -192,5 +192,12 @@ nameOverride: ""
 # -- full liqo name override
 fullnameOverride: ""
 
+# capsule subchart configuration
+capsule:
+  # -- liqo needs capsule to work properly, but you can use your already deployed capsule installation
+  install: true
+  # -- override the fullname to fix naming problems
+  fullnameOverride: capsule
+
 # -- enable experimental new authentication flow
 useNewAuth: false

--- a/install.sh
+++ b/install.sh
@@ -511,7 +511,7 @@ function install_liqo() {
 	${KUBECTL} create namespace "${LIQO_NAMESPACE}" 1>/dev/null 2>&1 || true
 	local LIQO_CHART="${TMPDIR}/${LIQO_CHARTS_PATH}"
 	info "[INSTALL]" "Packaging the chart..."
-	${HELM} package --version="${LIQO_CHART_VERSION}" --app-version="${LIQO_CHART_VERSION}" "${LIQO_CHART}" >/dev/null ||
+	${HELM} package --version="${LIQO_CHART_VERSION}" --app-version="${LIQO_CHART_VERSION}" "${LIQO_CHART}" --dependency-update >/dev/null ||
 			fatal "[INSTALL]" "Something went wrong while installing Liqo"
 
 	${HELM} install liqo --kube-context "${KUBECONFIG_CONTEXT}" --namespace "${LIQO_NAMESPACE}" "liqo-${LIQO_CHART_VERSION}.tgz" \


### PR DESCRIPTION
# Description

This pr adds [Clastix/Capsule](https://github.com/clastix/capsule) as a Liqo helm subchart. With this pr we are using the `v0.1.0-rc2` of the Capsule chart because the last stable version (`v0.0.5`) does not allow it to run in a different namespace from `capsule-system`.

This pr also includes some values customization for the subchart in the main Liqo values file.

# How Has This Been Tested?

- [x] locally on KinD
