### PR TITLE
Fix Kubelet Startup on EKS Provider

### DIFF
--- a/cmd/init-virtual-kubelet/main.go
+++ b/cmd/init-virtual-kubelet/main.go
@@ -58,11 +58,11 @@ func main() {
 	go informer.Run(cancelCtx.Done())
 	select {
 	case <-cancelCtx.Done():
-		klog.Fatalf("Unable to get certificate: timeout elapsed")
+		klog.Error("Unable to get certificate: timeout elapsed")
 	case cert = <-crtChan:
-		cancel()
 		if err := utils.WriteFile(vk.CertLocation, cert); err != nil {
 			klog.Fatalf("Unable to write the CRT file in location: %s", vk.CertLocation)
 		}
 	}
+	cancel()
 }


### PR DESCRIPTION
# Description

This pr includes a fix that allows the VirtualKubelet to start in an EKS cluster ignoring the absence of a certificate with node permissions

# How Has This Been Tested?

- [x] On EKS cluster
