### PR TITLE
Added OfferUpdater component which implement all ResourceOffer update.

### DIFF
--- a/apis/sharing/v1alpha1/resourceoffer_types.go
+++ b/apis/sharing/v1alpha1/resourceoffer_types.go
@@ -18,11 +18,6 @@ type ResourceOfferSpec struct {
 	Labels map[string]string `json:"labels,omitempty"`
 	// Prices contains the possible prices for every kind of resource (cpu, memory, image).
 	Prices corev1.ResourceList `json:"prices,omitempty"`
-	// Timestamp is the time instant when this ResourceOffer was created.
-	Timestamp metav1.Time `json:"timestamp"`
-	// TimeToLive is the time instant until this ResourceOffer will be valid.
-	// If not refreshed, an ResourceOffer will expire after 30 minutes.
-	TimeToLive metav1.Time `json:"timeToLive"`
 	// WithdrawalTimestamp is set when a graceful deletion is requested by the user.
 	WithdrawalTimestamp *metav1.Time `json:"withdrawalTimestamp,omitempty"`
 }

--- a/apis/sharing/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/sharing/v1alpha1/zz_generated.deepcopy.go
@@ -108,8 +108,6 @@ func (in *ResourceOfferSpec) DeepCopyInto(out *ResourceOfferSpec) {
 			(*out)[key] = val.DeepCopy()
 		}
 	}
