### PR TITLE
Persist VirtualKubelet Keys

### DIFF
--- a/deployments/liqo/files/liqo-controller-manager-ClusterRole.yaml
+++ b/deployments/liqo/files/liqo-controller-manager-ClusterRole.yaml
@@ -85,6 +85,8 @@ rules:
   verbs:
   - create
   - delete
+  - get
+  - update
 - apiGroups:
   - ""
   resources:

--- a/deployments/liqo/files/liqo-virtual-kubelet-local-ClusterRole.yaml
+++ b/deployments/liqo/files/liqo-virtual-kubelet-local-ClusterRole.yaml
@@ -63,6 +63,14 @@ rules:
   verbs:
   - create
 - apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - get
+  - update
+- apiGroups:
   - apps
   resources:
   - replicasets

--- a/pkg/liqo-controller-manager/resourceoffer-controller/resourceoffer_controller.go
+++ b/pkg/liqo-controller-manager/resourceoffer-controller/resourceoffer_controller.go
@@ -73,6 +73,7 @@ type ResourceOfferReconciler struct {
 //+kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=capsule.clastix.io,resources=tenants,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings,verbs=get;list;watch;create;update;patch;delete;deletecollection
+//+kubebuilder:rbac:groups="",resources=secrets,verbs=get;create;update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/pkg/virtualKubelet/roles/local/role.go
+++ b/pkg/virtualKubelet/roles/local/role.go
@@ -2,6 +2,7 @@
 package local
 
 // +kubebuilder:rbac:groups="",resources=configmaps;services;secrets,verbs=get;list;watch;delete;create
+// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;create;update
 // +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=nodes,verbs=get;update;patch;list;watch;delete;create
 // +kubebuilder:rbac:groups="",resources=pods,verbs=get;patch;list;watch;delete;create

--- a/pkg/vkMachinery/csr/const.go
+++ b/pkg/vkMachinery/csr/const.go
@@ -1,4 +1,10 @@
 package csr
 
-const kubeletServingSignerName = "kubernetes.io/kubelet-serving"
-const kubeletAPIServingSignerName = "kubernetes.io/kube-apiserver-client-kubelet"
+const (
+	kubeletServingSignerName    = "kubernetes.io/kubelet-serving"
+	kubeletAPIServingSignerName = "kubernetes.io/kube-apiserver-client-kubelet"
+)
+
+const (
+	csrSecretLabel = "liqo.io/virtual-kubelet-csr-secret" // nolint:gosec // not a credential
+)

--- a/pkg/vkMachinery/csr/secret.go
+++ b/pkg/vkMachinery/csr/secret.go
@@ -1,0 +1,126 @@
+package csr
+
+import (
+	"context"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+
+	"github.com/liqotech/liqo/pkg/utils"
+)
+
+const (
+	csrPrivateKey  = "privateKey"
+	csrKey         = "csr"
+	csrCertificate = "certificate"
+)
+
+// GetCSRSecret returns the secret containing the CSR data.
+func GetCSRSecret(ctx context.Context,
+	clientset kubernetes.Interface, nodeName, namespace string) (secret *v1.Secret, hasCertificate bool, err error) {
+	secret, err = clientset.CoreV1().Secrets(namespace).Get(ctx, nodeName, metav1.GetOptions{})
+	if err != nil {
+		klog.Error(err)
+		return nil, false, err
+	}
+
+	_, hasCertificate = secret.Data[csrCertificate]
+	return secret, hasCertificate, nil
+}
+
+// getCSRData reads the CSR data from the secret.
+func getCSRData(ctx context.Context,
+	clientset kubernetes.Interface, nodeName, namespace string) (privateKey, csr, certificate []byte, err error) {
+	secret, hasCertificate, err := GetCSRSecret(ctx, clientset, nodeName, namespace)
+	if err != nil {
+		klog.Error(err)
+		return nil, nil, nil, err
+	}
+
+	privateKey = secret.Data[csrPrivateKey]
+	csr = secret.Data[csrKey]
+	if hasCertificate {
+		certificate = secret.Data[csrCertificate]
+	}
+	return privateKey, csr, certificate, nil
+}
+
+// PersistCertificates persists the data stored in the secret into the default path.
+func PersistCertificates(ctx context.Context,
+	clientset kubernetes.Interface, nodeName, namespace,
+	csrLocation, keyLocation, certLocation string) error {
+	privateKey, csr, certificate, err := getCSRData(ctx, clientset, nodeName, namespace)
+	if err != nil {
+		klog.Error(err)
+		return err
+	}
+
+	if err := utils.WriteFile(csrLocation, csr); err != nil {
+		klog.Errorf("Unable to write the CSR file in location: %s", csrLocation)
+		return err
+	}
+
+	if err := utils.WriteFile(keyLocation, privateKey); err != nil {
+		klog.Errorf("Unable to write the KEY file in location: %s", keyLocation)
+		return err
+	}
+
+	if len(certificate) > 0 {
+		if err := utils.WriteFile(certLocation, certificate); err != nil {
+			klog.Errorf("Unable to write the CRT file in location: %s", certLocation)
+			return err
+		}
+	}
+
+	return nil
+}
+
+// createCSRSecret creates the CSR secret with the given key and csr.
+func createCSRSecret(ctx context.Context,
+	clientset kubernetes.Interface, privateKey, csr []byte,
+	nodeName, namespace string) error {
+	secret := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      nodeName,
+			Namespace: namespace,
+			Labels: map[string]string{
+				csrSecretLabel: "true",
+			},
+		},
+		Data: map[string][]byte{
+			csrPrivateKey: privateKey,
+			csrKey:        csr,
+		},
+	}
+
+	_, err := clientset.CoreV1().Secrets(namespace).Create(ctx, secret, metav1.CreateOptions{})
+	if err != nil {
+		klog.Error(err)
+		return err
+	}
+
+	return nil
+}
+
+// StoreCertificate stores the retrieved certificate into the CSR secret.
+func StoreCertificate(ctx context.Context,
+	clientset kubernetes.Interface, certificate []byte,
+	namespace, nodeName string) error {
+	secret, _, err := GetCSRSecret(ctx, clientset, nodeName, namespace)
+	if err != nil {
+		klog.Error(err)
+		return err
+	}
+
+	secret.Data[csrCertificate] = certificate
+
+	_, err = clientset.CoreV1().Secrets(namespace).Update(ctx, secret, metav1.UpdateOptions{})
+	if err != nil {
+		klog.Error(err)
+		return err
+	}
+
+	return nil
+}

