### PR TITLE
Fix a yaml file in the docs/examples.

### DIFF
--- a/docs/examples/hello-world.yaml
+++ b/docs/examples/hello-world.yaml
@@ -41,7 +41,7 @@ spec:
       requiredDuringSchedulingIgnoredDuringExecution:
         nodeSelectorTerms:
           - matchExpressions:
-              - key: type
+              - key: liqo.io/type
                 operator: In
                 values:
                   - virtual-node


### PR DESCRIPTION
# Description

The hello-world.yaml creates the "nginx-remote" pod with a "nodeAffinity" not correct, the label key "type" does not exists anymore. The key has been replaced with "liqo.io/type" like in the "nginx-local" pod.
