### PR TITLE
Bug fix in the deletion of the remote namespace.

### DIFF
--- a/cmd/advertisement-operator/main.go
+++ b/cmd/advertisement-operator/main.go
@@ -80,6 +80,7 @@ func main() {
 	var liqoNamespace, kubeletImage, initKubeletImage string
 	var resyncPeriod int64
 	var offloadingStatusControllerRequeueTime int64
+	var namespaceMapControllerRequeueTime int64
 
 	flag.StringVar(&metricsAddr, "metrics-addr", defaultMetricsaddr, "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
@@ -89,7 +90,9 @@ func main() {
 
 	flag.Int64Var(&resyncPeriod, "resyncPeriod", int64(10*time.Hour), "Period after that operators and informers will requeue events.")
 	flag.Int64Var(&offloadingStatusControllerRequeueTime, "offloadingStatusControllerRequeueTime", int64(10*time.Second),
-		"Period after that the offloadingStatusController is awaken on every namespaceOffloading in order to set its status.")
+		"Period after that the offloadingStatus Controller is awaken on every NamespaceOffloading to set its status.")
+	flag.Int64Var(&namespaceMapControllerRequeueTime, "namespaceMapControllerRequeueTime", int64(30*time.Second),
+		"Period after that the namespaceMap Controller is awaken on every NamespaceMap to enforce DesiredMappings.")
 	flag.StringVar(&localKubeconfig, "local-kubeconfig", "", "The path to the kubeconfig of your local cluster.")
 	flag.StringVar(&clusterId, "cluster-id", "", "The cluster ID of your cluster")
 	flag.StringVar(&liqoNamespace,
@@ -200,7 +203,7 @@ func main() {
 		RemoteClients:         make(map[string]kubernetes.Interface),
 		LocalClusterID:        clusterId,
 		IdentityManagerClient: clientset,
-		RequeueTime:           time.Second * 30,
+		RequeueTime:           time.Duration(namespaceMapControllerRequeueTime),
 	}
 
 	if err = namespaceMapReconciler.SetupWithManager(mgr); err != nil {

--- a/pkg/liqo-controller-manager/namespaceOffloading-controller/manage_desiredmappings.go
+++ b/pkg/liqo-controller-manager/namespaceOffloading-controller/manage_desiredmappings.go
@@ -31,7 +31,7 @@ func removeDesiredMapping(ctx context.Context, c client.Client, localName string
 			klog.Errorf("%s --> Unable to patch NamespaceMap '%s'", err, nm.GetName())
 			return err
 		}
-		klog.Infof(" Entry for the namespace '%s' is correctly deleted from the NamespaceMap '%s'", localName, nm.GetName())
+		klog.Infof(" Entry for the namespace '%s' is correctly deleted from the desiredMapping of NamespaceMap '%s'", localName, nm.GetName())
 	}
 	return nil
 }


### PR DESCRIPTION
# Description

This PR fixes some problems in the namespace mapping logic:

- If two statements are in OR and the first is true, the second is never executed. Now both statement "ensureRemoteNamespacesExistence" and "ensureRemoteNamespacesDeletion" are executed.  
https://github.com/liqotech/liqo/blob/7200a7725bd0aa7c767409a5f3d18f3cfa1f73f9/pkg/liqo-controller-manager/namespaceMap-controller/ensure_remote_namespaces.go#L158

- The NamespaceMap Controller restarts with exponential backoff if its NamespaceMap contains a namespace in CreationLoopBackOff status in the CurrentMapping. If the entry in CurrentMapping is not deleted, the controller always remains in backoff on that NamespaceMap, this causes delays in updating the resource status and therefore a delay in all the offloading logic. The controller no longer goes into exponential backoff if the error returned from the remote namespace creation process is invalid or alreadyExist, but it restarts every "n" seconds as if there was no error.