### PR TITLE
Some minor fixes in namespace-mapping controllers.

### DIFF
--- a/pkg/liqo-controller-manager/namespace-controller/namespace_controller.go
+++ b/pkg/liqo-controller-manager/namespace-controller/namespace_controller.go
@@ -7,7 +7,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 

--- a/pkg/liqo-controller-manager/namespace-controller/owned_namespaceoffloading_lifecycle.go
+++ b/pkg/liqo-controller-manager/namespace-controller/owned_namespaceoffloading_lifecycle.go
@@ -5,7 +5,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 
 	offv1alpha1 "github.com/liqotech/liqo/apis/offloading/v1alpha1"
 	liqoconst "github.com/liqotech/liqo/pkg/consts"

--- a/pkg/liqo-controller-manager/namespace-controller/suite_test.go
+++ b/pkg/liqo-controller-manager/namespace-controller/suite_test.go
@@ -26,7 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"

--- a/pkg/liqo-controller-manager/namespaceMap-controller/create_remote_clients.go
+++ b/pkg/liqo-controller-manager/namespaceMap-controller/create_remote_clients.go
@@ -1,41 +1,13 @@
 package namespacemapctrl
 
 import (
-	"context"
-	"fmt"
-
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
-	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 
 	"github.com/liqotech/liqo/pkg/clusterid"
 	identitymanager "github.com/liqotech/liqo/pkg/identityManager"
 	tenantcontrolnamespace "github.com/liqotech/liqo/pkg/tenantControlNamespace"
 )
-
-// getKubeConfig returns a rest.Config from a Kubeconfig contained in a Secret.
-func (r *NamespaceMapReconciler) getKubeConfig(reference *corev1.ObjectReference) (*rest.Config, error) {
-	if reference == nil {
-		return nil, fmt.Errorf("must specify reference")
-	}
-	secret := &corev1.Secret{}
-	if err := r.Get(context.TODO(), types.NamespacedName{
-		Namespace: reference.Namespace,
-		Name:      reference.Name,
-	}, secret); err != nil {
-		klog.Errorf("unable to get Secret '%s'", reference.Name)
-		return nil, err
-	}
-
-	kubeconfig := func() (*clientcmdapi.Config, error) {
-		return clientcmd.Load(secret.Data["kubeconfig"])
-	}
-	return clientcmd.BuildConfigFromKubeconfigGetter("", kubeconfig)
-}
 
 // checkRemoteClientPresence creates a new controller-runtime Client for a remote cluster, if it isn't already present
 // in RemoteClients Struct of NamespaceMap Controller.

