### PR TITLE
Enable Leader Election for liqo-gateway operator

### DIFF
--- a/deployments/liqo/files/liqo-gateway-ClusterRole.yaml
+++ b/deployments/liqo/files/liqo-gateway-ClusterRole.yaml
@@ -1,15 +1,5 @@
 rules:
 - apiGroups:
-  - config.liqo.io
-  resources:
-  - clusterconfigs
-  verbs:
-  - create
-  - get
-  - list
-  - update
-  - watch
-- apiGroups:
   - ""
   resources:
   - events

--- a/deployments/liqo/files/liqo-gateway-Role.yaml
+++ b/deployments/liqo/files/liqo-gateway-Role.yaml
@@ -1,5 +1,13 @@
 rules:
 - apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - update
+- apiGroups:
   - ""
   resources:
   - pods
@@ -18,14 +26,5 @@ rules:
   - get
   - list
   - patch
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - services
-  verbs:
-  - get
-  - list
   - update
   - watch

--- a/deployments/liqo/templates/_helpers.tpl
+++ b/deployments/liqo/templates/_helpers.tpl
@@ -96,10 +96,19 @@ Create the file name of a cluster role starting from a prefix, it accepts a dict
 {{- end }}
 
 {{/*
-Gateway pod labels
+Gateway pod labels.
+If you change any value here, please make sure that you change it also in the source code.
 */}}
 {{- define "liqo.gatewayPodLabels" -}}
