### PR TITLE
Improve resource replication latency

### DIFF
--- a/apis/config/v1alpha1/clusterconfig_types.go
+++ b/apis/config/v1alpha1/clusterconfig_types.go
@@ -195,8 +195,8 @@ type Resource struct {
 	// GroupVersionResource contains the GVR of the resource to replicate.
 	GroupVersionResource metav1.GroupVersionResource `json:"groupVersionResource"`
 	// PeeringPhase contains the peering phase when this resource should be replicated.
-	// +kubebuilder:validation:Enum="None";"All";"Established";"Incoming";"Outgoing";"Bidirectional"
-	// +kubebuilder:default="All"
+	// +kubebuilder:validation:Enum="None";"Authenticated";"Established";"Incoming";"Outgoing";"Bidirectional"
+	// +kubebuilder:default="None"
 	PeeringPhase consts.PeeringPhase `json:"peeringPhase,omitempty"`
 	// Ownership indicates the ownership over this resource.
 	// +kubebuilder:validation:Enum="Local";"Shared"

--- a/cmd/crd-replicator/main.go
+++ b/cmd/crd-replicator/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/liqotech/liqo/pkg/liqonet/utils"
 	"github.com/liqotech/liqo/pkg/mapperUtils"
 	tenantnamespace "github.com/liqotech/liqo/pkg/tenantNamespace"
+	"github.com/liqotech/liqo/pkg/utils/restcfg"
 )
 
 var (
@@ -35,11 +36,12 @@ func init() {
 }
 
 func main() {
+	restcfg.InitFlags(nil)
 	klog.InitFlags(nil)
 
 	flag.Parse()
 
-	cfg := ctrl.GetConfigOrDie()
+	cfg := restcfg.SetRateLimiter(ctrl.GetConfigOrDie())
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		MapperProvider: mapperUtils.LiqoMapperProvider(scheme),
 		Scheme:         scheme,
@@ -50,9 +52,9 @@ func main() {
 		klog.Error(err, "unable to start manager")
 		os.Exit(-1)
 	}
-	//create a clientSet
+	// Create a clientSet.
 	k8sClient := kubernetes.NewForConfigOrDie(cfg)
-	//get namespace where the operator is running
+	// Get the namespace where the operator is running.
 	namespaceName, found := os.LookupEnv("NAMESPACE")
 	if !found {
 		klog.Errorf("namespace env variable not set, please set it in manifest file of the operator")

--- a/deployments/liqo/crds/config.liqo.io_clusterconfigs.yaml
+++ b/deployments/liqo/crds/config.liqo.io_clusterconfigs.yaml
@@ -172,12 +172,12 @@ spec:
                           - Shared
                           type: string
                         peeringPhase:
-                          default: All
+                          default: None
                           description: PeeringPhase contains the peering phase when
                             this resource should be replicated.
                           enum:
                           - None
-                          - All
+                          - Authenticated
                           - Established
                           - Incoming
                           - Outgoing

--- a/deployments/liqo/templates/clusterconfig.yaml
+++ b/deployments/liqo/templates/clusterconfig.yaml
@@ -53,7 +53,7 @@ spec:
         group: discovery.liqo.io
         version: v1alpha1
         resource: resourcerequests
-      peeringPhase: All
+      peeringPhase: Authenticated
     - groupVersionResource:
         group: sharing.liqo.io
         version: v1alpha1

--- a/internal/crdReplicator/peeringPhase.go
+++ b/internal/crdReplicator/peeringPhase.go
@@ -16,7 +16,7 @@ import (
 // checkResourcesOnPeeringPhaseChange checks if some of the replicated resources
 // need to start replication of this specific ForeignCluster on this phase change.
 // If some of the replicated resources need to start replication, it lists all the
-// instances already that are already present in the local cluster and calls the
+// instances that are already present in the local cluster and calls the
 // AddHandler on them.
 func (c *Controller) checkResourcesOnPeeringPhaseChange(ctx context.Context,
 	remoteClusterID string, currentPhase, oldPhase consts.PeeringPhase) {
@@ -24,8 +24,8 @@ func (c *Controller) checkResourcesOnPeeringPhaseChange(ctx context.Context,
 		res := &c.RegisteredResources[i]
 		if !foreigncluster.IsReplicationEnabled(oldPhase, res) && foreigncluster.IsReplicationEnabled(currentPhase, res) {
 			// this change has triggered the replication on this resource
-			klog.Infof("phase from %v to %v triggers replication on resource %v",
-				oldPhase, currentPhase, res.GroupVersionResource)
+			klog.Infof("%v -> phase from %v to %v triggers replication of resource %v",
+				remoteClusterID, oldPhase, currentPhase, res.GroupVersionResource)
 			if err := c.startResourceReplicationHandler(ctx, remoteClusterID, res); err != nil {
 				klog.Error(err)
 				continue

--- a/internal/crdReplicator/peeringPhase_test.go
+++ b/internal/crdReplicator/peeringPhase_test.go
@@ -125,7 +125,7 @@ var _ = Describe("PeeringPhase-Based Replication", func() {
 					{
 						GroupVersionResource: metav1.GroupVersionResource(
 							netv1alpha1.NetworkConfigGroupVersionResource),
-						PeeringPhase: consts.PeeringPhaseAll,
+						PeeringPhase: consts.PeeringPhaseAuthenticated,
 					},
 				},
 				peeringPhases: map[string]consts.PeeringPhase{

--- a/internal/discovery/foreign-cluster-operator/foreign-cluster-operator_test.go
+++ b/internal/discovery/foreign-cluster-operator/foreign-cluster-operator_test.go
@@ -475,7 +475,6 @@ var _ = Describe("ForeignClusterOperator", func() {
 			foreignClusterStatus  discoveryv1alpha1.ForeignClusterStatus
 			resourceRequests      []discoveryv1alpha1.ResourceRequest
 			expectedIncomingPhase discoveryv1alpha1.PeeringConditionStatusType
-			expectedOutgoingPhase discoveryv1alpha1.PeeringConditionStatusType
 		}
 
 		var (
@@ -529,7 +528,7 @@ var _ = Describe("ForeignClusterOperator", func() {
 			}
 		)
 
-		DescribeTable("checkPeeringStatus",
+		DescribeTable("checkIncomingPeeringStatus",
 			func(c checkPeeringStatusTestcase) {
 				foreignCluster := &discoveryv1alpha1.ForeignCluster{
 					TypeMeta: metav1.TypeMeta{
@@ -572,11 +571,10 @@ var _ = Describe("ForeignClusterOperator", func() {
 					Expect(err).To(Succeed())
 				}
 
-				err = controller.checkPeeringStatus(ctx, foreignCluster)
+				err = controller.checkIncomingPeeringStatus(ctx, foreignCluster)
 				Expect(err).To(BeNil())
 
 				Expect(peeringconditionsutils.GetStatus(foreignCluster, discoveryv1alpha1.IncomingPeeringCondition)).To(Equal(c.expectedIncomingPhase))
-				Expect(peeringconditionsutils.GetStatus(foreignCluster, discoveryv1alpha1.OutgoingPeeringCondition)).To(Equal(c.expectedOutgoingPhase))
 			},
 
 			Entry("none", checkPeeringStatusTestcase{
@@ -597,7 +595,6 @@ var _ = Describe("ForeignClusterOperator", func() {
 				},
 				resourceRequests:      []discoveryv1alpha1.ResourceRequest{},
 				expectedIncomingPhase: discoveryv1alpha1.PeeringConditionStatusNone,
-				expectedOutgoingPhase: discoveryv1alpha1.PeeringConditionStatusNone,
 			}),
 
 			Entry("none and no update", checkPeeringStatusTestcase{
@@ -618,7 +615,6 @@ var _ = Describe("ForeignClusterOperator", func() {
 				},
 				resourceRequests:      []discoveryv1alpha1.ResourceRequest{},
 				expectedIncomingPhase: discoveryv1alpha1.PeeringConditionStatusNone,
-				expectedOutgoingPhase: discoveryv1alpha1.PeeringConditionStatusNone,
 			}),
 
 			Entry("outgoing", checkPeeringStatusTestcase{
@@ -641,7 +637,6 @@ var _ = Describe("ForeignClusterOperator", func() {
 					getOutgoingResourceRequest(true),
 				},
 				expectedIncomingPhase: discoveryv1alpha1.PeeringConditionStatusNone,
-				expectedOutgoingPhase: discoveryv1alpha1.PeeringConditionStatusEstablished,
 			}),
 
 			Entry("outgoing not accepted", checkPeeringStatusTestcase{
@@ -664,7 +659,6 @@ var _ = Describe("ForeignClusterOperator", func() {
 					getOutgoingResourceRequest(false),
 				},
 				expectedIncomingPhase: discoveryv1alpha1.PeeringConditionStatusNone,
-				expectedOutgoingPhase: discoveryv1alpha1.PeeringConditionStatusPending,
 			}),
 
 			Entry("incoming", checkPeeringStatusTestcase{
@@ -687,7 +681,6 @@ var _ = Describe("ForeignClusterOperator", func() {
 					getIncomingResourceRequest(),
 				},
 				expectedIncomingPhase: discoveryv1alpha1.PeeringConditionStatusEstablished,
-				expectedOutgoingPhase: discoveryv1alpha1.PeeringConditionStatusNone,
 			}),
 
 			Entry("bidirectional", checkPeeringStatusTestcase{
@@ -711,7 +704,6 @@ var _ = Describe("ForeignClusterOperator", func() {
 					getOutgoingResourceRequest(true),
 				},
 				expectedIncomingPhase: discoveryv1alpha1.PeeringConditionStatusEstablished,
-				expectedOutgoingPhase: discoveryv1alpha1.PeeringConditionStatusEstablished,
 			}),
 		)
 

--- a/internal/discovery/foreign-cluster-operator/permission.go
+++ b/internal/discovery/foreign-cluster-operator/permission.go
@@ -22,7 +22,7 @@ func (r *ForeignClusterReconciler) ensurePermission(ctx context.Context, foreign
 	}
 
 	switch peeringPhase {
-	case consts.PeeringPhaseNone:
+	case consts.PeeringPhaseNone, consts.PeeringPhaseAuthenticated:
 		if err = r.namespaceManager.UnbindClusterRoles(remoteClusterID,
 			clusterRolesToNames(r.peeringPermission.Outgoing)...); err != nil {
 			klog.Error(err)

--- a/internal/discovery/foreign-cluster-operator/resourceRequest.go
+++ b/internal/discovery/foreign-cluster-operator/resourceRequest.go
@@ -10,11 +10,12 @@ import (
 
 	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
 	crdreplicator "github.com/liqotech/liqo/internal/crdReplicator"
+	"github.com/liqotech/liqo/pkg/utils"
 )
 
-// createResourceRequest creates a resource request to be sent to the specified ForeignCluster.
-func (r *ForeignClusterReconciler) createResourceRequest(ctx context.Context,
-	foreignCluster *discoveryv1alpha1.ForeignCluster) (controllerutil.OperationResult, error) {
+// ensureResourceRequest ensures the presence of a resource request to be sent to the specified ForeignCluster.
+func (r *ForeignClusterReconciler) ensureResourceRequest(ctx context.Context,
+	foreignCluster *discoveryv1alpha1.ForeignCluster) (*discoveryv1alpha1.ResourceRequest, error) {
 	klog.Infof("[%v] ensuring ResourceRequest existence", foreignCluster.Spec.ClusterIdentity.ClusterID)
 
 	localClusterID := r.clusterID.GetClusterID()
@@ -23,7 +24,7 @@ func (r *ForeignClusterReconciler) createResourceRequest(ctx context.Context,
 
 	authURL, err := r.getHomeAuthURL()
 	if err != nil {
-		return controllerutil.OperationResultNone, err
+		return nil, err
 	}
 
 	resourceRequest := &discoveryv1alpha1.ResourceRequest{
@@ -57,12 +58,12 @@ func (r *ForeignClusterReconciler) createResourceRequest(ctx context.Context,
 	})
 	if err != nil {
 		klog.Error(err)
-		return controllerutil.OperationResultNone, err
+		return nil, err
 	}
-	klog.Infof("[%v] ensured the existence of ResourceRequest (with %v operation)",
+	klog.V(utils.FromResult(result)).Infof("[%v] ensured the existence of ResourceRequest (with %v operation)",
 		remoteClusterID, result)
 
-	return result, nil
+	return resourceRequest, nil
 }
 
 // deleteResourceRequest deletes a resource request related to the specified ForeignCluster.

--- a/pkg/consts/peering.go
+++ b/pkg/consts/peering.go
@@ -4,16 +4,16 @@ package consts
 type PeeringPhase string
 
 const (
-	// PeeringPhaseNone no pering has been established.
+	// PeeringPhaseNone -> no pering has been established.
 	PeeringPhaseNone PeeringPhase = "None"
-	// PeeringPhaseAll indicates that we have not be in any specific peering phase.
-	PeeringPhaseAll PeeringPhase = "All"
-	// PeeringPhaseEstablished the peering has been established.
+	// PeeringPhaseAuthenticated -> an identity to interact with the remote cluster is available.
+	PeeringPhaseAuthenticated PeeringPhase = "Authenticated"
+	// PeeringPhaseEstablished -> the peering has been established (either incoming or outgoing).
 	PeeringPhaseEstablished PeeringPhase = "Established"
-	// PeeringPhaseIncoming an incoming peering has been established.
+	// PeeringPhaseIncoming -> an incoming peering has been established.
 	PeeringPhaseIncoming PeeringPhase = "Incoming"
-	// PeeringPhaseOutgoing an outgoing peering has been established.
+	// PeeringPhaseOutgoing -> an outgoing peering has been established.
 	PeeringPhaseOutgoing PeeringPhase = "Outgoing"
-	// PeeringPhaseBidirectional both incoming and outgoing peerings has been established.
+	// PeeringPhaseBidirectional -> both incoming and outgoing peerings have been established.
 	PeeringPhaseBidirectional PeeringPhase = "Bidirectional"
 )

--- a/pkg/peering-roles/peeringPermission.go
+++ b/pkg/peering-roles/peeringPermission.go
@@ -19,12 +19,12 @@ type PeeringPermission struct {
 	// these ClusterRoles have the basic permissions to give to a remote cluster
 	Basic []*rbacv1.ClusterRole
 	// to be enabled when a ResourceRequest has been accepted,
-	// these ClusterRoles have the permissions required to a remote cluster
+	// these ClusterRoles have the permissions required by a remote cluster
 	// to manage an outgoing peering (incoming for the local cluster),
 	// when the Pods will be offloaded to the local cluster
 	Incoming []*rbacv1.ClusterRole
 	// to be enabled when we send a ResourceRequest,
-	// these ClusterRoles have the permissions required to a remote cluster
+	// these ClusterRoles have the permissions required by a remote cluster
 	// to manage an incoming peering (outgoing for the local cluster),
 	// when the Pods will be offloaded from the local cluster
 	Outgoing []*rbacv1.ClusterRole

--- a/pkg/utils/foreignCluster/peeringStatus.go
+++ b/pkg/utils/foreignCluster/peeringStatus.go
@@ -5,6 +5,12 @@ import (
 	peeringconditionsutils "github.com/liqotech/liqo/pkg/utils/peeringConditions"
 )
 
+// IsAuthenticated checks if the identity has been accepted by the remote cluster.
+func IsAuthenticated(foreignCluster *discoveryv1alpha1.ForeignCluster) bool {
+	curPhase := peeringconditionsutils.GetStatus(foreignCluster, discoveryv1alpha1.AuthenticationStatusCondition)
+	return curPhase == discoveryv1alpha1.PeeringConditionStatusEstablished
+}
+
 // IsIncomingJoined checks if the incoming peering has been completely established.
 func IsIncomingJoined(foreignCluster *discoveryv1alpha1.ForeignCluster) bool {
 	curPhase := peeringconditionsutils.GetStatus(foreignCluster, discoveryv1alpha1.IncomingPeeringCondition)

--- a/pkg/utils/log.go
+++ b/pkg/utils/log.go
@@ -1,0 +1,21 @@
+package utils
+
+import (
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+const (
+	// LogInfoLevel -> level associated with informational messages.
+	LogInfoLevel = 0
+	// LogDebugLevel -> level associated with debug messages.
+	LogDebugLevel = 4
+)
+
+// FromResult returns a logger level, given the result of a CreateOrUpdate operation.
+func FromResult(result controllerutil.OperationResult) klog.Level {
+	if result == controllerutil.OperationResultNone {
+		return LogDebugLevel
+	}
+	return LogInfoLevel
+}

--- a/test/unit/crdReplicator/crdReplicator-operator_test.go
+++ b/test/unit/crdReplicator/crdReplicator-operator_test.go
@@ -94,10 +94,18 @@ func getForeignClusterResource() *unstructured.Unstructured {
 			},
 			"spec": map[string]interface{}{
 				"clusterIdentity": map[string]interface{}{
-					"clusterID": "foreign-cluster",
+					"clusterID": "peering-cluster-1",
 				},
 				"join":           true,
 				"foreignAuthUrl": "https://192.168.2.100:30001",
+			},
+			"status": map[string]interface{}{
+				"peeringConditions": []interface{}{
+					map[string]interface{}{
+						"type":   "AuthenticationStatus",
+						"status": "Established",
+					},
+				},
 			},
 		},
 	}
@@ -143,7 +151,7 @@ func TestReplication1(t *testing.T) {
 }
 
 // we create a resource which type has been registered for the replication
-// we label it to be replicated on all the three clusters, so we expect to not find it on the remote clusters
+// we label it to be replicated on all the three clusters, so we expect to not find it on the remote clusters.
 func TestReplication2(t *testing.T) {
 	time.Sleep(1 * time.Second)
 	localResources := map[string]*netv1alpha1.TunnelEndpoint{}


### PR DESCRIPTION
# Description

This PR introduces some improvements to speed up the resource replication, with specific focus on ResourceRequests and ResourceOffers, to prevent it from being triggered by resyncs. Specifically:
* It ensures ResourceRequest replication is started as soon as the remote identity is available (this is done introducing a new `Authenticated` peering state, which triggers the replication start).
* It ensures outgoing permissions are configured as soon as a ResourceRequest is created. Previously, this was not working due to kinda a race condition, since the PeeringRequest status configured at ResourceRequest time was immediately overwritten by  the subsequent `checkPeeringStatus` function (since the given ResourceRequest was not yet in cache).
* It fixes a bunch of linting issues.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Unit testing (existing)
- [x] E2E testing (existing)
