### PR TITLE
Add AWS Configuration in the Helm Chart - AWS 2/3

### DIFF
--- a/deployments/liqo/README.md
+++ b/deployments/liqo/README.md
@@ -24,6 +24,10 @@
 | auth.service.annotations | object | `{}` | auth service annotations |
 | auth.service.type | string | `"NodePort"` | The type of service used to expose the Authentication Service If you are exposing this service with an Ingress consider to change it to ClusterIP, otherwise if you plan to use liqo over the Internet consider to change this field to "LoadBalancer". See https://doc.liqo.io/user/install/pre-install/ for more details. |
 | auth.tls | bool | `true` | Enable TLS for the Authentication Service Pod (using a self-signed certificate). If you are exposing this service with an Ingress consider to disable it or add the appropriate annotations to the Ingress resource. |
+| awsConfig.accessKeyId | string | `""` | accessKeyID for the Liqo user |
+| awsConfig.clusterName | string | `""` | name of the EKS cluster |
+| awsConfig.region | string | `""` | AWS region where the clsuter is runnnig |
+| awsConfig.secretAccessKey | string | `""` | secretAccessKey for the Liqo user |
 | capsule.fullnameOverride | string | `"capsule"` | override the fullname to fix naming problems |
 | capsule.install | bool | `true` | liqo needs capsule to work properly, but you can use your already deployed capsule installation |
 | capsule.manager.options.capsuleUserGroups[0] | string | `"capsule.clastix.io"` |  |

--- a/deployments/liqo/templates/liqo-auth-deployment.yaml
+++ b/deployments/liqo/templates/liqo-auth-deployment.yaml
@@ -1,5 +1,6 @@
 ---
 {{- $authConfig := (merge (dict "name" "auth" "module" "discovery" "containerName" "cert-creator") .) -}}
+{{- $awsConfig := (merge (dict "name" "aws-config" "module" "aws-config") .) -}}
 
 apiVersion: apps/v1
 kind: Deployment
@@ -63,15 +64,24 @@ spec:
           imagePullPolicy: {{ .Values.pullPolicy }}
           command: ["/usr/bin/auth-service"]
           args:
-          - "--namespace"
-          - "$(POD_NAMESPACE)"
-          - "--resyncSeconds"
-          - "30"
-          - "--listeningPort"
+          - "--namespace=$(POD_NAMESPACE)"
+          - "--resyncSeconds=30"
+          {{- if .Values.awsConfig.accessKeyId }}
+          - "--awsAccessKeyId=$(ACCESS_KEY_ID)"
+          {{- end }}
+          {{- if .Values.awsConfig.secretAccessKey }}
+          - "--awsSecretAccessKey=$(SECRET_ACCESS_KEY)"
+          {{- end }}
+          {{- if .Values.awsConfig.region }}
+          - "--awsRegion={{ .Values.awsConfig.region }}"
+          {{- end }}
+          {{- if .Values.awsConfig.clusterName }}
+          - "--awsClusterName={{ .Values.awsConfig.clusterName }}"
+          {{- end }}
           {{- if not .Values.auth.tls}}
-          - "5000"
+          - "--listeningPort=5000"
           {{- else }}
-          - "443"
+          - "--listeningPort=443"
           - "--useTls"
           {{- end }}
           env:
@@ -79,6 +89,20 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            {{- if .Values.awsConfig.accessKeyId }}
+            - name: ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "liqo.prefixedName" $awsConfig }}
+                  key: ACCESS_KEY_ID
+            {{- end }}
+            {{- if .Values.awsConfig.secretAccessKey }}
+            - name: SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "liqo.prefixedName" $awsConfig }}
+                  key: SECRET_ACCESS_KEY
+            {{- end }}
           resources:
             requests:
               cpu: 100m

--- a/deployments/liqo/templates/liqo-aws-credentials.yaml
+++ b/deployments/liqo/templates/liqo-aws-credentials.yaml
@@ -1,0 +1,16 @@
+---
+{{- $awsConfig := (merge (dict "name" "aws-config" "module" "aws-config") .) -}}
+
+{{- if and .Values.awsConfig.accessKeyId .Values.awsConfig.secretAccessKey }}
+
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    {{- include "liqo.labels" $awsConfig | nindent 4 }}
+  name: {{ include "liqo.prefixedName" $awsConfig }}
+data:
+    ACCESS_KEY_ID: {{ .Values.awsConfig.accessKeyId | quote }}
+    SECRET_ACCESS_KEY: {{ .Values.awsConfig.secretAccessKey | quote }}
+
+{{- end }}

--- a/deployments/liqo/values.yaml
+++ b/deployments/liqo/values.yaml
@@ -189,6 +189,20 @@ nameOverride: ""
 # -- full liqo name override
 fullnameOverride: ""
 
+# aws configuration for the local cluster and the Liqo user,
+# this user should be able to create new IAM user, to create new programmatic access
+# credentials, and to describe EKS clusters.
+# NOTE: set it only if running on EKS, otherwise let this fields with the default value
+awsConfig:
+  # -- accessKeyID for the Liqo user
+  accessKeyId: ""
+  # -- secretAccessKey for the Liqo user
+  secretAccessKey: ""
+  # -- AWS region where the clsuter is runnnig
+  region: ""
+  # -- name of the EKS cluster
+  clusterName: ""
+
 # capsule subchart configuration
 capsule:
   # -- liqo needs capsule to work properly, but you can use your already deployed capsule installation


### PR DESCRIPTION
# Description

This pr adds the AWS configuration in the Liqo helm chart.

# How Has This Been Tested?

- [x] On EKS cluster, to test that the new values are correctly used
- [x] Locally on KinD, to test that the non-AWS install is still working
