### PR TITLE
Improve node conditions management

### DIFF
--- a/pkg/virtualKubelet/liqoNodeProvider/conditions.go
+++ b/pkg/virtualKubelet/liqoNodeProvider/conditions.go
@@ -1,0 +1,124 @@
+package liqonodeprovider
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	resourcesMessageSufficient   = "The remote cluster is advertising sufficient resources"
+	resourcesMessageInsufficient = "The remote cluster is advertising no/insufficient resources"
+)
+
+// UnknownNodeConditions returns an array of node conditions with all unknown status.
+func UnknownNodeConditions() []corev1.NodeCondition {
+	return []corev1.NodeCondition{
+		*unknownCondition(corev1.NodeReady),
+		*unknownCondition(corev1.NodeMemoryPressure),
+		*unknownCondition(corev1.NodeDiskPressure),
+		*unknownCondition(corev1.NodePIDPressure),
+		*unknownCondition(corev1.NodeNetworkUnavailable),
+	}
+}
+
+// UpdateNodeCondition updates the specified node condition, depending on the outcome of the specified function.
+func UpdateNodeCondition(node *corev1.Node, conditionType corev1.NodeConditionType, conditionStatus func() (corev1.ConditionStatus, string, string)) {
+	condition, found := lookupConditionOrCreateUnknown(node, conditionType)
+
+	now := metav1.Now()
+	condition.LastHeartbeatTime = now
+
+	// Update the condition
+	if status, reason, message := conditionStatus(); status != condition.Status {
+		condition.Status = status
+		condition.Reason = reason
+		condition.Message = message
+		condition.LastTransitionTime = now
+	}
+
+	// Append the condition if it was not already present in the list.
+	if !found {
+		node.Status.Conditions = append(node.Status.Conditions, *condition)
+	}
+}
+
+// nodeReadyStatus returns a function containing the condition information about node readiness.
+func nodeReadyStatus(ready bool) func() (corev1.ConditionStatus, string, string) {
+	return func() (status corev1.ConditionStatus, reason, message string) {
+		if ready {
+			return corev1.ConditionTrue, "KubeletReady", "The Liqo Virtual Kubelet is posting ready status"
+		}
+		return corev1.ConditionFalse, "KubeletNotReady", "The Liqo Virtual Kubelet is currently not ready"
+	}
+}
+
+// nodeMemoryPressureStatus returns a function containing the condition information about the memory pressure status.
+func nodeMemoryPressureStatus(pressure bool) func() (corev1.ConditionStatus, string, string) {
+	return func() (status corev1.ConditionStatus, reason, message string) {
+		if pressure {
+			return corev1.ConditionTrue, "RemoteClusterHasMemoryPressure", resourcesMessageInsufficient
+		}
+		return corev1.ConditionFalse, "RemoteClusterHasSufficientMemory", resourcesMessageSufficient
+	}
+}
+
+// nodeDiskPressureStatus returns a function containing the condition information about the disk pressure status.
+func nodeDiskPressureStatus(pressure bool) func() (corev1.ConditionStatus, string, string) {
+	return func() (status corev1.ConditionStatus, reason, message string) {
+		if pressure {
+			return corev1.ConditionTrue, "RemoteClusterHasDiskPressure", resourcesMessageInsufficient
+		}
+		return corev1.ConditionFalse, "RemoteClusterHasNoDiskPressure", resourcesMessageSufficient
+	}
+}
+
+// nodePIDPressureStatus returns a function containing the condition information about the PID pressure status.
+func nodePIDPressureStatus(pressure bool) func() (corev1.ConditionStatus, string, string) {
+	return func() (status corev1.ConditionStatus, reason, message string) {
+		if pressure {
+			return corev1.ConditionTrue, "RemoteClusterHasPIDPressure", resourcesMessageInsufficient
+		}
+		return corev1.ConditionFalse, "RemoteClusterHasNoPIDPressure", resourcesMessageSufficient
+	}
+}
+
+// nodeNetworkUnavailableStatus returns a function containing the condition information about the networking status.
+func nodeNetworkUnavailableStatus(unavailable bool) func() (corev1.ConditionStatus, string, string) {
+	return func() (status corev1.ConditionStatus, reason, message string) {
+		if unavailable {
+			return corev1.ConditionTrue, "LiqoNetworkingDown", "The Liqo cluster interconnection is down"
+		}
+		return corev1.ConditionFalse, "LiqoNetworkingUp", "The Liqo cluster interconnection is established"
+	}
+}
+
+// unknownCondition returns a new condition with unknown status.
+func unknownCondition(desired corev1.NodeConditionType) *corev1.NodeCondition {
+	return &corev1.NodeCondition{
+		Type:   desired,
+		Status: corev1.ConditionUnknown,
+	}
+}
+
+// lookupCondition retrieves a desired condition from a node object, or nil if not found.
+func lookupCondition(node *corev1.Node, desired corev1.NodeConditionType) *corev1.NodeCondition {
+	for i := range node.Status.Conditions {
+		if node.Status.Conditions[i].Type == desired {
+			return &node.Status.Conditions[i]
+		}
+	}
+
+	return nil
+}
+
+// lookupConditionOrCreateUnknown retrieves a desired condition from a node object, or create a new one (with unknown status)
+// if not found. An additional boolean field specifies whether the condition was found or not.
+func lookupConditionOrCreateUnknown(node *corev1.Node, desired corev1.NodeConditionType) (*corev1.NodeCondition, bool) {
+	if condition := lookupCondition(node, desired); condition != nil {
+		return condition, true
+	}
+
+	// The condition is not immediately added, as it would get copied and the subsequent changes would get lost.
+	// Instead, a boolean value is returned to specify it needs to be appended once all modifications are performed.
+	return unknownCondition(desired), false
+}

