### PR TITLE
Deletion of remote namespace conditions in the NamespaceOffloading Resource

### DIFF
--- a/pkg/liqo-controller-manager/namespaceOffloading-controller/clusterselector_management.go
+++ b/pkg/liqo-controller-manager/namespaceOffloading-controller/clusterselector_management.go
@@ -75,12 +75,12 @@ func (r *NamespaceOffloadingReconciler) getClusterIDMap(ctx context.Context) (ma
 		return nil, err
 	}
 
+	clusterIDMap := make(map[string]*mapsv1alpha1.NamespaceMap)
 	if len(nms.Items) == 0 {
 		klog.Info("No NamespaceMaps at the moment in the cluster")
-		return nil, nil
+		return clusterIDMap, nil
 	}
 
-	clusterIDMap := make(map[string]*mapsv1alpha1.NamespaceMap)
 	for i := range nms.Items {
 		clusterIDMap[nms.Items[i].Labels[liqoconst.RemoteClusterID]] = &nms.Items[i]
 	}

--- a/pkg/liqo-controller-manager/namespaceOffloading-controller/namespaceoffloading_controller.go
+++ b/pkg/liqo-controller-manager/namespaceOffloading-controller/namespaceoffloading_controller.go
@@ -77,10 +77,6 @@ func (r *NamespaceOffloadingReconciler) Reconcile(ctx context.Context, req ctrl.
 	if err != nil {
 		return ctrl.Result{}, err
 	}
-	// There are no NamespaceMap in the cluster
-	if namespaceMapNumber == 0 {
-		return ctrl.Result{}, nil
-	}
 
 	// If deletion timestamp is set, it starts deletion logic and waits until all remote Namespaces
 	// associated with this resource are deleted.

--- a/pkg/liqo-controller-manager/resourceoffer-controller/resourceoffer_controller.go
+++ b/pkg/liqo-controller-manager/resourceoffer-controller/resourceoffer_controller.go
@@ -144,21 +144,19 @@ func (r *ResourceOfferReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	case kubeletDeletePhaseDrainingNode:
 		// set virtual kubelet in deleting phase
 		resourceOffer.Status.VirtualKubeletStatus = sharingv1alpha1.VirtualKubeletStatusDeleting
+		return result, nil
 	case kubeletDeletePhaseNone:
-		break
+		// create the virtual kubelet deployment
+		if err = r.createVirtualKubeletDeployment(ctx, &resourceOffer); err != nil {
+			klog.Error(err)
+			return ctrl.Result{}, err
+		}
+		return result, nil
 	default:
 		err = fmt.Errorf("unknown deleting phase %v", deletingPhase)
 		klog.Error(err)
 		return result, err
 	}
-
-	// create the virtual kubelet deployment
-	if err = r.createVirtualKubeletDeployment(ctx, &resourceOffer); err != nil {
-		klog.Error(err)
-		return ctrl.Result{}, err
-	}
-
-	return result, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.


### PR DESCRIPTION
# Description

- When a virtual node is deleted during the termination of the peering, the remote conditions contained in the namespaceOffloading resource must be updated. In particular, when the NamespaceMap corresponding to the virtual node no longer exists, the condition associated with that remote cluster must be removed. So a new check in the Offloading status controller is added: as long as the NamespaceOffloading is present, a periodic check is carried out on the remoteNamespaceConditions that must be present at that moment.
A new unit test is added in order to verify the behavior of this new feature.

- A return statement in the resourceOffer controller is added to avoid race conditions during the peering deletion phase.



