### PR TITLE
Remove Informer Factory from CrdReplicator

### DIFF
--- a/cmd/crd-replicator/main.go
+++ b/cmd/crd-replicator/main.go
@@ -5,11 +5,9 @@ import (
 	"os"
 	"time"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/dynamic"
-	"k8s.io/client-go/dynamic/dynamicinformer"
 	"k8s.io/client-go/kubernetes"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/klog/v2"
@@ -79,22 +77,18 @@ func main() {
 	clusterIDInterface := clusterid.NewStaticClusterID(clusterID)
 	namespaceManager := tenantnamespace.NewTenantNamespaceManager(k8sClient)
 	dynClient := dynamic.NewForConfigOrDie(cfg)
-	dynFac := dynamicinformer.NewFilteredDynamicSharedInformerFactory(
-		dynClient, crdreplicator.ResyncPeriod, metav1.NamespaceAll, crdreplicator.SetLabelsForLocalResources)
 	d := &crdreplicator.Controller{
-		Scheme:                         mgr.GetScheme(),
-		Client:                         mgr.GetClient(),
-		ClientSet:                      k8sClient,
-		ClusterID:                      clusterID,
-		RemoteDynClients:               make(map[string]dynamic.Interface),
-		LocalDynClient:                 dynClient,
-		LocalDynSharedInformerFactory:  dynFac,
-		RegisteredResources:            nil,
-		UnregisteredResources:          nil,
-		LocalWatchers:                  make(map[string]chan struct{}),
-		RemoteWatchers:                 make(map[string]map[string]chan struct{}),
-		RemoteDynSharedInformerFactory: make(map[string]dynamicinformer.DynamicSharedInformerFactory),
-		NamespaceManager:               namespaceManager,
+		Scheme:                mgr.GetScheme(),
+		Client:                mgr.GetClient(),
+		ClientSet:             k8sClient,
+		ClusterID:             clusterID,
+		RemoteDynClients:      make(map[string]dynamic.Interface),
+		LocalDynClient:        dynClient,
+		RegisteredResources:   nil,
+		UnregisteredResources: nil,
+		LocalWatchers:         make(map[string]chan struct{}),
+		RemoteWatchers:        make(map[string]map[string]chan struct{}),
+		NamespaceManager:      namespaceManager,
 		IdentityReader: identitymanager.NewCertificateIdentityReader(
 			k8sClient, clusterIDInterface, namespaceManager),
 		LocalToRemoteNamespaceMapper:     map[string]string{},

--- a/internal/crdReplicator/crdReplicator-operator_test.go
+++ b/internal/crdReplicator/crdReplicator-operator_test.go
@@ -13,7 +13,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
-	"k8s.io/client-go/dynamic/dynamicinformer"
 	"k8s.io/klog/v2"
 
 	configv1alpha1 "github.com/liqotech/liqo/apis/config/v1alpha1"
@@ -94,16 +93,14 @@ func getCRDReplicator() Controller {
 	tenantmanager := tenantnamespace.NewTenantNamespaceManager(k8sclient)
 	clusterIDInterface := clusterid.NewStaticClusterID(localClusterID)
 	return Controller{
-		Scheme:                         nil,
-		ClusterID:                      localClusterID,
-		RemoteDynClients:               map[string]dynamic.Interface{remoteClusterID: dynClient},
-		RemoteDynSharedInformerFactory: map[string]dynamicinformer.DynamicSharedInformerFactory{remoteClusterID: dynFac},
-		RegisteredResources:            nil,
-		UnregisteredResources:          nil,
-		RemoteWatchers:                 map[string]map[string]chan struct{}{},
-		LocalDynClient:                 dynClient,
-		LocalDynSharedInformerFactory:  localDynFac,
-		LocalWatchers:                  map[string]chan struct{}{},
+		Scheme:                nil,
+		ClusterID:             localClusterID,
+		RemoteDynClients:      map[string]dynamic.Interface{remoteClusterID: dynClient},
+		RegisteredResources:   nil,
+		UnregisteredResources: nil,
+		RemoteWatchers:        map[string]map[string]chan struct{}{},
+		LocalDynClient:        dynClient,
+		LocalWatchers:         map[string]chan struct{}{},
 
 		NamespaceManager:                 tenantmanager,
 		IdentityReader:                   identitymanager.NewCertificateIdentityReader(k8sclient, clusterIDInterface, tenantmanager),
@@ -385,7 +382,7 @@ func TestCRDReplicatorReconciler_RemoteResourceModifiedHandler(t *testing.T) {
 	//the modified resource does not exist on the cluster
 	//we expect the resource to be created and error to be nil
 	test1 := getObj()
-	d.RemoteResourceModifiedHandler(test1, gvr, remoteClusterID, consts.OwnershipShared)
+	d.RemoteResourceModifiedHandler(dynClient, test1, gvr, remoteClusterID, consts.OwnershipShared)
 	time.Sleep(1 * time.Second)
 	_, err := dynClient.Resource(gvr).Namespace(testNamespace).Get(context.TODO(), test1.GetName(), metav1.GetOptions{})
 	assert.True(t, apierrors.IsNotFound(err), "error should be not found")
@@ -399,7 +396,7 @@ func TestCRDReplicatorReconciler_RemoteResourceModifiedHandler(t *testing.T) {
 	test1.SetLabels(map[string]string{
 		"labelTestin": "labelling",
 	})
-	d.RemoteResourceModifiedHandler(test1, gvr, remoteClusterID, consts.OwnershipShared)
+	d.RemoteResourceModifiedHandler(dynClient, test1, gvr, remoteClusterID, consts.OwnershipShared)
 	time.Sleep(1 * time.Second)
 	obj, err := dynClient.Resource(gvr).Namespace(testNamespace).Get(context.TODO(), test1.GetName(), metav1.GetOptions{})
 	assert.Nil(t, err, "error should be empty")
@@ -416,7 +413,7 @@ func TestCRDReplicatorReconciler_RemoteResourceModifiedHandler(t *testing.T) {
 	}
 	err = unstructured.SetNestedMap(obj.Object, newStatus, "status")
 	assert.Nil(t, err, "error should be nil")
-	d.RemoteResourceModifiedHandler(test1, gvr, remoteClusterID, consts.OwnershipShared)
+	d.RemoteResourceModifiedHandler(dynClient, test1, gvr, remoteClusterID, consts.OwnershipShared)
 	time.Sleep(1 * time.Second)
 	obj, err = dynClient.Resource(gvr).Namespace(testNamespace).Get(context.TODO(), test1.GetName(), metav1.GetOptions{})
 	assert.Nil(t, err, "error should be empty")

--- a/test/unit/crdReplicator/env_test.go
+++ b/test/unit/crdReplicator/env_test.go
@@ -10,7 +10,6 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/dynamic"
-	"k8s.io/client-go/dynamic/dynamicinformer"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
@@ -30,16 +29,16 @@ import (
 var (
 	numberPeeringClusters = 1
 
-	peeringIDTemplate           = "peering-cluster-"
-	localClusterID              = "localClusterID"
-	peeringClustersTestEnvs     = map[string]*envtest.Environment{}
-	peeringClustersManagers     = map[string]ctrl.Manager{}
-	peeringClustersDynClients   = map[string]dynamic.Interface{}
-	peeringClustersDynFactories = map[string]dynamicinformer.DynamicSharedInformerFactory{}
-	configClusterClient         *crdclient.CRDClient
-	k8sManagerLocal             ctrl.Manager
-	testEnvLocal                *envtest.Environment
-	dOperator                   *crdreplicator.Controller
+	peeringIDTemplate                = "peering-cluster-"
+	localClusterID                   = "localClusterID"
+	peeringClustersTestEnvs          = map[string]*envtest.Environment{}
+	peeringClustersManagers          = map[string]ctrl.Manager{}
+	peeringClustersDynClients        = map[string]dynamic.Interface{}
+	configClusterClient              *crdclient.CRDClient
+	k8sManagerLocal                  ctrl.Manager
+	testEnvLocal                     *envtest.Environment
+	dOperator                        *crdreplicator.Controller
+	clusterIDToRemoteNamespaceMapper = map[string]string{}
 )
 
 func TestMain(m *testing.M) {
@@ -131,11 +130,7 @@ func setupEnv() {
 		peeringClustersManagers[peeringClusterID] = manager
 		dynClient := dynamic.NewForConfigOrDie(manager.GetConfig())
 		peeringClustersDynClients[peeringClusterID] = dynClient
-		dynFac := dynamicinformer.NewFilteredDynamicSharedInformerFactory(dynClient, crdreplicator.ResyncPeriod, metav1.NamespaceAll, func(options *metav1.ListOptions) {
-			//we want to watch only the resources that have been created by us on the remote cluster
-			options.LabelSelector = crdreplicator.RemoteLabelSelector + "=" + localClusterID
-		})
-		peeringClustersDynFactories[peeringClusterID] = dynFac
+		clusterIDToRemoteNamespaceMapper[peeringClusterID] = testNamespace
 	}
 	//setup the local testing environment
 	testEnvLocal = &envtest.Environment{


### PR DESCRIPTION
# Description

This pr removes the informer factory from the CrdReplicator. The informer factory was causing pods restarts at each unpeer/peer operation since it does not allow restarting stopped informers

# How Has This Been Tested?

- [x] Locally on KinD
