### PR TITLE
Improved IPAM recovery procedure

### DIFF
--- a/apis/net/v1alpha1/ipamstorage_types.go
+++ b/apis/net/v1alpha1/ipamstorage_types.go
@@ -62,7 +62,9 @@ type IpamSpec struct {
 	ClusterSubnets map[string]Subnets `json:"clusterSubnets"`
 	// Cluster ExternalCIDR
 	ExternalCIDR string `json:"externalCIDR"`
-	// Endpoint IP mappings. Key is the IP address of the local endpoint, value is the IP of the remote endpoint, so it belongs to an ExternalCIDR
+	// Endpoint IP mappings. Key is the IP address of the local endpoint, value is an EndpointMapping struct
+	// that contains the related IP belonging to the ExternalCIDR and also the list of clusters
+	// on which this mapping is active
 	EndpointMappings map[string]EndpointMapping `json:"endpointMappings"`
 	// NatMappingsConfigured is a map that contains all the remote clusters
 	// for which NatMappings have been already configured.

--- a/deployments/liqo/crds/net.liqo.io_ipamstorages.yaml
+++ b/deployments/liqo/crds/net.liqo.io_ipamstorages.yaml
@@ -89,8 +89,9 @@ spec:
                   - ip
                   type: object
                 description: Endpoint IP mappings. Key is the IP address of the local
-                  endpoint, value is the IP of the remote endpoint, so it belongs
-                  to an ExternalCIDR
+                  endpoint, value is an EndpointMapping struct that contains the related
+                  IP belonging to the ExternalCIDR and also the list of clusters on
+                  which this mapping is active
                 type: object
               externalCIDR:
                 description: Cluster ExternalCIDR

--- a/pkg/liqonet/ipam/ipam.pb.go
+++ b/pkg/liqonet/ipam/ipam.pb.go
@@ -7,10 +7,11 @@
 package ipam
 
 import (
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
+
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (

--- a/pkg/liqonet/ipam/ipam_grpc.pb.go
+++ b/pkg/liqonet/ipam/ipam_grpc.pb.go
@@ -4,6 +4,7 @@ package ipam
 
 import (
 	context "context"
+
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"


### PR DESCRIPTION
This PR solves possible problems that could arise if the network manager were killed unespectedly. In particular, it manages the case in which there are inconsistencies between the IPAM configuration and some NatMapping resources: at startup, the two resources are compared and the IPAM configuration is used as source of true if conflicts are found.