--- a/pkg/vkMachinery/csr/secret_test.go
+++ b/pkg/vkMachinery/csr/secret_test.go
@@ -1,0 +1,116 @@
+package csr
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/liqotech/liqo/pkg/utils/testutil"
+)
+
+const (
+	nodeName  = "node-name"
+	namespace = "default"
+)
+
+func TestSecret(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Secret Suite")
+}
+
+var _ = Describe("Secret", func() {
+
+	var (
+		cluster testutil.Cluster
+		err     error
+		ctx     context.Context
+		cancel  context.CancelFunc
+	)
+
+	BeforeSuite(func() {
+		ctx, cancel = context.WithCancel(context.Background())
+
+		cluster, _, err = testutil.NewTestCluster([]string{filepath.Join("..", "..", "..", "deployments", "liqo", "crds")})
+		Expect(err).To(BeNil())
+	})
+
+	AfterSuite(func() {
+		cancel()
+
+		err := cluster.GetEnv().Stop()
+		Expect(err).To(BeNil())
+	})
+
+	It("Secret Lifecycle", func() {
+
+		client := kubernetes.NewForConfigOrDie(cluster.GetCfg())
+
+		By("Create the CSR secret")
+
+		Expect(createCSRSecret(ctx, client, []byte("key"), []byte("csr"), nodeName, namespace)).To(Succeed())
+
+		secret, err := client.CoreV1().Secrets(namespace).Get(ctx, nodeName, metav1.GetOptions{})
+		Expect(err).To(Succeed())
+		Expect(secret).ToNot(BeNil())
+		Expect(func() bool { _, ok := secret.Labels[csrSecretLabel]; return ok }()).To(BeTrue())
+
+		keys := func(m map[string][]byte) []string {
+			var res []string
+			for k, v := range m {
+				if len(v) > 0 {
+					res = append(res, k)
+				}
+			}
+			return res
+		}
+
+		Expect(keys(secret.Data)).To(ContainElements(csrPrivateKey, csrKey))
+
+		By("Store the certificate in the CSR secret")
+
+		Expect(StoreCertificate(ctx, client, []byte("cert"), namespace, nodeName)).To(Succeed())
+
+		secret, err = client.CoreV1().Secrets(namespace).Get(ctx, nodeName, metav1.GetOptions{})
+		Expect(err).To(Succeed())
+		Expect(secret).ToNot(BeNil())
+		Expect(keys(secret.Data)).To(ContainElements(csrPrivateKey, csrKey, csrCertificate))
+
+		By("Get the data stored in the secret")
+
+		key, csr, cert, err := getCSRData(ctx, client, nodeName, namespace)
+		Expect(err).To(Succeed())
+		Expect(key).To(Equal([]byte("key")))
+		Expect(csr).To(Equal([]byte("csr")))
+		Expect(cert).To(Equal([]byte("cert")))
+
+		By("Persist the data in files")
+
+		csrLocation := "data.csr"
+		keyLocation := "data.key"
+		certLocation := "data.crt"
+
+		Expect(PersistCertificates(ctx, client, nodeName, namespace, csrLocation, keyLocation, certLocation)).To(Succeed())
+
+		info, err := os.Stat(csrLocation)
+		Expect(err).To(Succeed())
+		Expect(info.Size()).To(BeNumerically(">", 0))
+		info, err = os.Stat(keyLocation)
+		Expect(err).To(Succeed())
+		Expect(info.Size()).To(BeNumerically(">", 0))
+		info, err = os.Stat(certLocation)
+		Expect(err).To(Succeed())
+		Expect(info.Size()).To(BeNumerically(">", 0))
+
+		Expect(os.Remove(csrLocation)).To(Succeed())
+		Expect(os.Remove(keyLocation)).To(Succeed())
+		Expect(os.Remove(certLocation)).To(Succeed())
+
+	})
+
+})

--- a/pkg/vkMachinery/forge/forge.go
+++ b/pkg/vkMachinery/forge/forge.go
@@ -66,6 +66,10 @@ func forgeVKInitContainers(nodeName, initVKImage string) []v1.Container {
 					ValueFrom: &v1.EnvVarSource{FieldRef: &v1.ObjectFieldSelector{FieldPath: "metadata.name", APIVersion: "v1"}},
 				},
 				{
+					Name:      "POD_NAMESPACE",
+					ValueFrom: &v1.EnvVarSource{FieldRef: &v1.ObjectFieldSelector{FieldPath: "metadata.namespace", APIVersion: "v1"}},
+				},
+				{
 					Name:  "NODE_NAME",
 					Value: nodeName,
 				},


### PR DESCRIPTION
# Description

This pr includes the logic to store in a secret the key and the certificate created for a virtual node. In the next VirtualKubelet runs this certificate has not to be created again but it will be restored from the secret.

# How Has This Been Tested?

- [x] Add Unit Test
- [x] Locally on KinD