### PR TITLE
Remove Limits on Liqo deployments

### DIFF
--- a/deployments/liqo/templates/liqo-advertisement-deployment.yaml
+++ b/deployments/liqo/templates/liqo-advertisement-deployment.yaml
@@ -50,9 +50,6 @@ spec:
              fieldRef:
                fieldPath: metadata.namespace
         resources:
-          limits:
-            cpu: 100m
-            memory: 50M
           requests:
             cpu: 100m
-            memory: 50M
+            memory: 150M

--- a/deployments/liqo/templates/liqo-auth-deployment.yaml
+++ b/deployments/liqo/templates/liqo-auth-deployment.yaml
@@ -80,9 +80,6 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
           resources:
-            limits:
-              cpu: 100m
-              memory: 50M
             requests:
               cpu: 100m
               memory: 50M

--- a/deployments/liqo/templates/liqo-crd-replicator-deployment.yaml
+++ b/deployments/liqo/templates/liqo-crd-replicator-deployment.yaml
@@ -40,9 +40,6 @@ spec:
           - "--useNewAuth"
           {{- end }}
           resources:
-            limits:
-              cpu: 30m
-              memory: 50M
             requests:
               cpu: 30m
               memory: 50M

--- a/deployments/liqo/templates/liqo-network-manager-deployment.yaml
+++ b/deployments/liqo/templates/liqo-network-manager-deployment.yaml
@@ -35,9 +35,6 @@ spec:
           args:
             - "-run-as=tunnelEndpointCreator-operator"
           resources:
-            limits:
-              cpu: 20m
-              memory: 50M
             requests:
-              cpu: 20m
+              cpu: 50m
               memory: 50M

--- a/deployments/liqo/templates/liqo-peering-request-deployment.yaml
+++ b/deployments/liqo/templates/liqo-peering-request-deployment.yaml
@@ -51,9 +51,6 @@ spec:
               value: "{{ .Values.apiServer.trustedCA }}"
             {{- end }}
           resources:
-            limits:
-              cpu: 100m
-              memory: 50M
             requests:
               cpu: 100m
               memory: 50M

--- a/deployments/liqo/templates/liqo-route-daemonset.yaml
+++ b/deployments/liqo/templates/liqo-route-daemonset.yaml
@@ -44,9 +44,6 @@ spec:
           command: ["/usr/bin/liqonet"]
           args: ["-run-as=liqo-route"]
           resources:
-            limits:
-              cpu: 100m
-              memory: 80M
             requests:
               cpu: 100m
               memory: 80M

--- a/deployments/liqo/templates/liqo-webhook-deployment.yaml
+++ b/deployments/liqo/templates/liqo-webhook-deployment.yaml
@@ -47,9 +47,6 @@ spec:
             - mountPath: /etc/ssl/liqo
               name: cert-volume
           resources:
-            limits:
-              cpu: "1"
-              memory: "100M"
             requests:
               cpu: "200m"
               memory: "100M"
@@ -61,9 +58,6 @@ spec:
             - mountPath: /etc/ssl/liqo
               name: cert-volume
           resources:
-            limits:
-              cpu: 100m
-              memory: 50M
             requests:
               cpu: 100m
               memory: 50M

--- a/test/e2e/peering_e2e/basic_test.go
+++ b/test/e2e/peering_e2e/basic_test.go
@@ -30,7 +30,7 @@ var _ = Describe("Liqo E2E", func() {
 		testContext = tester.GetTester(ctx)
 		namespace   = "liqo"
 		interval    = 3 * time.Second
-		timeout     = 2 * time.Minute
+		timeout     = 5 * time.Minute
 	)
 
 	Describe("Assert that Liqo is up, pod offloading and network connectivity are working", func() {


### PR DESCRIPTION
# Description

This commit removes default values for limits in Liqo components deployments to avoid unwanted performance degradation.

# How Has This Been Tested?

There are no functional changes in this PR, just E2E testing though.