### PR TITLE
Crypto: use ED25519 instead of RSA for better performance

### DIFF
--- a/internal/auth-service/auth_test.go
+++ b/internal/auth-service/auth_test.go
@@ -2,8 +2,8 @@ package authservice
 
 import (
 	"context"
+	"crypto/ed25519"
 	"crypto/rand"
-	"crypto/rsa"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/asn1"
@@ -62,7 +62,7 @@ func (man *tokenManagerMock) createToken() error {
 
 // getCSR get a CertificateSigningRequest for testing purposes
 func getCSR(localClusterID string) (csrBytes []byte, err error) {
-	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	_, key, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
 		klog.Error(err)
 		return nil, err
@@ -82,7 +82,7 @@ func getCSR(localClusterID string) (csrBytes []byte, err error) {
 
 	template := x509.CertificateRequest{
 		RawSubject:         asn1Subj,
-		SignatureAlgorithm: x509.SHA256WithRSA,
+		SignatureAlgorithm: x509.PureEd25519,
 	}
 
 	csrBytes, err = x509.CreateCertificateRequest(rand.Reader, &template, key)

--- a/pkg/identityManager/const.go
+++ b/pkg/identityManager/const.go
@@ -1,7 +1,5 @@
 package identitymanager
 
-const keyLength = 2048
-
 const defaultOrganization = "liqo.io"
 
 const (

--- a/pkg/identityManager/identityManager_test.go
+++ b/pkg/identityManager/identityManager_test.go
@@ -2,6 +2,7 @@ package identitymanager
 
 import (
 	"context"
+	"crypto/ed25519"
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/pem"
@@ -131,7 +132,8 @@ var _ = Describe("IdentityManager", func() {
 			Expect(len(privateKey)).NotTo(Equal(0))
 
 			b, _ := pem.Decode(privateKey)
-			_, err = x509.ParsePKCS1PrivateKey(b.Bytes)
+			key, err := x509.ParsePKCS8PrivateKey(b.Bytes)
+			Expect(key).To(BeAssignableToTypeOf(ed25519.PrivateKey{}))
 			Expect(err).To(BeNil())
 		})
 

--- a/pkg/vkMachinery/csr/generation.go
+++ b/pkg/vkMachinery/csr/generation.go
@@ -1,9 +1,8 @@
 package csr
 
 import (
-	"crypto/ecdsa"
-	"crypto/elliptic"
-	cryptorand "crypto/rand"
+	"crypto/ed25519"
+	"crypto/rand"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
@@ -21,11 +20,11 @@ import (
 // with the K8s kubelet-serving signer taking a name as input.
 func generateVKCertificateBundle(name string) (csrPEM, keyPEM []byte, err error) {
 	// Generate a new private key.
-	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), cryptorand.Reader)
+	_, privateKey, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to generate a new private key: %w", err)
 	}
-	der, err := x509.MarshalECPrivateKey(privateKey)
+	der, err := x509.MarshalPKCS8PrivateKey(privateKey)
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to marshal the new key to DER: %w", err)
 	}


### PR DESCRIPTION
# Description

This PR changes the asymmetric cryptography algorithm from RSA to ED25519, to reduce the peering time (which includes a new key generation), as well as to uniform key generation operations across the repo.

## Benchmarks
```
RSA 2048 key generation took on average 296.144ms
RSA 4096 key generation took on average 3190.145ms
ECDSA P224 key generation took on average 1.179ms
ECDSA P256 key generation took on average 1.017ms
ECDSA P384 key generation took on average 5.250ms
ECDSA P521 key generation took on average 8.622ms
ED25519 key generation took on average 0.082ms

RSA 2048 signature took on average 2.3094ms
ECDSA P256 signature took on average 0.0778ms
ED25519 signature took on average 0.1235ms
```

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] Unit testing (existing)
- [X] E2E testing (existing)