--- a/pkg/virtualKubelet/liqoNodeProvider/conditions_test.go
+++ b/pkg/virtualKubelet/liqoNodeProvider/conditions_test.go
@@ -1,0 +1,261 @@
+package liqonodeprovider
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("Liqo node conditions generation", func() {
+	Describe("The UnknownNodeConditions function", func() {
+		When("generating the conditions", func() {
+			var conditions []corev1.NodeCondition
+
+			DescribeBody := func(conditionType corev1.NodeConditionType) func() {
+				return func() {
+					It("Should be present and have unknown status", func() {
+						Expect(conditions).To(ContainElement(*unknownCondition(conditionType)))
+					})
+				}
+			}
+
+			JustBeforeEach(func() { conditions = UnknownNodeConditions() })
+			Describe("The NodeReady condition", DescribeBody(corev1.NodeReady))
+			Describe("The NodeMemoryPressure condition", DescribeBody(corev1.NodeMemoryPressure))
+			Describe("The NodeDiskPressure condition", DescribeBody(corev1.NodeDiskPressure))
+			Describe("The NodePIDPressure condition", DescribeBody(corev1.NodePIDPressure))
+			Describe("The NodeNetworkUnavailable condition", DescribeBody(corev1.NodeNetworkUnavailable))
+		})
+	})
+
+	Describe("The UpdateNodeCondition function", func() {
+		var (
+			node     corev1.Node
+			modified *corev1.NodeCondition
+			status   corev1.ConditionStatus
+		)
+
+		BeforeEach(func() {
+			node = corev1.Node{Status: corev1.NodeStatus{
+				Conditions: []corev1.NodeCondition{{Type: corev1.NodeNetworkUnavailable}},
+			}}
+			status = corev1.ConditionTrue
+		})
+		JustBeforeEach(func() {
+			updater := func() (corev1.ConditionStatus, string, string) {
+				return status, "reason", "message"
+			}
+			UpdateNodeCondition(&node, corev1.NodeReady, updater)
+			modified = lookupCondition(&node, corev1.NodeReady)
+		})
+
+		DescribeBodyUpdated := func() func() {
+			return func() {
+				It("Should be present", func() { Expect(modified).ToNot(BeNil()) })
+				It("Should have the correct status", func() { Expect(modified.Status).To(Equal(status)) })
+				It("Should have the correct reason", func() { Expect(modified.Reason).To(Equal("reason")) })
+				It("Should have the correct message", func() { Expect(modified.Message).To(Equal("message")) })
+				It("Should have the heartbeat time updated", func() {
+					Expect(modified.LastHeartbeatTime.Time).To(BeTemporally("~", time.Now(), time.Second))
+				})
+				It("Should have the transition time updated", func() {
+					Expect(modified.LastTransitionTime.Time).To(BeTemporally("~", time.Now(), time.Second))
+				})
+			}
+		}
+
+		DescribeBodyUnchanged := func() func() {
+			return func() {
+				It("Should be present", func() { Expect(modified).ToNot(BeNil()) })
+				It("Should have the correct status", func() { Expect(modified.Status).To(Equal(status)) })
+				It("Should have the unmodified reason", func() { Expect(modified.Reason).To(Equal("previous reason")) })
+				It("Should have the unmodified message", func() { Expect(modified.Message).To(Equal("previous message")) })
+				It("Should have the heartbeat time updated", func() {
+					Expect(modified.LastHeartbeatTime.Time).To(BeTemporally("~", time.Now(), time.Second))
+				})
+				It("Should have the transition time unchanged", func() {
+					Expect(modified.LastTransitionTime.Time).To(BeTemporally("~", time.Now().Add(-1*time.Hour), time.Second))
+				})
+			}
+		}
+
+		When("the condition does not yet exist", func() {
+			Describe("updating the condition", DescribeBodyUpdated())
+		})
+
+		When("the condition already exists", func() {
+			BeforeEach(func() {
+				node.Status.Conditions = append(node.Status.Conditions, corev1.NodeCondition{
+					Type:               corev1.NodeReady,
+					Status:             corev1.ConditionTrue,
+					Reason:             "previous reason",
+					Message:            "previous message",
+					LastHeartbeatTime:  metav1.NewTime(time.Now().Add(-1 * time.Hour)),
+					LastTransitionTime: metav1.NewTime(time.Now().Add(-1 * time.Hour)),
+				})
+			})
+
+			When("it already has the correct status", func() {
+				Describe("updating the condition", DescribeBodyUnchanged())
+			})
+
+			When("it has incorrect status", func() {
+				BeforeEach(func() { status = corev1.ConditionFalse })
+				Describe("updating the condition", DescribeBodyUpdated())
+			})
+		})
+	})
+
+	Describe("Node conditions status generation", func() {
+		type StatusGenerationCase struct {
+			Generator       func() (status corev1.ConditionStatus, reason, message string)
+			ExpectedStatus  corev1.ConditionStatus
+			ExpectedReason  string
+			ExpectedMessage string
+		}
+
+		DescribeTable("Check correct status generation",
+			func(c StatusGenerationCase) {
+				status, reason, message := c.Generator()
+				Expect(status).To(BeIdenticalTo(c.ExpectedStatus))
+				Expect(reason).To(BeIdenticalTo(c.ExpectedReason))
+				Expect(message).To(BeIdenticalTo(c.ExpectedMessage))
+			},
+			Entry("of the ready condition, when ready", StatusGenerationCase{
+				Generator:       nodeReadyStatus(true),
+				ExpectedStatus:  corev1.ConditionTrue,
+				ExpectedReason:  "KubeletReady",
+				ExpectedMessage: "The Liqo Virtual Kubelet is posting ready status",
+			}),
+			Entry("of the ready condition, when not ready", StatusGenerationCase{
+				Generator:       nodeReadyStatus(false),
+				ExpectedStatus:  corev1.ConditionFalse,
+				ExpectedReason:  "KubeletNotReady",
+				ExpectedMessage: "The Liqo Virtual Kubelet is currently not ready",
+			}),
+			Entry("of the memory pressure condition, when set", StatusGenerationCase{
+				Generator:       nodeMemoryPressureStatus(true),
+				ExpectedStatus:  corev1.ConditionTrue,
+				ExpectedReason:  "RemoteClusterHasMemoryPressure",
+				ExpectedMessage: "The remote cluster is advertising no/insufficient resources",
+			}),
+			Entry("of the memory pressure condition, when unset", StatusGenerationCase{
+				Generator:       nodeMemoryPressureStatus(false),
+				ExpectedStatus:  corev1.ConditionFalse,
+				ExpectedReason:  "RemoteClusterHasSufficientMemory",
+				ExpectedMessage: "The remote cluster is advertising sufficient resources",
+			}),
+			Entry("of the disk pressure condition, when set", StatusGenerationCase{
+				Generator:       nodeDiskPressureStatus(true),
+				ExpectedStatus:  corev1.ConditionTrue,
+				ExpectedReason:  "RemoteClusterHasDiskPressure",
+				ExpectedMessage: "The remote cluster is advertising no/insufficient resources",
+			}),
+			Entry("of the disk pressure condition, when unset", StatusGenerationCase{
+				Generator:       nodeDiskPressureStatus(false),
+				ExpectedStatus:  corev1.ConditionFalse,
+				ExpectedReason:  "RemoteClusterHasNoDiskPressure",
+				ExpectedMessage: "The remote cluster is advertising sufficient resources",
+			}),
+			Entry("of the PID pressure condition, when set", StatusGenerationCase{
+				Generator:       nodePIDPressureStatus(true),
+				ExpectedStatus:  corev1.ConditionTrue,
+				ExpectedReason:  "RemoteClusterHasPIDPressure",
+				ExpectedMessage: "The remote cluster is advertising no/insufficient resources",
+			}),
+			Entry("of the PID pressure condition, when unset", StatusGenerationCase{
+				Generator:       nodePIDPressureStatus(false),
+				ExpectedStatus:  corev1.ConditionFalse,
+				ExpectedReason:  "RemoteClusterHasNoPIDPressure",
+				ExpectedMessage: "The remote cluster is advertising sufficient resources",
+			}),
+			Entry("of the network unavailable condition, when set", StatusGenerationCase{
+				Generator:       nodeNetworkUnavailableStatus(true),
+				ExpectedStatus:  corev1.ConditionTrue,
+				ExpectedReason:  "LiqoNetworkingDown",
+				ExpectedMessage: "The Liqo cluster interconnection is down",
+			}),
+			Entry("of the network unavailable condition, when unset", StatusGenerationCase{
+				Generator:       nodeNetworkUnavailableStatus(false),
+				ExpectedStatus:  corev1.ConditionFalse,
+				ExpectedReason:  "LiqoNetworkingUp",
+				ExpectedMessage: "The Liqo cluster interconnection is established",
+			}),
+		)
+	})
+
+	Describe("Checking the unknownCondition function", func() {
+		When("generating a new node condition", func() {
+			var (
+				condition *corev1.NodeCondition
+				desired   corev1.NodeConditionType
+			)
+
+			JustBeforeEach(func() { condition = unknownCondition(desired) })
+			It("Should have the desired type", func() { Expect(condition.Type).To(BeIdenticalTo(desired)) })
+			It("Should have unknown status", func() { Expect(condition.Status).To(BeIdenticalTo(corev1.ConditionUnknown)) })
+		})
+	})
+
+	Describe("Checking the lookupCondition function", func() {
+		var (
+			node    corev1.Node
+			desired corev1.NodeCondition
+		)
+
+		BeforeEach(func() {
+			desired = corev1.NodeCondition{Type: corev1.NodeReady}
+			node = corev1.Node{Status: corev1.NodeStatus{
+				Conditions: []corev1.NodeCondition{desired, {Type: corev1.NodeMemoryPressure}},
+			}}
+		})
+
+		When("the condition exists", func() {
+			It("should return the expected value", func() {
+				Expect(*lookupCondition(&node, corev1.NodeReady)).To(Equal(desired))
+			})
+		})
+
+		When("the condition does not exist", func() {
+			It("should return return nil", func() {
+				Expect(lookupCondition(&node, corev1.NodeNetworkUnavailable)).To(BeNil())
+			})
+		})
+	})
+
+	Describe("Checking the lookupConditionOrCreateUnknown function", func() {
+		var (
+			node               corev1.Node
+			key                corev1.NodeConditionType
+			desired, retrieved *corev1.NodeCondition
+			found              bool
+		)
+
+		BeforeEach(func() {
+			desired = &corev1.NodeCondition{Type: corev1.NodeReady}
+			node = corev1.Node{Status: corev1.NodeStatus{
+				Conditions: []corev1.NodeCondition{*desired, {Type: corev1.NodeMemoryPressure}},
+			}}
+		})
+
+		JustBeforeEach(func() {
+			retrieved, found = lookupConditionOrCreateUnknown(&node, key)
+		})
+
+		When("the condition exists", func() {
+			BeforeEach(func() { key = corev1.NodeReady })
+			It("should return the expected value", func() { Expect(*retrieved).To(Equal(*desired)) })
+			It("should return a found value equal to true", func() { Expect(found).To(BeTrue()) })
+		})
+
+		When("the condition does not exist", func() {
+			BeforeEach(func() { key = corev1.NodeNetworkUnavailable })
+			It("should return a new condition", func() { Expect(*retrieved).To(Equal(*unknownCondition(key))) })
+			It("should return a found value equal to false", func() { Expect(found).To(BeFalse()) })
+		})
+	})
+})

