### PR TITLE
Ensure no ClusterID Repetition

### DIFF
--- a/apis/discovery/v1alpha1/foreigncluster_types.go
+++ b/apis/discovery/v1alpha1/foreigncluster_types.go
@@ -47,6 +47,10 @@ const (
 	// This is only used by the AuthenticationCondition Type, and indicates that
 	// the identity verification was denied with an empty token.
 	PeeringConditionStatusEmptyDenied PeeringConditionStatusType = "EmptyDenied"
+	// PeeringConditionStatusError indicates that an error has occurred.
+	PeeringConditionStatusError PeeringConditionStatusType = "Error"
+	// PeeringConditionStatusSuccess indicates that the condition is successful.
+	PeeringConditionStatusSuccess PeeringConditionStatusType = "Success"
 )
 
 // PeeringEnabledType indicates the desired state for the peering with this remote cluster.
@@ -127,15 +131,17 @@ const (
 	NetworkStatusCondition PeeringConditionType = "NetworkStatus"
 	// AuthenticationStatusCondition informs users about the Authentication status.
 	AuthenticationStatusCondition PeeringConditionType = "AuthenticationStatus"
+	// ProcessableForeignCluster informs users about the Authentication status.
+	ProcessForeignClusterStatusCondition PeeringConditionType = "ProcessForeignClusterStatus"
 )
 
 // PeeringCondition contains details about state of the peering.
 type PeeringCondition struct {
 	// Type of the peering condition.
-	// +kubebuilder:validation:Enum="OutgoingPeering";"IncomingPeering";"NetworkStatus";"AuthenticationStatus"
+	// +kubebuilder:validation:Enum="OutgoingPeering";"IncomingPeering";"NetworkStatus";"AuthenticationStatus";"ProcessForeignClusterStatus"
 	Type PeeringConditionType `json:"type"`
 	// Status of the condition.
-	// +kubebuilder:validation:Enum="None";"Pending";"Established";"Disconnecting";"Denied";"EmptyDenied"
+	// +kubebuilder:validation:Enum="None";"Pending";"Established";"Disconnecting";"Denied";"EmptyDenied";"Error";"Success"
 	// +kubebuilder:default="None"
 	Status PeeringConditionStatusType `json:"status"`
 	// LastTransitionTime -> timestamp for when the condition last transitioned from one status to another.
@@ -161,6 +167,7 @@ type TenantNamespaceType struct {
 
 // ForeignCluster is the Schema for the foreignclusters API.
 // +kubebuilder:printcolumn:name="ClusterID",type=string,priority=1,JSONPath=`.spec.clusterIdentity.clusterID`
+// +kubebuilder:printcolumn:name="ClusterName",type=string,priority=1,JSONPath=`.spec.clusterIdentity.clusterName`
 // +kubebuilder:printcolumn:name="Outgoing peering phase",type=string,JSONPath=`.status.peeringConditions[?(@.type == 'OutgoingPeering')].status`
 // +kubebuilder:printcolumn:name="Incoming peering phase",type=string,JSONPath=`.status.peeringConditions[?(@.type == 'IncomingPeering')].status`
 // +kubebuilder:printcolumn:name="Networking status",type=string,JSONPath=`.status.peeringConditions[?(@.type == 'NetworkStatus')].status`

--- a/deployments/liqo/crds/discovery.liqo.io_foreignclusters.yaml
+++ b/deployments/liqo/crds/discovery.liqo.io_foreignclusters.yaml
@@ -21,6 +21,10 @@ spec:
       name: ClusterID
       priority: 1
       type: string
+    - jsonPath: .spec.clusterIdentity.clusterName
+      name: ClusterName
+      priority: 1
+      type: string
     - jsonPath: .status.peeringConditions[?(@.type == 'OutgoingPeering')].status
       name: Outgoing peering phase
       type: string
@@ -128,6 +132,8 @@ spec:
                       - Disconnecting
                       - Denied
                       - EmptyDenied
+                      - Error
+                      - Success
                       type: string
                     type:
                       description: Type of the peering condition.
@@ -136,6 +142,7 @@ spec:
                       - IncomingPeering
                       - NetworkStatus
                       - AuthenticationStatus
+                      - ProcessForeignClusterStatus
                       type: string
                   required:
                   - status

--- a/internal/discovery/foreign-cluster-operator/clusterIdentityDefaulting.go
+++ b/internal/discovery/foreign-cluster-operator/clusterIdentityDefaulting.go
@@ -1,7 +1,6 @@
 package foreignclusteroperator
 
 import (
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
 
 	"github.com/liqotech/liqo/apis/discovery/v1alpha1"
@@ -15,10 +14,9 @@ func (r *ForeignClusterReconciler) needsClusterIdentityDefaulting(fc *v1alpha1.F
 	return fc.Spec.ClusterIdentity.ClusterID == ""
 }
 
-// load the default values for that ForeignCluster basing on the AuthUrl value, an HTTP request is sent and the retrieved
-// values are applied for the following fields (if they are empty): Namespace, ClusterIdentity.ClusterID, ClusterIdentity.Namespace
-// and the TrustMode
-// if it returns no error, the ForeignCluster CR has been updated.
+// clusterIdentityDefaulting loads the default values for that ForeignCluster basing on the AuthUrl value, an HTTP request
+// is sent and the retrieved values are applied for the following fields (if they are empty):
+// ClusterIdentity.ClusterID, ClusterIdentity.ClusterName.
 func (r *ForeignClusterReconciler) clusterIdentityDefaulting(fc *v1alpha1.ForeignCluster) error {
 	klog.V(4).Infof("Defaulting ClusterIdentity values for ForeignCluster %v", fc.Name)
 	ids, err := utils.GetClusterInfo(foreignclusterutils.InsecureSkipTLSVerify(fc), fc.Spec.ForeignAuthURL)
@@ -37,11 +35,5 @@ func (r *ForeignClusterReconciler) clusterIdentityDefaulting(fc *v1alpha1.Foreig
 	klog.V(4).Infof("New values:\n\tClusterId:\t%v\n\tClusterName:\t%v",
 		fc.Spec.ClusterIdentity.ClusterID,
 		fc.Spec.ClusterIdentity.ClusterName)
-
-	// update the ForeignCluster
-	if _, err = r.crdClient.Resource("foreignclusters").Update(fc.Name, fc, &metav1.UpdateOptions{}); err != nil {
-		klog.Error(err)
-		return err
-	}
 	return nil
 }

--- a/internal/discovery/foreign.go
+++ b/internal/discovery/foreign.go
@@ -238,5 +238,5 @@ func (discovery *Controller) getForeignClusterByID(clusterID string) (*v1alpha1.
 			Resource: "foreignclusters",
 		}, clusterID)
 	}
-	return &fcs.Items[0], nil
+	return foreignclusterutils.GetOlderForeignCluster(fcs), nil
 }

--- a/pkg/utils/peeringConditions/peeringConditionsUtils.go
+++ b/pkg/utils/peeringConditions/peeringConditionsUtils.go
@@ -40,11 +40,9 @@ func EnsureStatus(
 // it returns the None status.
 func GetStatus(foreignCluster *discoveryv1alpha1.ForeignCluster,
 	conditionType discoveryv1alpha1.PeeringConditionType) discoveryv1alpha1.PeeringConditionStatusType {
-	for i := range foreignCluster.Status.PeeringConditions {
-		cond := &foreignCluster.Status.PeeringConditions[i]
-		if cond.Type == conditionType {
-			return cond.Status
-		}
+	cond := findCondition(foreignCluster, conditionType)
+	if cond != nil {
+		return cond.Status
 	}
 	return discoveryv1alpha1.PeeringConditionStatusNone
 }
@@ -53,11 +51,32 @@ func GetStatus(foreignCluster *discoveryv1alpha1.ForeignCluster,
 // it returns an empty string.
 func GetReason(foreignCluster *discoveryv1alpha1.ForeignCluster,
 	conditionType discoveryv1alpha1.PeeringConditionType) string {
+	cond := findCondition(foreignCluster, conditionType)
+	if cond != nil {
+		return cond.Reason
+	}
+	return ""
+}
+
+// GetMessage returns the message for the given peering condition. If the condition is not set,
+// it returns an empty string.
+func GetMessage(foreignCluster *discoveryv1alpha1.ForeignCluster,
+	conditionType discoveryv1alpha1.PeeringConditionType) string {
+	cond := findCondition(foreignCluster, conditionType)
+	if cond != nil {
+		return cond.Message
+	}
+	return ""
+}
+
+// findCondition returns a condition given its type.
+func findCondition(foreignCluster *discoveryv1alpha1.ForeignCluster,
+	conditionType discoveryv1alpha1.PeeringConditionType) *discoveryv1alpha1.PeeringCondition {
 	for i := range foreignCluster.Status.PeeringConditions {
 		cond := &foreignCluster.Status.PeeringConditions[i]
 		if cond.Type == conditionType {
-			return cond.Reason
+			return cond
 		}
 	}
-	return ""
+	return nil
 }


### PR DESCRIPTION
# Description

This pr prevents the multiple ForeignClusters with the same ClusterID can be reconciled simultaneously.

Only the ForeignCluster with the older creationTimestamp is reconciled. For the others, a condition signaling the impossibility to process them is added.

# How Has This Been Tested?

- [x] Locally on KinD
- [x] Add unit test to verify that if multiple clusters with the same id exist, the conditions are correctly updated
