### PR TITLE
Fix permissions for liqo-gateway

### DIFF
--- a/deployments/liqo/files/liqo-gateway-Role.yaml
+++ b/deployments/liqo/files/liqo-gateway-Role.yaml
@@ -35,3 +35,4 @@ rules:
   verbs:
   - list
   - update
+  - watch

--- a/internal/liqonet/tunnel-operator/labelerOperator.go
+++ b/internal/liqonet/tunnel-operator/labelerOperator.go
@@ -14,6 +14,9 @@ import (
 	liqoutils "github.com/liqotech/liqo/pkg/liqonet/utils"
 )
 
+// +kubebuilder:rbac:groups=core,namespace="do-not-care",resources=pods,verbs=get;list;watch;update
+// +kubebuilder:rbac:groups=core,namespace="do-not-care",resources=services,verbs=list;watch;update
+
 const (
 	// These labels are the ones set during the deployment of liqo using the helm chart.
 	// Any change to those labels on the helm chart has also to be reflected here.

--- a/internal/liqonet/tunnel-operator/tunnel-operator.go
+++ b/internal/liqonet/tunnel-operator/tunnel-operator.go
@@ -81,8 +81,6 @@ type TunnelController struct {
 // role
 // +kubebuilder:rbac:groups=coordination.k8s.io,namespace="do-not-care",resources=leases,verbs=get;create;update
 // +kubebuilder:rbac:groups=core,namespace="do-not-care",resources=secrets,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=core,namespace="do-not-care",resources=pods,verbs=get;list;watch;update
-// +kubebuilder:rbac:groups=core,namespace="do-not-care",resources=services,verbs=list;update
 
 // NewTunnelController instantiates and initializes the tunnel controller.
 func NewTunnelController(podIP, namespace string, er record.EventRecorder,


### PR DESCRIPTION
# Description

This PR adds the `watch` verb to the `liqo-gateway` component for the `service` resources.
