### PR TITLE
Fix AWS Client Creation and Credentials Secret

### DIFF
--- a/deployments/liqo/templates/liqo-aws-credentials.yaml
+++ b/deployments/liqo/templates/liqo-aws-credentials.yaml
@@ -10,7 +10,7 @@ metadata:
     {{- include "liqo.labels" $awsConfig | nindent 4 }}
   name: {{ include "liqo.prefixedName" $awsConfig }}
 data:
-    ACCESS_KEY_ID: {{ .Values.awsConfig.accessKeyId | quote }}
-    SECRET_ACCESS_KEY: {{ .Values.awsConfig.secretAccessKey | quote }}
+    ACCESS_KEY_ID: {{ .Values.awsConfig.accessKeyId | b64enc }}
+    SECRET_ACCESS_KEY: {{ .Values.awsConfig.secretAccessKey | b64enc }}
 
 {{- end }}

--- a/pkg/identityManager/identityManager.go
+++ b/pkg/identityManager/identityManager.go
@@ -29,13 +29,7 @@ func NewCertificateIdentityManager(client kubernetes.Interface,
 		client:           client,
 	}
 
-	return &identityManager{
-		client:           client,
-		localClusterID:   localClusterID,
-		namespaceManager: namespaceManager,
-
-		identityProvider: idProvider,
-	}
+	return newIdentityManager(client, localClusterID, namespaceManager, idProvider)
 }
 
 // NewIAMIdentityManager gets a new identity manager to handle IAM identities.
@@ -47,6 +41,13 @@ func NewIAMIdentityManager(client kubernetes.Interface,
 		client:    client,
 	}
 
+	return newIdentityManager(client, localClusterID, namespaceManager, idProvider)
+}
+
+func newIdentityManager(client kubernetes.Interface,
+	localClusterID clusterid.ClusterID,
+	namespaceManager tenantnamespace.Manager,
+	idProvider identityProvider) IdentityManager {
 	iamTokenManager := &iamTokenManager{
 		client:                    client,
 		availableClusterIDSecrets: map[string]types.NamespacedName{},


### PR DESCRIPTION
# Description

This pr fixes two bugs interacting with EKS clusters:
* client creation
* AWS credentials secret

# How Has This Been Tested?

- [x] On EKS cluster peering
