### PR TITLE
Some fixes to webhook logic and test e2e

### DIFF
--- a/test/e2e/testutils/net/net.go
+++ b/test/e2e/testutils/net/net.go
@@ -27,7 +27,7 @@ var (
 
 // ConnectivityCheckNodeToPod creates a NodePort Service and check its availability.
 func ConnectivityCheckNodeToPod(ctx context.Context, homeClusterClient kubernetes.Interface, clusterID string) error {
-	nodePort, err := EnsureNodePortService(homeClusterClient, clusterID)
+	nodePort, err := EnsureNodePortService(ctx, homeClusterClient, clusterID)
 	if err != nil {
 		return err
 	}
@@ -35,8 +35,8 @@ func ConnectivityCheckNodeToPod(ctx context.Context, homeClusterClient kubernete
 }
 
 // EnsureNodePortService creates a nodePortService. It returns the port to contact to reach the service and occurred errors.
-func EnsureNodePortService(homeClusterClient kubernetes.Interface, clusterID string) (int, error) {
-	nodePort, err := EnsureNodePort(homeClusterClient, clusterID, "tester-remote", TestNamespaceName)
+func EnsureNodePortService(ctx context.Context, homeClusterClient kubernetes.Interface, clusterID string) (int, error) {
+	nodePort, err := EnsureNodePort(ctx, homeClusterClient, clusterID, podTesterRemoteCl, TestNamespaceName)
 	if err != nil {
 		return 0, err
 	}
@@ -53,13 +53,13 @@ func CheckNodeToPortConnectivity(ctx context.Context, homeClusterClient kubernet
 }
 
 // CheckPodConnectivity contacts the remote service by executing the command inside podRemoteUpdateCluster1.
-func CheckPodConnectivity(homeConfig *restclient.Config, homeClient kubernetes.Interface) error {
-	podLocalUpdate, err := homeClient.CoreV1().Pods(TestNamespaceName).Get(context.TODO(), podTesterLocalCl, metav1.GetOptions{})
+func CheckPodConnectivity(ctx context.Context, homeConfig *restclient.Config, homeClient kubernetes.Interface) error {
+	podLocalUpdate, err := homeClient.CoreV1().Pods(TestNamespaceName).Get(ctx, podTesterLocalCl, metav1.GetOptions{})
 	if err != nil {
 		klog.Error(err)
 		return err
 	}
-	podRemoteUpdateCluster1, err := homeClient.CoreV1().Pods(TestNamespaceName).Get(context.TODO(), podTesterRemoteCl, metav1.GetOptions{})
+	podRemoteUpdateCluster1, err := homeClient.CoreV1().Pods(TestNamespaceName).Get(ctx, podTesterRemoteCl, metav1.GetOptions{})
 	if err != nil {
 		klog.Error(err)
 		return err


### PR DESCRIPTION
# Description

- The Liqo webhook reads the pod namespace from the admissionReview.Request, no more directly from the pod.
- Some fixes in the nodeport update (peering_e2e).
- Some checks on the Pod NodeAffinity added in the E2E Testing with Online Boutique (peering_e2e).
