### PR TITLE
Fix Documentation Pipeline Bug

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -159,6 +159,12 @@ jobs:
     needs: configure
     if: needs.configure.outputs.ok-to-continue == 'true' && github.event.pull_request.draft == false
     steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+        with:
+          ref: "${{ needs.configure.outputs.commit_ref }}"
+          repository: "${{ needs.configure.outputs.repo-name }}"
+          persist-credentials: false
       - name: Check if /docs files changed
         uses: dorny/paths-filter@v2
         id: pathFilter


### PR DESCRIPTION
# Description

This PR fixes a bug on the documentation trigger pipeline. As documented on the [dorny/path filter repository](https://github.com/dorny/paths-filter#change-detection-workflows), when this action is run on a push event (as it is on the master branch), it should be executed after a repo checkout (which was missing).