### PR TITLE
Add support for aws load balancers in liqo-network-manager

### DIFF
--- a/internal/liqonet/tunnelEndpointCreator/serviceWatcher.go
+++ b/internal/liqonet/tunnelEndpointCreator/serviceWatcher.go
@@ -92,7 +92,11 @@ func (tec *TunnelEndpointCreator) serviceHandlerAdd(obj interface{}) {
 			klog.Infof("ingress IPs has not been set for service %s in namespace %s of type %s", s.GetName(), s.GetNamespace(), s.Spec.Type)
 			return
 		}
-		endpointIP = s.Status.LoadBalancer.Ingress[0].IP
+		if s.Status.LoadBalancer.Ingress[0].IP != "" {
+			endpointIP = s.Status.LoadBalancer.Ingress[0].IP
+		} else if s.Status.LoadBalancer.Ingress[0].Hostname != "" {
+			endpointIP = s.Status.LoadBalancer.Ingress[0].Hostname
+		}
 
 		for _, port := range s.Spec.Ports {
 			if port.Name == wireguard.DriverName {


### PR DESCRIPTION
# Description

When checking if the IP address of a loadbalancer has been set we also consider the `hostname` field inside the status.
If the ip address is not set than we check the `hostname`.

- `IP`  is set for load-balancer ingress points that are IP based, typically GCE or OpenStack load-balancers. 

- `Hostname`  is set for load-balancer ingress points that are DNS based, typically AWS load-balancers.

Fixes #(issue)
The network configuration is now correctly exchanged between `aws eks` clusters.
# How Has This Been Tested?

