### PR TITLE
Activation of the new webhook logic

### DIFF
--- a/deployments/liqo/README.md
+++ b/deployments/liqo/README.md
@@ -68,7 +68,6 @@
 | webhook.imageName | string | `"liqo/liqo-webhook"` | webhook image repository |
 | webhook.initContainer.imageName | string | `"liqo/webhook-configuration"` | webhook init container image repository |
 | webhook.mutatingWebhookConfiguration.annotations | object | `{}` | mutatingWebhookConfiguration annotations |
-| webhook.mutatingWebhookConfiguration.namespaceSelector | object | `{"liqo.io/enabled":"true"}` | The label that needs to be applied to a namespace to make it eligible for pod offloading in a remote cluster |
 | webhook.pod.annotations | object | `{}` | webhook pod annotations |
 | webhook.pod.labels | object | `{}` | webhook pod labels |
 | webhook.service.annotations | object | `{}` | webhook service annotations |

--- a/deployments/liqo/templates/liqo-webhook.yaml
+++ b/deployments/liqo/templates/liqo-webhook.yaml
@@ -41,4 +41,4 @@ webhooks:
     failurePolicy: Ignore
     namespaceSelector:
       matchLabels:
-        {{- toYaml .Values.webhook.mutatingWebhookConfiguration.namespaceSelector | nindent 8 }}
+        liqo.io/scheduling-enabled: "true"

--- a/deployments/liqo/values.yaml
+++ b/deployments/liqo/values.yaml
@@ -167,9 +167,6 @@ webhook:
   mutatingWebhookConfiguration:
     # -- mutatingWebhookConfiguration annotations
     annotations: {}
-    # -- The label that needs to be applied to a namespace to make it eligible for pod offloading in a remote cluster
-    namespaceSelector:
-      liqo.io/enabled: "true"
 
 peeringRequest:
   pod:

--- a/pkg/mutate/server.go
+++ b/pkg/mutate/server.go
@@ -27,12 +27,14 @@ type MutationServer struct {
 
 	webhookClient client.Client
 	config        *MutationConfig
+	ctx           context.Context
 }
 
 // NewMutationServer creates a new mutation server.
 func NewMutationServer(ctx context.Context, c *MutationConfig) (*MutationServer, error) {
 	s := &MutationServer{}
 	s.config = c
+	s.ctx = ctx
 
 	// This scheme is necessary for the WebhookClient.
 	scheme := runtime.NewScheme()

--- a/test/e2e/testutils/net/net.go
+++ b/test/e2e/testutils/net/net.go
@@ -22,7 +22,7 @@ var (
 	// label to list only the real nodes excluding the virtual ones.
 	labelSelectorNodes = fmt.Sprintf("%v!=%v", liqoconst.TypeLabel, liqoconst.TypeNode)
 	//TODO: use the retry mechanism of curl without sleeping before running the command.
-	command = "curl --fail -s -o /dev/null -w '%{http_code}' "
+	command = "curl --fail --max-time 5 -s -o /dev/null -w '%{http_code}' "
 )
 
 // ConnectivityCheckNodeToPod creates a NodePort Service and check its availability.


### PR DESCRIPTION
# Description

This PR activates the new webhook logic. When a pod is deployed in a namespace enabled for the liqo offloading, the liqo toleration and the right node selector are added to the pod according to the PodOffloadingStrategy specified in the NamespaceOffloading resource.

Ref. #572 
