### PR TITLE
Fix information leakage vulnerability in the Webhook server.

### DIFF
--- a/pkg/mutate/server.go
+++ b/pkg/mutate/server.go
@@ -62,16 +62,19 @@ func NewMutationServer(ctx context.Context, c *MutationConfig) (*MutationServer,
 func (s *MutationServer) handleMutate(w http.ResponseWriter, r *http.Request) {
 	// read the body / request
 	body, err := ioutil.ReadAll(r.Body)
-
 	if err != nil {
-		s.sendError(err, w)
+		klog.Error(err)
+		standardErrMessage := fmt.Errorf("unable to correctly read the body of the request")
+		s.sendError(standardErrMessage, w)
 		return
 	}
 
 	// mutate the request
 	mutated, err := s.Mutate(body)
 	if err != nil {
-		s.sendError(err, w)
+		klog.Error(err)
+		standardErrMessage := fmt.Errorf("unable to correctly mutate the request")
+		s.sendError(standardErrMessage, w)
 		return
 	}
 


### PR DESCRIPTION
# Description

If the body of the request was not correctly read the error provided was directly sent to the user. Now a standard error message is sent every time there is a problem in the processing of the request body, this fix avoid also the information leakage due to the use of specific errors for every different problem.
