### PR TITLE
bugfix pod termination

### DIFF
--- a/pkg/virtualKubelet/apiReflection/reflectors/incoming/apiTypes.go
+++ b/pkg/virtualKubelet/apiReflection/reflectors/incoming/apiTypes.go
@@ -13,7 +13,9 @@ var ReflectorBuilder = map[apimgmt.ApiType]func(reflector ri.APIReflector, opts 
 
 func podsReflectorBuilder(reflector ri.APIReflector, opts map[options.OptionKey]options.Option) ri.IncomingAPIReflector {
 	return &PodsIncomingReflector{
-		APIReflector: reflector}
+		APIReflector:  reflector,
+		HomePodGetter: GetHomePodFunc,
+	}
 }
 
 func replicaSetsReflectorBuilder(reflector ri.APIReflector, _ map[options.OptionKey]options.Option) ri.IncomingAPIReflector {

--- a/pkg/virtualKubelet/apiReflection/reflectors/incoming/pods_test.go
+++ b/pkg/virtualKubelet/apiReflection/reflectors/incoming/pods_test.go
@@ -1,23 +1,30 @@
 package incoming_test
 
 import (
+	"bytes"
+	"errors"
+	"flag"
+	"fmt"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
 
 	"github.com/liqotech/liqo/pkg/virtualKubelet"
 	apimgmt "github.com/liqotech/liqo/pkg/virtualKubelet/apiReflection"
 	"github.com/liqotech/liqo/pkg/virtualKubelet/apiReflection/reflectors"
 	"github.com/liqotech/liqo/pkg/virtualKubelet/apiReflection/reflectors/incoming"
+	ri "github.com/liqotech/liqo/pkg/virtualKubelet/apiReflection/reflectors/reflectorsInterfaces"
 	"github.com/liqotech/liqo/pkg/virtualKubelet/forge"
 	"github.com/liqotech/liqo/pkg/virtualKubelet/namespacesMapping/test"
 	storageTest "github.com/liqotech/liqo/pkg/virtualKubelet/storage/test"
 )
 
-var _ = Describe("Pods", func() {
+var _ = Describe("Pod incoming reflector", func() {
 
 	var (
 		cacheManager          *storageTest.MockManager
@@ -36,22 +43,148 @@ var _ = Describe("Pods", func() {
 			NamespaceNatting: namespaceNattingTable,
 			CacheManager:     cacheManager,
 		}
-		reflector = &incoming.PodsIncomingReflector{APIReflector: genericReflector}
-		reflector.APIReflector = genericReflector
+		reflector = &incoming.PodsIncomingReflector{
+			APIReflector:  genericReflector,
+			HomePodGetter: incoming.GetHomePodFunc,
+		}
 
 		reflector.SetSpecializedPreProcessingHandlers()
 		forge.InitForger(namespaceNattingTable)
 	})
 
-	Describe("pre routines", func() {
-		When("empty caches", func() {
-			Context("pre add", func() {
+	AfterEach(func() {
+		namespaceNattingTable.Clear()
+		cacheManager.Clear()
+	})
+
+	Describe("PreProcessingHandlers", func() {
+		Context("PreDelete", func() {
+			var (
+				foreignPod          interface{}
+				podGot              interface{}
+				homePodGetterCalled int
+				homePodGetterError  error
+
+				buffer *bytes.Buffer
+				flags  *flag.FlagSet
+			)
+
+			When("it's not possible to get a home pod for the foreign pod", func() {
+				BeforeEach(func() {
+					// setup logger
+					buffer = &bytes.Buffer{}
+					flags = &flag.FlagSet{}
+					klog.InitFlags(flags)
+					_ = flags.Set("logtostderr", "false")
+					_ = flags.Set("v", "5")
+					klog.SetOutput(buffer)
+
+					// setup getHomePod mock to return an error
+					homePodGetterCalled = 0
+					reflector.HomePodGetter = func(reflector ri.APIReflector, foreignPod *corev1.Pod) (*corev1.Pod, error) {
+						homePodGetterCalled++
+						homePodGetterError = errors.New("home pod not found")
+						return nil, homePodGetterError
+					}
+
+					// trigger unit under test
+					foreignPod = &corev1.Pod{}
+					podGot, _ = reflector.PreDelete(foreignPod)
+
+					klog.Flush()
+				})
+
+				It("should call GetHomePod once", func() {
+					Expect(homePodGetterCalled).To(Equal(1))
+				})
+
+				It("should return nil", func() {
+					Expect(podGot).To(BeNil())
+				})
+
+				It("should log an error", func() {
+					Expect(buffer.String()).To(ContainSubstring("cannot get home pod for foreign pod"))
+					Expect(buffer.String()).To(ContainSubstring(homePodGetterError.Error()))
+				})
+
+			})
+
+			When("it's possible to get a home pod for the foreign pod", func() {
+				var (
+					foreignPod *corev1.Pod
+				)
+
+				BeforeEach(func() {
+					// setup getHomePod mock to return a valid pod object
+					homePodGetterCalled = 0
+					reflector.HomePodGetter = func(reflector ri.APIReflector, foreignPod *corev1.Pod) (*corev1.Pod, error) {
+						homePodGetterCalled++
+						return &corev1.Pod{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "homePodName",
+							},
+							Status: corev1.PodStatus{
+								ContainerStatuses: []corev1.ContainerStatus{
+									{
+										State: corev1.ContainerState{
+											Running: &corev1.ContainerStateRunning{},
+										},
+									},
+								},
+							},
+						}, nil
+					}
+
+					// configure foreign pod and put it in blacklist
+					foreignPod = &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "homePodName-foreign",
+							Namespace: "preDeleteNamespace-natted",
+						},
+					}
+					foreignPodKey := reflector.Keyer(foreignPod.Namespace, foreignPod.Name)
+					reflectors.Blacklist[apimgmt.Pods][foreignPodKey] = struct{}{}
+
+					// trigger unit under test
+					podGot, _ = reflector.PreDelete(foreignPod)
+				})
+
+				It("should call GetHomePod once", func() {
+					Expect(homePodGetterCalled).To(Equal(1))
+				})
+
+				It("should return the deleted home pod", func() {
+					Expect(podGot).NotTo(BeNil())
+					homePod := podGot.(*corev1.Pod)
+					Expect(homePod.Name).To(Equal("homePodName"))
+				})
+
+				It("should remove the foreign pod from the black list", func() {
+					foreignPodKey := reflector.Keyer(foreignPod.Namespace, foreignPod.Name)
+					podsBlackList := reflectors.Blacklist[apimgmt.Pods]
+					Expect(podsBlackList).NotTo(ContainElement(foreignPodKey))
+				})
+
+				It("should set each container statuses to terminated", func() {
+					homePod := podGot.(*corev1.Pod)
+					containerStatuses := homePod.Status.ContainerStatuses
+					Expect(containerStatuses).To(HaveLen(1))
+
+					for _, status := range containerStatuses {
+						Expect(status.State.Terminated).NotTo(BeNil())
+					}
+				})
+			})
+		})
+
+		When("caches are empty", func() {
+			Context("PreAdd", func() {
 				type addTestcase struct {
 					input          *corev1.Pod
 					expectedOutput types.GomegaMatcher
 				}
 
-				DescribeTable("pre add test cases",
+				DescribeTable("PreAdd test cases",
 					func(c addTestcase) {
 						ret, _ := reflector.PreProcessAdd(c.input)
 						Expect(ret).To(c.expectedOutput)
@@ -85,7 +218,7 @@ var _ = Describe("Pods", func() {
 			})
 		})
 
-		When("not empty caches", func() {
+		When("caches are not empty", func() {
 			Context("pre add", func() {
 				var (
 					homePod, foreignPod *corev1.Pod
@@ -121,6 +254,7 @@ var _ = Describe("Pods", func() {
 
 				It("correct foreign pod added", func() {
 					ret, _ := reflector.PreProcessAdd(foreignPod)
+					Expect(ret).NotTo(BeNil())
 					Expect(ret.(*corev1.Pod).Name).To(Equal(homePod.Name))
 					Expect(ret.(*corev1.Pod).Namespace).To(Equal(homePod.Namespace))
 					Expect(ret.(*corev1.Pod).Status).To(Equal(foreignPod.Status))
@@ -128,9 +262,213 @@ var _ = Describe("Pods", func() {
 
 				It("correct foreign pod updated", func() {
 					ret, _ := reflector.PreProcessUpdate(foreignPod, nil)
+					Expect(ret).NotTo(BeNil())
 					Expect(ret.(*corev1.Pod).Name).To(Equal(homePod.Name))
 					Expect(ret.(*corev1.Pod).Namespace).To(Equal(homePod.Namespace))
 					Expect(ret.(*corev1.Pod).Status).To(Equal(foreignPod.Status))
+				})
+			})
+		})
+
+		Describe("GetHomePodFunc", func() {
+			When("a home pod doesn't have labels", func() {
+				var (
+					foreignPod *corev1.Pod
+					err        error
+				)
+
+				BeforeEach(func() {
+					foreignPod = &corev1.Pod{}
+					_, err = incoming.GetHomePodFunc(reflector, foreignPod)
+				})
+
+				It("should error", func() {
+					Expect(err).NotTo(BeNil())
+					Expect(err.Error()).To(Equal("foreign pod labels not found"))
+				})
+			})
+
+			When("a home pod doesn't have the label requested for foreign to home pod translation", func() {
+				var (
+					foreignPod *corev1.Pod
+					err        error
+				)
+
+				BeforeEach(func() {
+					foreignPod = &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{
+								"app": "liqo",
+							},
+						},
+					}
+
+					_, err = incoming.GetHomePodFunc(reflector, foreignPod)
+				})
+
+				It("should error", func() {
+					Expect(err).NotTo(BeNil())
+					expectedErrorMessage := fmt.Sprintf("foreign pod label with key: %s, not found", virtualKubelet.ReflectedpodKey)
+					Expect(err.Error()).To(Equal(expectedErrorMessage))
+				})
+			})
+
+			When("cannot denat namespace", func() {
+				var (
+					foreignPod *corev1.Pod
+					err        error
+				)
+
+				BeforeEach(func() {
+					foreignPod = &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{
+								virtualKubelet.ReflectedpodKey: "testHomePod",
+							},
+						},
+					}
+
+					_, err = incoming.GetHomePodFunc(reflector, foreignPod)
+				})
+
+				It("should error", func() {
+					Expect(err).NotTo(BeNil())
+					Expect(err.Error()).To(ContainSubstring("cannot get home pod namespace"))
+				})
+			})
+
+			When("cannot get home pod from cache", func() {
+				var (
+					foreignPod *corev1.Pod
+					err        error
+				)
+
+				BeforeEach(func() {
+					nattedNamespace, testSetupError := namespaceNattingTable.NatNamespace("testNamespace", true)
+					if testSetupError != nil {
+						Fail("failed to setup test: cannot nat namespace using fake namespace natter")
+					}
+
+					foreignPod = &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{
+								virtualKubelet.ReflectedpodKey: "testHomePod",
+							},
+							Namespace: nattedNamespace,
+						},
+					}
+
+					_, err = incoming.GetHomePodFunc(reflector, foreignPod)
+				})
+
+				It("should error", func() {
+					Expect(err).NotTo(BeNil())
+					Expect(err.Error()).To(ContainSubstring("cannot get home pod from cache manager"))
+				})
+			})
+
+			When("cache misbehaving - returns non-pod object", func() {
+				var (
+					foreignPod   *corev1.Pod
+					nonPodObject interface{}
+					err          error
+				)
+
+				BeforeEach(func() {
+					homeNamespace := "cacheMisbehaving"
+					nattedNamespace, testSetupError := namespaceNattingTable.NatNamespace(homeNamespace, true)
+					if testSetupError != nil {
+						Fail("failed to setup test: cannot nat namespace using fake namespace natter")
+					}
+
+					// setup cache manager
+					if testSetupError = cacheManager.AddHomeNamespace(homeNamespace); testSetupError != nil {
+						Fail("failed to setup test: cannot setup fake cache manager")
+					}
+
+					if testSetupError = cacheManager.AddForeignNamespace(nattedNamespace); testSetupError != nil {
+						Fail("failed to setup test: cannot setup fake cache manager")
+					}
+
+					nonPodObject = &corev1.Service{}
+					nonPodObj, ok := nonPodObject.(metav1.Object)
+					if !ok {
+						Fail("failed to setup test: cannot complete fake cacheManager setup")
+					}
+					homePodName := "testCacheMisbehavingHomePod"
+					nonPodObj.SetName(homePodName)
+
+					cacheManager.AddHomeEntry(homeNamespace, apimgmt.Pods, nonPodObj)
+
+					foreignPod = &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{
+								virtualKubelet.ReflectedpodKey: homePodName,
+							},
+							Namespace: nattedNamespace,
+						},
+					}
+
+					_, err = incoming.GetHomePodFunc(reflector, foreignPod)
+				})
+
+				It("should error", func() {
+					Expect(err).NotTo(BeNil())
+					Expect(err.Error()).To(ContainSubstring("could not execute type conversion: GetHomeNamespacedObject expected to return a Pod object"))
+				})
+			})
+
+			When("it's possible to retrieve home pod for foreign pod", func() {
+				var (
+					foreignPod *corev1.Pod
+					homePod    interface{}
+					err        error
+				)
+
+				BeforeEach(func() {
+					// setup namespace natter
+					homeNamespace := "GetHomePodNamespace"
+					nattedNamespace, testSetupError := namespaceNattingTable.NatNamespace(homeNamespace, true)
+					if testSetupError != nil {
+						Fail("failed to setup test: cannot nat namespace using fake namespace natter")
+					}
+
+					// setup cache manager
+					if testSetupError = cacheManager.AddHomeNamespace(homeNamespace); testSetupError != nil {
+						Fail("failed to setup test: cannot setup fake cache manager")
+					}
+
+					if testSetupError = cacheManager.AddForeignNamespace(nattedNamespace); testSetupError != nil {
+						Fail("failed to setup test: cannot setup fake cache manager")
+					}
+
+					homePod = &corev1.Pod{}
+					homePodObj, ok := homePod.(metav1.Object)
+					if !ok {
+						Fail("failed to setup test: cannot complete fake cacheManager setup")
+					}
+					homePodName := "testHomePod"
+					homePodObj.SetName(homePodName)
+					cacheManager.AddHomeEntry(homeNamespace, apimgmt.Pods, homePodObj)
+
+					// configure foreign pod
+					foreignPod = &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{
+								virtualKubelet.ReflectedpodKey: homePodName,
+							},
+							Namespace: nattedNamespace,
+						},
+					}
+
+					// trigger unit under test
+					homePod, err = incoming.GetHomePodFunc(reflector, foreignPod)
+				})
+
+				It("should return home pod", func() {
+					Expect(err).To(BeNil())
+					Expect(homePod).NotTo(BeNil())
+					Expect(homePod).To(BeAssignableToTypeOf(&corev1.Pod{}))
 				})
 			})
 		})

--- a/pkg/virtualKubelet/forge/pods.go
+++ b/pkg/virtualKubelet/forge/pods.go
@@ -78,18 +78,14 @@ func (f *apiForger) podStatusForeignToHome(foreignObj, homeObj runtime.Object) *
 	return homePod
 }
 
-// setPodToBeDeleted set the pod status such that it can be collected by the replicasetController,
-// setting the pod status to PodUnknwon and all the containers in terminated status.
+// Set pod's container statutes to terminated so that the pod can be deleted.
 func (f *apiForger) setPodToBeDeleted(pod *corev1.Pod) *corev1.Pod {
-	now := metav1.Now()
-
 	pod.Status.Phase = corev1.PodUnknown
 	for i := range pod.Status.ContainerStatuses {
 		pod.Status.ContainerStatuses[i].State = corev1.ContainerState{
 			Terminated: &corev1.ContainerStateTerminated{},
 		}
 	}
-	pod.DeletionTimestamp = &now
 
 	return pod
 }
@@ -130,6 +126,7 @@ func (f *apiForger) podHomeToForeign(homeObj, foreignObj runtime.Object, reflect
 func (f *apiForger) forgePodSpec(inputPodSpec corev1.PodSpec) corev1.PodSpec {
 	outputPodSpec := corev1.PodSpec{}
 
+	outputPodSpec.TerminationGracePeriodSeconds = inputPodSpec.TerminationGracePeriodSeconds
 	outputPodSpec.Volumes = forgeVolumes(inputPodSpec.Volumes)
 	outputPodSpec.InitContainers = forgeContainers(inputPodSpec.InitContainers, outputPodSpec.Volumes)
 	outputPodSpec.Containers = forgeContainers(inputPodSpec.Containers, outputPodSpec.Volumes)

--- a/pkg/virtualKubelet/namespacesMapping/test/mockNamespaceMapper.go
+++ b/pkg/virtualKubelet/namespacesMapping/test/mockNamespaceMapper.go
@@ -28,3 +28,10 @@ func (m *MockNamespaceMapper) DeNatNamespace(namespace string) (string, error) {
 	}
 	return "", errors.New("not found")
 }
+
+// Clear is a function used in tests only to clear the mock's state.
+func (m *MockNamespaceMapper) Clear() {
+	for k := range m.Cache {
+		delete(m.Cache, k)
+	}
+}

--- a/pkg/virtualKubelet/storage/test/mockCacheManager.go
+++ b/pkg/virtualKubelet/storage/test/mockCacheManager.go
@@ -125,3 +125,14 @@ func (m *MockManager) GetHomeAPIByIndex(apiType apimgmt.ApiType, s, s2 string) (
 func (m *MockManager) GetForeignAPIByIndex(apiType apimgmt.ApiType, s, s2 string) (interface{}, error) {
 	panic("implement me")
 }
+
+// Clear is a function used in tests only to clear the mock's state.
+func (m *MockManager) Clear() {
+	for k := range m.HomeCache {
+		delete(m.HomeCache, k)
+	}
+
+	for k := range m.ForeignCache {
+		delete(m.ForeignCache, k)
+	}
+}


### PR DESCRIPTION
# Description

Pod deletion initiated from the home pod was not completed correctly.
Indeed, the pod's container statuses in the home was never set to
terminated so the virtual kubelet was not able to delete pod.

This fix updates the container statuses in one go, when the foreign pod
is deleted, ie. we miss to update the home pod when the foreign
containers are terminated. Fixing this problem is out of scope and would
probably require modifying the pod black listing mechanism which seems
too risky at this time. Issue described here:
#721.

Resolves: #598

# How Has This Been Tested?

- Manually on my development workstation using 2 local clusters (created with kind).
- Unit tests added for PodIncomingReflector.