### PR TITLE
Minor fixes on Liqo network module

### DIFF
--- a/internal/liqonet/tunnelEndpointCreator/tunnelEndpointCreator-operator.go
+++ b/internal/liqonet/tunnelEndpointCreator/tunnelEndpointCreator-operator.go
@@ -306,7 +306,7 @@ func (tec *TunnelEndpointCreator) deleteNetConfig(fc *discoveryv1alpha1.ForeignC
 	}
 	if len(netConfigList.Items) != 1 {
 		if len(netConfigList.Items) == 0 {
-			klog.Infof("nothing to remove: a resource of type %s for remote cluster %s not found",
+			klog.V(4).Infof("nothing to remove: a resource of type %s for remote cluster %s not found",
 				netv1alpha1.GroupVersion.String(), clusterID)
 			return nil
 		}

--- a/pkg/liqonet/iptables/iptables.go
+++ b/pkg/liqonet/iptables/iptables.go
@@ -681,6 +681,7 @@ func getPostroutingRules(tep *netv1alpha1.TunnelEndpoint) ([]IPTableRule, error)
 		}
 		return []IPTableRule{
 			{"-s", localPodCIDR, "-d", remotePodCIDR, "-j", NETMAP, "--to", localRemappedPodCIDR},
+			{"-s", localPodCIDR, "-d", remoteExternalCIDR, "-j", NETMAP, "--to", localRemappedPodCIDR},
 			{"!", "-s", localPodCIDR, "-d", remotePodCIDR, "-j", SNAT, "--to-source", natIP},
 			{"!", "-s", localPodCIDR, "-d", remoteExternalCIDR, "-j", SNAT, "--to-source", natIP},
 		}, nil

--- a/pkg/liqonet/iptables/iptables_test.go
+++ b/pkg/liqonet/iptables/iptables_test.go
@@ -671,6 +671,7 @@ var _ = Describe("iptables", func() {
 				Expect(newPostRoutingRules).ToNot(ContainElements(postRoutingRules))
 				Expect(newPostRoutingRules).To(ContainElements([]string{
 					fmt.Sprintf("-s %s -d %s -j %s --to %s", tep.Status.LocalPodCIDR, tep.Status.RemoteNATPodCIDR, NETMAP, tep.Status.LocalNATPodCIDR),
+					fmt.Sprintf("-s %s -d %s -j %s --to %s", tep.Status.LocalPodCIDR, tep.Status.RemoteNATExternalCIDR, NETMAP, tep.Status.LocalNATPodCIDR),
 					fmt.Sprintf("! -s %s -d %s -j %s --to-source %s", tep.Status.LocalPodCIDR, tep.Status.RemoteNATPodCIDR,
 						SNAT, mustGetFirstIP(tep.Status.LocalNATPodCIDR)),
 					fmt.Sprintf("! -s %s -d %s -j %s --to-source %s", tep.Status.LocalPodCIDR, tep.Status.RemoteNATExternalCIDR,
@@ -695,6 +696,7 @@ var _ = Describe("iptables", func() {
 				func() []string {
 					return []string{
 						fmt.Sprintf("-s %s -d %s -j %s --to %s", tep.Status.LocalPodCIDR, tep.Status.RemoteNATPodCIDR, NETMAP, tep.Status.LocalNATPodCIDR),
+						fmt.Sprintf("-s %s -d %s -j %s --to %s", tep.Status.LocalPodCIDR, tep.Status.RemoteNATExternalCIDR, NETMAP, tep.Status.LocalNATPodCIDR),
 						fmt.Sprintf("! -s %s -d %s -j %s --to-source %s", tep.Status.LocalPodCIDR, tep.Status.RemoteNATPodCIDR,
 							SNAT, mustGetFirstIP(tep.Status.LocalNATPodCIDR)),
 						fmt.Sprintf("! -s %s -d %s -j %s --to-source %s", tep.Status.LocalPodCIDR, tep.Status.RemoteNATExternalCIDR,
@@ -720,6 +722,7 @@ var _ = Describe("iptables", func() {
 				func() []string {
 					return []string{
 						fmt.Sprintf("-s %s -d %s -j %s --to %s", tep.Status.LocalPodCIDR, tep.Spec.PodCIDR, NETMAP, tep.Status.LocalNATPodCIDR),
+						fmt.Sprintf("-s %s -d %s -j %s --to %s", tep.Status.LocalPodCIDR, tep.Status.RemoteNATExternalCIDR, NETMAP, tep.Status.LocalNATPodCIDR),
 						fmt.Sprintf("! -s %s -d %s -j %s --to-source %s", tep.Status.LocalPodCIDR, tep.Spec.PodCIDR,
 							SNAT, mustGetFirstIP(tep.Status.LocalNATPodCIDR)),
 						fmt.Sprintf("! -s %s -d %s -j %s --to-source %s", tep.Status.LocalPodCIDR, tep.Status.RemoteNATExternalCIDR,
@@ -747,6 +750,7 @@ var _ = Describe("iptables", func() {
 				func() []string {
 					return []string{
 						fmt.Sprintf("-s %s -d %s -j %s --to %s", tep.Status.LocalPodCIDR, tep.Status.RemoteNATPodCIDR, NETMAP, tep.Status.LocalNATPodCIDR),
+						fmt.Sprintf("-s %s -d %s -j %s --to %s", tep.Status.LocalPodCIDR, tep.Spec.ExternalCIDR, NETMAP, tep.Status.LocalNATPodCIDR),
 						fmt.Sprintf("! -s %s -d %s -j %s --to-source %s", tep.Status.LocalPodCIDR, tep.Status.RemoteNATPodCIDR,
 							SNAT, mustGetFirstIP(tep.Status.LocalNATPodCIDR)),
 						fmt.Sprintf("! -s %s -d %s -j %s --to-source %s", tep.Status.LocalPodCIDR, tep.Spec.ExternalCIDR,
@@ -778,6 +782,7 @@ var _ = Describe("iptables", func() {
 				func() []string {
 					return []string{
 						fmt.Sprintf("-s %s -d %s -j %s --to %s", tep.Status.LocalPodCIDR, tep.Spec.PodCIDR, NETMAP, tep.Status.LocalNATPodCIDR),
+						fmt.Sprintf("-s %s -d %s -j %s --to %s", tep.Status.LocalPodCIDR, tep.Spec.ExternalCIDR, NETMAP, tep.Status.LocalNATPodCIDR),
 						fmt.Sprintf("! -s %s -d %s -j %s --to-source %s", tep.Status.LocalPodCIDR, tep.Spec.PodCIDR,
 							SNAT, mustGetFirstIP(tep.Status.LocalNATPodCIDR)),
 						fmt.Sprintf("! -s %s -d %s -j %s --to-source %s", tep.Status.LocalPodCIDR, tep.Spec.ExternalCIDR,


### PR DESCRIPTION
This PR fixes a couple of bugs in Liqo networking. The first causes connection problems on environments that do not NAT Pod traffic, therefore it has been fixed by adding an appropriate NAT rule. The second causes problems during endpoint reflection after the Liqo network manager is rescheduled: the NatMappingInflater module do not recover correctly and therefore remote clusters appear to have no configuration. It has been fixed by recovering correctly taking advantage on existing natmappingresources.