### PR TITLE
Make deployment arguments configurable with Helm

### DIFF
--- a/cmd/liqo-webhook/main.go
+++ b/cmd/liqo-webhook/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"flag"
 	"os/signal"
 	"syscall"
 	"time"
@@ -14,6 +15,9 @@ import (
 const gracefulPeriod = 5 * time.Second
 
 func main() {
+	klog.InitFlags(nil)
+	flag.Parse()
+
 	config := &mutate.MutationConfig{}
 	setOptions(config)
 

--- a/cmd/liqonet/main.go
+++ b/cmd/liqonet/main.go
@@ -88,6 +88,8 @@ func main() {
 		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
 	flag.StringVar(&runAs, "run-as", liqoconst.LiqoGatewayOperatorName,
 		"The accepted values are: liqo-gateway, liqo-route, tunnelEndpointCreator-operator. The default value is \"liqo-gateway\"")
+
+	klog.InitFlags(nil)
 	flag.Parse()
 
 	switch runAs {

--- a/deployments/liqo/README.md
+++ b/deployments/liqo/README.md
@@ -12,6 +12,7 @@
 | auth.ingress.host | string | `""` | Set the hostname for your ingress |
 | auth.initContainer.imageName | string | `"liqo/cert-creator"` | auth init container image repository |
 | auth.pod.annotations | object | `{}` | auth pod annotations |
+| auth.pod.extraArgs | list | `[]` | auth pod extra arguments |
 | auth.pod.labels | object | `{}` | auth pod labels |
 | auth.portOverride | string | `""` | Overrides the port were your service is available, you should configure it if behind a NAT or using an Ingress with a port different from 443. |
 | auth.service.annotations | object | `{}` | auth service annotations |
@@ -27,11 +28,13 @@
 | capsule.manager.options.capsuleUserGroups[1] | string | `"liqo.io"` |  |
 | controllerManager.config.enableBroadcaster | bool | `true` | If set to false, the remote clusters will not be able to leverage your resources, but you will still be able to use theirs. |
 | controllerManager.config.resourceSharingPercentage | int | `30` | It defines the percentage of available cluster resources that you are willing to share with foreign clusters. |
-| controllerManager.imageName | string | `"liqo/liqo-controller-manager"` | advertisement image repository |
-| controllerManager.pod.annotations | object | `{}` | advertisement pod annotations |
-| controllerManager.pod.labels | object | `{}` | advertisement pod labels |
+| controllerManager.imageName | string | `"liqo/liqo-controller-manager"` | controller-manager image repository |
+| controllerManager.pod.annotations | object | `{}` | controller-manager pod annotations |
+| controllerManager.pod.extraArgs | list | `[]` | controller-manager pod extra arguments |
+| controllerManager.pod.labels | object | `{}` | controller-manager pod labels |
 | crdReplicator.imageName | string | `"liqo/crd-replicator"` | crdReplicator image repository |
 | crdReplicator.pod.annotations | object | `{}` | crdReplicator pod annotations |
+| crdReplicator.pod.extraArgs | list | `[]` | crdReplicator pod extra arguments |
 | crdReplicator.pod.labels | object | `{}` | crdReplicator pod labels |
 | discovery.config.autojoin | bool | `true` | Automatically join discovered clusters |
 | discovery.config.clusterLabels | object | `{}` | A set of labels which characterizes the local cluster when exposed remotely as a virtual node. It is suggested to specify the distinguishing characteristics that may be used to decide whether to offload pods on this cluster. |
@@ -41,24 +44,28 @@
 | discovery.config.ttl | int | `90` | Time-to-live before an automatically discovered clusters is deleted from the list of available ones if no longer announced (in seconds) |
 | discovery.imageName | string | `"liqo/discovery"` | discovery image repository |
 | discovery.pod.annotations | object | `{}` | discovery pod annotations |
+| discovery.pod.extraArgs | list | `[]` | discovery pod extra arguments |
 | discovery.pod.labels | object | `{}` | discovery pod labels |
 | fullnameOverride | string | `""` | full liqo name override |
 | gateway.imageName | string | `"liqo/liqonet"` | gateway image repository |
 | gateway.pod.annotations | object | `{}` | gateway pod annotations |
+| gateway.pod.extraArgs | list | `[]` | gateway pod extra arguments |
 | gateway.pod.labels | object | `{}` | gateway pod labels |
 | gateway.service.annotations | object | `{}` |  |
 | gateway.service.type | string | `"LoadBalancer"` | If you plan to use liqo over the Internet consider to change this field to "LoadBalancer". More generally, if your cluster nodes are directly reachable by the cluster to whom you are peering, you may change it to "NodePort". |
 | nameOverride | string | `""` | liqo name override |
-| networkManager.config.additionalPools | list | `[]` | Set of additional network pools.  Network pools are used to map a cluster network into another one in order to prevent conflicts. Default set of network pools is: [10.0.0.0/8, 192.168.0.0/16, 172.16.0.0/12] |
+| networkManager.config.additionalPools | list | `[]` | Set of additional network pools. Network pools are used to map a cluster network into another one in order to prevent conflicts. Default set of network pools is: [10.0.0.0/8, 192.168.0.0/16, 172.16.0.0/12] |
 | networkManager.config.podCIDR | string | `""` | The subnet used by the cluster for the pods, in CIDR notation |
 | networkManager.config.reservedSubnets | list | `[]` | Usually the IPs used for the pods in k8s clusters belong to private subnets In order to prevent IP conflicting between locally used private subnets in your infrastructure and private subnets belonging to remote clusters you need tell liqo the subnets used in your cluster. E.g if your cluster nodes belong to the 192.168.2.0/24 subnet then you should add that subnet to the reservedSubnets. PodCIDR and serviceCIDR used in the local cluster are automatically added to the reserved list. |
 | networkManager.config.serviceCIDR | string | `""` | The subnet used by the cluster for the services, in CIDR notation |
 | networkManager.imageName | string | `"liqo/liqonet"` | networkManager image repository |
 | networkManager.pod.annotations | object | `{}` | networkManager pod annotations |
+| networkManager.pod.extraArgs | list | `[]` | networkManager pod extra arguments |
 | networkManager.pod.labels | object | `{}` | networkManager pod labels |
 | pullPolicy | string | `"IfNotPresent"` | The pullPolicy for liqo pods |
 | route.imageName | string | `"liqo/liqonet"` | route image repository |
 | route.pod.annotations | object | `{}` | route pod annotations |
+| route.pod.extraArgs | list | `[]` | route pod extra arguments |
 | route.pod.labels | object | `{}` | route pod labels |
 | tag | string | `""` | Images' tag to select a development version of liqo instead of a release |
 | virtualKubelet.imageName | string | `"liqo/virtual-kubelet"` | virtual kubelet image repository |
@@ -67,5 +74,6 @@
 | webhook.initContainer.imageName | string | `"liqo/webhook-configuration"` | webhook init container image repository |
 | webhook.mutatingWebhookConfiguration.annotations | object | `{}` | mutatingWebhookConfiguration annotations |
 | webhook.pod.annotations | object | `{}` | webhook pod annotations |
+| webhook.pod.extraArgs | list | `[]` | webhook pod extra arguments |
 | webhook.pod.labels | object | `{}` | webhook pod labels |
 | webhook.service.annotations | object | `{}` | webhook service annotations |

--- a/deployments/liqo/templates/liqo-auth-deployment.yaml
+++ b/deployments/liqo/templates/liqo-auth-deployment.yaml
@@ -61,25 +61,28 @@ spec:
           imagePullPolicy: {{ .Values.pullPolicy }}
           command: ["/usr/bin/auth-service"]
           args:
-          - "--namespace=$(POD_NAMESPACE)"
-          - "--resyncSeconds=30"
+          - --namespace=$(POD_NAMESPACE)
+          - --resyncSeconds=30
           {{- if .Values.awsConfig.accessKeyId }}
-          - "--awsAccessKeyId=$(ACCESS_KEY_ID)"
+          - --awsAccessKeyId=$(ACCESS_KEY_ID)
           {{- end }}
           {{- if .Values.awsConfig.secretAccessKey }}
-          - "--awsSecretAccessKey=$(SECRET_ACCESS_KEY)"
+          - --awsSecretAccessKey=$(SECRET_ACCESS_KEY)
           {{- end }}
           {{- if .Values.awsConfig.region }}
-          - "--awsRegion={{ .Values.awsConfig.region }}"
+          - --awsRegion={{ .Values.awsConfig.region }}
           {{- end }}
           {{- if .Values.awsConfig.clusterName }}
-          - "--awsClusterName={{ .Values.awsConfig.clusterName }}"
+          - --awsClusterName={{ .Values.awsConfig.clusterName }}
           {{- end }}
           {{- if not .Values.auth.tls}}
-          - "--listeningPort=5000"
+          - --listeningPort=5000
           {{- else }}
-          - "--listeningPort=443"
-          - "--useTls"
+          - --listeningPort=443
+          - --useTls
+          {{- end }}
+          {{- if .Values.auth.pod.extraArgs }}
+          {{- toYaml .Values.auth.pod.extraArgs | nindent 10 }}
           {{- end }}
           env:
             - name: POD_NAMESPACE

--- a/deployments/liqo/templates/liqo-controller-manager.yaml
+++ b/deployments/liqo/templates/liqo-controller-manager.yaml
@@ -31,14 +31,13 @@ spec:
         name: {{ $ctrlManagerConfig.name }}
         command: ["/usr/bin/liqo-controller-manager"]
         args:
-          - "--cluster-id"
-          - "$(CLUSTER_ID)"
-          - "--liqo-namespace"
-          - "$(POD_NAMESPACE)"
-          - "--kubelet-image"
-          - {{ .Values.virtualKubelet.imageName }}{{ include "liqo.suffix" $ctrlManagerConfig }}:{{ include "liqo.version" $ctrlManagerConfig }}
-          - "--init-kubelet-image"
-          - {{ .Values.virtualKubelet.initContainer.imageName }}{{ include "liqo.suffix" $ctrlManagerConfig }}:{{ include "liqo.version" $ctrlManagerConfig }}
+          - --cluster-id=$(CLUSTER_ID)
+          - --liqo-namespace=$(POD_NAMESPACE)
+          - --kubelet-image={{ .Values.virtualKubelet.imageName }}{{ include "liqo.suffix" $ctrlManagerConfig }}:{{ include "liqo.version" $ctrlManagerConfig }}
+          - --init-kubelet-image={{ .Values.virtualKubelet.initContainer.imageName }}{{ include "liqo.suffix" $ctrlManagerConfig }}:{{ include "liqo.version" $ctrlManagerConfig }}
+          {{- if .Values.controllerManager.pod.extraArgs }}
+          {{- toYaml .Values.controllerManager.pod.extraArgs | nindent 10 }}
+          {{- end }}
         env:
           - name: CLUSTER_ID
             valueFrom:

--- a/deployments/liqo/templates/liqo-crd-replicator-deployment.yaml
+++ b/deployments/liqo/templates/liqo-crd-replicator-deployment.yaml
@@ -13,7 +13,7 @@ spec:
     matchLabels:
       {{- include "liqo.selectorLabels" $crdReplicatorConfig | nindent 6 }}
   template:
-    metadata: 
+    metadata:
     {{- if .Values.crdReplicator.pod.annotations }}
       annotations:
         {{- toYaml .Values.crdReplicator.pod.annotations | nindent 8 }}
@@ -30,6 +30,10 @@ spec:
           imagePullPolicy: {{ .Values.pullPolicy }}
           name: {{ $crdReplicatorConfig.name }}
           command: ["/usr/bin/crd-replicator"]
+          {{- if .Values.crdReplicator.pod.extraArgs }}
+          args:
+            {{- toYaml .Values.crdReplicator.pod.extraArgs | nindent 12 }}
+          {{- end }}
           env:
             - name: NAMESPACE
               valueFrom:

--- a/deployments/liqo/templates/liqo-discovery-deployment.yaml
+++ b/deployments/liqo/templates/liqo-discovery-deployment.yaml
@@ -30,8 +30,11 @@ spec:
           imagePullPolicy: {{ .Values.pullPolicy }}
           command: ["/usr/bin/discovery"]
           args:
-          - "--namespace=$(POD_NAMESPACE)"
-          - "--requeueAfter=30"
+          - --namespace=$(POD_NAMESPACE)
+          - --requeueAfter=30
+          {{- if .Values.discovery.pod.extraArgs }}
+          {{- toYaml .Values.discovery.pod.extraArgs | nindent 10 }}
+          {{- end }}
           env:
             - name: POD_NAMESPACE
               valueFrom:

--- a/deployments/liqo/templates/liqo-gateway-deployment.yaml
+++ b/deployments/liqo/templates/liqo-gateway-deployment.yaml
@@ -35,8 +35,11 @@ spec:
           - containerPort: 5871
           command: ["/usr/bin/liqonet"]
           args:
-          - -run-as=liqo-gateway
-          - -leader-elect=true
+          - --run-as=liqo-gateway
+          - --leader-elect=true
+          {{- if .Values.gateway.pod.extraArgs }}
+          {{- toYaml .Values.gateway.pod.extraArgs | nindent 10 }}
+          {{- end }}
           resources:
             requests:
               cpu: 250m

--- a/deployments/liqo/templates/liqo-network-manager-deployment.yaml
+++ b/deployments/liqo/templates/liqo-network-manager-deployment.yaml
@@ -33,7 +33,10 @@ spec:
             - name: ipam-api
               containerPort: 6000
           args:
-            - "-run-as=tunnelEndpointCreator-operator"
+            - --run-as=tunnelEndpointCreator-operator
+            {{- if .Values.networkManager.pod.extraArgs }}
+            {{- toYaml .Values.networkManager.pod.extraArgs | nindent 12 }}
+            {{- end }}
           resources:
             requests:
               cpu: 50m

--- a/deployments/liqo/templates/liqo-route-daemonset.yaml
+++ b/deployments/liqo/templates/liqo-route-daemonset.yaml
@@ -42,7 +42,11 @@ spec:
           imagePullPolicy: {{ .Values.pullPolicy }}
           name: {{ $routeConfig.name }}
           command: ["/usr/bin/liqonet"]
-          args: ["-run-as=liqo-route"]
+          args:
+          - --run-as=liqo-route
+          {{- if .Values.route.pod.extraArgs }}
+          {{- toYaml .Values.route.pod.extraArgs | nindent 10 }}
+          {{- end }}
           resources:
             requests:
               cpu: 100m

--- a/deployments/liqo/templates/liqo-webhook-deployment.yaml
+++ b/deployments/liqo/templates/liqo-webhook-deployment.yaml
@@ -32,8 +32,7 @@ spec:
           image: {{ .Values.webhook.initContainer.imageName}}{{ include "liqo.suffix" $webhookConfig }}:{{ include "liqo.version" $webhookConfig }}
           imagePullPolicy: {{ .Values.pullPolicy }}
           args:
-            - "--webhook-name"
-            - {{ include "liqo.prefixedName" $webhookConfig }}
+            - --webhook-name={{ include "liqo.prefixedName" $webhookConfig }}
           env:
             - name: POD_NAME
               valueFrom:
@@ -54,6 +53,10 @@ spec:
         - name: {{ $webhookConfig.name }}
           image: {{ .Values.webhook.imageName }}{{ include "liqo.suffix" $webhookConfig }}:{{ include "liqo.version" $webhookConfig }}
           imagePullPolicy: {{ .Values.pullPolicy }}
+          {{- if .Values.webhook.pod.extraArgs }}
+          args:
+            {{- toYaml .Values.webhook.pod.extraArgs | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - mountPath: /etc/ssl/liqo
               name: cert-volume

--- a/deployments/liqo/values.yaml
+++ b/deployments/liqo/values.yaml
@@ -14,11 +14,13 @@ apiServer:
 
 controllerManager:
   pod:
-    # -- advertisement pod annotations
+    # -- controller-manager pod annotations
     annotations: {}
-    # -- advertisement pod labels
+    # -- controller-manager pod labels
     labels: {}
-  # -- advertisement image repository
+    # -- controller-manager pod extra arguments
+    extraArgs: []
+  # -- controller-manager image repository
   imageName: "liqo/liqo-controller-manager"
   config:
     # -- It defines the percentage of available cluster resources that you are willing to share with foreign clusters.
@@ -32,6 +34,8 @@ route:
     annotations: {}
     # -- route pod labels
     labels: {}
+    # -- route pod extra arguments
+    extraArgs: []
   # -- route image repository
   imageName: "liqo/liqonet"
 
@@ -41,6 +45,8 @@ gateway:
     annotations: {}
     # -- gateway pod labels
     labels: {}
+    # -- gateway pod extra arguments
+    extraArgs: []
   # -- gateway image repository
   imageName: "liqo/liqonet"
   service:
@@ -55,6 +61,8 @@ networkManager:
     annotations: {}
     # -- networkManager pod labels
     labels: {}
+    # -- networkManager pod extra arguments
+    extraArgs: []
   # -- networkManager image repository
   imageName: "liqo/liqonet"
   config:
@@ -67,7 +75,7 @@ networkManager:
     # you need tell liqo the subnets used in your cluster. E.g if your cluster nodes belong to the 192.168.2.0/24 subnet then
     # you should add that subnet to the reservedSubnets. PodCIDR and serviceCIDR used in the local cluster are automatically added to the reserved list.
     reservedSubnets: []
-    # -- Set of additional network pools. 
+    # -- Set of additional network pools.
     # Network pools are used to map a cluster network into another one in order to prevent conflicts.
     # Default set of network pools is: [10.0.0.0/8, 192.168.0.0/16, 172.16.0.0/12]
     additionalPools: []
@@ -78,6 +86,8 @@ crdReplicator:
     annotations: {}
     # -- crdReplicator pod labels
     labels: {}
+    # -- crdReplicator pod extra arguments
+    extraArgs: []
   # -- crdReplicator image repository
   imageName: "liqo/crd-replicator"
 
@@ -87,6 +97,8 @@ discovery:
     annotations: {}
     # -- discovery pod labels
     labels: {}
+    # -- discovery pod extra arguments
+    extraArgs: []
   # -- discovery image repository
   imageName: "liqo/discovery"
   config:
@@ -113,11 +125,13 @@ auth:
     annotations: {}
     # -- auth pod labels
     labels: {}
+    # -- auth pod extra arguments
+    extraArgs: []
   # -- auth image repository
   imageName: "liqo/auth-service"
   initContainer:
     # -- auth init container image repository
-    imageName: "liqo/cert-creator" 
+    imageName: "liqo/cert-creator"
   service:
     # -- The type of service used to expose the Authentication Service
     # If you are exposing this service with an Ingress consider to change it to ClusterIP,
@@ -150,6 +164,8 @@ webhook:
     annotations: {}
     # -- webhook pod labels
     labels: {}
+    # -- webhook pod extra arguments
+    extraArgs: []
   # -- webhook image repository
   imageName: "liqo/liqo-webhook"
   initContainer:


### PR DESCRIPTION
# Description

This PR introduces the possibility to customize the deployment arguments through helm (e.g., to set a given log level), and adds the klog flags to the components that were missing them. 

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] Checking the correct installation
- [X] E2E tests (existing)
