### PR TITLE
Overlay Network Bug Fix

### DIFF
--- a/internal/liqonet/route-operator/symmetricRoutingOperator.go
+++ b/internal/liqonet/route-operator/symmetricRoutingOperator.go
@@ -11,7 +11,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	k8sApiErrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/klog/v2"
-	"k8s.io/kubernetes/pkg/api/v1/pod"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -154,8 +153,9 @@ func (src *SymmetricRoutingController) podFilter(obj client.Object) bool {
 		klog.V(4).Infof("skipping pod {%s} running on our same node {%s}", p.Name, p.Spec.NodeName)
 		return false
 	}
-	// If pod is not ready return false.
-	if !pod.IsPodReady(p) {
+	// If podIP is not set return false.
+	if p.Status.PodIP == "" {
+		klog.Infof("skipping pod {%s} running on node {%s} has ip address set to empty", p.Name, p.Spec.NodeName)
 		return false
 	}
 	return true

--- a/internal/liqonet/route-operator/symmetricRoutingOperator_test.go
+++ b/internal/liqonet/route-operator/symmetricRoutingOperator_test.go
@@ -306,17 +306,13 @@ var _ = Describe("SymmetricRoutingOperator", func() {
 		})
 
 		Context("when pod is running on different node than operator", func() {
-			It("pod is not ready, should return false", func() {
+			It("podIP is not set, should return false", func() {
 				ok := src.podFilter(srcTestPod)
 				Expect(ok).Should(BeFalse())
 			})
 
-			It("pod is ready, should return true", func() {
-				srcTestPod.Status.Conditions = []corev1.PodCondition{
-					{Type: corev1.PodReady,
-						Status: corev1.ConditionTrue,
-					},
-				}
+			It("podIP is set, should return true", func() {
+				srcTestPod.Status.PodIP = srcPodIP
 				ok := src.podFilter(srcTestPod)
 				Expect(ok).Should(BeTrue())
 			})

--- a/pkg/liqonet/overlay/vxlan_test.go
+++ b/pkg/liqonet/overlay/vxlan_test.go
@@ -267,4 +267,13 @@ var _ = Describe("Vxlan", func() {
 			})
 		})
 	})
+
+	Describe("configure reverse path filtering for vxlan interface", func() {
+		Context("setting the rp_filter to 2", func() {
+			It("should return nil", func() {
+				err := vxlanDev.enableRPFilter()
+				Expect(err).ShouldNot(HaveOccurred())
+			})
+		})
+	})
 })


### PR DESCRIPTION
# Description

This PR sets the `rp_filter` in loose mode for the `vxlan` network interfaces. At the same time, the filter function used to `filter out` the not ready pods in the `symmetric routing operator` has been changed. Now it does not check if the pod is ready but if the `podIP` has been set.

Fixes #(issue)

When the CNI is configured not to perform `SNAT` on the packets generated by local pods and destined to remote networks the traffic is dropped by the `overlay` network. By enabling the `rp_filter` the problem is solved.
In the case of the `symmetric routing operator` in some case when the `ready` condition of a pod depends on the network configuration of `liqo` a `dead lock` is verified. By checking only the `podIP` field of the pods we overcome this problem.

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

Unit tests.
