### PR TITLE
Use ClusterID in the Tenant Namespace Name

### DIFF
--- a/apis/discovery/v1alpha1/foreigncluster_types.go
+++ b/apis/discovery/v1alpha1/foreigncluster_types.go
@@ -160,6 +160,7 @@ type TenantNamespaceType struct {
 // +kubebuilder:subresource:status
 
 // ForeignCluster is the Schema for the foreignclusters API.
+// +kubebuilder:printcolumn:name="ClusterID",type=string,priority=1,JSONPath=`.spec.clusterIdentity.clusterID`
 // +kubebuilder:printcolumn:name="Outgoing peering phase",type=string,JSONPath=`.status.peeringConditions[?(@.type == 'OutgoingPeering')].status`
 // +kubebuilder:printcolumn:name="Incoming peering phase",type=string,JSONPath=`.status.peeringConditions[?(@.type == 'IncomingPeering')].status`
 // +kubebuilder:printcolumn:name="Networking status",type=string,JSONPath=`.status.peeringConditions[?(@.type == 'NetworkStatus')].status`

--- a/deployments/liqo/crds/discovery.liqo.io_foreignclusters.yaml
+++ b/deployments/liqo/crds/discovery.liqo.io_foreignclusters.yaml
@@ -17,6 +17,10 @@ spec:
   scope: Cluster
   versions:
   - additionalPrinterColumns:
+    - jsonPath: .spec.clusterIdentity.clusterID
+      name: ClusterID
+      priority: 1
+      type: string
     - jsonPath: .status.peeringConditions[?(@.type == 'OutgoingPeering')].status
       name: Outgoing peering phase
       type: string

--- a/pkg/identityManager/identityManager_test.go
+++ b/pkg/identityManager/identityManager_test.go
@@ -78,9 +78,9 @@ var _ = Describe("IdentityManager", func() {
 
 	BeforeSuite(func() {
 		localClusterID = test.ClusterIDMock{
-			Id: "localID",
+			Id: "local-id",
 		}
-		remoteClusterID = "remoteID"
+		remoteClusterID = "remote-id"
 
 		var err error
 		cluster, _, err = testUtils.NewTestCluster([]string{filepath.Join("..", "..", "deployments", "liqo", "crds")})

--- a/pkg/tenantNamespace/tenantNamespaceManager_test.go
+++ b/pkg/tenantNamespace/tenantNamespaceManager_test.go
@@ -35,7 +35,7 @@ var _ = Describe("TenantNamespace", func() {
 	)
 
 	BeforeSuite(func() {
-		clusterID = "testCreation"
+		clusterID = "test-creation"
 
 		var err error
 		cluster, _, err = testUtils2.NewTestCluster([]string{filepath.Join("..", "..", "deployments", "liqo", "crds")})
@@ -101,7 +101,7 @@ var _ = Describe("TenantNamespace", func() {
 
 		BeforeEach(func() {
 			cnt += 1
-			clusterID = fmt.Sprintf("testPermission%v", cnt)
+			clusterID = fmt.Sprintf("test-permission-%v", cnt)
 			client = cluster.GetClient().Client()
 
 			cr := &rbacv1.ClusterRole{


### PR DESCRIPTION
# Description

This pr includes some small changes to improve visibility and navigation:
* the Tenant Namespace Name contains the clusterID if the remote cluster, as the ForeignCluster and the VirtualNode
* now it is possible to obtain the clusterIDs getting `k get foreigncluster -o wide`

# How Has This Been Tested?

- [x] locally on KinD
