### PR TITLE
Add custom columns to "kubectl get" output for liqo CRDs

### DIFF
--- a/apis/discovery/v1alpha1/resourcerequest_types.go
+++ b/apis/discovery/v1alpha1/resourcerequest_types.go
@@ -34,6 +34,8 @@ type ResourceRequestStatus struct {
 // +kubebuilder:subresource:status
 
 // ResourceRequest is the Schema for the ResourceRequests API.
+// +kubebuilder:printcolumn:name="Local",type=string,JSONPath=`.metadata.labels.liqo\.io/replication`
+// +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 type ResourceRequest struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/apis/net/v1alpha1/networkconfig_types.go
+++ b/apis/net/v1alpha1/networkconfig_types.go
@@ -64,6 +64,12 @@ type NetworkConfigStatus struct {
 // +kubebuilder:subresource:status
 
 // NetworkConfig is the Schema for the networkconfigs API.
+// +kubebuilder:printcolumn:name="Peering Cluster ID",type=string,JSONPath=`.spec.clusterID`
+// +kubebuilder:printcolumn:name="Endpoint IP",type=string,JSONPath=`.spec.endpointIP`,priority=1
+// +kubebuilder:printcolumn:name="VPN Backend",type=string,JSONPath=`.spec.backendType`,priority=1
+// +kubebuilder:printcolumn:name="Processed",type=string,JSONPath=`.status.processed`
+// +kubebuilder:printcolumn:name="Local",type=string,JSONPath=`.metadata.labels.liqo\.io/replication`
+// +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 type NetworkConfig struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/apis/net/v1alpha1/tunnel_endpoint_types.go
+++ b/apis/net/v1alpha1/tunnel_endpoint_types.go
@@ -96,9 +96,11 @@ const (
 // +kubebuilder:subresource:status
 
 // TunnelEndpoint is the Schema for the endpoints API.
-// +kubebuilder:printcolumn:name="Endpoint IP",type=string,JSONPath=`.spec.endpointIP`
+// +kubebuilder:printcolumn:name="Peering Cluster ID",type=string,JSONPath=`.spec.clusterID`
+// +kubebuilder:printcolumn:name="Endpoint IP",type=string,JSONPath=`.spec.endpointIP`,priority=1
 // +kubebuilder:printcolumn:name="Backend type",type=string,JSONPath=`.spec.backendType`
 // +kubebuilder:printcolumn:name="Connection status",type=string,JSONPath=`.status.connection.status`
+// +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 type TunnelEndpoint struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/apis/sharing/v1alpha1/resourceoffer_types.go
+++ b/apis/sharing/v1alpha1/resourceoffer_types.go
@@ -73,8 +73,8 @@ type ResourceOfferStatus struct {
 
 // ResourceOffer is the Schema for the resourceOffers API.
 // +kubebuilder:printcolumn:name="Status",type=string,JSONPath=`.status.phase`
-// +kubebuilder:printcolumn:name="Expiration",type=string,JSONPath=`.spec.timeToLive`
 // +kubebuilder:printcolumn:name="VirtualKubeletStatus",type=string,JSONPath=`.status.virtualKubeletStatus`
+// +kubebuilder:printcolumn:name="Local",type=string,JSONPath=`.metadata.labels.liqo\.io/replication`
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 type ResourceOffer struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/deployments/liqo/crds/discovery.liqo.io_resourcerequests.yaml
+++ b/deployments/liqo/crds/discovery.liqo.io_resourcerequests.yaml
@@ -16,7 +16,14 @@ spec:
     singular: resourcerequest
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.labels.liqo\.io/replication
+      name: Local
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: ResourceRequest is the Schema for the ResourceRequests API.

--- a/deployments/liqo/crds/net.liqo.io_networkconfigs.yaml
+++ b/deployments/liqo/crds/net.liqo.io_networkconfigs.yaml
@@ -16,7 +16,28 @@ spec:
     singular: networkconfig
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.clusterID
+      name: Peering Cluster ID
+      type: string
+    - jsonPath: .spec.endpointIP
+      name: Endpoint IP
+      priority: 1
+      type: string
+    - jsonPath: .spec.backendType
+      name: VPN Backend
+      priority: 1
+      type: string
+    - jsonPath: .status.processed
+      name: Processed
+      type: string
+    - jsonPath: .metadata.labels.liqo\.io/replication
+      name: Local
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: NetworkConfig is the Schema for the networkconfigs API.

--- a/deployments/liqo/crds/net.liqo.io_tunnelendpoints.yaml
+++ b/deployments/liqo/crds/net.liqo.io_tunnelendpoints.yaml
@@ -17,8 +17,12 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
+    - jsonPath: .spec.clusterID
+      name: Peering Cluster ID
+      type: string
     - jsonPath: .spec.endpointIP
       name: Endpoint IP
+      priority: 1
       type: string
     - jsonPath: .spec.backendType
       name: Backend type
@@ -26,6 +30,9 @@ spec:
     - jsonPath: .status.connection.status
       name: Connection status
       type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     name: v1alpha1
     schema:
       openAPIV3Schema:

--- a/deployments/liqo/crds/sharing.liqo.io_resourceoffers.yaml
+++ b/deployments/liqo/crds/sharing.liqo.io_resourceoffers.yaml
@@ -22,11 +22,11 @@ spec:
     - jsonPath: .status.phase
       name: Status
       type: string
-    - jsonPath: .spec.timeToLive
-      name: Expiration
-      type: string
     - jsonPath: .status.virtualKubeletStatus
       name: VirtualKubeletStatus
+      type: string
+    - jsonPath: .metadata.labels.liqo\.io/replication
+      name: Local
       type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age


### PR DESCRIPTION
# Description
 
This PR adds custom columns to "kubectl get" output for liqo CRDs. Here is an example when a `kubectl get -o wide` is performed:

![kubectl get](https://user-images.githubusercontent.com/17413176/125475196-f234c971-dfd3-4e86-b8f4-cae7b3b645c2.png)


Fixes #(issue)

Now with a simple `kubectl get` it is clear if a resource has been generated on the current cluster or has been replicated from a remote cluster.

