### PR TITLE
Change remote clients in NamespaceMap controller and fix some bugs.

### DIFF
--- a/cmd/advertisement-operator/main.go
+++ b/cmd/advertisement-operator/main.go
@@ -28,7 +28,6 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 
 	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
@@ -236,9 +235,10 @@ func main() {
 
 	namespaceMapReconciler := &mapsctrl.NamespaceMapReconciler{
 		Client:                mgr.GetClient(),
-		RemoteClients:         make(map[string]client.Client),
+		RemoteClients:         make(map[string]kubernetes.Interface),
 		LocalClusterID:        clusterId,
 		IdentityManagerClient: clientset,
+		RequeueTime:           time.Second * 30,
 	}
 
 	if err = namespaceMapReconciler.SetupWithManager(mgr); err != nil {

--- a/pkg/consts/namespace_mapping.go
+++ b/pkg/consts/namespace_mapping.go
@@ -29,4 +29,7 @@ const (
 	RoleBindingLabelKey = "capsule.clastix.io/tenant"
 	// RoleBindingLabelValuePrefix prefix of the value that the RoleBindingLabel must have.
 	RoleBindingLabelValuePrefix = "tenant"
+	// RemoteNamespaceAnnotationKey is the annotation that all remote namespaces created by the NamespaceMap controller
+	// must have.
+	RemoteNamespaceAnnotationKey = "liqo.io/remote-namespace"
 )

--- a/pkg/liqo-controller-manager/namespaceMap-controller/namespacemap_controller.go
+++ b/pkg/liqo-controller-manager/namespaceMap-controller/namespacemap_controller.go
@@ -19,6 +19,7 @@ package namespacemapctrl
 import (
 	"context"
 	"reflect"
+	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/kubernetes"
@@ -36,9 +37,10 @@ import (
 // NamespaceMapReconciler creates remote namespaces and updates NamespaceMaps Status.
 type NamespaceMapReconciler struct {
 	client.Client
-	RemoteClients         map[string]client.Client
+	RemoteClients         map[string]kubernetes.Interface
 	IdentityManagerClient kubernetes.Interface
 	LocalClusterID        string
+	RequeueTime           time.Duration
 }
 
 // cluster-role
@@ -81,7 +83,7 @@ func (r *NamespaceMapReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			return ctrl.Result{}, err
 		}
 	}
-	return ctrl.Result{}, nil
+	return ctrl.Result{RequeueAfter: r.RequeueTime}, nil
 }
 
 // Events not filtered:


### PR DESCRIPTION
# Description

- change remote clients from controller-runtime ones to standard ones (kubernetes.Interface).
- create Tenant with a new annotation for remote namespaces.
- add some consts to pkg/consts/namespace_mapping.go.
- namespaceMap controller now restarts with a resync period.
- change the annotation that the remote namespaces must have.


