### PR TITLE
Add clusterLabels to ResourceOffer.

### DIFF
--- a/internal/resource-request-operator/utils.go
+++ b/internal/resource-request-operator/utils.go
@@ -39,6 +39,7 @@ func (r *ResourceRequestReconciler) generateResourceOffer(ctx context.Context, r
 			ResourceQuota: corev1.ResourceQuotaSpec{
 				Hard: resources,
 			},
+			Labels:     r.Broadcaster.clusterConfig.Spec.DiscoveryConfig.ClusterLabels,
 			Timestamp:  creationTime,
 			TimeToLive: metav1.NewTime(creationTime.Add(timeToLive)),
 		}


### PR DESCRIPTION
# Description

ClusterLabels is a set of labels that characterizes the local cluster when exposed remotely as a virtual node.
ClusterLabels are obtained from the ClusterConfig resource, and they are inserted in ResourceOffer.Spec.Labels.

Ref. #572 
