### PR TITLE
Integration tests for IPAM module

### DIFF
--- a/test/integration/endpoint_reflection_test.go
+++ b/test/integration/endpoint_reflection_test.go
@@ -1,0 +1,231 @@
+package integration_tests_test
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/containernetworking/plugins/pkg/ns"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/kubectl/pkg/util/slice"
+
+	liqonetIpam "github.com/liqotech/liqo/pkg/liqonet/ipam"
+)
+
+var _ = Describe("EndpointReflection", func() {
+	/*
+		The following tests intend to check that components supporting
+		applications that span across more than 2 clusters behave as they
+		are supposed to do. In particular, here the focus is mainly on the IPAM
+		module and on the Gateway: Virtual Kubelet is excluded from these tests.
+		The IPAM module is the main actor here, as it receives requests to map Endpoint IPs
+		from the VK (tests simulate this behavior). We'll ask IPAM module to
+		map remote endpoint IPs, therefore we expect IPAM to use an
+		IP taken from the ExternalCIDR. Whevener there's a remapping of this type
+		the IPAM should notify the Gateway about it. The GW in turn will
+		insert a new DNAT rule: tests will ensure those rules are present.
+	*/
+	Describe("Endpoint IP mapping", func() {
+		Context("Map the endpoint IP of a remote endpoint", func() {
+			It("DNAT rule should be inserted by the natmappingoperator", func() {
+				response, err := ipam.MapEndpointIP(context.Background(), &liqonetIpam.MapRequest{
+					ClusterID: clusterID1,
+					Ip:        remoteEndpointIP,
+				})
+				Expect(err).To(BeNil())
+				newEndpointIP := response.GetIp()
+				Expect(newEndpointIP).To(HavePrefix("10.80.")) // Local NAT ExternalCIDR is 10.80.0.0/24
+				Eventually(func() bool {
+					rules, err := listRulesInChainInCustomNs(fmt.Sprintf("LIQO-PRRT-MAP-CLS-%s", clusterID1))
+					if err != nil {
+						Fail(fmt.Sprintf("failed to list rules in chain %s: %s", fmt.Sprintf("LIQO-PRRT-MAP-CLS-%s", clusterID1), err))
+					}
+					if slice.ContainsString(rules, fmt.Sprintf("-d %s -j DNAT --to-destination %s", response.GetIp(), remoteEndpointIP), nil) {
+						return true
+					}
+					return false
+				}, timeout, interval).Should(BeTrue())
+			})
+		})
+		Context("Ask to map more IPs of a remote endpoints", func() {
+			It("DNAT rules should be inserted for each of them"+
+				" by the natmappingoperator", func() {
+				response, err := ipam.MapEndpointIP(context.Background(), &liqonetIpam.MapRequest{
+					ClusterID: clusterID1,
+					Ip:        remoteEndpointIP,
+				})
+				Expect(err).To(BeNil())
+				newEndpointIP := response.GetIp()
+				Expect(newEndpointIP).To(HavePrefix("10.80.")) // Local NAT ExternalCIDR is 10.80.0.0/24
+				Eventually(func() bool {
+					rules, err := listRulesInChainInCustomNs(fmt.Sprintf("LIQO-PRRT-MAP-CLS-%s", clusterID1))
+					if err != nil {
+						Fail(fmt.Sprintf("failed to list rules in chain %s: %s", fmt.Sprintf("LIQO-PRRT-MAP-CLS-%s", clusterID1), err))
+					}
+					if slice.ContainsString(rules, fmt.Sprintf("-d %s -j DNAT --to-destination %s", response.GetIp(), remoteEndpointIP), nil) {
+						return true
+					}
+					return false
+				}, timeout, interval).Should(BeTrue())
+				response, err = ipam.MapEndpointIP(context.Background(), &liqonetIpam.MapRequest{
+					ClusterID: clusterID1,
+					Ip:        remoteEndpointIP2,
+				})
+				Expect(err).To(BeNil())
+				newEndpointIP2 := response.GetIp()
+				Expect(newEndpointIP2).To(HavePrefix("10.80.")) // Local NAT ExternalCIDR is 10.80.0.0/24
+				Eventually(func() bool {
+					rules, err := listRulesInChainInCustomNs(fmt.Sprintf("LIQO-PRRT-MAP-CLS-%s", clusterID1))
+					if err != nil {
+						Fail(fmt.Sprintf("failed to list rules in chain %s: %s", fmt.Sprintf("LIQO-PRRT-MAP-CLS-%s", clusterID1), err))
+					}
+					// Should contain both rules
+					if slice.ContainsString(rules, fmt.Sprintf("-d %s -j DNAT --to-destination %s", newEndpointIP, remoteEndpointIP), nil) &&
+						slice.ContainsString(rules, fmt.Sprintf("-d %s -j DNAT --to-destination %s", newEndpointIP2, remoteEndpointIP2), nil) {
+						return true
+					}
+					return false
+				}, timeout, interval).Should(BeTrue())
+			})
+		})
+		Context("Map the same endpoint IP on more clusters", func() {
+			It("DNAT rules should be inserted by the natmappingoperator", func() {
+				response, err := ipam.MapEndpointIP(context.Background(), &liqonetIpam.MapRequest{
+					ClusterID: clusterID1,
+					Ip:        remoteEndpointIP,
+				})
+				Expect(err).To(BeNil())
+				newEndpointIPCluster1 := response.GetIp()
+				Expect(newEndpointIPCluster1).To(HavePrefix("10.80.")) // Local NAT ExternalCIDR is 10.80.0.0/24
+				Eventually(func() bool {
+					rules, err := listRulesInChainInCustomNs(fmt.Sprintf("LIQO-PRRT-MAP-CLS-%s", clusterID1))
+					if err != nil {
+						Fail(fmt.Sprintf("failed to list rules in chain %s: %s", fmt.Sprintf("LIQO-PRRT-MAP-CLS-%s", clusterID1), err))
+					}
+					if slice.ContainsString(rules, fmt.Sprintf("-d %s -j DNAT --to-destination %s", newEndpointIPCluster1, remoteEndpointIP), nil) {
+						return true
+					}
+					return false
+				}, timeout, interval).Should(BeTrue())
+				response, err = ipam.MapEndpointIP(context.Background(), &liqonetIpam.MapRequest{
+					ClusterID: clusterID2,
+					Ip:        remoteEndpointIP,
+				})
+				Expect(err).To(BeNil())
+				newEndpointIPCluster2 := response.GetIp()
+				Expect(newEndpointIPCluster2).To(HavePrefix("10.80.")) // Local NAT ExternalCIDR is 10.80.0.0/24
+				Eventually(func() bool {
+					rules, err := listRulesInChainInCustomNs(fmt.Sprintf("LIQO-PRRT-MAP-CLS-%s", clusterID1))
+					if err != nil {
+						Fail(fmt.Sprintf("failed to list rules in chain %s: %s", fmt.Sprintf("LIQO-PRRT-MAP-CLS-%s", clusterID2), err))
+					}
+					if slice.ContainsString(rules, fmt.Sprintf("-d %s -j DNAT --to-destination %s", newEndpointIPCluster2, remoteEndpointIP), nil) {
+						return true
+					}
+					return false
+				}, timeout, interval).Should(BeTrue())
+			})
+		})
+	})
+	Describe("Terminate an Endpoint IP mapping", func() {
+		Context("Ask to terminate to map the IP of a remote endpoint", func() {
+			It("IPAM module should return no errors and a DNAT rule should be deleted"+
+				" by the natmappingoperator", func() {
+				response, err := ipam.MapEndpointIP(context.Background(), &liqonetIpam.MapRequest{
+					ClusterID: clusterID1,
+					Ip:        remoteEndpointIP,
+				})
+				Expect(err).To(BeNil())
+				Expect(response.GetIp()).To(HavePrefix("10.80.")) // Local NAT ExternalCIDR is 10.80.0.0/24
+				Eventually(func() bool {
+					rules, err := listRulesInChainInCustomNs(fmt.Sprintf("LIQO-PRRT-MAP-CLS-%s", clusterID1))
+					if err != nil {
+						Fail(fmt.Sprintf("failed to list rules in chain %s: %s", fmt.Sprintf("LIQO-PRRT-MAP-CLS-%s", clusterID1), err))
+					}
+					if slice.ContainsString(rules, fmt.Sprintf("-d %s -j DNAT --to-destination %s", response.GetIp(), remoteEndpointIP), nil) {
+						return true
+					}
+					return false
+				}, timeout, interval).Should(BeTrue())
+				_, err = ipam.UnmapEndpointIP(context.Background(), &liqonetIpam.UnmapRequest{
+					ClusterID: clusterID1,
+					Ip:        remoteEndpointIP,
+				})
+				Expect(err).To(BeNil())
+				Eventually(func() bool {
+					rules, err := listRulesInChainInCustomNs(fmt.Sprintf("LIQO-PRRT-MAP-CLS-%s", clusterID1))
+					if err != nil {
+						Fail(fmt.Sprintf("failed to list rules in chain %s: %s", fmt.Sprintf("LIQO-PRRT-MAP-CLS-%s", clusterID1), err))
+					}
+					if !slice.ContainsString(rules, fmt.Sprintf("-d %s -j DNAT --to-destination %s", response.GetIp(), remoteEndpointIP), nil) {
+						return true
+					}
+					return false
+				}, timeout, interval).Should(BeTrue())
+			})
+		})
+		Context("Ask to terminate to map the IP of a remote endpoint while there are other still active", func() {
+			It("DNAT rule should be deleted only for the requested endpoint"+
+				" by the natmappingoperator", func() {
+				// Map remoteEndpointIP and remoteEndpointIP2
+				response, err := ipam.MapEndpointIP(context.Background(), &liqonetIpam.MapRequest{
+					ClusterID: clusterID1,
+					Ip:        remoteEndpointIP,
+				})
+				Expect(err).To(BeNil())
+				newEndpointIP := response.GetIp()
+				Expect(newEndpointIP).To(HavePrefix("10.80.")) // Local NAT ExternalCIDR is 10.80.0.0/24
+				response, err = ipam.MapEndpointIP(context.Background(), &liqonetIpam.MapRequest{
+					ClusterID: clusterID1,
+					Ip:        remoteEndpointIP2,
+				})
+				Expect(err).To(BeNil())
+				newEndpointIP2 := response.GetIp()
+				Expect(newEndpointIP2).To(HavePrefix("10.80.")) // Local NAT ExternalCIDR is 10.80.0.0/24
+				Eventually(func() bool {
+					rules, err := listRulesInChainInCustomNs(fmt.Sprintf("LIQO-PRRT-MAP-CLS-%s", clusterID1))
+					if err != nil {
+						Fail(fmt.Sprintf("failed to list rules in chain %s: %s", fmt.Sprintf("LIQO-PRRT-MAP-CLS-%s", clusterID1), err))
+					}
+					// Should contain both rules
+					if slice.ContainsString(rules, fmt.Sprintf("-d %s -j DNAT --to-destination %s", newEndpointIP, remoteEndpointIP), nil) &&
+						slice.ContainsString(rules, fmt.Sprintf("-d %s -j DNAT --to-destination %s", newEndpointIP2, remoteEndpointIP2), nil) {
+						return true
+					}
+					return false
+				}, timeout, interval).Should(BeTrue())
+				// Terminate only mapping of remoteEndpointIP
+				_, err = ipam.UnmapEndpointIP(context.Background(), &liqonetIpam.UnmapRequest{
+					ClusterID: clusterID1,
+					Ip:        remoteEndpointIP,
+				})
+				Expect(err).To(BeNil())
+				Eventually(func() bool {
+					rules, err := listRulesInChainInCustomNs(fmt.Sprintf("LIQO-PRRT-MAP-CLS-%s", clusterID1))
+					if err != nil {
+						Fail(fmt.Sprintf("failed to list rules in chain %s: %s", fmt.Sprintf("LIQO-PRRT-MAP-CLS-%s", clusterID1), err))
+					}
+					// Rule for remoteEndpointIP2 should be still present
+					if !slice.ContainsString(rules, fmt.Sprintf("-d %s -j DNAT --to-destination %s", newEndpointIP, remoteEndpointIP), nil) &&
+						slice.ContainsString(rules, fmt.Sprintf("-d %s -j DNAT --to-destination %s", newEndpointIP2, remoteEndpointIP2), nil) {
+						return true
+					}
+					return false
+				}, timeout, interval).Should(BeTrue())
+			})
+		})
+	})
+})
+
+func listRulesInChainInCustomNs(chain string) ([]string, error) {
+	var rules []string
+	var err error
+	err = iptNetns.Do(func(nn ns.NetNS) error {
+		rules, err = ipt.ListRulesInChain(chain)
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+	return rules, nil
+}

--- a/test/integration/integration_suite_test.go
+++ b/test/integration/integration_suite_test.go
@@ -1,0 +1,235 @@
+package integration_tests_test
+
+import (
+	"context"
+	"crypto/rand"
+	"math/big"
+	"path/filepath"
+	sync "sync"
+	"testing"
+	"time"
+
+	"github.com/containernetworking/plugins/pkg/ns"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/kubectl/pkg/scheme"
+	controllerruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+
+	netv1alpha1 "github.com/liqotech/liqo/apis/net/v1alpha1"
+	tunneloperator "github.com/liqotech/liqo/internal/liqonet/tunnel-operator"
+	liqonetIpam "github.com/liqotech/liqo/pkg/liqonet/ipam"
+	"github.com/liqotech/liqo/pkg/liqonet/iptables"
+	"github.com/liqotech/liqo/pkg/liqonet/netns"
+)
+
+const (
+	iptNetnsName       = "iptNetNs"
+	clusterID1         = "cluster1"
+	clusterID2         = "cluster2"
+	remotePodCIDR      = "10.50.0.0/16"
+	remoteExternalCIDR = "10.60.0.0/16"
+	localPodCIDR       = "10.70.0.0/16"
+	localExternalCIDR  = "10.80.0.0/16"
+	homePodCIDR        = "10.0.0.0/24"
+	remoteEndpointIP   = "12.0.3.4"
+	remoteEndpointIP2  = "12.0.5.4"
+	timeout            = time.Second * 10
+	interval           = time.Millisecond * 250
+)
+
+var (
+	err                error
+	envTest            *envtest.Environment
+	ipt                iptables.IPTHandler
+	ipam               *liqonetIpam.IPAM
+	homeExternalCIDR   string
+	k8sClient          client.Client
+	dynClient          dynamic.Interface
+	controller         *tunneloperator.NatMappingController
+	readyClustersMutex sync.Mutex
+	readyClusters      = map[string]struct{}{
+		clusterID1: {},
+		clusterID2: {},
+	}
+	iptNetns ns.NetNS
+	tep1     = &netv1alpha1.TunnelEndpoint{
+		Spec: netv1alpha1.TunnelEndpointSpec{
+			ClusterID:    clusterID1,
+			PodCIDR:      "10.0.0.0/24",
+			ExternalCIDR: "10.0.1.0/24",
+		},
+		Status: netv1alpha1.TunnelEndpointStatus{
+			LocalPodCIDR:          "192.168.0.0/24",
+			LocalNATPodCIDR:       "192.168.1.0/24",
+			RemoteNATPodCIDR:      "10.0.70.0/24",
+			LocalExternalCIDR:     "192.168.3.0/24",
+			LocalNATExternalCIDR:  "192.168.4.0/24",
+			RemoteNATExternalCIDR: "192.168.5.0/24",
+		},
+	}
+	tep2 = &netv1alpha1.TunnelEndpoint{
+		Spec: netv1alpha1.TunnelEndpointSpec{
+			ClusterID:    clusterID2,
+			PodCIDR:      "10.0.0.0/24",
+			ExternalCIDR: "10.0.1.0/24",
+		},
+		Status: netv1alpha1.TunnelEndpointStatus{
+			LocalPodCIDR:          "192.168.0.0/24",
+			LocalNATPodCIDR:       "192.168.1.0/24",
+			RemoteNATPodCIDR:      "10.0.70.0/24",
+			LocalExternalCIDR:     "192.168.3.0/24",
+			LocalNATExternalCIDR:  "192.168.4.0/24",
+			RemoteNATExternalCIDR: "192.168.5.0/24",
+		},
+	}
+)
+
+func TestIntegration(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Integration Suite")
+}
+
+var _ = BeforeSuite(func() {
+	// Create custom network namespace for natmapping-operator.
+	iptNetns, err = netns.CreateNetns(iptNetnsName)
+	Expect(err).To(BeNil())
+
+	// Config NAT driver for remote clusters
+	err = initNATDriver()
+	Expect(err).To(BeNil())
+
+	// Launch natmapping operator
+	err = initNatMappingController()
+	Expect(err).To(BeNil())
+
+	// Init Ipam
+	err = initIpam()
+	Expect(err).To(BeNil())
+})
+
+var _ = AfterSuite(func() {
+	err := envTest.Stop()
+	Expect(err).To(BeNil())
+	err = terminateNATDriver()
+	Expect(err).To(BeNil())
+	err = iptNetns.Close()
+	Expect(err).To(BeNil())
+})
+
+func initNatMappingController() error {
+	err = netv1alpha1.AddToScheme(scheme.Scheme)
+	if err != nil {
+		return err
+	}
+	envTest = &envtest.Environment{
+		CRDDirectoryPaths: []string{filepath.Join("..", "..", "deployments", "liqo", "crds")},
+	}
+	config, err := envTest.Start()
+	if err != nil {
+		return err
+	}
+	mgr, err := controllerruntime.NewManager(config, controllerruntime.Options{
+		Scheme:             scheme.Scheme,
+		MetricsBindAddress: "0",
+	})
+
+	controller, err = tunneloperator.NewNatMappingController(mgr.GetClient(), &readyClustersMutex, readyClusters, iptNetns)
+	if err != nil {
+		return err
+	}
+	go func() {
+		if err = mgr.Start(context.Background()); err != nil {
+			panic(err)
+		}
+	}()
+	dynClient = dynamic.NewForConfigOrDie(mgr.GetConfig())
+	k8sClient = mgr.GetClient()
+	return controller.SetupWithManager(mgr)
+}
+
+func initIpam() error {
+	ipam = liqonetIpam.NewIPAM()
+	n, err := rand.Int(rand.Reader, big.NewInt(2000))
+	if err != nil {
+		return err
+	}
+	err = ipam.Init(liqonetIpam.Pools, dynClient, 2000+int(n.Int64()))
+	if err != nil {
+		return err
+	}
+	// Set home cluster PodCIDR and ExternalCIDR
+	err = ipam.SetPodCIDR(homePodCIDR)
+	if err != nil {
+		return err
+	}
+	homeExternalCIDR, err = ipam.GetExternalCIDR(uint8(24))
+	if err != nil {
+		return err
+	}
+	// Assign networks to clusterID1
+	_, _, err = ipam.GetSubnetsPerCluster(remotePodCIDR, remoteExternalCIDR, clusterID1)
+	if err != nil {
+		return err
+	}
+	err = ipam.AddLocalSubnetsPerCluster(localPodCIDR, localExternalCIDR, clusterID1)
+	if err != nil {
+		return err
+	}
+	// Assign networks to clusterID2
+	_, _, err = ipam.GetSubnetsPerCluster(remotePodCIDR, remoteExternalCIDR, clusterID2)
+	if err != nil {
+		return err
+	}
+	return ipam.AddLocalSubnetsPerCluster(localPodCIDR, localExternalCIDR, clusterID2)
+}
+
+func terminateNATDriver() error {
+	err := iptNetns.Do(func(nn ns.NetNS) error {
+		var err error
+		err = ipt.RemoveIPTablesConfigurationPerCluster(tep1)
+		if err != nil {
+			return err
+		}
+		err = ipt.RemoveIPTablesConfigurationPerCluster(tep2)
+		if err != nil {
+			return err
+		}
+		err = ipt.Terminate()
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+	return err
+}
+
+func initNATDriver() error {
+	err := iptNetns.Do(func(nn ns.NetNS) error {
+		var err error
+		// Allocate new IPTables handler
+		ipt, err = iptables.NewIPTHandler()
+		if err != nil {
+			return err
+		}
+		if err := ipt.Init(); err != nil {
+			return err
+		}
+		if err := ipt.EnsureChainsPerCluster(clusterID1); err != nil {
+			return err
+		}
+		if err := ipt.EnsureChainRulesPerCluster(tep1); err != nil {
+			return err
+		}
+		if err := ipt.EnsureChainsPerCluster(clusterID2); err != nil {
+			return err
+		}
+		if err := ipt.EnsureChainRulesPerCluster(tep2); err != nil {
+			return err
+		}
+		return nil
+	})
+	return err
+}


### PR DESCRIPTION
This PR introduces a set of integration tests for the IPAM module. This important Liqo component is involved in the remapping of IPs of remote endpoints to be reflected in foreign clusters: in particular the IPAM is asked to map an IP by the Virtual Kubelet, responsible of service reflections. However, the VK is not itested in this PR. When the IPAM maps an IP with ExternalCIDR network, it notifies the Gateway via the NatMapping resource, that in turn adds the appropriate DNAT rules. This PR consists of tests on the communication between the IPAM and the Gateway, as well as tests on the correct update of NAT rules by the Gateway.