-	in.Timestamp.DeepCopyInto(&out.Timestamp)
-	in.TimeToLive.DeepCopyInto(&out.TimeToLive)
 	if in.WithdrawalTimestamp != nil {
 		in, out := &in.WithdrawalTimestamp, &out.WithdrawalTimestamp
 		*out = (*in).DeepCopy()

--- a/deployments/liqo/crds/sharing.liqo.io_resourceoffers.yaml
+++ b/deployments/liqo/crds/sharing.liqo.io_resourceoffers.yaml
@@ -155,17 +155,6 @@ spec:
                       type: string
                     type: array
                 type: object
-              timeToLive:
-                description: TimeToLive is the time instant until this ResourceOffer
-                  will be valid. If not refreshed, an ResourceOffer will expire after
-                  30 minutes.
-                format: date-time
-                type: string
-              timestamp:
-                description: Timestamp is the time instant when this ResourceOffer
-                  was created.
-                format: date-time
-                type: string
               withdrawalTimestamp:
                 description: WithdrawalTimestamp is set when a graceful deletion is
                   requested by the user.
@@ -173,8 +162,6 @@ spec:
                 type: string
             required:
             - clusterId
-            - timeToLive
-            - timestamp
             type: object
           status:
             description: ResourceOfferStatus defines the observed state of ResourceOffer.

--- a/internal/resource-request-operator/interfaces/clusterResourceInterface.go
+++ b/internal/resource-request-operator/interfaces/clusterResourceInterface.go
@@ -1,0 +1,18 @@
+package interfaces
+
+import (
+	corev1 "k8s.io/api/core/v1"
+
+	configv1alpha1 "github.com/liqotech/liqo/apis/config/v1alpha1"
+)
+
+// ClusterResourceInterface represents a generic subset of Broadcaster exported methods to be used instead of a direct access to
+// the Broadcaster instance and get/update some cluster resources information.
+type ClusterResourceInterface interface {
+	// ReadResources returns all free cluster resources calculated for a given clusterID scaled by a percentage value.
+	ReadResources(clusterID string) corev1.ResourceList
+	// RemoveClusterID removes given clusterID from all internal structures and it will be no more valid.
+	RemoveClusterID(clusterID string)
+	// GetConfig returns a ClusterConfig instance.
+	GetConfig() *configv1alpha1.ClusterConfig
+}

--- a/internal/resource-request-operator/interfaces/doc.go
+++ b/internal/resource-request-operator/interfaces/doc.go
@@ -1,0 +1,2 @@
+// Package interfaces contains all the ResourceRequestOperator interfaces representing some of its components.
+package interfaces

--- a/internal/resource-request-operator/interfaces/updaterInterface.go
+++ b/internal/resource-request-operator/interfaces/updaterInterface.go
@@ -1,0 +1,15 @@
+package interfaces
+
+import (
+	"context"
+	"sync"
+)
+
+// UpdaterInterface represents a generic subset of Updater exported methods to be used instead of a direct access to
+// a particular Updater instance.
+type UpdaterInterface interface {
+	// Start runs an instance of an updater which will be stopped when ctx.Done() is closed.
+	Start(ctx context.Context, group *sync.WaitGroup)
+	// Push adds the clusterID to the internal queue to be processed as soon as possible.
+	Push(clusterID string)
+}

--- a/internal/resource-request-operator/offerUpdater.go
+++ b/internal/resource-request-operator/offerUpdater.go
@@ -1,0 +1,182 @@
+package resourcerequestoperator
+
+import (
+	"context"
+	"crypto/rand"
+	"fmt"
+	"math/big"
+	"sync"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
+	sharingv1alpha1 "github.com/liqotech/liqo/apis/sharing/v1alpha1"
+	crdreplicator "github.com/liqotech/liqo/internal/crdReplicator"
+	"github.com/liqotech/liqo/internal/resource-request-operator/interfaces"
+	"github.com/liqotech/liqo/pkg/discovery"
+)
+
+// requeueTimeout define a period of processed items requeue.
+const requeueTimeout = 5 * time.Minute
+
+// maxRandom is used to generate a random delta to add to requeueTimeout to avoid syncing.
+const maxRandom = 60
+
+// OfferUpdater is a component which wraps all ResourceOffer update logic.
+type OfferUpdater struct {
+	queue workqueue.RateLimitingInterface
+	client.Client
+	broadcasterInt interfaces.ClusterResourceInterface
+	homeClusterID  string
+	scheme         *runtime.Scheme
+}
+
+// Setup initializes all parameters of the OfferUpdater component.
+func (u *OfferUpdater) Setup(clusterID string, scheme *runtime.Scheme, broadcaster interfaces.ClusterResourceInterface, k8Client client.Client) {
+	u.broadcasterInt = broadcaster
+	u.Client = k8Client
+	u.homeClusterID = clusterID
+	u.scheme = scheme
+	u.queue = workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "Offer update queue")
+}
+
+// Start runs the OfferUpdate worker.
+func (u *OfferUpdater) Start(ctx context.Context, group *sync.WaitGroup) {
+	defer u.queue.ShutDown()
+	group.Add(1)
+	defer group.Done()
+	go u.startRunner(ctx)
+	<-ctx.Done()
+}
+
+func (u *OfferUpdater) startRunner(ctx context.Context) {
+	wait.Until(u.run, 2*time.Second, ctx.Done())
+}
+
+func (u *OfferUpdater) run() {
+	for u.processNextItem() {
+	}
+}
+
+func (u *OfferUpdater) processNextItem() bool {
+	obj, shutdown := u.queue.Get()
+	if shutdown {
+		return false
+	}
+	err := func(obj interface{}) error {
+		defer u.queue.Done(obj)
+		var clusterID string
+		var ok bool
+		if clusterID, ok = obj.(string); !ok {
+			// As the item in the workqueue is actually invalid, we call
+			// Forget here else we'd go into a loop of attempting to
+			// process a work item that is invalid.
+			u.queue.Forget(obj)
+			return fmt.Errorf("error getting object %v from OfferUpater queue. It is not a string", obj)
+		}
+		// call createOrUpdate which after some controls generate a new resourceOffer for this clusterID or update it if exists.
+		if requeue, err := u.createOrUpdateOffer(clusterID); err != nil {
+			if requeue {
+				// requeue is true due to a transient error so put the item back on the workqueue.
+				u.queue.AddRateLimited(clusterID)
+			} else {
+				// requeue == false means that the clusterID is no more valid and so it will be not requeued.
+				u.Remove(clusterID)
+				u.broadcasterInt.RemoveClusterID(clusterID)
+			}
+			return fmt.Errorf("error during updating ResourceOffer for cluster %s: %w", clusterID, err)
+		}
+		return nil
+	}(obj)
+	if err != nil {
+		klog.Errorf("Error occurred during ResourceOffer update %s", err)
+		return true
+	}
+	klog.Infof("Update cluster %s processed", obj.(string))
+
+	// requeue after timeout seconds
+	u.queue.AddAfter(obj, getRandomTimeout())
+	return true
+}
+
+func (u *OfferUpdater) createOrUpdateOffer(clusterID string) (bool, error) {
+	list, err := u.getResourceRequest(clusterID)
+	if err != nil {
+		return true, err
+	} else if len(list.Items) != 1 {
+		// invalid clusterID so return requeue = false. The clusterID will be removed from the workqueue and broadacaster maps.
+		return false, fmt.Errorf("ClusterID %s is no more valid. Deleting", clusterID)
+	}
+	request := list.Items[0]
+	resources := u.broadcasterInt.ReadResources(clusterID)
+	offer := &sharingv1alpha1.ResourceOffer{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: request.GetNamespace(),
+			Name:      offerPrefix + u.homeClusterID,
+		},
+	}
+
+	op, err := controllerutil.CreateOrUpdate(context.Background(), u.Client, offer, func() error {
+		if offer.Labels != nil {
+			offer.Labels[discovery.ClusterIDLabel] = request.Spec.ClusterIdentity.ClusterID
+			offer.Labels[crdreplicator.LocalLabelSelector] = "true"
+			offer.Labels[crdreplicator.DestinationLabel] = request.Spec.ClusterIdentity.ClusterID
+		} else {
+			offer.Labels = map[string]string{
+				discovery.ClusterIDLabel:         request.Spec.ClusterIdentity.ClusterID,
+				crdreplicator.LocalLabelSelector: "true",
+				crdreplicator.DestinationLabel:   request.Spec.ClusterIdentity.ClusterID,
+			}
+		}
+		offer.Spec.ClusterId = u.homeClusterID
+		offer.Spec.ResourceQuota.Hard = resources.DeepCopy()
+		offer.Spec.Labels = u.broadcasterInt.GetConfig().Spec.DiscoveryConfig.ClusterLabels
+		return controllerutil.SetControllerReference(&request, offer, u.scheme)
+	})
+
+	if err != nil {
+		klog.Error(err)
+		return true, err
+	}
+	klog.Infof("%s -> %s Offer: %s/%s", u.homeClusterID, op, offer.Namespace, offer.Name)
+	return true, nil
+}
+
+func (u *OfferUpdater) getResourceRequest(clusterID string) (*discoveryv1alpha1.ResourceRequestList, error) {
+	resourceRequestList := &discoveryv1alpha1.ResourceRequestList{}
+	err := u.Client.List(context.Background(), resourceRequestList, client.MatchingLabels{
+		crdreplicator.RemoteLabelSelector: clusterID,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return resourceRequestList, nil
+}
+
+// Push add new clusterID to update queue which will be processes as soon as possible.
+func (u *OfferUpdater) Push(clusterID string) {
+	u.queue.Add(clusterID)
+}
+
+// Remove removes a specified clusterID from the update queue and it will be no more processed.
+func (u *OfferUpdater) Remove(clusterID string) {
+	u.queue.Forget(clusterID)
+	klog.Infof("Removed cluster %s from update queue", clusterID)
+}
+
+func getRandomTimeout() time.Duration {
+	max := new(big.Int)
+	max.SetInt64(int64(maxRandom))
+	n, err := rand.Int(rand.Reader, max)
+	if err != nil {
+		return requeueTimeout
+	}
+	return requeueTimeout + time.Duration(n.Int64())*time.Second
+}

--- a/internal/resource-request-operator/resourceRequest_controller.go
+++ b/internal/resource-request-operator/resourceRequest_controller.go
@@ -2,7 +2,6 @@ package resourcerequestoperator
 
 import (
 	"context"
-	"time"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/klog/v2"
@@ -26,7 +25,6 @@ type ResourceRequestReconciler struct {
 
 const (
 	offerPrefix = "resourceoffer-"
-	timeToLive  = 30 * time.Minute
 )
 
 // +kubebuilder:rbac:groups=discovery.liqo.io,resources=resourceRequests,verbs=get;list;watch;create;update;patch;
@@ -89,7 +87,7 @@ func (r *ResourceRequestReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	}()
 
 	if resourceRequest.Spec.WithdrawalTimestamp.IsZero() {
-		err = r.generateResourceOffer(ctx, &resourceRequest)
+		r.Broadcaster.enqueueForCreationOrUpdate(remoteClusterID)
 		if err != nil {
 			klog.Errorf("%s -> Error generating resourceOffer: %s", remoteClusterID, err)
 			return ctrl.Result{}, err

--- a/internal/resource-request-operator/suite_test.go
+++ b/internal/resource-request-operator/suite_test.go
@@ -26,7 +26,7 @@ import (
 var (
 	cfg            *rest.Config
 	k8sClient      client.Client
-	clusterId      string
+	clusterID      string
 	clientset      kubernetes.Interface
 	testEnv        *envtest.Environment
 	newBroadcaster Broadcaster
@@ -71,7 +71,10 @@ func createCluster() {
 	})
 	Expect(err).ToNot(HaveOccurred())
 	clientset = kubernetes.NewForConfigOrDie(k8sManager.GetConfig())
-	err = newBroadcaster.SetupBroadcaster(clientset, 5*time.Second)
+	clusterID = clusterid.NewStaticClusterID("test-cluster").GetClusterID()
+	updater := OfferUpdater{}
+	updater.Setup(clusterID, k8sManager.GetScheme(), &newBroadcaster, k8sManager.GetClient())
+	err = newBroadcaster.SetupBroadcaster(clientset, &updater, 5*time.Second, 5)
 	Expect(err).ToNot(HaveOccurred())
 	newBroadcaster.StartBroadcaster(ctx, &group)
 	testClusterConf := &configv1alpha1.ClusterConfig{
@@ -84,11 +87,10 @@ func createCluster() {
 		},
 	}
 	newBroadcaster.setConfig(testClusterConf)
-	clusterId = clusterid.NewStaticClusterID("test-cluster").GetClusterID()
 	err = (&ResourceRequestReconciler{
 		Client:      k8sManager.GetClient(),
 		Scheme:      k8sManager.GetScheme(),
-		ClusterID:   clusterId,
+		ClusterID:   clusterID,
 		Broadcaster: &newBroadcaster,
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())

--- a/pkg/liqo-controller-manager/resourceoffer-controller/resourceoffer_controller_test.go
+++ b/pkg/liqo-controller-manager/resourceoffer-controller/resourceoffer_controller_test.go
@@ -155,9 +155,7 @@ var _ = Describe("ResourceOffer Controller", func() {
 					},
 				},
 				Spec: sharingv1alpha1.ResourceOfferSpec{
-					ClusterId:  clusterID,
-					Timestamp:  metav1.Now(),
-					TimeToLive: metav1.NewTime(time.Now().Add(1 * time.Hour)),
+					ClusterId: clusterID,
 				},
 			},
 			expectedPhase: sharingv1alpha1.ResourceOfferAccepted,
@@ -171,9 +169,7 @@ var _ = Describe("ResourceOffer Controller", func() {
 					Namespace: testNamespace,
 				},
 				Spec: sharingv1alpha1.ResourceOfferSpec{
-					ClusterId:  clusterID,
-					Timestamp:  metav1.Now(),
-					TimeToLive: metav1.NewTime(time.Now().Add(1 * time.Hour)),
+					ClusterId: clusterID,
 				},
 			},
 			expectedPhase: "",
@@ -193,9 +189,7 @@ var _ = Describe("ResourceOffer Controller", func() {
 					},
 				},
 				Spec: sharingv1alpha1.ResourceOfferSpec{
-					ClusterId:  clusterID,
-					Timestamp:  metav1.Now(),
-					TimeToLive: metav1.NewTime(time.Now().Add(1 * time.Hour)),
+					ClusterId: clusterID,
 				},
 			}
 			key := client.ObjectKeyFromObject(resourceOffer)

--- a/pkg/virtualKubelet/liqoNodeProvider/nodeProvider_test.go
+++ b/pkg/virtualKubelet/liqoNodeProvider/nodeProvider_test.go
@@ -172,9 +172,7 @@ var _ = Describe("NodeProvider", func() {
 					},
 				},
 				Spec: sharingv1alpha1.ResourceOfferSpec{
-					ClusterId:  "remote-id",
-					Timestamp:  metav1.NewTime(time.Now()),
-					TimeToLive: metav1.NewTime(time.Now().Add(1 * time.Hour)),
+					ClusterId: "remote-id",
 					ResourceQuota: v1.ResourceQuotaSpec{
 						Hard: v1.ResourceList{
 							v1.ResourceCPU:    *resource.NewQuantity(2, resource.DecimalSI),
@@ -266,9 +264,7 @@ var _ = Describe("NodeProvider", func() {
 					},
 				},
 				Spec: sharingv1alpha1.ResourceOfferSpec{
-					ClusterId:  "remote-id",
-					Timestamp:  metav1.NewTime(time.Now()),
-					TimeToLive: metav1.NewTime(time.Now().Add(1 * time.Hour)),
+					ClusterId: "remote-id",
 					ResourceQuota: v1.ResourceQuotaSpec{
 						Hard: v1.ResourceList{
 							v1.ResourceCPU:    *resource.NewQuantity(2, resource.DecimalSI),


### PR DESCRIPTION
# Description
This P.R. adds all the missing logic concerning the ResourceOffer update. 
Introduce a new component, the Updater, which use a workqueue to process all locally existing ResourceOffer and update the offered resources to all the peered clusters. Every change in cluster nodes/pods trigger this component adding a new key (the clusterID of the remote cluster) which identifies the resourceOffer that will be updated as soon as possible.
In case of a dropped peering the key will be removed from the queue.

Refers to fifth point of Issue #548
 