--- a/pkg/liqo-controller-manager/namespaceMap-controller/manage_namespacemap_controller_finalizer.go
+++ b/pkg/liqo-controller-manager/namespaceMap-controller/manage_namespacemap_controller_finalizer.go
@@ -3,7 +3,7 @@ package namespacemapctrl
 import (
 	"context"
 
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlutils "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 

--- a/pkg/liqo-controller-manager/namespaceMap-controller/namespacemap_controller.go
+++ b/pkg/liqo-controller-manager/namespaceMap-controller/namespacemap_controller.go
@@ -23,7 +23,7 @@ import (
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -77,12 +77,6 @@ func (r *NamespaceMapReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{}, err
 	}
 
-	// Only when all remote namespaces associated with this NamespaceMap are deleted, remove finalizer.
-	if len(namespaceMap.Status.CurrentMapping) == 0 {
-		if err := r.RemoveNamespaceMapControllerFinalizer(ctx, namespaceMap); err != nil {
-			return ctrl.Result{}, err
-		}
-	}
 	return ctrl.Result{RequeueAfter: r.RequeueTime}, nil
 }
 

--- a/pkg/liqo-controller-manager/namespaceMap-controller/suite_test.go
+++ b/pkg/liqo-controller-manager/namespaceMap-controller/suite_test.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
-	"k8s.io/klog"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
@@ -86,10 +85,6 @@ var _ = BeforeSuite(func(done Done) {
 	remoteCluster2Env = &envtest.Environment{
 		CRDDirectoryPaths: []string{filepath.Join("..", "..", "..", "deployments", "liqo", "crds")},
 	}
-
-	flags = &flag.FlagSet{}
-	klog.InitFlags(flags)
-	_ = flags.Set("v", "8")
 
 	var err error
 

--- a/pkg/liqo-controller-manager/namespaceOffloading-controller/manage_liqo_scheduling_label.go
+++ b/pkg/liqo-controller-manager/namespaceOffloading-controller/manage_liqo_scheduling_label.go
@@ -5,7 +5,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	liqoconst "github.com/liqotech/liqo/pkg/consts"

--- a/pkg/liqo-controller-manager/namespaceOffloading-controller/namespaceoffloading_controller.go
+++ b/pkg/liqo-controller-manager/namespaceOffloading-controller/namespaceoffloading_controller.go
@@ -20,7 +20,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlutils "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -94,7 +94,7 @@ func (r *NamespaceOffloadingReconciler) Reconcile(ctx context.Context, req ctrl.
 		}
 	}
 	// Request creation of remote Namespaces according to the ClusterSelector field.
-	if err := r.enforceClusterSelector(namespaceOffloading, clusterIDMap); err != nil {
+	if err := r.enforceClusterSelector(ctx, namespaceOffloading, clusterIDMap); err != nil {
 		return ctrl.Result{}, err
 	}
 

--- a/pkg/liqo-controller-manager/namespaceOffloading-controller/namespaceoffloading_lifecycle.go
+++ b/pkg/liqo-controller-manager/namespaceOffloading-controller/namespaceoffloading_lifecycle.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlutils "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -22,7 +22,7 @@ func (r *NamespaceOffloadingReconciler) deletionLogic(ctx context.Context,
 		return err
 	}
 	// 2 - remove the involved DesiredMapping from the NamespaceMap.
-	if err := removeDesiredMappings(r.Client, noff.Namespace, clusterIDMap); err != nil {
+	if err := removeDesiredMappings(ctx, r.Client, noff.Namespace, clusterIDMap); err != nil {
 		return err
 	}
 	// 3 - check if all remote namespaces associated with this NamespaceOffloading resource are really deleted.

--- a/pkg/liqo-controller-manager/namespaceOffloading-controller/suite_test.go
+++ b/pkg/liqo-controller-manager/namespaceOffloading-controller/suite_test.go
@@ -25,7 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"

--- a/pkg/liqo-controller-manager/offloadingStatus-controller/namespaceoffloading_status_management.go
+++ b/pkg/liqo-controller-manager/offloadingStatus-controller/namespaceoffloading_status_management.go
@@ -2,7 +2,7 @@ package offloadingstatuscontroller
 
 import (
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 
 	offv1alpha1 "github.com/liqotech/liqo/apis/offloading/v1alpha1"
 	mapsv1alpha1 "github.com/liqotech/liqo/apis/virtualKubelet/v1alpha1"

--- a/pkg/liqo-controller-manager/offloadingStatus-controller/offloadingstatus_controller.go
+++ b/pkg/liqo-controller-manager/offloadingStatus-controller/offloadingstatus_controller.go
@@ -21,7 +21,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"

--- a/pkg/liqo-controller-manager/offloadingStatus-controller/suite_test.go
+++ b/pkg/liqo-controller-manager/offloadingStatus-controller/suite_test.go
@@ -26,7 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"


### PR DESCRIPTION
# Description

- remove some unused function.
- check that there are the 3 RoleBindings with the capsule label in the remote namespace.
- propagate the context in some function.
- upgrade klog to version v2 in some files.
- NamespaceMap will always have the finalizer until it is deleted, before this commit the finalizer was removed every time the status was empty.

