### PR TITLE
Fix bug causing liqo-gateway to crash when restarting

### DIFF
--- a/deployments/liqo/files/liqo-gateway-ClusterRole.yaml
+++ b/deployments/liqo/files/liqo-gateway-ClusterRole.yaml
@@ -12,6 +12,23 @@ rules:
   - update
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - list
+  - update
+  - watch
+- apiGroups:
   - net.liqo.io
   resources:
   - natmappings

--- a/deployments/liqo/files/liqo-gateway-Role.yaml
+++ b/deployments/liqo/files/liqo-gateway-Role.yaml
@@ -10,15 +10,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
-  verbs:
-  - get
-  - list
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
   - secrets
   verbs:
   - create
@@ -26,13 +17,5 @@ rules:
   - get
   - list
   - patch
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - services
-  verbs:
-  - list
   - update
   - watch

--- a/internal/liqonet/tunnel-operator/labelerOperator.go
+++ b/internal/liqonet/tunnel-operator/labelerOperator.go
@@ -14,8 +14,8 @@ import (
 	liqoutils "github.com/liqotech/liqo/pkg/liqonet/utils"
 )
 
-// +kubebuilder:rbac:groups=core,namespace="do-not-care",resources=pods,verbs=get;list;watch;update
-// +kubebuilder:rbac:groups=core,namespace="do-not-care",resources=services,verbs=list;watch;update
+// +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch;update
+// +kubebuilder:rbac:groups=core,resources=services,verbs=list;watch;update
 
 const (
 	// These labels are the ones set during the deployment of liqo using the helm chart.

--- a/internal/liqonet/tunnel-operator/tunnel_operator_suite_test.go
+++ b/internal/liqonet/tunnel-operator/tunnel_operator_suite_test.go
@@ -88,6 +88,8 @@ var _ = BeforeSuite(func() {
 	gatewayNetns, err = netns.CreateNetns(consts.GatewayNetnsName)
 	Expect(err).To(BeNil())
 	tc.gatewayNetns = gatewayNetns
+	tc.hostNetns, err = ns.GetCurrentNS()
+	Expect(err).To(BeNil())
 
 	// Create custom network namespace for natmapping-operator.
 	iptNetns, err = netns.CreateNetns(iptNetnsName)

--- a/internal/liqonet/tunnel-operator/tunnel_operator_test.go
+++ b/internal/liqonet/tunnel-operator/tunnel_operator_test.go
@@ -50,7 +50,6 @@ var _ = Describe("TunnelOperator", func() {
 
 					return nil
 				})
-				Expect(tc.hostNetns.Close()).ShouldNot(HaveOccurred())
 			})
 
 			It("incorrect name for veth interface, should return error", func() {

--- a/pkg/consts/liqonet.go
+++ b/pkg/consts/liqonet.go
@@ -74,4 +74,6 @@ const (
 	RemoteNATPodCIDR = "RemoteNATPodCIDR"
 	// RemoteNATExternalCIDR is a field of the TunnelEndpoint resource.
 	RemoteNATExternalCIDR = "RemoteNATExternalCIDR"
+	// FinalizersSuffix suffix used by the network operators to create the finalizers added to k8s resources.
+	FinalizersSuffix = "net.liqo.io"
 )

--- a/pkg/liqonet/netns/netns_suite_test.go
+++ b/pkg/liqonet/netns/netns_suite_test.go
@@ -37,11 +37,15 @@ func setUpNetns(name string) {
 	// Set the newly created newNs
 	err = netns.Set(newNs)
 	Expect(err).ShouldNot(HaveOccurred())
-	// Create a dummy network interface
-	err = netlink.LinkAdd(&netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: "foo"}})
+	// Create a dummy network interface in gateway netns.
+	err = netlink.LinkAdd(&netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: existingGatewayVeth}})
 	Expect(err).ShouldNot(HaveOccurred())
 	err = originNetns.Set()
-	Expect(err).ShouldNot(HaveOccurred())
+	// Create dummy network interface in host netns.
+	err = netlink.LinkAdd(&netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: existingHostVeth}})
+	if !errors.Is(err, unix.EEXIST) {
+		Expect(err).ShouldNot(HaveOccurred())
+	}
 	// Save newly created netns.
 	newNetns, err = ns.GetNS("/run/netns/" + netnsName)
 	Expect(err).ShouldNot(HaveOccurred())

--- a/pkg/liqonet/netns/netns_test.go
+++ b/pkg/liqonet/netns/netns_test.go
@@ -12,8 +12,10 @@ import (
 )
 
 var (
-	hostVeth    = "originVeth"
-	gatewayVeth = "dstVeth"
+	hostVeth            = "originVeth"
+	existingHostVeth    = "host-foo"
+	gatewayVeth         = "dstVeth"
+	existingGatewayVeth = "gateway-foo"
 )
 
 var _ = Describe("Netns", func() {
@@ -111,9 +113,14 @@ var _ = Describe("Netns", func() {
 				setUpNetns(netnsName)
 			})
 
-			It("should return error", func() {
-				err := CreateVethPair(hostVeth, "foo", originNetns, newNetns, 1500)
+			It("link exists in gateway netns, should return error", func() {
+				err := CreateVethPair(hostVeth, existingGatewayVeth, originNetns, newNetns, 1500)
 				Expect(err).Should(HaveOccurred())
+			})
+
+			It("link exists in host netns, should remove it and create again", func() {
+				err := CreateVethPair(existingHostVeth, gatewayVeth, originNetns, newNetns, 1500)
+				Expect(err).Should(BeNil())
 			})
 		})
 


### PR DESCRIPTION
# Description

Issues fixed in this PR:

1. Moved back the labelOperator in the main manager to fix the problems of the leader election process causing the secondary managers to start, being them unrelated with the leader election of the main manager.
2. Some times, based on the load of the operating system, some network interfaces are not garbage collected by the kernel when their related network namespace has been removed. This caused the operator to restart when these network interfaces are still present. Now when the operator starts removes the outdated network interfaces before trying to create them again.
3. The finalizer added to the `tunnelendpoints.net.liqo.io` by the operator are related to the IP address that the operator has when the finalizer is added. When the operator is rescheduled or another replica becomes the `leader` it would add a new finalizer different from the first one. The old one would prevent the deletion of the resources. Now the finalizer of `liqo-gateway` is a constant, and at the same time, when the operator exits, tries to remove all it's finalizers from the existing resources.  


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B
