### PR TITLE
Restricting cache clients in liqo-route component

### DIFF
--- a/internal/liqonet/route-operator/symmetricRoutingOperator.go
+++ b/internal/liqonet/route-operator/symmetricRoutingOperator.go
@@ -150,10 +150,11 @@ func (src *SymmetricRoutingController) podFilter(obj client.Object) bool {
 		return false
 	}
 	// If podIP is not set return false.
-	// Here the newly created pods scheduled on a virtual node will be skipped. The filtered cache for all the pods
-	// scheduled on a virtual node works only when the correct label has been added to the pod. When pods are created
-	// the label is not present, but we are sure that it will be added before the IP address for the same pod is set.
-	//Once the pods have been labeled the api server should not inform the controller about them.
+	// Here the newly created pods scheduled on a virtual node will be skipped. It is a temporary situation untile
+	// the pods are labeled. The filtered cache for all the pods scheduled on a virtual node works only when the correct
+	// label has been added to the pod. When pods are created the label is not present, but we are sure that it will be
+	// added before the IP address for the same pod is set.
+	// Once the pods have been labeled they are filtered out at the cache level by the client.
 	if p.Status.PodIP == "" {
 		klog.V(infoLogLevel).Infof("skipping pod {%s} running on node {%s} has ip address set to empty", p.Name, p.Spec.NodeName)
 		return false

--- a/internal/liqonet/route-operator/symmetricRoutingOperator_test.go
+++ b/internal/liqonet/route-operator/symmetricRoutingOperator_test.go
@@ -296,15 +296,6 @@ var _ = Describe("SymmetricRoutingOperator", func() {
 			})
 		})
 
