### PR TITLE
Create Client from IAM Identity - AWS 3/3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,8 @@ bin
 .vscode
 .devcontainer
 
+# directory where liqo stores the downloaded external crd
 externalcrds
+
+# directory where liqo stores the bearer tokens got by identity providers (i.e. Amazon IAM)
+token

--- a/deployments/liqo/files/liqo-auth-ClusterRole.yaml
+++ b/deployments/liqo/files/liqo-auth-ClusterRole.yaml
@@ -31,6 +31,15 @@ rules:
   - watch
 - apiGroups:
   - ""
+  resourceNames:
+  - aws-auth
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - ""
   resources:
   - namespaces
   verbs:

--- a/internal/auth-service/auth-service.go
+++ b/internal/auth-service/auth-service.go
@@ -33,6 +33,7 @@ import (
 // cluster-role
 // +kubebuilder:rbac:groups=core,resources=nodes,verbs=get;list;watch
 // +kubebuilder:rbac:groups=core,resources=namespaces,verbs=get;list;watch;create
+// +kubebuilder:rbac:groups=core,resourceNames="aws-auth",resources=configmaps,verbs=get;update
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,verbs=create;delete;list;deletecollection;get
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings,verbs=create;delete;list;deletecollection
 // +kubebuilder:rbac:groups=config.liqo.io,resources=clusterconfigs,verbs=get;list;watch;create

--- a/internal/auth-service/identity.go
+++ b/internal/auth-service/identity.go
@@ -105,7 +105,7 @@ func (authService *Controller) handleIdentity(
 
 	// make the response to send to the remote cluster
 	response, err := auth.NewCertificateIdentityResponse(
-		namespace.Name, &identityResponse, authService.getConfigProvider(), authService.clientset, authService.restConfig)
+		namespace.Name, identityResponse, authService.getConfigProvider(), authService.clientset, authService.restConfig)
 	if err != nil {
 		klog.Error(err)
 		return nil, err

--- a/pkg/auth/identityResponse.go
+++ b/pkg/auth/identityResponse.go
@@ -33,6 +33,15 @@ type CertificateIdentityResponse struct {
 	AWSIdentityInfo AWSIdentityInfo `json:"aws,omitempty"`
 }
 
+// HasAWSValues checks if the response has all the required AWS fields set.
+func (resp *CertificateIdentityResponse) HasAWSValues() bool {
+	credentials := resp.AWSIdentityInfo.AccessKeyID != "" && resp.AWSIdentityInfo.SecretAccessKey != ""
+	region := resp.AWSIdentityInfo.Region != ""
+	cluster := resp.AWSIdentityInfo.EKSClusterID != ""
+	userArn := resp.AWSIdentityInfo.IAMUserArn != ""
+	return credentials && region && cluster && userArn
+}
+
 // NewCertificateIdentityResponse makes a new CertificateIdentityResponse.
 func NewCertificateIdentityResponse(
 	namespace string, identityResponse *responsetypes.SigningRequestResponse,

--- a/pkg/identityManager/certificateIdentityProvider.go
+++ b/pkg/identityManager/certificateIdentityProvider.go
@@ -38,7 +38,7 @@ type certificateIdentityProvider struct {
 // GetRemoteCertificate retrieves a certificate issued in the past,
 // given the clusterid and the signingRequest.
 func (identityProvider *certificateIdentityProvider) GetRemoteCertificate(clusterID,
-	signingRequest string) (response responsetypes.SigningRequestResponse, err error) {
+	signingRequest string) (response *responsetypes.SigningRequestResponse, err error) {
 	namespace, err := identityProvider.namespaceManager.GetNamespace(clusterID)
 	if err != nil {
 		klog.Error(err)
@@ -72,7 +72,9 @@ func (identityProvider *certificateIdentityProvider) GetRemoteCertificate(cluste
 		return response, err
 	}
 
-	response.ResponseType = responsetypes.SigningRequestResponseCertificate
+	response = &responsetypes.SigningRequestResponse{
+		ResponseType: responsetypes.SigningRequestResponseCertificate,
+	}
 	response.Certificate, ok = secret.Data[certificateSecretKey]
 	if !ok {
 		klog.Errorf("no %v key in secret %v/%v", certificateSecretKey, secret.Namespace, secret.Name)
@@ -90,7 +92,7 @@ func (identityProvider *certificateIdentityProvider) GetRemoteCertificate(cluste
 // It creates a CertificateSigningRequest CR to be issued by the local cluster, and approves it.
 // This function will wait (with a timeout) for an available certificate before returning.
 func (identityProvider *certificateIdentityProvider) ApproveSigningRequest(clusterID,
-	signingRequest string) (response responsetypes.SigningRequestResponse, err error) {
+	signingRequest string) (response *responsetypes.SigningRequestResponse, err error) {
 	rnd := fmt.Sprintf("%v", rand.Int63())
 
 	signingBytes, err := base64.StdEncoding.DecodeString(signingRequest)
@@ -134,8 +136,10 @@ func (identityProvider *certificateIdentityProvider) ApproveSigningRequest(clust
 		return response, err
 	}
 
+	response = &responsetypes.SigningRequestResponse{
+		ResponseType: responsetypes.SigningRequestResponseCertificate,
+	}
 	// retrieve the certificate issued by the Kubernetes issuer in the CSR
-	response.ResponseType = responsetypes.SigningRequestResponseCertificate
 	response.Certificate, err = identityProvider.getCertificate(cert, rnd)
 	if err != nil {
 		klog.Error(err)

--- a/pkg/identityManager/client.go
+++ b/pkg/identityManager/client.go
@@ -24,6 +24,10 @@ func (certManager *identityManager) GetConfig(remoteClusterID, namespace string)
 		return nil, err
 	}
 
+	if certManager.isAwsIdentity(secret) {
+		return certManager.getIAMConfig(secret, remoteClusterID)
+	}
+
 	// retrieve the data required to build the rest config
 
 	keyData, ok := secret.Data[privateKeySecretKey]
@@ -101,4 +105,8 @@ func (certManager *identityManager) GetRemoteTenantNamespace(
 		return "", err
 	}
 	return string(remoteNamespace), nil
+}
+
+func (certManager *identityManager) getIAMConfig(secret *v1.Secret, remoteClusterID string) (*rest.Config, error) {
+	return certManager.iamTokenManager.getConfig(secret, remoteClusterID)
 }

--- a/pkg/identityManager/const.go
+++ b/pkg/identityManager/const.go
@@ -24,4 +24,10 @@ const (
 	apiServerURLSecretKey = "apiServerUrl"
 	apiServerCaSecretKey  = "apiServerCa"
 	namespaceSecretKey    = "namespace"
+
+	awsAccessKeyIDSecretKey     = "awsAccessKeyID"
+	awsSecretAccessKeySecretKey = "awsSecretAccessKey"
+	awsRegionSecretKey          = "awsRegion"
+	awsEKSClusterIDSecretKey    = "awsEksClusterID" // nolint:gosec // not a credential
+	awsIAMUserArnSecretKey      = "awsIamUserArn"   // nolint:gosec // not a credential
 )

--- a/pkg/identityManager/iamIdentityProvider.go
+++ b/pkg/identityManager/iamIdentityProvider.go
@@ -36,7 +36,7 @@ type mapUser struct {
 }
 
 func (identityProvider *iamIdentityProvider) GetRemoteCertificate(clusterID,
-	signingRequest string) (response responsetypes.SigningRequestResponse, err error) {
+	signingRequest string) (response *responsetypes.SigningRequestResponse, err error) {
 	// this method has no meaning for this identity provider
 	return response, kerrors.NewNotFound(schema.GroupResource{
 		Group:    "v1",
@@ -45,7 +45,7 @@ func (identityProvider *iamIdentityProvider) GetRemoteCertificate(clusterID,
 }
 
 func (identityProvider *iamIdentityProvider) ApproveSigningRequest(clusterID,
-	signingRequest string) (response responsetypes.SigningRequestResponse, err error) {
+	signingRequest string) (response *responsetypes.SigningRequestResponse, err error) {
 	sess, err := session.NewSession(&aws.Config{
 		Region: aws.String(identityProvider.awsConfig.AwsRegion),
 		Credentials: credentials.NewStaticCredentialsFromCreds(credentials.Value{
@@ -83,7 +83,7 @@ func (identityProvider *iamIdentityProvider) ApproveSigningRequest(clusterID,
 		return response, err
 	}
 
-	return responsetypes.SigningRequestResponse{
+	return &responsetypes.SigningRequestResponse{
 		ResponseType: responsetypes.SigningRequestResponseIAM,
 		AwsIdentityResponse: responsetypes.AwsIdentityResponse{
 			IamUserArn: userArn,
@@ -100,7 +100,6 @@ func (identityProvider *iamIdentityProvider) ensureIamUser(sess *session.Session
 	}
 
 	createUserResult, err := iamSvc.CreateUser(createUser)
-
 	if err != nil {
 		// if the IAM user already exists, we cannot create another access key, since the previous creation
 		// can be made from another cluster. We have to validate a secret from the remote cluster before to continue

--- a/pkg/identityManager/identityManager.go
+++ b/pkg/identityManager/identityManager.go
@@ -1,6 +1,9 @@
 package identitymanager
 
 import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/liqotech/liqo/pkg/clusterid"
@@ -13,6 +16,8 @@ type identityManager struct {
 	client           kubernetes.Interface
 	localClusterID   clusterid.ClusterID
 	namespaceManager tenantnamespace.Manager
+
+	iamTokenManager tokenManager
 }
 
 // NewCertificateIdentityManager gets a new certificate identity manager.
@@ -42,11 +47,19 @@ func NewIAMIdentityManager(client kubernetes.Interface,
 		client:    client,
 	}
 
+	iamTokenManager := &iamTokenManager{
+		client:                    client,
+		availableClusterIDSecrets: map[string]types.NamespacedName{},
+	}
+	iamTokenManager.start(context.TODO())
+
 	return &identityManager{
 		client:           client,
 		localClusterID:   localClusterID,
 		namespaceManager: namespaceManager,
 
 		identityProvider: idProvider,
+
+		iamTokenManager: iamTokenManager,
 	}
 }

--- a/pkg/identityManager/interface.go
+++ b/pkg/identityManager/interface.go
@@ -26,6 +26,6 @@ type localManager interface {
 
 // interface that allows to manage the identity in the target cluster, where this identity has to be used.
 type identityProvider interface {
-	ApproveSigningRequest(clusterID, signingRequest string) (response responsetypes.SigningRequestResponse, err error)
-	GetRemoteCertificate(clusterID, signingRequest string) (response responsetypes.SigningRequestResponse, err error)
+	ApproveSigningRequest(clusterID, signingRequest string) (response *responsetypes.SigningRequestResponse, err error)
+	GetRemoteCertificate(clusterID, signingRequest string) (response *responsetypes.SigningRequestResponse, err error)
 }

--- a/pkg/identityManager/tokenManager.go
+++ b/pkg/identityManager/tokenManager.go
@@ -1,0 +1,212 @@
+package identitymanager
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	v1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/aws-iam-authenticator/pkg/token"
+)
+
+type tokenManager interface {
+	start(ctx context.Context)
+	getConfig(secret *v1.Secret, remoteClusterID string) (*rest.Config, error)
+}
+
+const tokenDir = "token"
+
+type iamTokenManager struct {
+	client                    kubernetes.Interface
+	availableClusterIDSecrets map[string]types.NamespacedName
+	availableTokenMutex       sync.Mutex
+}
+
+func (tokMan *iamTokenManager) start(ctx context.Context) {
+	go func() {
+		for {
+			select {
+			case <-time.NewTicker(10 * time.Minute).C:
+				klog.V(4).Info("Refreshing tokens...")
+				for remoteClusterID, namespacedName := range tokMan.availableClusterIDSecrets {
+					if err := tokMan.refreshToken(ctx, remoteClusterID, namespacedName); err != nil {
+						klog.Error(err)
+						continue
+					}
+				}
+				klog.V(4).Info("Tokens refresh completed")
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+}
+
+func (tokMan *iamTokenManager) refreshToken(ctx context.Context, remoteClusterID string, namespacedName types.NamespacedName) error {
+	secret, err := tokMan.client.CoreV1().Secrets(namespacedName.Namespace).Get(ctx, namespacedName.Name, metav1.GetOptions{})
+	if err != nil {
+		klog.Errorf("[%v] %v", remoteClusterID, err)
+		return err
+	}
+
+	tok, err := getIAMBearerToken(secret, remoteClusterID)
+	if err != nil {
+		klog.Errorf("[%v] %v", remoteClusterID, err)
+		return err
+	}
+
+	if _, err = tokMan.storeToken(remoteClusterID, tok); err != nil {
+		klog.Errorf("[%v] %v", remoteClusterID, err)
+		return err
+	}
+	return nil
+}
+
+func (tokMan *iamTokenManager) getConfig(secret *v1.Secret, remoteClusterID string) (*rest.Config, error) {
+	tok, err := getIAMBearerToken(secret, remoteClusterID)
+	if err != nil {
+		klog.Error(err)
+		return nil, err
+	}
+
+	clusterEndpoint, err := getValue(secret, apiServerURLSecretKey, remoteClusterID)
+	if err != nil {
+		klog.Error(err)
+		return nil, err
+	}
+
+	ca, err := getValue(secret, apiServerCaSecretKey, remoteClusterID)
+	if err != nil {
+		klog.Error(err)
+		return nil, err
+	}
+
+	filename, err := tokMan.storeToken(remoteClusterID, tok)
+	if err != nil {
+		klog.Error(err)
+		return nil, err
+	}
+
+	tokMan.addClusterID(remoteClusterID, types.NamespacedName{
+		Namespace: secret.Namespace,
+		Name:      secret.Name,
+	})
+
+	// create the rest config
+	return &rest.Config{
+		Host:            string(clusterEndpoint),
+		BearerTokenFile: filename,
+		TLSClientConfig: rest.TLSClientConfig{
+			CAData: ca,
+		},
+	}, nil
+}
+
+func (tokMan *iamTokenManager) addClusterID(remoteClusterID string, secret types.NamespacedName) {
+	tokMan.availableTokenMutex.Lock()
+	defer tokMan.availableTokenMutex.Unlock()
+	tokMan.availableClusterIDSecrets[remoteClusterID] = secret
+}
+
+func (tokMan *iamTokenManager) storeToken(remoteClusterID string, tok *token.Token) (string, error) {
+	_, err := os.Stat(tokenDir)
+	if os.IsNotExist(err) {
+		if err = os.Mkdir(tokenDir, 0750); err != nil {
+			klog.Error(err)
+			return "", err
+		}
+	}
+
+	filename := filepath.Join(tokenDir, remoteClusterID)
+	err = ioutil.WriteFile(filename, []byte(tok.Token), 0600)
+	if err != nil {
+		klog.Error(err)
+		return "", err
+	}
+
+	return filename, nil
+}
+
+func getIAMBearerToken(secret *v1.Secret, remoteClusterID string) (*token.Token, error) {
+	region, err := getValue(secret, awsRegionSecretKey, remoteClusterID)
+	if err != nil {
+		klog.Error(err)
+		return nil, err
+	}
+
+	accessKeyID, err := getValue(secret, awsAccessKeyIDSecretKey, remoteClusterID)
+	if err != nil {
+		klog.Error(err)
+		return nil, err
+	}
+
+	secretAccessKey, err := getValue(secret, awsSecretAccessKeySecretKey, remoteClusterID)
+	if err != nil {
+		klog.Error(err)
+		return nil, err
+	}
+
+	// start a new AWS session
+	sessRemote, err := session.NewSession(&aws.Config{
+		Region: aws.String(string(region)),
+		Credentials: credentials.NewStaticCredentialsFromCreds(credentials.Value{
+			AccessKeyID:     string(accessKeyID),
+			SecretAccessKey: string(secretAccessKey),
+		}),
+	})
+	if err != nil {
+		klog.Error(err)
+		return nil, err
+	}
+
+	eksClusterID, err := getValue(secret, awsEKSClusterIDSecretKey, remoteClusterID)
+	if err != nil {
+		klog.Error(err)
+		return nil, err
+	}
+
+	// set token options
+	opts := &token.GetTokenOptions{
+		ClusterID: string(eksClusterID),
+		Session:   sessRemote,
+	}
+
+	gen, err := token.NewGenerator(true, false)
+	if err != nil {
+		return nil, err
+	}
+
+	// get a new bearer token
+	tok, err := gen.GetWithOptions(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return &tok, nil
+}
+
+func getValue(secret *v1.Secret, key, remoteClusterID string) ([]byte, error) {
+	value, ok := secret.Data[key]
+	if !ok {
+		klog.Errorf("key %v not found in secret %v/%v", key, secret.Namespace, secret.Name)
+		err := kerrors.NewNotFound(schema.GroupResource{
+			Group:    "v1",
+			Resource: "secrets",
+		}, remoteClusterID)
+		return nil, err
+	}
+	return value, nil
+}


### PR DESCRIPTION
# Description

This pr includes the logic for the creation of a rest.Client from an IAM identity with a bearer token and its periodic refresh

# How Has This Been Tested?

- [x] On EKS cluster, to test that the new values are correctly used
- [x] Locally on KinD, to test that the non-AWS install is still working