-net.liqo.io/gatewayPod: "true"
+net.liqo.io/gateway: "standby"
+{{- end }}
+
+{{/*
+Label selector used by the gateway service to select the right gateway pod.
+If you change any value here, please make sure that you change it also in the source code.
+*/}}
+{{- define "liqo.gatewaySelector" -}}
+net.liqo.io/gateway: "active"
 {{- end }}
 
 {{/*

--- a/deployments/liqo/templates/liqo-gateway-deployment.yaml
+++ b/deployments/liqo/templates/liqo-gateway-deployment.yaml
@@ -22,7 +22,6 @@ spec:
     {{- end }}
       labels:
         {{- include "liqo.labels" $gatewayConfig | nindent 8 }}
-        {{- include "liqo.gatewayPodLabels" . | nindent 8 }}
         {{- if .Values.gateway.pod.labels }}
           {{- toYaml .Values.gateway.pod.labels | nindent 8 }}
         {{- end }}
@@ -35,11 +34,13 @@ spec:
           ports:
           - containerPort: 5871
           command: ["/usr/bin/liqonet"]
-          args: ["-run-as=liqo-gateway"]
+          args:
+          - -run-as=liqo-gateway
+          - -leader-elect=true
           resources:
             limits:
-              cpu: 10m
-              memory: 30M
+              cpu: 500m
+              memory: 300M
             requests:
               cpu: 10m
               memory: 30M

--- a/deployments/liqo/templates/liqo-gateway-service.yaml
+++ b/deployments/liqo/templates/liqo-gateway-service.yaml
@@ -19,8 +19,5 @@ spec:
       port: 5871
       targetPort: 5871
       protocol: UDP
-    - name: wireguard-overlay
-      port: 51871
-      protocol: UDP
   selector:
-    {{- include "liqo.gatewayPodLabels" $gatewayConfig | nindent 4 }}
+    {{- include "liqo.gatewaySelector" $gatewayConfig | nindent 4 }}

--- a/internal/liqonet/tunnel-operator/labelerOperator.go
+++ b/internal/liqonet/tunnel-operator/labelerOperator.go
@@ -1,0 +1,91 @@
+package tunneloperator
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/klog/v2"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	liqoutils "github.com/liqotech/liqo/pkg/liqonet/utils"
+)
+
+var (
+	// This labels are the ones set during the deployment of liqo using the helm chart.
+	// Any change to those labels on the helm chart has also to be reflected here.
+	podInstanceLabelKey       = "app.kubernetes.io/instance"
+	podInstanceLabelValue     = "liqo-gateway"
+	podNameLabelKey           = "app.kubernetes.io/name"
+	podNameLabelValue         = "gateway"
+	serviceSelectorLabelKey   = "net.liqo.io/gatewayPod"
+	serviceSelectorLabelValue = "true"
+	// LabelSelector instructs the informer to only cache the pod objects that satisfies the selector.
+	// Only the pod objects with the right labels will be reconciled.
+	LabelSelector = cache.SelectorsByObject{
+		&corev1.Pod{}: {
+			Label: labels.SelectorFromSet(labels.Set{
+				podInstanceLabelKey: podInstanceLabelValue,
+				podNameLabelKey:     podNameLabelValue,
+			}),
+		},
+	}
+)
+
+// LabelerController reconciles pods objects, in our case the tunnel operator pods.
+type LabelerController struct {
+	client.Client
+	PodIP string
+}
+
+// NewLabelerController  returns a new controller ready to be setup and started with the controller manager.
+func NewLabelerController(podIP string, cl client.Client) *LabelerController {
+	return &LabelerController{
+		Client: cl,
+		PodIP:  podIP,
+	}
+}
+
+// Reconcile for a given pod, replica of the current operator, it checks if it is the current pod
+// meaning the pod where this code is running. If yes, then it adds a the label to the pod if it does
+// not have it. If the pod is not the current one the operator makes sure that it does not have the
+// label by removing it if present.
+func (lbc *LabelerController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	pod := new(corev1.Pod)
+	err := lbc.Get(ctx, req.NamespacedName, pod)
+	if err != nil {
+		klog.Errorf("an error occurred while getting pod {%s}: %v", req.NamespacedName, err)
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+	// If it is our pod/current pod then add the right label.
+	if lbc.PodIP == pod.Status.PodIP {
+		if liqoutils.AddLabelToObj(pod, serviceSelectorLabelKey, serviceSelectorLabelValue) {
+			if err := lbc.Update(ctx, pod); err != nil {
+				klog.Errorf("an error occurred while adding selector label to pod {%s}: %v", req.String(), err)
+				return ctrl.Result{}, err
+			}
+			klog.Infof("successfully added label {%s: %s} to pod {%s}",
+				serviceSelectorLabelKey, serviceSelectorLabelValue, req.String())
+		}
+		return ctrl.Result{}, nil
+	}
+	// Make sure that the other replicas does not have the selector label.
+	if val := liqoutils.GetLabelValueFromObj(pod, serviceSelectorLabelKey); val != "" {
+		delete(pod.GetLabels(), serviceSelectorLabelKey)
+		if err := lbc.Update(ctx, pod); err != nil {
+			klog.Errorf("an error occurred while removing selector label to pod {%s}: %v", req.String(), err)
+			return ctrl.Result{}, err
+		}
+		klog.Infof("successfully removed label {%s: %s} to pod {%s}",
+			serviceSelectorLabelKey, serviceSelectorLabelValue, req.String())
+	}
+	return ctrl.Result{}, nil
+}
+
+// SetupWithManager used to set up the controller with a given manager.
+func (lbc *LabelerController) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).For(&corev1.Pod{}).
+		Complete(lbc)
+}

--- a/internal/liqonet/tunnel-operator/labelerOperator_test.go
+++ b/internal/liqonet/tunnel-operator/labelerOperator_test.go
@@ -1,0 +1,219 @@
+package tunneloperator
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+var (
+	// IP given to the labelerController.
+	labelerCurrentPodIP = "10.1.1.1"
+	// IP given to pods that simulate other replicas of the operator.
+	labelerOtherPodIP = "10.2.2.2"
+	labelerTestPod    *corev1.Pod
+	labelerNamespace  = "labeler-namespace"
+	labelerPodName    = "labeler-test-pod"
+	labelerReq        ctrl.Request
+	// Controller to be tested.
+	lbc *LabelerController
+)
+
+var _ = Describe("LabelerOperator", func() {
+	// Before each test we create an empty pod.
+	// The right fields will be filled according to each test case.
+	JustBeforeEach(func() {
+		labelerReq = ctrl.Request{
+			NamespacedName: types.NamespacedName{
+				Namespace: labelerNamespace,
+				Name:      labelerPodName,
+			},
+		}
+		// Create the test pod with the labels already set.
+		labelerTestPod = &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      labelerReq.Name,
+				Namespace: labelerReq.Namespace,
+			},
+			Spec: corev1.PodSpec{
+				NodeName: "overlaytestnodename",
+				Containers: []corev1.Container{
+					{
+						Name:            "busybox",
+						Image:           "busybox",
+						ImagePullPolicy: corev1.PullIfNotPresent,
+						Command: []string{
+							"sleep",
+							"3600",
+						},
+					},
+				},
+			},
+		}
+		lbc = &LabelerController{
+			PodIP:  labelerCurrentPodIP,
+			Client: k8sClient,
+		}
+	})
+
+	Describe("testing NewOverlayOperator function", func() {
+		Context("when input parameters are correct", func() {
+			It("should return labeler controller ", func() {
+				lbc1 := NewLabelerController(labelerCurrentPodIP, k8sClient)
+				Expect(lbc1).ShouldNot(BeNil())
+			})
+		})
+	})
+
+	Describe("testing reconcile function", func() {
+		Context("when the pod is the current one", func() {
+			It("pod does not have the label, should label the pod", func() {
+				Eventually(func() error { return k8sClient.Create(context.TODO(), labelerTestPod) }).Should(BeNil())
+				newPod := &corev1.Pod{}
+				Eventually(func() error { return k8sClient.Get(context.TODO(), labelerReq.NamespacedName, newPod) }).Should(BeNil())
+				newPod.Status.PodIP = labelerCurrentPodIP
+				// Set IP address of the newly created pod.
+				Eventually(func() error { return k8sClient.Status().Update(context.TODO(), newPod) }).Should(BeNil())
+				// Check that the IP address has been set.
+				Eventually(func() error {
+					err := k8sClient.Get(context.TODO(), labelerReq.NamespacedName, newPod)
+					if err != nil {
+						return err
+					}
+					if newPod.Status.PodIP != labelerCurrentPodIP {
+						return fmt.Errorf("pod ip has not been set yet")
+					}
+					return nil
+				}).Should(BeNil())
+				Eventually(func() error { _, err := lbc.Reconcile(context.TODO(), labelerReq); return err }).Should(BeNil())
+				Eventually(func() error {
+					err := k8sClient.Get(context.TODO(), labelerReq.NamespacedName, newPod)
+					if err != nil {
+						return err
+					}
+					if newPod.GetLabels()[serviceSelectorLabelKey] != serviceSelectorLabelValue {
+						return fmt.Errorf(" error: label %s is different than %s", newPod.GetLabels()[serviceSelectorLabelKey], serviceSelectorLabelValue)
+					}
+					return nil
+				}).Should(BeNil())
+			})
+
+			It("pod does have the label, should not change the pod", func() {
+				const podName = "current-pod-with-labels"
+				labelerReq.Name = podName
+				labelerTestPod.Name = podName
+				labelerTestPod.SetLabels(map[string]string{
+					serviceSelectorLabelKey: serviceSelectorLabelValue,
+				})
+				Eventually(func() error { return k8sClient.Create(context.TODO(), labelerTestPod) }).Should(BeNil())
+				newPod := &corev1.Pod{}
+				Eventually(func() error { return k8sClient.Get(context.TODO(), labelerReq.NamespacedName, newPod) }).Should(BeNil())
+				newPod.Status.PodIP = labelerCurrentPodIP
+				// Set IP address of the newly created pod.
+				Eventually(func() error { return k8sClient.Status().Update(context.TODO(), newPod) }).Should(BeNil())
+				// Check that the IP address has been set.
+				Eventually(func() error {
+					err := k8sClient.Get(context.TODO(), labelerReq.NamespacedName, newPod)
+					if err != nil {
+						return err
+					}
+					if newPod.Status.PodIP != labelerCurrentPodIP {
+						return fmt.Errorf("pod ip has not been set yet")
+					}
+					return nil
+				}).Should(BeNil())
+				Eventually(func() error { _, err := lbc.Reconcile(context.TODO(), labelerReq); return err }).Should(BeNil())
+				Eventually(func() error {
+					err := k8sClient.Get(context.TODO(), labelerReq.NamespacedName, newPod)
+					if err != nil {
+						return err
+					}
+					if newPod.GetLabels()[serviceSelectorLabelKey] != serviceSelectorLabelValue {
+						return fmt.Errorf(" error: label %s is different than %s", newPod.GetLabels()[serviceSelectorLabelKey], serviceSelectorLabelValue)
+					}
+					return nil
+				}).Should(BeNil())
+			})
+		})
+
+		Context("when the pod is not the current one", func() {
+			It("pod does not have the label, does nothing", func() {
+				const podName = "other-pod-without-labels"
+				labelerReq.Name = podName
+				labelerTestPod.Name = podName
+				Eventually(func() error { return k8sClient.Create(context.TODO(), labelerTestPod) }).Should(BeNil())
+				newPod := &corev1.Pod{}
+				Eventually(func() error { return k8sClient.Get(context.TODO(), labelerReq.NamespacedName, newPod) }).Should(BeNil())
+				newPod.Status.PodIP = labelerOtherPodIP
+				// Set IP address of the newly created pod.
+				Eventually(func() error { return k8sClient.Status().Update(context.TODO(), newPod) }).Should(BeNil())
+				// Check that the IP address has been set.
+				Eventually(func() error {
+					err := k8sClient.Get(context.TODO(), labelerReq.NamespacedName, newPod)
+					if err != nil {
+						return err
+					}
+					if newPod.Status.PodIP != labelerOtherPodIP {
+						return fmt.Errorf("pod ip has not been set yet")
+					}
+					return nil
+				}).Should(BeNil())
+				Eventually(func() error { _, err := lbc.Reconcile(context.TODO(), labelerReq); return err }).Should(BeNil())
+			})
+
+			It("pod does have the label, should remove the label", func() {
+				const podName = "other-pod-with-labels"
+				labelerReq.Name = podName
+				labelerTestPod.Name = podName
+				labelerTestPod.SetLabels(map[string]string{
+					serviceSelectorLabelKey: serviceSelectorLabelValue,
+				})
+				Eventually(func() error { return k8sClient.Create(context.TODO(), labelerTestPod) }).Should(BeNil())
+				newPod := &corev1.Pod{}
+				Eventually(func() error { return k8sClient.Get(context.TODO(), labelerReq.NamespacedName, newPod) }).Should(BeNil())
+				newPod.Status.PodIP = labelerOtherPodIP
+				// Set IP address of the newly created pod.
+				Eventually(func() error { return k8sClient.Status().Update(context.TODO(), newPod) }).Should(BeNil())
+				// Check that the IP address has been set.
+				Eventually(func() error {
+					err := k8sClient.Get(context.TODO(), labelerReq.NamespacedName, newPod)
+					if err != nil {
+						return err
+					}
+					if newPod.Status.PodIP != labelerOtherPodIP {
+						return fmt.Errorf("pod ip has not been set yet")
+					}
+					return nil
+				}).Should(BeNil())
+				Eventually(func() error { _, err := lbc.Reconcile(context.TODO(), labelerReq); return err }).Should(BeNil())
+				Eventually(func() error {
+					err := k8sClient.Get(context.TODO(), labelerReq.NamespacedName, newPod)
+					if err != nil {
+						return err
+					}
+					if newPod.GetLabels()[serviceSelectorLabelKey] != "" {
+						return fmt.Errorf(" error: label %s is different than empty string", newPod.GetLabels()[serviceSelectorLabelKey])
+					}
+					return nil
+				}).Should(BeNil())
+			})
+		})
+
+		Context("pod does not exit", func() {
+			It("shold return nil", func() {
+				const podName = "pod-does-not-exist"
+				labelerReq.Name = podName
+				labelerTestPod.Name = podName
+				_, err := lbc.Reconcile(context.TODO(), labelerReq)
+				Expect(err).Should(BeNil())
+			})
+		})
+
+	})
+})

--- a/internal/liqonet/tunnel-operator/tunnel-operator.go
+++ b/internal/liqonet/tunnel-operator/tunnel-operator.go
@@ -78,10 +78,9 @@ type TunnelController struct {
 // +kubebuilder:rbac:groups=net.liqo.io,resources=tunnelendpoints,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=net.liqo.io,resources=tunnelendpoints/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=core,resources=events,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=config.liqo.io,resources=clusterconfigs,verbs=get;list;watch;create;update
 // role
+// +kubebuilder:rbac:groups=coordination.k8s.io,namespace="do-not-care",resources=leases,verbs=get;create;update
 // +kubebuilder:rbac:groups=core,namespace="do-not-care",resources=secrets,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=core,namespace="do-not-care",resources=services,verbs=get;list;watch;update
 // +kubebuilder:rbac:groups=core,namespace="do-not-care",resources=pods,verbs=get;list;watch;update
 
 // NewTunnelController instantiates and initializes the tunnel controller.

--- a/internal/liqonet/tunnel-operator/tunnel_operator_suite_test.go
+++ b/internal/liqonet/tunnel-operator/tunnel_operator_suite_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/containernetworking/plugins/pkg/ns"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -115,6 +117,13 @@ var _ = BeforeSuite(func() {
 		}
 	}()
 	k8sClient = mgr.GetClient()
+	// Create labeler test namespace.
+	labNamespace := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: labelerNamespace,
+		},
+	}
+	Eventually(func() error { return k8sClient.Create(context.TODO(), labNamespace) }).Should(BeNil())
 	// We reconcile on a resource that does not exist with
 	// an Eventually block in order to wait for
 	// cache to start and then begin with unit tests.

--- a/internal/liqonet/tunnelEndpointCreator/gatewayPodWatcher.go
+++ b/internal/liqonet/tunnelEndpointCreator/gatewayPodWatcher.go
@@ -19,11 +19,16 @@ import (
 )
 
 var (
-	podResource     = "pods"
-	GwPodLabelKey   = "net.liqo.io/gatewayPod"
-	GwPodLabelValue = "true"
+	podResource = "pods"
+	// GwPodLabelKey label key used to get the gateway pod.
+	GwPodLabelKey = "net.liqo.io/gateway"
+	// GwPodLabelValue label value used to get the gateway pod.
+	GwPodLabelValue = "active"
 )
 
+// StartGWPodWatcher starts the informer for the gateway pod.
+// TODO: this code will be removed in the next PR. The functionality will be moved
+// in the labelOperator inside the gateway component.
 func (tec *TunnelEndpointCreator) StartGWPodWatcher() {
 	dynFactory := dynamicinformer.NewFilteredDynamicSharedInformerFactory(tec.DynClient, ResyncPeriod, tec.Namespace, setGWPodSelectorLabel)
 	go tec.Watcher(dynFactory, corev1.SchemeGroupVersion.WithResource(podResource), cache.ResourceEventHandlerFuncs{

--- a/pkg/consts/liqonet.go
+++ b/pkg/consts/liqonet.go
@@ -37,6 +37,8 @@ const (
 	LiqoRouteOperatorName = "liqo-route"
 	// LiqoGatewayOperatorName name of the operator.
 	LiqoGatewayOperatorName = "liqo-gateway"
+	// GatewayLeaderElectionID used as name for the lease.coordination.k8s.io resource.
+	GatewayLeaderElectionID = "1d5hml1.gateway.net.liqo.io"
 	// GatewayNetnsName name of the custom network namespace used by liqo-gateway.
 	GatewayNetnsName = "liqo-netns"
 	// HostVethName name of the veth device living in the host network namespace,

--- a/pkg/liqonet/utils/utils.go
+++ b/pkg/liqonet/utils/utils.go
@@ -19,6 +19,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/klog"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	netv1alpha1 "github.com/liqotech/liqo/apis/net/v1alpha1"
 	"github.com/liqotech/liqo/internal/utils/errdefs"
@@ -340,4 +341,58 @@ func GetOverlayIP(ip string) string {
 	}
 	tokens := strings.Split(ip, ".")
 	return strings.Join([]string{consts.OverlayNetworkPrefix, tokens[1], tokens[2], tokens[3]}, ".")
+}
+
+// AddAnnotationToObj for a given object it adds the annotation with the given key and value.
+// It return a bool which is true when the annotations has been added or false if the
+// annotation is already present.
+func AddAnnotationToObj(obj client.Object, aKey, aValue string) bool {
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string, 1)
+	}
+	oldAnnValue, ok := annotations[aKey]
+	// If the annotations does not exist or is outdated then set it.
+	if !ok || oldAnnValue != aValue {
+		annotations[aKey] = aValue
+		obj.SetAnnotations(annotations)
+		return true
+	}
+	return false
+}
+
+// GetAnnotationValueFromObj for a given object it return the value of the label denoted by the
+// given key. If the key does not exist it returns an empty string.
+func GetAnnotationValueFromObj(obj client.Object, akey string) string {
+	if obj.GetAnnotations() == nil {
+		return ""
+	}
+	return obj.GetAnnotations()[akey]
+}
+
+// AddLabelToObj for a given object it adds the label with the given key and value.
+// It return a bool which is true when the label has been added or false if the
+// label is already present.
+func AddLabelToObj(obj client.Object, labelKey, labelValue string) bool {
+	labels := obj.GetLabels()
+	if labels == nil {
+		labels = make(map[string]string, 1)
+	}
+	oldLabelValue, ok := labels[labelKey]
+	// If the labels does not exist or is outdated then set it.
+	if !ok || oldLabelValue != labelValue {
+		labels[labelKey] = labelValue
+		obj.SetLabels(labels)
+		return true
+	}
+	return false
+}
+
+// GetLabelValueFromObj for a given object it return the value of the label denoted by the
+// given key. If the key does not exist it returns an empty string.
+func GetLabelValueFromObj(obj client.Object, labelKey string) string {
+	if obj.GetLabels() == nil {
+		return ""
+	}
+	return obj.GetLabels()[labelKey]
 }


### PR DESCRIPTION
# Description
`Liqo-Gateway` operator can now have more than one replica. One of the replicas will be elected `leader` and serve all the inter cluster traffic. In case of failure of the current `leader` one of the other replicas will become the new `leader` and will act as the new `gateway`. 
A new operator has been added to the `liqo-gateway` called `labelerOperator.` Since the `liqo-gateway` is exposed through a `nodePort/loadBalancer` service all the replicas, when ready, are added as endpoints to the service. But being only one of the replicas the `gateway` which can handle the inter cluster traffic the other replicas could act as `network black holes`. Hence the `labelerOperator` adds the label `net.liqo.io/gateway=active` to the current leader. The same label is used as a `selector` by the liqo-gateway service. All the other replicas are labeled as `net.liqo.io/gateway=standby`

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Unit tests
