### PR TITLE
Fixed some issues regarding ExternalCIDR traffic

### DIFF
--- a/pkg/liqonet/iptables/iptables.go
+++ b/pkg/liqonet/iptables/iptables.go
@@ -707,7 +707,7 @@ func getChainRulesPerCluster(tep *netv1alpha1.TunnelEndpoint) (map[string][]IPTa
 	}
 	clusterID := tep.Spec.ClusterID
 	localRemappedPodCIDR, remotePodCIDR := utils.GetPodCIDRS(tep)
-	localRemappedExternalCIDR, _ := utils.GetExternalCIDRS(tep)
+	localRemappedExternalCIDR, remoteExternalCIDR := utils.GetExternalCIDRS(tep)
 
 	// Init chain rules
 	chainRules := make(map[string][]IPTableRule)
@@ -719,7 +719,8 @@ func getChainRulesPerCluster(tep *netv1alpha1.TunnelEndpoint) (map[string][]IPTa
 	// For these rules, source in not necessary since
 	// the remotePodCIDR is unique in home cluster
 	chainRules[liqonetPostroutingChain] = append(chainRules[liqonetPostroutingChain],
-		IPTableRule{"-d", remotePodCIDR, "-j", getClusterPostRoutingChain(clusterID)})
+		IPTableRule{"-d", remotePodCIDR, "-j", getClusterPostRoutingChain(clusterID)},
+		IPTableRule{"-d", remoteExternalCIDR, "-j", getClusterPostRoutingChain(clusterID)})
 	chainRules[liqonetInputChain] = append(chainRules[liqonetInputChain],
 		IPTableRule{"-d", remotePodCIDR, "-j", getClusterInputChain(clusterID)})
 	chainRules[liqonetForwardingChain] = append(chainRules[liqonetForwardingChain],


### PR DESCRIPTION
This PR enables traffic toward ExternalCIDR by introducing a couple of modifications that were missing in PR #708.
In particular, it adds ExternalCIDR to WireGuard configuration(allowedIPs, the networks allowed to enter into a wg tunnel) and modifies the iptables module to allow the traffic toward ExternalCIDR of a remote cluster to correctly trigger the right SNAT rule.