### PR TITLE
Remove resource limits for liqo deployments

### DIFF
--- a/deployments/liqo/templates/liqo-auth-deployment.yaml
+++ b/deployments/liqo/templates/liqo-auth-deployment.yaml
@@ -51,9 +51,6 @@ spec:
             - -out
             - /certs/cert.pem
           resources:
-            limits:
-              cpu: "1"
-              memory: "100M"
             requests:
               cpu: "200m"
               memory: "100M"

--- a/deployments/liqo/templates/liqo-discovery-deployment.yaml
+++ b/deployments/liqo/templates/liqo-discovery-deployment.yaml
@@ -38,9 +38,6 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
           resources:
-            limits:
-              cpu: 50m
-              memory: 50M
             requests:
               cpu: 50m
               memory: 50M

--- a/deployments/liqo/templates/liqo-gateway-deployment.yaml
+++ b/deployments/liqo/templates/liqo-gateway-deployment.yaml
@@ -38,12 +38,9 @@ spec:
           - -run-as=liqo-gateway
           - -leader-elect=true
           resources:
-            limits:
-              cpu: 500m
-              memory: 300M
             requests:
-              cpu: 10m
-              memory: 30M
+              cpu: 250m
+              memory: 100M
           securityContext:
             privileged: true
           env:


### PR DESCRIPTION
# Description

Removing  resource limits for the `liqo` deployments in the helm chart.

Fixes #(issue)
#602