-		Context("when pod is running on same node as the operator", func() {
-			It("should return false", func() {
-				// Set the same node name.
-				srcTestPod.Spec.NodeName = srcNodeName
-				ok := src.podFilter(srcTestPod)
-				Expect(ok).Should(BeFalse())
-			})
-		})
-
 		Context("when pod is running on different node than operator", func() {
 			It("podIP is not set, should return false", func() {
 				ok := src.podFilter(srcTestPod)

--- a/pkg/consts/replication.go
+++ b/pkg/consts/replication.go
@@ -11,4 +11,8 @@ const (
 	// - the spec of the resource is owned by the local cluster.
 	// - the status by the remote cluster.
 	OwnershipShared OwnershipType = "Shared"
+	// LocalPodLabelKey label key added to all the local pods that have been offloaded/replicated to a remote cluster.
+	LocalPodLabelKey = "liqo.io/shadowPod"
+	// LocalPodLabelValue value of the label added to the local pods that have been offloaded/replicated to a remote cluster.
+	LocalPodLabelValue = "true"
 )

--- a/pkg/virtualKubelet/provider/pods.go
+++ b/pkg/virtualKubelet/provider/pods.go
@@ -58,6 +58,8 @@ func (p *LiqoProvider) CreatePod(ctx context.Context, homePod *corev1.Pod) error
 
 	// Add a finalizer to allow the pod to be garbage collected by the incoming replicaset reflector.
 	// Add label to distinct the offloaded pods from the local ones.
+	// The merge strategy is types.StrategicMergePatchType in order to merger the previous state
+	// with the new configuration.
 	homePodPatch := []byte(fmt.Sprintf(
 		`{"metadata":{"labels":{"%s":"%s"},"finalizers":["%s"]}}`,
 		liqoconst.LocalPodLabelKey, liqoconst.LocalPodLabelValue, virtualKubelet.HomePodFinalizer))

--- a/test/e2e/peering_e2e/basic_test.go
+++ b/test/e2e/peering_e2e/basic_test.go
@@ -56,7 +56,9 @@ var _ = Describe("Liqo E2E", func() {
 				Entry("VirtualNode is Ready on cluster 2", testContext.Clusters[0], namespace),
 				Entry("VirtualNode is Ready on cluster 1", testContext.Clusters[1], namespace),
 			)
+		})
 
+		Context("E2E network testing with pods and services", func() {
 			DescribeTable("Liqo Pod to Pod Connectivity Check",
 				func(homeCluster, foreignCluster tester.ClusterContext, namespace string) {
 					By("Deploy Tester Pod", func() {
@@ -75,8 +77,9 @@ var _ = Describe("Liqo E2E", func() {
 					})
 
 					By("Check Service NodePort Connectivity", func() {
-						err := net.ConnectivityCheckNodeToPod(ctx, homeCluster.Client, homeCluster.ClusterID)
-						Expect(err).ToNot(HaveOccurred())
+						Eventually(func() error {
+							return net.ConnectivityCheckNodeToPod(ctx, homeCluster.Client, homeCluster.ClusterID)
+						}, timeout, interval).ShouldNot(HaveOccurred())
 					})
 				},
 				Entry("Check Pod to Pod connectivity from cluster 1", testContext.Clusters[0], testContext.Clusters[1], namespace),

--- a/test/e2e/testutils/net/net.go
+++ b/test/e2e/testutils/net/net.go
@@ -64,6 +64,7 @@ func CheckPodConnectivity(ctx context.Context, homeConfig *restclient.Config, ho
 		return err
 	}
 	cmd := command + podRemoteUpdateCluster1.Status.PodIP
+	klog.Infof("running command %s", cmd)
 	stdout, stderr, err := util.ExecCmd(homeConfig, homeClient, podLocalUpdate.Name, podLocalUpdate.Namespace, cmd)
 	if stdout == "200" && err == nil {
 		return nil

--- a/test/e2e/testutils/net/net.go
+++ b/test/e2e/testutils/net/net.go
@@ -21,8 +21,7 @@ var (
 	TestNamespaceName = "test-connectivity"
 	// label to list only the real nodes excluding the virtual ones.
 	labelSelectorNodes = fmt.Sprintf("%v!=%v", liqoconst.TypeLabel, liqoconst.TypeNode)
-	//TODO: use the retry mechanism of curl without sleeping before running the command.
-	command = "curl --fail --max-time 5 -s -o /dev/null -w '%{http_code}' "
+	command            = "curl --retry 60 --fail --max-time 2 -s -o /dev/null -w '%{http_code}' "
 )
 
 // ConnectivityCheckNodeToPod creates a NodePort Service and check its availability.

--- a/test/e2e/testutils/net/svc.go
+++ b/test/e2e/testutils/net/svc.go
@@ -40,14 +40,6 @@ func EnsureNodePort(ctx context.Context, client kubernetes.Interface, clusterID,
 			klog.Error(err)
 			return nil, err
 		}
-		clusterIP := nodePort.Spec.ClusterIP
-		nodePort.Spec = serviceSpec
-		nodePort.Spec.ClusterIP = clusterIP
-		_, err = client.CoreV1().Services(namespace).Update(ctx, nodePort, metav1.UpdateOptions{})
-		if err != nil {
-			klog.Errorf("%s -> an error occurred while updating nodePort service %s : %s", clusterID, name, err)
-			return nil, err
-		}
 	}
 	if err != nil {
 		klog.Errorf("%s -> an error occurred while creating nodePort service %s in namespace %s: %s", clusterID, name, namespace, err)

--- a/test/e2e/testutils/util/exec.go
+++ b/test/e2e/testutils/util/exec.go
@@ -61,9 +61,10 @@ func TriggerCheckNodeConnectivity(localNodes *v1.NodeList, command string, nodeP
 		klog.Infof("running command %s", cmd)
 		err := c.Run()
 		if err != nil {
+			klog.Error(err)
 			klog.Info(output.String())
 			klog.Info(errput.String())
-			return nil
+			return err
 		}
 	}
 	return nil


### PR DESCRIPTION

# Description
`Liqo-Route` component is made up by three operators: `route operator, overlay operator and symmetricRouting operator`. 
`Overlay and symmetricRouting operator` used to watch for changes for all `pods` in the cluster, and reconciling only the needed pods. Now the `overlay` operator watches for events only the "liqo-route" pods in the namespace where the operator is installed. In the other hand the `symmetricRouting` operator watches the `pods` that are running on nodes different from the node where the operator is running and ignores the pods schedule on a `virtual node`. For this reason all the `pods` offloaded to a remote cluster presents the label `liqo.io/shadowPod=true`.  

Fixes #(issue)

`Liqo-Route` is now faster while configuring the routes configuration on the nodes.

# How Has This Been Tested?

Existing unit and e2e tests covers the changes made in this PR.
