### PR TITLE
Foreign cluster operator performance improvements

### DIFF
--- a/cmd/discovery/main.go
+++ b/cmd/discovery/main.go
@@ -21,6 +21,7 @@ import (
 	searchdomainoperator "github.com/liqotech/liqo/internal/discovery/search-domain-operator"
 	"github.com/liqotech/liqo/pkg/clusterid"
 	"github.com/liqotech/liqo/pkg/mapperUtils"
+	"github.com/liqotech/liqo/pkg/utils/restcfg"
 )
 
 var (
@@ -53,13 +54,14 @@ func main() {
 	flag.Int64Var(&dialTCPTimeout,
 		"dialTcpTimeout", 500, "Time to wait for a TCP connection to a remote cluster before to consider it as not reachable (milliseconds)")
 
+	restcfg.InitFlags(nil)
 	klog.InitFlags(nil)
 	flag.Parse()
 
 	klog.Info("Namespace: ", namespace)
 	klog.Info("RequeueAfter: ", requeueAfter)
 
-	config := ctrl.GetConfigOrDie()
+	config := restcfg.SetRateLimiter(ctrl.GetConfigOrDie())
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		klog.Errorf("Failed to create a new Kubernetes client: %w", err)

--- a/cmd/discovery/main.go
+++ b/cmd/discovery/main.go
@@ -7,9 +7,11 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
 	nettypes "github.com/liqotech/liqo/apis/net/v1alpha1"
@@ -57,46 +59,70 @@ func main() {
 	klog.Info("Namespace: ", namespace)
 	klog.Info("RequeueAfter: ", requeueAfter)
 
-	localClusterID, err := clusterid.NewClusterID(kubeconfigPath)
+	config := ctrl.GetConfigOrDie()
+	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {
-		klog.Error(err, err.Error())
+		klog.Errorf("Failed to create a new Kubernetes client: %w", err)
+		os.Exit(1)
+	}
+
+	localClusterID, err := clusterid.NewClusterIDFromClient(clientset)
+	if err != nil {
+		klog.Error(err.Error())
 		os.Exit(1)
 	}
 	err = localClusterID.SetupClusterID(namespace)
 	if err != nil {
-		klog.Error(err, err.Error())
+		klog.Error(err.Error())
 		os.Exit(1)
 	}
 
 	discoveryCtl, err := discovery.NewDiscoveryCtrl(namespace, localClusterID, kubeconfigPath,
 		resolveContextRefreshTime, time.Duration(dialTCPTimeout)*time.Millisecond)
 	if err != nil {
-		klog.Error(err, err.Error())
+		klog.Error(err.Error())
 		os.Exit(1)
 	}
 
 	discoveryCtl.StartDiscovery()
 
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+	mgr, err := ctrl.NewManager(config, ctrl.Options{
 		MapperProvider:   mapperUtils.LiqoMapperProvider(scheme),
 		Scheme:           scheme,
-		Port:             9443,
 		LeaderElection:   false,
 		LeaderElectionID: "b3156c4e.liqo.io",
 	})
 	if err != nil {
-		klog.Error(err, "unable to start manager")
+		klog.Errorf("Unable to create main manager: %w", err)
+		os.Exit(1)
+	}
+
+	// Create an accessory manager restricted to the given namespace only, to avoid introducing
+	// performance overhead and requiring excessively wide permissions when not necessary.
+	auxmgr, err := ctrl.NewManager(config, ctrl.Options{
+		MapperProvider:     mapperUtils.LiqoMapperProvider(scheme),
+		Scheme:             scheme,
+		Namespace:          namespace,
+		MetricsBindAddress: "0", // Disable the metrics of the auxiliary manager to prevent conflicts.
+	})
+	if err != nil {
+		klog.Errorf("Unable to create auxiliary (namespaced) manager: %w", err)
 		os.Exit(1)
 	}
 
 	klog.Info("Starting SearchDomain operator")
-	searchdomainoperator.StartOperator(mgr, time.Duration(requeueAfter)*time.Second, discoveryCtl, kubeconfigPath)
+	searchdomainoperator.StartOperator(mgr, time.Duration(requeueAfter)*time.Second, discoveryCtl)
 
 	klog.Info("Starting ForeignCluster operator")
-	foreignclusteroperator.StartOperator(mgr, namespace, time.Duration(requeueAfter)*time.Second, discoveryCtl, kubeconfigPath)
+	namespacedClient := client.NewNamespacedClient(auxmgr.GetClient(), namespace)
+	foreignclusteroperator.StartOperator(mgr, namespacedClient, clientset, time.Duration(requeueAfter)*time.Second, discoveryCtl, localClusterID)
 
+	if err := mgr.Add(auxmgr); err != nil {
+		klog.Errorf("Unable to add the auxiliary manager to the main one: %w", err)
+		os.Exit(1)
+	}
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
-		klog.Error(err, "problem running manager")
+		klog.Errorf("Unable to start manager: %w", err)
 		os.Exit(1)
 	}
 }

--- a/deployments/liqo/files/liqo-discovery-Role.yaml
+++ b/deployments/liqo/files/liqo-discovery-Role.yaml
@@ -36,6 +36,8 @@ rules:
   - services
   verbs:
   - get
+  - list
+  - watch
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:

--- a/internal/discovery/foreign-cluster-operator/foreign-cluster-controller.go
+++ b/internal/discovery/foreign-cluster-operator/foreign-cluster-controller.go
@@ -22,14 +22,14 @@ import (
 	"fmt"
 	"time"
 
-	apiv1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/rest"
-	"k8s.io/client-go/util/retry"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/trace"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -45,7 +45,6 @@ import (
 	"github.com/liqotech/liqo/pkg/auth"
 	"github.com/liqotech/liqo/pkg/clusterid"
 	liqoconst "github.com/liqotech/liqo/pkg/consts"
-	crdclient "github.com/liqotech/liqo/pkg/crdClient"
 	discoveryPkg "github.com/liqotech/liqo/pkg/discovery"
 	identitymanager "github.com/liqotech/liqo/pkg/identityManager"
 	peeringRoles "github.com/liqotech/liqo/pkg/peering-roles"
@@ -94,10 +93,9 @@ type ForeignClusterReconciler struct {
 	client.Client
 	Scheme *runtime.Scheme
 
-	Namespace    string
-	crdClient    *crdclient.CRDClient
-	clusterID    clusterid.ClusterID
-	RequeueAfter time.Duration
+	LiqoNamespacedClient client.Client
+	clusterID            clusterid.ClusterID
+	RequeueAfter         time.Duration
 
 	namespaceManager tenantnamespace.Manager
 	identityManager  identitymanager.IdentityManager
@@ -106,9 +104,6 @@ type ForeignClusterReconciler struct {
 
 	ConfigProvider     discovery.ConfigProvider
 	AuthConfigProvider auth.ConfigProvider
-
-	// testing
-	ForeignConfig *rest.Config
 }
 
 // clusterRole
@@ -132,7 +127,7 @@ type ForeignClusterReconciler struct {
 // +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;create;delete;update
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;create;deletecollection;delete
 // role
-// +kubebuilder:rbac:groups=core,namespace="liqo",resources=services,verbs=get
+// +kubebuilder:rbac:groups=core,namespace="liqo",resources=services,verbs=get;list;watch
 // +kubebuilder:rbac:groups=core,namespace="liqo",resources=configmaps,verbs=get;list;watch;create;update;delete
 // +kubebuilder:rbac:groups=core,namespace="liqo",resources=serviceaccounts,verbs=get;list;watch;create
 // +kubebuilder:rbac:groups=core,namespace="liqo",resources=secrets,verbs=get;list;watch;create;update;delete
@@ -150,10 +145,7 @@ func (r *ForeignClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	var foreignCluster discoveryv1alpha1.ForeignCluster
 	if err := r.Client.Get(ctx, req.NamespacedName, &foreignCluster); err != nil {
 		klog.Error(err)
-		if errors.IsNotFound(err) {
-			return ctrl.Result{}, nil
-		}
-		return ctrl.Result{}, err
+		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 	tracer.Step("Retrieved the foreign cluster")
 
@@ -278,7 +270,7 @@ func (r *ForeignClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		klog.Infof("[%v] Delete ForeignCluster %v with discovery type %v",
 			foreignCluster.Spec.ClusterIdentity.ClusterID,
 			foreignCluster.Name, foreignclusterutils.GetDiscoveryType(&foreignCluster))
-		if err := r.deleteForeignCluster(ctx, &foreignCluster); err != nil {
+		if err := r.Client.Delete(ctx, &foreignCluster); err != nil {
 			klog.Error(err)
 			return ctrl.Result{}, err
 		}
@@ -292,38 +284,6 @@ func (r *ForeignClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		Requeue:      true,
 		RequeueAfter: r.RequeueAfter,
 	}, nil
-}
-
-func (r *ForeignClusterReconciler) update(fc *discoveryv1alpha1.ForeignCluster) (*discoveryv1alpha1.ForeignCluster, error) {
-	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		if tmp, err := r.crdClient.Resource("foreignclusters").Update(fc.Name, fc, &metav1.UpdateOptions{}); err == nil {
-			var ok bool
-			fc, ok = tmp.(*discoveryv1alpha1.ForeignCluster)
-			if !ok {
-				err = goerrors.New("this object is not a ForeignCluster")
-				klog.Error(err, tmp)
-				return err
-			}
-			return nil
-		} else if !errors.IsConflict(err) {
-			return err
-		}
-		tmp, err := r.crdClient.Resource("foreignclusters").Get(fc.Name, &metav1.GetOptions{})
-		if err != nil {
-			klog.Error(err)
-			return err
-		}
-		fc2, ok := tmp.(*discoveryv1alpha1.ForeignCluster)
-		if !ok {
-			err = goerrors.New("this object is not a ForeignCluster")
-			klog.Error(err, tmp)
-			return err
-		}
-		fc.ResourceVersion = fc2.ResourceVersion
-		fc.Generation = fc2.Generation
-		return err
-	})
-	return fc, err
 }
 
 // peerNamespaced enables the peering creating the resources in the correct TenantNamespace.
@@ -476,14 +436,16 @@ func (r *ForeignClusterReconciler) getAddress() (string, error) {
 		return address, nil
 	}
 
-	// get the authentication service
-	svc, err := r.crdClient.Client().CoreV1().Services(r.Namespace).Get(context.TODO(), discovery.AuthServiceName, metav1.GetOptions{})
-	if err != nil {
+	// get the authentication service  (the namespace is automatically inferred by the namespaced client).
+	var svc corev1.Service
+	ref := types.NamespacedName{Name: discovery.AuthServiceName}
+	if err := r.LiqoNamespacedClient.Get(context.TODO(), ref, &svc); err != nil {
 		klog.Error(err)
 		return "", err
 	}
+
 	// if the service is exposed as LoadBalancer
-	if svc.Spec.Type == apiv1.ServiceTypeLoadBalancer {
+	if svc.Spec.Type == corev1.ServiceTypeLoadBalancer {
 		// get the IP from the LoadBalancer service
 		if len(svc.Status.LoadBalancer.Ingress) == 0 {
 			// the service has no external IPs
@@ -510,34 +472,19 @@ func (r *ForeignClusterReconciler) getAddress() (string, error) {
 	// we need to get an address from a physical node, if we have established peerings in the past with other clusters,
 	// we may have some virtual nodes in our cluster. Since their IPs will not be reachable from other clusters, we cannot use them
 	// as address for a local NodePort Service
-	labelSelector, err := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{
-		MatchExpressions: []metav1.LabelSelectorRequirement{
-			{
-				Key:      liqoconst.TypeLabel,
-				Operator: metav1.LabelSelectorOpNotIn,
-				Values:   []string{liqoconst.TypeNode},
-			},
-		},
-	})
-	if err != nil {
+	req, err := labels.NewRequirement(liqoconst.TypeLabel, selection.NotIn, []string{liqoconst.TypeNode})
+	utilruntime.Must(err)
+
+	// get the IP from the Nodes, to be used with NodePort services
+	nodes := corev1.NodeList{}
+	if err := r.Client.List(context.TODO(), &nodes, client.MatchingLabelsSelector{Selector: labels.NewSelector().Add(*req)}); err != nil {
 		klog.Error(err)
 		return "", err
 	}
 
-	// get the IP from the Nodes, to be used with NodePort services
-	nodes, err := r.crdClient.Client().CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{
-		LabelSelector: labelSelector.String(),
-	})
-	if err != nil {
-		klog.Error(err)
-		return "", err
-	}
 	if len(nodes.Items) == 0 {
 		// there are no node is the cluster, we cannot get the address on any of them
-		err = errors.NewNotFound(schema.GroupResource{
-			Group:    apiv1.GroupName,
-			Resource: "nodes",
-		}, "")
+		err = errors.NewNotFound(corev1.Resource("nodes"), "")
 		klog.Error(err)
 		return "", err
 	}
@@ -559,27 +506,26 @@ func (r *ForeignClusterReconciler) getPort() (string, error) {
 		return port, nil
 	}
 
-	// get the authentication service
-	svc, err := r.crdClient.Client().CoreV1().Services(r.Namespace).Get(context.TODO(), discovery.AuthServiceName, metav1.GetOptions{})
-	if err != nil {
-		klog.Error(err)
-		return "", err
-	}
-	if len(svc.Spec.Ports) == 0 {
-		// the service has no available port, we cannot get it
-		err = errors.NewNotFound(schema.GroupResource{
-			Group:    apiv1.GroupName,
-			Resource: string(apiv1.ResourceServices),
-		}, discovery.AuthServiceName)
+	// get the authentication service (the namespace is automatically inferred by the namespaced client).
+	var svc corev1.Service
+	ref := types.NamespacedName{Name: discovery.AuthServiceName}
+	if err := r.LiqoNamespacedClient.Get(context.TODO(), ref, &svc); err != nil {
 		klog.Error(err)
 		return "", err
 	}
 
-	if svc.Spec.Type == apiv1.ServiceTypeLoadBalancer {
+	if len(svc.Spec.Ports) == 0 {
+		// the service has no available port, we cannot get it
+		err := errors.NewNotFound(corev1.Resource(string(corev1.ResourceServices)), discovery.AuthServiceName)
+		klog.Error(err)
+		return "", err
+	}
+
+	if svc.Spec.Type == corev1.ServiceTypeLoadBalancer {
 		// return the LoadBalancer service external port
 		return fmt.Sprintf("%v", svc.Spec.Ports[0].Port), nil
 	}
-	if svc.Spec.Type == apiv1.ServiceTypeNodePort {
+	if svc.Spec.Type == corev1.ServiceTypeNodePort {
 		// return the NodePort service port
 		return fmt.Sprintf("%v", svc.Spec.Ports[0].NodePort), nil
 	}
@@ -686,11 +632,6 @@ func (r *ForeignClusterReconciler) checkTEP(ctx context.Context,
 		}
 	}
 	return nil
-}
-
-func (r *ForeignClusterReconciler) deleteForeignCluster(ctx context.Context,
-	foreignCluster *discoveryv1alpha1.ForeignCluster) error {
-	return r.Client.Delete(ctx, foreignCluster)
 }
 
 func isTunnelEndpointReason(reason string) bool {

--- a/internal/discovery/foreign-cluster-operator/foreign-cluster-operator_test.go
+++ b/internal/discovery/foreign-cluster-operator/foreign-cluster-operator_test.go
@@ -17,6 +17,7 @@ import (
 	machtypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	"github.com/liqotech/liqo/apis/config/v1alpha1"
@@ -117,10 +118,7 @@ var _ = Describe("ForeignClusterOperator", func() {
 		controller = ForeignClusterReconciler{
 			Client:           mgr.GetClient(),
 			Scheme:           mgr.GetScheme(),
-			Namespace:        "default",
-			crdClient:        cluster.GetClient(),
 			clusterID:        cID,
-			ForeignConfig:    cluster.GetCfg(),
 			RequeueAfter:     300,
 			ConfigProvider:   &config,
 			namespaceManager: namespaceManager,
@@ -157,43 +155,33 @@ var _ = Describe("ForeignClusterOperator", func() {
 				c.fc.Status.TenantNamespace.Local = tenantNamespace.Name
 
 				// create the foreigncluster CR
-				obj, err := controller.crdClient.Resource("foreignclusters").Create(&c.fc, &metav1.CreateOptions{})
-				Expect(err).To(BeNil())
-				Expect(obj).NotTo(BeNil())
-
-				fc, ok := obj.(*discoveryv1alpha1.ForeignCluster)
-				Expect(ok).To(BeTrue())
-				Expect(fc).NotTo(BeNil())
+				fc := c.fc.DeepCopy()
+				Expect(controller.Create(ctx, fc)).To(Succeed())
 
 				fc.Status = *c.fc.Status.DeepCopy()
-				obj, err = controller.crdClient.Resource("foreignclusters").UpdateStatus(fc.Name, fc, &metav1.UpdateOptions{})
-				Expect(err).To(BeNil())
-				Expect(obj).NotTo(BeNil())
-
-				fc, ok = obj.(*discoveryv1alpha1.ForeignCluster)
-				Expect(ok).To(BeTrue())
-				Expect(fc).NotTo(BeNil())
+				Expect(controller.Status().Update(ctx, fc)).To(Succeed())
 
 				// enable the peering for that foreigncluster
-				err = controller.peerNamespaced(ctx, fc)
-				Expect(err).To(BeNil())
+				Expect(controller.peerNamespaced(ctx, fc)).To(Succeed())
 
 				// check that the incoming and the outgoing statuses are the expected ones
 				Expect(peeringconditionsutils.GetStatus(fc, discoveryv1alpha1.OutgoingPeeringCondition)).To(c.expectedOutgoing)
 				Expect(peeringconditionsutils.GetStatus(fc, discoveryv1alpha1.IncomingPeeringCondition)).To(c.expectedIncoming)
 
 				// get the resource requests in the local tenant namespace
-				obj, err = controller.crdClient.Resource("resourcerequests").Namespace(tenantNamespace.Name).List(&metav1.ListOptions{})
-				Expect(err).To(BeNil())
-				Expect(obj).NotTo(BeNil())
+				rrs := discoveryv1alpha1.ResourceRequestList{}
+				Eventually(func() error {
+					if err := controller.List(ctx, &rrs, client.InNamespace(tenantNamespace.Name)); err != nil {
+						return err
+					}
 
-				rrs, ok := obj.(*discoveryv1alpha1.ResourceRequestList)
-				Expect(ok).To(BeTrue())
-				Expect(rrs).NotTo(BeNil())
-
-				// check that the length of the resource request list is the expected one,
-				// and the resource request has been created in the correct namespace
-				Expect(len(rrs.Items)).To(c.expectedPeeringLength)
+					// check that the length of the resource request list is the expected one,
+					// and the resource request has been created in the correct namespace
+					if ok, err := c.expectedPeeringLength.Match(rrs.Items); !ok {
+						return err
+					}
+					return nil
+				}).Should(Succeed())
 			},
 
 			Entry("peer", peerTestcase{
@@ -218,7 +206,7 @@ var _ = Describe("ForeignClusterOperator", func() {
 						TenantNamespace: defaultTenantNamespace,
 					},
 				},
-				expectedPeeringLength: Equal(1),
+				expectedPeeringLength: HaveLen(1),
 				expectedOutgoing:      Equal(discoveryv1alpha1.PeeringConditionStatusPending), // we expect a joined flag set to true for the outgoing peering
 				expectedIncoming:      Equal(discoveryv1alpha1.PeeringConditionStatusNone),
 			}),
@@ -245,65 +233,55 @@ var _ = Describe("ForeignClusterOperator", func() {
 
 				// populate the resourcerequest CR
 				c.rr.Name = controller.clusterID.GetClusterID()
+				c.rr.Namespace = tenantNamespace.Name
 				c.rr.Spec.ClusterIdentity.ClusterID = c.fc.Spec.ClusterIdentity.ClusterID
 				c.rr.Labels = resourceRequestLabels(c.fc.Spec.ClusterIdentity.ClusterID)
 
 				// create the foreigncluster CR
-				obj, err := controller.crdClient.Resource("foreignclusters").Create(&c.fc, &metav1.CreateOptions{})
-				Expect(err).To(BeNil())
-				Expect(obj).NotTo(BeNil())
-
-				fc, ok := obj.(*discoveryv1alpha1.ForeignCluster)
-				Expect(ok).To(BeTrue())
-				Expect(fc).NotTo(BeNil())
+				fc := c.fc.DeepCopy()
+				Expect(controller.Create(ctx, fc)).To(Succeed())
 
 				fc.Status = *c.fc.Status.DeepCopy()
-				obj, err = controller.crdClient.Resource("foreignclusters").UpdateStatus(fc.Name, fc, &metav1.UpdateOptions{})
-				Expect(err).To(BeNil())
-				Expect(obj).NotTo(BeNil())
-
-				fc, ok = obj.(*discoveryv1alpha1.ForeignCluster)
-				Expect(ok).To(BeTrue())
-				Expect(fc).NotTo(BeNil())
+				Expect(controller.Status().Update(ctx, fc)).To(Succeed())
 
 				// create the resourcerequest CR
-				obj, err = controller.crdClient.Resource("resourcerequests").Namespace(tenantNamespace.Name).Create(&c.rr, &metav1.CreateOptions{})
-				Expect(err).To(BeNil())
-				Expect(obj).NotTo(BeNil())
-
-				rr, ok := obj.(*discoveryv1alpha1.ResourceRequest)
-				Expect(ok).To(BeTrue())
-				Expect(rr).NotTo(BeNil())
+				rr := c.rr.DeepCopy()
+				Expect(controller.Create(ctx, rr)).To(Succeed())
 
 				// set the ResourceRequest status to created
-				obj, err = controller.crdClient.Resource("resourcerequests").Namespace(tenantNamespace.Name).UpdateStatus(rr.Name, rr, &metav1.UpdateOptions{})
-				Expect(err).To(BeNil())
-				Expect(obj).NotTo(BeNil())
-
-				rr, ok = obj.(*discoveryv1alpha1.ResourceRequest)
-				Expect(ok).To(BeTrue())
-				Expect(rr).NotTo(BeNil())
+				rr.Status = *c.rr.Status.DeepCopy()
+				Expect(controller.Status().Update(ctx, rr)).To(Succeed())
 
 				// disable the peering for that foreigncluster
-				err = controller.unpeerNamespaced(ctx, fc)
-				Expect(err).To(BeNil())
+				Expect(controller.unpeerNamespaced(ctx, fc)).To(Succeed())
 
 				// check that the incoming and the outgoing statuses are the expected ones
 				Expect(peeringconditionsutils.GetStatus(fc, discoveryv1alpha1.OutgoingPeeringCondition)).To(c.expectedOutgoing)
 				Expect(peeringconditionsutils.GetStatus(fc, discoveryv1alpha1.IncomingPeeringCondition)).To(c.expectedIncoming)
 
 				// get the resource requests in the local tenant namespace
-				obj, err = controller.crdClient.Resource("resourcerequests").Namespace(tenantNamespace.Name).List(&metav1.ListOptions{})
-				Expect(err).To(BeNil())
-				Expect(obj).NotTo(BeNil())
+				rrs := discoveryv1alpha1.ResourceRequestList{}
+				Eventually(func() error {
+					if err := controller.List(ctx, &rrs, client.InNamespace(tenantNamespace.Name)); err != nil {
+						return err
+					}
 
-				rrs, ok := obj.(*discoveryv1alpha1.ResourceRequestList)
-				Expect(ok).To(BeTrue())
-				Expect(rrs).NotTo(BeNil())
+					// check that the length of the resource request list is the expected one.
+					if ok, err := c.expectedPeeringLength.Match(rrs.Items); !ok {
+						return err
+					}
 
-				// check that the length of the resource request list is the expected one,
-				// and the resource request has been set for deletion in the correct namespace
-				Expect(len(rrs.Items)).To(c.expectedPeeringLength)
+					// Check that the resource request has been set for deletion in the correct namespace
+					if len(rrs.Items) > 0 {
+						if ok, err := BeFalse().Match(rrs.Items[0].Spec.WithdrawalTimestamp.IsZero()); !ok {
+							return err
+						}
+						rr = &rrs.Items[0]
+					}
+					return nil
+				}).Should(Succeed())
+
+				// Check that the resource request has been set for deletion in the correct namespace
 				if len(rrs.Items) > 0 {
 					Expect(rrs.Items[0].Spec.WithdrawalTimestamp.IsZero()).To(BeFalse())
 					rr = &rrs.Items[0]
@@ -311,18 +289,12 @@ var _ = Describe("ForeignClusterOperator", func() {
 
 				// set the ResourceRequest status to deleted
 				rr.Status.OfferWithdrawalTimestamp = &now
-				obj, err = controller.crdClient.Resource("resourcerequests").Namespace(tenantNamespace.Name).UpdateStatus(rr.Name, rr, &metav1.UpdateOptions{})
-				Expect(err).To(BeNil())
-				Expect(obj).NotTo(BeNil())
-
-				rr, ok = obj.(*discoveryv1alpha1.ResourceRequest)
-				Expect(ok).To(BeTrue())
-				Expect(rr).NotTo(BeNil())
+				Expect(controller.Status().Update(ctx, rr)).To(Succeed())
 
 				// call for the second time the unpeer function to delete the ResourceRequest
-				err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+				err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 					// make sure to be working on the last ForeignCluster version
-					err = controller.Client.Get(ctx, machtypes.NamespacedName{
+					err := controller.Client.Get(ctx, machtypes.NamespacedName{
 						Name: fc.GetName(),
 					}, fc)
 					if err != nil {
@@ -334,15 +306,17 @@ var _ = Describe("ForeignClusterOperator", func() {
 				Expect(err).To(BeNil())
 
 				// get the resource requests in the local tenant namespace
-				obj, err = controller.crdClient.Resource("resourcerequests").Namespace(tenantNamespace.Name).List(&metav1.ListOptions{})
-				Expect(err).To(BeNil())
-				Expect(obj).NotTo(BeNil())
+				Eventually(func() error {
+					if err := controller.List(ctx, &rrs, client.InNamespace(tenantNamespace.Name)); err != nil {
+						return err
+					}
 
-				rrs, ok = obj.(*discoveryv1alpha1.ResourceRequestList)
-				Expect(ok).To(BeTrue())
-				Expect(rrs).NotTo(BeNil())
-
-				Expect(len(rrs.Items)).To(BeNumerically("==", 0))
+					// check that no resource requests are present in the end.
+					if ok, err := HaveLen(0).Match(rrs.Items); !ok {
+						return err
+					}
+					return nil
+				}).Should(Succeed())
 			},
 
 			Entry("unpeer", unpeerTestcase{
@@ -386,7 +360,7 @@ var _ = Describe("ForeignClusterOperator", func() {
 						AuthURL: "",
 					},
 				},
-				expectedPeeringLength: Equal(1),
+				expectedPeeringLength: HaveLen(1),
 				expectedOutgoing:      Equal(discoveryv1alpha1.PeeringConditionStatusDisconnecting),
 				expectedIncoming:      Equal(discoveryv1alpha1.PeeringConditionStatusNone),
 			}),

--- a/internal/discovery/foreign-cluster-operator/setup.go
+++ b/internal/discovery/foreign-cluster-operator/setup.go
@@ -5,15 +5,16 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
 	"github.com/liqotech/liqo/internal/discovery"
 	"github.com/liqotech/liqo/pkg/auth"
 	"github.com/liqotech/liqo/pkg/clusterid"
-	crdclient "github.com/liqotech/liqo/pkg/crdClient"
 	identitymanager "github.com/liqotech/liqo/pkg/identityManager"
 	peeringroles "github.com/liqotech/liqo/pkg/peering-roles"
 	tenantnamespace "github.com/liqotech/liqo/pkg/tenantNamespace"
@@ -31,46 +32,30 @@ func init() {
 
 // StartOperator setups the ForeignCluster operator.
 func StartOperator(
-	mgr manager.Manager, namespace string, requeueAfter time.Duration,
-	discoveryCtrl *discovery.Controller, kubeconfigPath string) {
-	config, err := crdclient.NewKubeconfig(kubeconfigPath, &discoveryv1alpha1.GroupVersion, nil)
-	if err != nil {
-		klog.Error(err, "unable to get kube config")
-		os.Exit(1)
-	}
-	discoveryClient, err := crdclient.NewFromConfig(config)
-	if err != nil {
-		klog.Error(err, "unable to create crd client")
-		os.Exit(1)
-	}
-	localClusterID, err := clusterid.NewClusterID(kubeconfigPath)
-	if err != nil {
-		klog.Error(err, "unable to get clusterid")
-		os.Exit(1)
-	}
+	mgr manager.Manager, namespacedClient client.Client, clientset kubernetes.Interface,
+	requeueAfter time.Duration, discoveryCtrl *discovery.Controller, localClusterID clusterid.ClusterID) {
+	namespaceManager := tenantnamespace.NewTenantNamespaceManager(clientset)
+	idManager := identitymanager.NewCertificateIdentityManager(clientset, localClusterID, namespaceManager)
 
-	namespaceManager := tenantnamespace.NewTenantNamespaceManager(discoveryClient.Client())
-	idManager := identitymanager.NewCertificateIdentityManager(discoveryClient.Client(), localClusterID, namespaceManager)
-
-	if err = (getForeignClusterReconciler(
+	if err := getForeignClusterReconciler(
 		mgr,
-		namespace,
-		discoveryClient,
+		namespacedClient,
+		clientset,
 		localClusterID,
 		requeueAfter,
 		discoveryCtrl,
 		discoveryCtrl,
 		namespaceManager,
 		idManager,
-	)).SetupWithManager(mgr); err != nil {
+	).SetupWithManager(mgr); err != nil {
 		klog.Error(err, "unable to create controller", "controller", "ForeignCluster")
 		os.Exit(1)
 	}
 }
 
 func getForeignClusterReconciler(mgr manager.Manager,
-	namespace string,
-	client *crdclient.CRDClient,
+	namespacedClient client.Client,
+	clientset kubernetes.Interface,
 	localClusterID clusterid.ClusterID,
 	requeueAfter time.Duration,
 	configProvider discovery.ConfigProvider,
@@ -78,21 +63,19 @@ func getForeignClusterReconciler(mgr manager.Manager,
 	namespaceManager tenantnamespace.Manager,
 	idManager identitymanager.IdentityManager) *ForeignClusterReconciler {
 	reconciler := &ForeignClusterReconciler{
-		Client:             mgr.GetClient(),
-		Scheme:             mgr.GetScheme(),
-		Namespace:          namespace,
-		crdClient:          client,
-		clusterID:          localClusterID,
-		ForeignConfig:      nil,
-		RequeueAfter:       requeueAfter,
-		ConfigProvider:     configProvider,
-		AuthConfigProvider: authConfigProvider,
-		namespaceManager:   namespaceManager,
-		identityManager:    idManager,
+		Client:               mgr.GetClient(),
+		LiqoNamespacedClient: namespacedClient,
+		Scheme:               mgr.GetScheme(),
+		clusterID:            localClusterID,
+		RequeueAfter:         requeueAfter,
+		ConfigProvider:       configProvider,
+		AuthConfigProvider:   authConfigProvider,
+		namespaceManager:     namespaceManager,
+		identityManager:      idManager,
 	}
 
 	// populate the lists of ClusterRoles to bind in the different peering states
-	if err := reconciler.populatePermission(); err != nil {
+	if err := reconciler.populatePermission(clientset); err != nil {
 		klog.Errorf("unable to populate peering permission: %v", err)
 		os.Exit(1)
 	}
@@ -101,8 +84,8 @@ func getForeignClusterReconciler(mgr manager.Manager,
 }
 
 // populatePermission populates the list of ClusterRoles to bind in the different peering phases reading the ClusterConfig CR.
-func (r *ForeignClusterReconciler) populatePermission() error {
-	peeringPermission, err := peeringroles.GetPeeringPermission(r.crdClient.Client(), r.AuthConfigProvider)
+func (r *ForeignClusterReconciler) populatePermission(clientset kubernetes.Interface) error {
+	peeringPermission, err := peeringroles.GetPeeringPermission(clientset, r.AuthConfigProvider)
 	if err != nil {
 		klog.Error(err)
 		return err

--- a/internal/discovery/foreign-cluster-operator/validator.go
+++ b/internal/discovery/foreign-cluster-operator/validator.go
@@ -42,8 +42,7 @@ func (r *ForeignClusterReconciler) validateForeignCluster(ctx context.Context,
 	}
 
 	if requireUpdate {
-		_, err = r.update(foreignCluster)
-		if err != nil {
+		if err = r.Client.Update(ctx, foreignCluster); err != nil {
 			klog.Error(err, err.Error())
 			return false, ctrl.Result{
 				Requeue:      true,

--- a/pkg/utils/restcfg/doc.go
+++ b/pkg/utils/restcfg/doc.go
@@ -1,0 +1,2 @@
+// Package restcfg contains utility functions to deal with rest configs.
+package restcfg

--- a/pkg/utils/restcfg/ratelimiting.go
+++ b/pkg/utils/restcfg/ratelimiting.go
@@ -1,0 +1,42 @@
+package restcfg
+
+import (
+	"flag"
+
+	"k8s.io/client-go/rest"
+)
+
+const (
+	// DefaultQPS -> The default QPS value assigned to client-go clients.
+	DefaultQPS = uint(100)
+	// DefaultBurst -> The default burst value assigned to client-go clients.
+	DefaultBurst = uint(100)
+)
+
+var (
+	qps   = DefaultQPS
+	burst = DefaultBurst
+)
+
+// InitFlags initializes the flags to configure the rate limiter parameters.
+func InitFlags(flagset *flag.FlagSet) {
+	if flagset == nil {
+		flagset = flag.CommandLine
+	}
+
+	flagset.UintVar(&qps, "client-qps", qps, "The maximum number of queries per second performed towards the API server.")
+	flagset.UintVar(&burst, "client-max-burst", qps, "The maximum burst of requests in excess of the rate limit towards the API server.")
+}
+
+// SetRateLimiter configures the rate limiting parameters of the given rest configuration
+// to the values obtained from the command line parameters.
+func SetRateLimiter(cfg *rest.Config) *rest.Config {
+	return SetRateLimiterWithCustomParamenters(cfg, float32(qps), int(burst))
+}
+
+// SetRateLimiterWithCustomParamenters configures the rate limiting parameters of the given rest configuration.
+func SetRateLimiterWithCustomParamenters(cfg *rest.Config, qps float32, burst int) *rest.Config {
+	cfg.QPS = qps
+	cfg.Burst = burst
+	return cfg
+}

--- a/pkg/utils/restcfg/ratelimiting_test.go
+++ b/pkg/utils/restcfg/ratelimiting_test.go
@@ -1,0 +1,65 @@
+package restcfg_test
+
+import (
+	"flag"
+	"strconv"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/rest"
+
+	"github.com/liqotech/liqo/pkg/utils/restcfg"
+)
+
+var _ = Describe("The rate limiting utility functions", func() {
+
+	var (
+		cfg    rest.Config
+		output *rest.Config
+	)
+
+	const (
+		qps   = 67
+		burst = 89
+	)
+
+	Describe("the SetRateLimiter function", func() {
+		Context("configuring the rate limiting parameters", func() {
+			var fs flag.FlagSet
+
+			BeforeEach(func() {
+				fs = *flag.NewFlagSet("test-flags", flag.PanicOnError)
+				restcfg.InitFlags(&fs)
+			})
+			JustBeforeEach(func() { output = restcfg.SetRateLimiter(&cfg) })
+
+			When("using the default configuration", func() {
+				It("should return a pointer to the original object", func() { Expect(output).To(BeIdenticalTo(&cfg)) })
+				It("should set the default QPS value", func() { Expect(cfg.QPS).To(BeNumerically("==", restcfg.DefaultQPS)) })
+				It("should set the default burst value", func() { Expect(cfg.Burst).To(BeNumerically("==", restcfg.DefaultBurst)) })
+			})
+
+			When("specifying a custom configuration", func() {
+				BeforeEach(func() {
+					utilruntime.Must(fs.Set("client-qps", strconv.FormatInt(qps, 10)))
+					utilruntime.Must(fs.Set("client-max-burst", strconv.FormatInt(burst, 10)))
+				})
+
+				It("should return a pointer to the original object", func() { Expect(output).To(BeIdenticalTo(&cfg)) })
+				It("should set the desired QPS value", func() { Expect(cfg.QPS).To(BeNumerically("==", qps)) })
+				It("should set the desired burst value", func() { Expect(cfg.Burst).To(BeNumerically("==", burst)) })
+			})
+		})
+	})
+
+	Describe("the SetRateLimiterWithCustomParamenters function", func() {
+		Context("configuring the rate limiting parameters", func() {
+			JustBeforeEach(func() { output = restcfg.SetRateLimiterWithCustomParamenters(&cfg, qps, burst) })
+
+			It("should return a pointer to the original object", func() { Expect(output).To(BeIdenticalTo(&cfg)) })
+			It("should set the desired QPS value", func() { Expect(cfg.QPS).To(BeNumerically("==", qps)) })
+			It("should set the desired burst value", func() { Expect(cfg.Burst).To(BeNumerically("==", burst)) })
+		})
+	})
+})

--- a/pkg/utils/restcfg/restcfg_suite_test.go
+++ b/pkg/utils/restcfg/restcfg_suite_test.go
@@ -1,0 +1,13 @@
+package restcfg_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestRestcfg(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "RestConfig Suite")
+}

--- a/pkg/utils/trace/doc.go
+++ b/pkg/utils/trace/doc.go
@@ -1,0 +1,2 @@
+// Package trace contains utility functions to deal with traces.
+package trace

--- a/pkg/utils/trace/trace.go
+++ b/pkg/utils/trace/trace.go
@@ -1,0 +1,21 @@
+package trace
+
+import (
+	"time"
+
+	"k8s.io/klog/v2"
+)
+
+// LongThreshold returns the treshold to show a tracing log, depending on the configured klog level.
+func LongThreshold() time.Duration {
+	switch {
+	case klog.V(5).Enabled():
+		return 100 * time.Millisecond
+	case klog.V(4).Enabled():
+		return 250 * time.Millisecond
+	case klog.V(2).Enabled():
+		return 500 * time.Millisecond
+	default:
+		return time.Second
+	}
+}

--- a/pkg/utils/trace/trace_suite_test.go
+++ b/pkg/utils/trace/trace_suite_test.go
@@ -1,0 +1,13 @@
+package trace_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestTrace(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Trace Suite")
+}

--- a/pkg/utils/trace/trace_test.go
+++ b/pkg/utils/trace/trace_test.go
@@ -1,0 +1,42 @@
+package trace_test
+
+import (
+	"flag"
+	"strconv"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/klog/v2"
+
+	"github.com/liqotech/liqo/pkg/utils/trace"
+)
+
+var _ = Describe("Trace utilities", func() {
+
+	var fs flag.FlagSet
+
+	BeforeEach(func() {
+		fs = *flag.NewFlagSet("test-flags", flag.PanicOnError)
+		klog.InitFlags(&fs)
+	})
+
+	DescribeTable("The LongThreshold function",
+		func(level int, expected time.Duration) {
+			utilruntime.Must(fs.Set("v", strconv.FormatInt(int64(level), 10)))
+			Expect(trace.LongThreshold()).To(Equal(expected))
+		},
+		Entry("with log level 0", 0, time.Second),
+		Entry("with log level 1", 1, time.Second),
+		Entry("with log level 2", 2, 500*time.Millisecond),
+		Entry("with log level 3", 3, 500*time.Millisecond),
+		Entry("with log level 4", 4, 250*time.Millisecond),
+		Entry("with log level 5", 5, 100*time.Millisecond),
+		Entry("with log level 6", 6, 100*time.Millisecond),
+		Entry("with log level 7", 7, 100*time.Millisecond),
+		Entry("with log level 8", 8, 100*time.Millisecond),
+		Entry("with log level 9", 9, 100*time.Millisecond),
+	)
+})


### PR DESCRIPTION
# Description

This PR introduces different changes to improve the performance of the foreign cluster operator. Specifically:
* Addition of minimal tracing to detect bottlenecks
* Reduction of the number of clients, to better exploit the available caches
* Custom configuration of the client rate limiters, to reduce throttling (customizable by the users) 

Fixes #(issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Unit testing (new + existing)
- [X] E2E testing (existing)