--- a/pkg/virtualKubelet/liqoNodeProvider/nodeProvider_test.go
+++ b/pkg/virtualKubelet/liqoNodeProvider/nodeProvider_test.go
@@ -10,6 +10,8 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+	. "github.com/onsi/gomega/types"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -105,11 +107,17 @@ var _ = Describe("NodeProvider", func() {
 	type nodeProviderTestcase struct {
 		resourceOffer      *sharingv1alpha1.ResourceOffer
 		tunnelEndpoint     *netv1alpha1.TunnelEndpoint
-		expectedConditions []v1.NodeCondition
+		expectedConditions []GomegaMatcher
+	}
+
+	ConditionMatcher := func(key v1.NodeConditionType, status v1.ConditionStatus) GomegaMatcher {
+		return MatchFields(IgnoreExtras, Fields{
+			"Type":   BeIdenticalTo(key),
+			"Status": BeIdenticalTo(status),
+		})
 	}
 
 	DescribeTable("NodeProvider table",
-
 		func(c nodeProviderTestcase) {
 			dynClient := dynamic.NewForConfigOrDie(cluster.GetCfg())
 
@@ -182,27 +190,12 @@ var _ = Describe("NodeProvider", func() {
 				},
 			},
 			tunnelEndpoint: nil,
-			expectedConditions: []v1.NodeCondition{
-				{
-					Type:   v1.NodeReady,
-					Status: v1.ConditionFalse,
-				},
-				{
-					Type:   v1.NodeMemoryPressure,
-					Status: v1.ConditionFalse,
-				},
-				{
-					Type:   v1.NodeDiskPressure,
-					Status: v1.ConditionFalse,
-				},
-				{
-					Type:   v1.NodePIDPressure,
-					Status: v1.ConditionFalse,
-				},
-				{
-					Type:   v1.NodeNetworkUnavailable,
-					Status: v1.ConditionTrue,
-				},
+			expectedConditions: []GomegaMatcher{
+				ConditionMatcher(v1.NodeReady, v1.ConditionFalse),
+				ConditionMatcher(v1.NodeMemoryPressure, v1.ConditionFalse),
+				ConditionMatcher(v1.NodeDiskPressure, v1.ConditionFalse),
+				ConditionMatcher(v1.NodePIDPressure, v1.ConditionFalse),
+				ConditionMatcher(v1.NodeNetworkUnavailable, v1.ConditionTrue),
 			},
 		}),
 
@@ -226,27 +219,12 @@ var _ = Describe("NodeProvider", func() {
 					},
 				},
 			},
-			expectedConditions: []v1.NodeCondition{
-				{
-					Type:   v1.NodeReady,
-					Status: v1.ConditionFalse,
-				},
-				{
-					Type:   v1.NodeMemoryPressure,
-					Status: v1.ConditionTrue,
-				},
-				{
-					Type:   v1.NodeDiskPressure,
-					Status: v1.ConditionFalse,
-				},
-				{
-					Type:   v1.NodePIDPressure,
-					Status: v1.ConditionFalse,
-				},
-				{
-					Type:   v1.NodeNetworkUnavailable,
-					Status: v1.ConditionFalse,
-				},
+			expectedConditions: []GomegaMatcher{
+				ConditionMatcher(v1.NodeReady, v1.ConditionFalse),
+				ConditionMatcher(v1.NodeMemoryPressure, v1.ConditionTrue),
+				ConditionMatcher(v1.NodeDiskPressure, v1.ConditionTrue),
+				ConditionMatcher(v1.NodePIDPressure, v1.ConditionTrue),
+				ConditionMatcher(v1.NodeNetworkUnavailable, v1.ConditionFalse),
 			},
 		}),
 
@@ -291,27 +269,12 @@ var _ = Describe("NodeProvider", func() {
 					},
 				},
 			},
