### PR TITLE
Use namespace lister in tenant namespace manager

### DIFF
--- a/deployments/liqo/files/liqo-crd-replicator-ClusterRole.yaml
+++ b/deployments/liqo/files/liqo-crd-replicator-ClusterRole.yaml
@@ -10,6 +10,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - secrets
   verbs:
   - get

--- a/internal/auth-service/identity.go
+++ b/internal/auth-service/identity.go
@@ -78,7 +78,7 @@ func (authService *Controller) handleIdentity(
 
 	// check that there is no available certificate for that clusterID
 	if _, err = authService.identityManager.GetRemoteCertificate(
-		identityRequest.ClusterID, identityRequest.CertificateSigningRequest); err == nil {
+		identityRequest.ClusterID, namespace.Name, identityRequest.CertificateSigningRequest); err == nil {
 		klog.Info("multiple identity validations with unique clusterID")
 		err = &kerrors.StatusError{ErrStatus: metav1.Status{
 			Status: metav1.StatusFailure,

--- a/internal/crdReplicator/crdReplicator-operator.go
+++ b/internal/crdReplicator/crdReplicator-operator.go
@@ -113,6 +113,7 @@ type Controller struct {
 // +kubebuilder:rbac:groups=core,namespace="do-not-care",resources=configmaps,verbs=get;list
 
 // identity management
+// +kubebuilder:rbac:groups=core,resources=namespaces,verbs=get;list;watch
 // +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list
 
 // Reconcile handles requests for subscribed types of object.

--- a/pkg/identityManager/certificateIdentityProvider.go
+++ b/pkg/identityManager/certificateIdentityProvider.go
@@ -37,15 +37,9 @@ type certificateIdentityProvider struct {
 
 // GetRemoteCertificate retrieves a certificate issued in the past,
 // given the clusterid and the signingRequest.
-func (identityProvider *certificateIdentityProvider) GetRemoteCertificate(clusterID,
+func (identityProvider *certificateIdentityProvider) GetRemoteCertificate(clusterID, namespace,
 	signingRequest string) (response *responsetypes.SigningRequestResponse, err error) {
-	namespace, err := identityProvider.namespaceManager.GetNamespace(clusterID)
-	if err != nil {
-		klog.Error(err)
-		return response, err
-	}
-
-	secret, err := identityProvider.client.CoreV1().Secrets(namespace.Name).Get(context.TODO(), remoteCertificateSecret, metav1.GetOptions{})
+	secret, err := identityProvider.client.CoreV1().Secrets(namespace).Get(context.TODO(), remoteCertificateSecret, metav1.GetOptions{})
 	if err != nil {
 		if kerrors.IsNotFound(err) {
 			klog.V(4).Info(err)

--- a/pkg/identityManager/iamIdentityProvider.go
+++ b/pkg/identityManager/iamIdentityProvider.go
@@ -35,7 +35,7 @@ type mapUser struct {
 	Groups   []string `json:"groups"`
 }
 
-func (identityProvider *iamIdentityProvider) GetRemoteCertificate(clusterID,
+func (identityProvider *iamIdentityProvider) GetRemoteCertificate(clusterID, namespace,
 	signingRequest string) (response *responsetypes.SigningRequestResponse, err error) {
 	// this method has no meaning for this identity provider
 	return response, kerrors.NewNotFound(schema.GroupResource{

--- a/pkg/identityManager/identityManager_test.go
+++ b/pkg/identityManager/identityManager_test.go
@@ -98,6 +98,8 @@ var _ = Describe("IdentityManager", func() {
 			By(err.Error())
 			os.Exit(1)
 		}
+		// Make sure the namespace has been cached for subsequent retrieval.
+		Eventually(func() (*v1.Namespace, error) { return namespaceManager.GetNamespace(remoteClusterID) }).Should(Equal(namespace))
 	})
 
 	AfterSuite(func() {
@@ -192,14 +194,14 @@ var _ = Describe("IdentityManager", func() {
 		})
 
 		It("Retrieve Remote Certificate", func() {
-			certificate, err := identityMan.GetRemoteCertificate(remoteClusterID, base64.StdEncoding.EncodeToString(csrBytes))
+			certificate, err := identityMan.GetRemoteCertificate(remoteClusterID, namespace.Name, base64.StdEncoding.EncodeToString(csrBytes))
 			Expect(err).To(BeNil())
 			Expect(certificate).NotTo(BeNil())
 			Expect(certificate.Certificate).To(Equal([]byte(idManTest.FakeCRT)))
 		})
 
 		It("Retrieve Remote Certificate wrong clusterid", func() {
-			certificate, err := identityMan.GetRemoteCertificate("fake", base64.StdEncoding.EncodeToString(csrBytes))
+			certificate, err := identityMan.GetRemoteCertificate("fake", "fake", base64.StdEncoding.EncodeToString(csrBytes))
 			Expect(err).NotTo(BeNil())
 			Expect(kerrors.IsNotFound(err)).To(BeTrue())
 			Expect(kerrors.IsBadRequest(err)).To(BeFalse())
@@ -207,7 +209,7 @@ var _ = Describe("IdentityManager", func() {
 		})
 
 		It("Retrieve Remote Certificate wrong CSR", func() {
-			certificate, err := identityMan.GetRemoteCertificate(remoteClusterID, base64.StdEncoding.EncodeToString([]byte("fake")))
+			certificate, err := identityMan.GetRemoteCertificate(remoteClusterID, namespace.Name, base64.StdEncoding.EncodeToString([]byte("fake")))
 			Expect(err).NotTo(BeNil())
 			Expect(kerrors.IsNotFound(err)).To(BeFalse())
 			Expect(kerrors.IsBadRequest(err)).To(BeTrue())

--- a/pkg/identityManager/interface.go
+++ b/pkg/identityManager/interface.go
@@ -26,6 +26,6 @@ type localManager interface {
 
 // interface that allows to manage the identity in the target cluster, where this identity has to be used.
 type identityProvider interface {
+	GetRemoteCertificate(clusterID, namespace, signingRequest string) (response *responsetypes.SigningRequestResponse, err error)
 	ApproveSigningRequest(clusterID, signingRequest string) (response *responsetypes.SigningRequestResponse, err error)
-	GetRemoteCertificate(clusterID, signingRequest string) (response *responsetypes.SigningRequestResponse, err error)
 }


### PR DESCRIPTION
# Description

This PR converts the tenant namespace manager to use a lister instead of performing direct get operations, to reduce the number of API requests and improve the overall performance. Finally, it adds a predicate to the foreign cluster controller to prevent its execution in case only the status changed.

**Warning**: this is a bit opinionated, since it introduces the possibility for race conditions if a namespace if first created and then immediately retrieved (since it might not have already been cached). IMHO, this should not be a problem, since the real controllers either create the namespace or retrieve it (and even in case of race condition, they would return an error and immediately retry). Differently, this creates problems in the tests, which have been fixed adding an `Eventually` clause to ensure the cache was populated. @liqotech/maintainers, if you do not like this modification feel free to close the PR.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Unit tests (existing)
- [x] E2E tests (existing)