-			expectedConditions: []v1.NodeCondition{
-				{
-					Type:   v1.NodeReady,
-					Status: v1.ConditionTrue,
-				},
-				{
-					Type:   v1.NodeMemoryPressure,
-					Status: v1.ConditionFalse,
-				},
-				{
-					Type:   v1.NodeDiskPressure,
-					Status: v1.ConditionFalse,
-				},
-				{
-					Type:   v1.NodePIDPressure,
-					Status: v1.ConditionFalse,
-				},
-				{
-					Type:   v1.NodeNetworkUnavailable,
-					Status: v1.ConditionFalse,
-				},
+			expectedConditions: []GomegaMatcher{
+				ConditionMatcher(v1.NodeReady, v1.ConditionTrue),
+				ConditionMatcher(v1.NodeMemoryPressure, v1.ConditionFalse),
+				ConditionMatcher(v1.NodeDiskPressure, v1.ConditionFalse),
+				ConditionMatcher(v1.NodePIDPressure, v1.ConditionFalse),
+				ConditionMatcher(v1.NodeNetworkUnavailable, v1.ConditionFalse),
 			},
 		}),
 	)

--- a/pkg/virtualKubelet/provider/node.go
+++ b/pkg/virtualKubelet/provider/node.go
@@ -5,9 +5,9 @@ import (
 
 	"go.opencensus.io/trace"
 	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	liqoconst "github.com/liqotech/liqo/pkg/consts"
+	liqonodeprovider "github.com/liqotech/liqo/pkg/virtualKubelet/liqoNodeProvider"
 )
 
 func (p *LiqoProvider) ConfigureNode(ctx context.Context, n *v1.Node) {
@@ -16,7 +16,7 @@ func (p *LiqoProvider) ConfigureNode(ctx context.Context, n *v1.Node) {
 
 	n.Status.Capacity = v1.ResourceList{}
 	n.Status.Allocatable = v1.ResourceList{}
-	n.Status.Conditions = p.nodeConditions()
+	n.Status.Conditions = liqonodeprovider.UnknownNodeConditions()
 	n.Status.Addresses = p.nodeAddresses()
 	n.Status.DaemonEndpoints = p.nodeDaemonEndpoints()
 	os := p.operatingSystem
@@ -32,54 +32,6 @@ func (p *LiqoProvider) ConfigureNode(ctx context.Context, n *v1.Node) {
 		n.Annotations = map[string]string{}
 	}
 	n.Annotations[liqoconst.RemoteClusterID] = p.foreignClusterID
-}
-
-// NodeConditions returns a list of conditions (Ready, OutOfDisk, etc), for updates to the node status
-// within Kubernetes.
-func (p *LiqoProvider) nodeConditions() []v1.NodeCondition {
-	// TODO: Make this configurable
-	return []v1.NodeCondition{
-		{
-			Type:               "Ready",
-			Status:             v1.ConditionFalse,
-			LastHeartbeatTime:  metav1.Now(),
-			LastTransitionTime: metav1.Now(),
-			Reason:             "KubeletReady",
-			Message:            "kubelet is ready.",
-		},
-		{
-			Type:               "OutOfDisk",
-			Status:             v1.ConditionFalse,
-			LastHeartbeatTime:  metav1.Now(),
-			LastTransitionTime: metav1.Now(),
-			Reason:             "KubeletHasSufficientDisk",
-			Message:            "kubelet has sufficient disk space available",
-		},
-		{
-			Type:               "MemoryPressure",
-			Status:             v1.ConditionFalse,
-			LastHeartbeatTime:  metav1.Now(),
-			LastTransitionTime: metav1.Now(),
-			Reason:             "KubeletHasSufficientMemory",
-			Message:            "kubelet has sufficient memory available",
-		},
-		{
-			Type:               "DiskPressure",
-			Status:             v1.ConditionFalse,
-			LastHeartbeatTime:  metav1.Now(),
-			LastTransitionTime: metav1.Now(),
-			Reason:             "KubeletHasNoDiskPressure",
-			Message:            "kubelet has no disk pressure",
-		},
-		{
-			Type:               "NetworkUnavailable",
-			Status:             v1.ConditionTrue,
-			LastHeartbeatTime:  metav1.Now(),
-			LastTransitionTime: metav1.Now(),
-			Reason:             "RouteCreated",
-			Message:            "RouteController created a route",
-		},
-	}
 }
 
 // NodeAddresses returns a list of addresses for the node status


### PR DESCRIPTION
# Description

This PR improves the management of the virtual node conditions by the liqo provider, including custom reason and messages to provide additional information and the correct update of the last transition/heartbeat timestamps.

Fixes #616

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Unit testing (with additional tests)
- [x] E2E testing
