### PR TITLE
Authentication service performance improvements

### DIFF
--- a/cmd/auth-service/main.go
+++ b/cmd/auth-service/main.go
@@ -10,6 +10,7 @@ import (
 
 	authservice "github.com/liqotech/liqo/internal/auth-service"
 	identitymanager "github.com/liqotech/liqo/pkg/identityManager"
+	"github.com/liqotech/liqo/pkg/utils/restcfg"
 )
 
 func main() {
@@ -39,6 +40,7 @@ func main() {
 	flag.StringVar(&awsConfig.AwsRegion, "awsRegion", "", "AWS region where the local cluster is running")
 	flag.StringVar(&awsConfig.AwsClusterName, "awsClusterName", "", "Name of the local EKS cluster")
 
+	restcfg.InitFlags(nil)
 	klog.InitFlags(nil)
 	flag.Parse()
 

--- a/cmd/crd-replicator/main.go
+++ b/cmd/crd-replicator/main.go
@@ -95,7 +95,7 @@ func main() {
 		RemoteWatchers:                 make(map[string]map[string]chan struct{}),
 		RemoteDynSharedInformerFactory: make(map[string]dynamicinformer.DynamicSharedInformerFactory),
 		NamespaceManager:               namespaceManager,
-		IdentityManager: identitymanager.NewCertificateIdentityManager(
+		IdentityReader: identitymanager.NewCertificateIdentityReader(
 			k8sClient, clusterIDInterface, namespaceManager),
 		LocalToRemoteNamespaceMapper:     map[string]string{},
 		RemoteToLocalNamespaceMapper:     map[string]string{},

--- a/internal/auth-service/auth-service.go
+++ b/internal/auth-service/auth-service.go
@@ -25,6 +25,7 @@ import (
 	identitymanager "github.com/liqotech/liqo/pkg/identityManager"
 	peeringRoles "github.com/liqotech/liqo/pkg/peering-roles"
 	tenantnamespace "github.com/liqotech/liqo/pkg/tenantNamespace"
+	"github.com/liqotech/liqo/pkg/utils/restcfg"
 )
 
 // cluster-role
@@ -73,6 +74,7 @@ func NewAuthServiceCtrl(namespace, kubeconfigPath string,
 	if err != nil {
 		return nil, err
 	}
+	restcfg.SetRateLimiter(config)
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		return nil, err

--- a/internal/auth-service/auth_test.go
+++ b/internal/auth-service/auth_test.go
@@ -282,7 +282,7 @@ var _ = Describe("Auth", func() {
 				Expect(err).To(BeNil())
 				c.request.CertificateSigningRequest = base64.StdEncoding.EncodeToString(csr)
 
-				response, err := authService.handleIdentity(c.request)
+				response, err := authService.handleIdentity(context.TODO(), c.request)
 				Expect(err).To(c.expectedOutput)
 				c.expectedResponse(response)
 			},

--- a/internal/auth-service/identity.go
+++ b/internal/auth-service/identity.go
@@ -88,7 +88,7 @@ func (authService *Controller) handleIdentity(
 	tracer.Step("Tenant namespace created")
 
 	// check that there is no available certificate for that clusterID
-	if _, err = authService.identityManager.GetRemoteCertificate(
+	if _, err = authService.identityProvider.GetRemoteCertificate(
 		identityRequest.ClusterID, namespace.Name, identityRequest.CertificateSigningRequest); err == nil {
 		klog.Info("multiple identity validations with unique clusterID")
 		err = &kerrors.StatusError{ErrStatus: metav1.Status{
@@ -105,7 +105,7 @@ func (authService *Controller) handleIdentity(
 	tracer.Step("Cluster ID uniqueness ensured")
 
 	// issue certificate request
-	identityResponse, err := authService.identityManager.ApproveSigningRequest(
+	identityResponse, err := authService.identityProvider.ApproveSigningRequest(
 		identityRequest.ClusterID, identityRequest.CertificateSigningRequest)
 	if err != nil {
 		klog.Error(err)

--- a/internal/auth-service/idsHttpHandler.go
+++ b/internal/auth-service/idsHttpHandler.go
@@ -3,9 +3,11 @@ package authservice
 import (
 	"encoding/json"
 	"net/http"
+	"time"
 
 	"github.com/julienschmidt/httprouter"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/trace"
 
 	"github.com/liqotech/liqo/pkg/auth"
 )
@@ -14,8 +16,10 @@ import (
 // it returns a JSON encoded ClusterInfo struct with the following fields:
 // - clusterID		-> the id of the home cluster.
 // - clusterName	-> the custom name for the home cluster (to be displayed in GUIs).
-// - guestNamespace	-> the namespace where to create secrets and resources to be shared with the home cluster.
 func (authService *Controller) ids(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	tracer := trace.New("IDs handler")
+	defer tracer.LogIfLong(10 * time.Millisecond)
+
 	idsResponse := authService.getIdsResponse()
 
 	res, err := json.Marshal(idsResponse)

--- a/internal/crdReplicator/crdReplicator-operator.go
+++ b/internal/crdReplicator/crdReplicator-operator.go
@@ -88,8 +88,8 @@ type Controller struct {
 
 	// NamespaceManager is an interface to manage the tenant namespaces.
 	NamespaceManager tenantnamespace.Manager
-	// IdentityManager is an interface to manage remote identities, and to get the rest config.
-	IdentityManager identitymanager.IdentityManager
+	// IdentityReader is an interface to manage remote identities, and to get the rest config.
+	IdentityReader identitymanager.IdentityReader
 	// LocalToRemoteNamespaceMapper maps local namespaces to remote ones.
 	LocalToRemoteNamespaceMapper map[string]string
 	// RemoteToLocalNamespaceMapper maps remote namespaces to local ones.
@@ -191,7 +191,7 @@ func (c *Controller) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			c.ClusterID, req.NamespacedName, remoteClusterID)
 		return result, nil
 	}
-	config, err := c.IdentityManager.GetConfig(remoteClusterID, fc.Status.TenantNamespace.Local)
+	config, err := c.IdentityReader.GetConfig(remoteClusterID, fc.Status.TenantNamespace.Local)
 	if err != nil {
 		klog.Errorf("%s -> unable to retrieve config from resource %s for remote peering cluster %s: %s",
 			c.ClusterID, req.NamespacedName, remoteClusterID, err)

--- a/internal/crdReplicator/crdReplicator-operator_test.go
+++ b/internal/crdReplicator/crdReplicator-operator_test.go
@@ -106,7 +106,7 @@ func getCRDReplicator() Controller {
 		LocalWatchers:                  map[string]chan struct{}{},
 
 		NamespaceManager:                 tenantmanager,
-		IdentityManager:                  identitymanager.NewCertificateIdentityManager(k8sclient, clusterIDInterface, tenantmanager),
+		IdentityReader:                   identitymanager.NewCertificateIdentityReader(k8sclient, clusterIDInterface, tenantmanager),
 		LocalToRemoteNamespaceMapper:     map[string]string{},
 		RemoteToLocalNamespaceMapper:     map[string]string{},
 		ClusterIDToLocalNamespaceMapper:  map[string]string{},

--- a/internal/crdReplicator/peeringPhase_test.go
+++ b/internal/crdReplicator/peeringPhase_test.go
@@ -94,7 +94,7 @@ var _ = Describe("PeeringPhase-Based Replication", func() {
 			LocalWatchers:                  map[string]chan struct{}{},
 
 			NamespaceManager:                 tenantmanager,
-			IdentityManager:                  identitymanager.NewCertificateIdentityManager(k8sclient, clusterIDInterface, tenantmanager),
+			IdentityReader:                   identitymanager.NewCertificateIdentityReader(k8sclient, clusterIDInterface, tenantmanager),
 			LocalToRemoteNamespaceMapper:     map[string]string{},
 			RemoteToLocalNamespaceMapper:     map[string]string{},
 			ClusterIDToLocalNamespaceMapper:  map[string]string{},

--- a/pkg/identityManager/const.go
+++ b/pkg/identityManager/const.go
@@ -4,7 +4,7 @@ const defaultOrganization = "liqo.io"
 
 const (
 	localIdentitySecretLabel  = "discovery.liqo.io/local-identity"
-	randomIDLabel             = "discovery.liqo.io/random-id"
+	remoteTenantCSRLabel      = "discovery.liqo.io/remote-tenant-csr"
 	certificateAvailableLabel = "discovery.liqo.io/certificate-available"
 )
 

--- a/pkg/identityManager/identityManager.go
+++ b/pkg/identityManager/identityManager.go
@@ -3,15 +3,19 @@ package identitymanager
 import (
 	"context"
 
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/liqotech/liqo/pkg/clusterid"
 	tenantnamespace "github.com/liqotech/liqo/pkg/tenantNamespace"
+	"github.com/liqotech/liqo/pkg/vkMachinery/csr"
 )
 
 type identityManager struct {
-	identityProvider
+	IdentityProvider
 
 	client           kubernetes.Interface
 	localClusterID   clusterid.ClusterID
@@ -20,16 +24,45 @@ type identityManager struct {
 	iamTokenManager tokenManager
 }
 
+// NewCertificateIdentityReader gets a new certificate identity reader.
+func NewCertificateIdentityReader(client kubernetes.Interface,
+	localClusterID clusterid.ClusterID, namespaceManager tenantnamespace.Manager) IdentityReader {
+	return NewCertificateIdentityManager(client, localClusterID, namespaceManager)
+}
+
 // NewCertificateIdentityManager gets a new certificate identity manager.
 func NewCertificateIdentityManager(client kubernetes.Interface,
-	localClusterID clusterid.ClusterID,
-	namespaceManager tenantnamespace.Manager) IdentityManager {
+	localClusterID clusterid.ClusterID, namespaceManager tenantnamespace.Manager) IdentityManager {
 	idProvider := &certificateIdentityProvider{
 		namespaceManager: namespaceManager,
 		client:           client,
 	}
 
 	return newIdentityManager(client, localClusterID, namespaceManager, idProvider)
+}
+
+// NewCertificateIdentityProvider gets a new certificate identity approver.
+func NewCertificateIdentityProvider(ctx context.Context, client kubernetes.Interface,
+	localClusterID clusterid.ClusterID, namespaceManager tenantnamespace.Manager) IdentityProvider {
+	req, err := labels.NewRequirement(remoteTenantCSRLabel, selection.Exists, []string{})
+	utilruntime.Must(err)
+
+	csrWatcher := csr.NewWatcher(client, 0, labels.NewSelector().Add(*req))
+	csrWatcher.Start(ctx)
+	idProvider := &certificateIdentityProvider{
+		namespaceManager: namespaceManager,
+		client:           client,
+		csrWatcher:       csrWatcher,
+	}
+
+	return newIdentityManager(client, localClusterID, namespaceManager, idProvider)
+}
+
+// NewIAMIdentityReader gets a new identity reader to handle IAM identities.
+func NewIAMIdentityReader(client kubernetes.Interface,
+	localClusterID clusterid.ClusterID, awsConfig *AwsConfig,
+	namespaceManager tenantnamespace.Manager) IdentityManager {
+	return NewIAMIdentityManager(client, localClusterID, awsConfig, namespaceManager)
 }
 
 // NewIAMIdentityManager gets a new identity manager to handle IAM identities.
@@ -44,10 +77,22 @@ func NewIAMIdentityManager(client kubernetes.Interface,
 	return newIdentityManager(client, localClusterID, namespaceManager, idProvider)
 }
 
+// NewIAMIdentityProvider gets a new identity approver to handle IAM identities.
+func NewIAMIdentityProvider(client kubernetes.Interface,
+	localClusterID clusterid.ClusterID, awsConfig *AwsConfig,
+	namespaceManager tenantnamespace.Manager) IdentityProvider {
+	idProvider := &iamIdentityProvider{
+		awsConfig: awsConfig,
+		client:    client,
+	}
+
+	return newIdentityManager(client, localClusterID, namespaceManager, idProvider)
+}
+
 func newIdentityManager(client kubernetes.Interface,
 	localClusterID clusterid.ClusterID,
 	namespaceManager tenantnamespace.Manager,
-	idProvider identityProvider) IdentityManager {
+	idProvider IdentityProvider) *identityManager {
 	iamTokenManager := &iamTokenManager{
 		client:                    client,
 		availableClusterIDSecrets: map[string]types.NamespacedName{},
@@ -59,7 +104,7 @@ func newIdentityManager(client kubernetes.Interface,
 		localClusterID:   localClusterID,
 		namespaceManager: namespaceManager,
 
-		identityProvider: idProvider,
+		IdentityProvider: idProvider,
 
 		iamTokenManager: iamTokenManager,
 	}

--- a/pkg/identityManager/interface.go
+++ b/pkg/identityManager/interface.go
@@ -8,24 +8,23 @@ import (
 	responsetypes "github.com/liqotech/liqo/pkg/identityManager/responseTypes"
 )
 
-// IdentityManager interface provides the methods to manage identities for the remote clusters.
-type IdentityManager interface {
-	localManager
-	identityProvider
-}
-
-// interface that allows to manage the identity in the owner cluster.
-type localManager interface {
-	CreateIdentity(remoteClusterID string) (*v1.Secret, error)
-	GetSigningRequest(remoteClusterID string) ([]byte, error)
-	StoreCertificate(remoteClusterID string, identityResponse *auth.CertificateIdentityResponse) error
-
+// IdentityReader provides the interface to retrieve the identities for the remote clusters.
+type IdentityReader interface {
 	GetConfig(remoteClusterID string, namespace string) (*rest.Config, error)
 	GetRemoteTenantNamespace(remoteClusterID string, namespace string) (string, error)
 }
 
-// interface that allows to manage the identity in the target cluster, where this identity has to be used.
-type identityProvider interface {
+// IdentityManager interface provides the methods to manage identities for the remote clusters.
+type IdentityManager interface {
+	IdentityReader
+
+	CreateIdentity(remoteClusterID string) (*v1.Secret, error)
+	GetSigningRequest(remoteClusterID string) ([]byte, error)
+	StoreCertificate(remoteClusterID string, identityResponse *auth.CertificateIdentityResponse) error
+}
+
+// IdentityProvider provides the interface to retrieve and approve remote cluster identities.
+type IdentityProvider interface {
 	GetRemoteCertificate(clusterID, namespace, signingRequest string) (response *responsetypes.SigningRequestResponse, err error)
 	ApproveSigningRequest(clusterID, signingRequest string) (response *responsetypes.SigningRequestResponse, err error)
 }

--- a/pkg/liqo-controller-manager/namespaceMap-controller/create_remote_clients.go
+++ b/pkg/liqo-controller-manager/namespaceMap-controller/create_remote_clients.go
@@ -19,7 +19,7 @@ func (r *NamespaceMapReconciler) checkRemoteClientPresence(remoteClusterID strin
 	if _, ok := r.RemoteClients[remoteClusterID]; !ok {
 		clusterID := clusterid.NewStaticClusterID(r.LocalClusterID)
 		tenantNamespaceManager := tenantnamespace.NewTenantNamespaceManager(r.IdentityManagerClient)
-		identityManager := identitymanager.NewCertificateIdentityManager(r.IdentityManagerClient, clusterID, tenantNamespaceManager)
+		identityManager := identitymanager.NewCertificateIdentityReader(r.IdentityManagerClient, clusterID, tenantNamespaceManager)
 		restConfig, err := identityManager.GetConfig(remoteClusterID, "")
 		if err != nil {
 			klog.Error(err)

--- a/pkg/utils/testutil/csr.go
+++ b/pkg/utils/testutil/csr.go
@@ -1,0 +1,66 @@
+package testutil
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"encoding/pem"
+	"math/big"
+	"time"
+
+	"k8s.io/klog/v2"
+)
+
+// FakeCSRRequest returns the content of a CSR request for testing purposes.
+func FakeCSRRequest(commonName string) (csrBytes []byte, err error) {
+	_, key, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return nil, err
+	}
+
+	asn1Subj, err := asn1.Marshal(pkix.Name{CommonName: commonName, Organization: []string{"liqo.io"}}.ToRDNSequence())
+	if err != nil {
+		klog.Error(err)
+		return nil, err
+	}
+
+	template := x509.CertificateRequest{
+		RawSubject:         asn1Subj,
+		SignatureAlgorithm: x509.PureEd25519,
+	}
+
+	csrBytes, err = x509.CreateCertificateRequest(rand.Reader, &template, key)
+	if err != nil {
+		klog.Error(err)
+		return nil, err
+	}
+
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE REQUEST", Bytes: csrBytes}), nil
+}
+
+// FakeSelfSignedCertificate returns the content of a self-signed certificate for testing purposes.
+func FakeSelfSignedCertificate(commonName string) (certificate []byte, err error) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return nil, err
+	}
+
+	cert := &x509.Certificate{
+		SerialNumber:          big.NewInt(99),
+		Subject:               pkix.Name{CommonName: commonName, Organization: []string{"liqo.io"}},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().AddDate(1, 0, 0),
+		IsCA:                  false,
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+	}
+
+	certBytes, err := x509.CreateCertificate(rand.Reader, cert, cert, pub, priv)
+	if err != nil {
+		return nil, err
+	}
+
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certBytes}), nil
+}

--- a/pkg/virtualKubelet/provider/provider.go
+++ b/pkg/virtualKubelet/provider/provider.go
@@ -70,7 +70,7 @@ func NewLiqoProvider(ctx context.Context, nodeName, foreignClusterID, homeCluste
 
 	clusterID := clusterid.NewStaticClusterID(homeClusterID)
 	tenantNamespaceManager := tenantnamespace.NewTenantNamespaceManager(homeClient)
-	identityManager := identitymanager.NewCertificateIdentityManager(homeClient, clusterID, tenantNamespaceManager)
+	identityManager := identitymanager.NewCertificateIdentityReader(homeClient, clusterID, tenantNamespaceManager)
 	namespace, err := utils.RetrieveNamespace()
 	if err != nil {
 		return nil, err

--- a/pkg/vkMachinery/csr/approve.go
+++ b/pkg/vkMachinery/csr/approve.go
@@ -2,21 +2,16 @@ package csr
 
 import (
 	"context"
-	"sync"
-	"time"
 
-	certificatesv1 "k8s.io/api/certificates/v1"
+	certv1 "k8s.io/api/certificates/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/client-go/informers"
 	k8s "k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 )
 
-// ApproveCSR approves the provided CertificateSigningRequest.
-func ApproveCSR(clientSet k8s.Interface, csr *certificatesv1.CertificateSigningRequest, reason, message string) error {
+// Approve approves the provided CertificateSigningRequest.
+func Approve(clientSet k8s.Interface, csr *certv1.CertificateSigningRequest, reason, message string) error {
 	// certificate already added to CSR
 	if csr.Status.Certificate != nil {
 		return nil
@@ -28,8 +23,8 @@ func ApproveCSR(clientSet k8s.Interface, csr *certificatesv1.CertificateSigningR
 		}
 	}
 	// Approve
-	csr.Status.Conditions = append(csr.Status.Conditions, certificatesv1.CertificateSigningRequestCondition{
-		Type:           certificatesv1.CertificateApproved,
+	csr.Status.Conditions = append(csr.Status.Conditions, certv1.CertificateSigningRequestCondition{
+		Type:           certv1.CertificateApproved,
 		Reason:         reason,
 		Message:        message,
 		LastUpdateTime: metav1.Now(),
@@ -43,68 +38,13 @@ func ApproveCSR(clientSet k8s.Interface, csr *certificatesv1.CertificateSigningR
 	return nil
 }
 
-// WatchCSR initializes informers to watch the creation of new CSRs issued for VirtualKubelet instances.
-func WatchCSR(ctx context.Context, clientset k8s.Interface, label string, resyncPeriod time.Duration, wg *sync.WaitGroup) {
-	defer wg.Done()
-	informer := informers.NewSharedInformerFactoryWithOptions(clientset, resyncPeriod, informers.WithTweakListOptions(
-		func(options *metav1.ListOptions) {
-			options.LabelSelector = label
-		}))
-	csrInformer := informer.Certificates().V1().CertificateSigningRequests().Informer()
-	csrInformer.AddEventHandler(&cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
-			csr, ok := obj.(*certificatesv1.CertificateSigningRequest)
-			if !ok {
-				klog.Error("Unable to cast object")
-				return
-			}
-			err := ApproveCSR(clientset, csr, "LiqoApproval", "This CSR was approved by Liqo Advertisement Operator")
-			if err != nil {
-				klog.Error(err)
-			} else {
-				klog.Infof("CSR %v correctly approved", csr.Name)
-			}
-		},
-	})
-
-	go informer.Start(ctx.Done())
-}
-
-// ForgeInformer returns a SharedInformer. The informer watches a CSR, which name is specified by the name parameter,
-// and returns a valid CRT, by pushing it inside the crtChan.
-func ForgeInformer(client k8s.Interface, name string, crtChan chan []byte) cache.SharedIndexInformer {
-	var resyncPeriod = 10 * time.Second
-	var fieldSelector = map[string]string{
-		"metadata.name": name,
+// ApproverHandler returns an handler to approve CSRs.
+func ApproverHandler(clientset k8s.Interface, reason, message string) func(*certv1.CertificateSigningRequest) {
+	return func(csr *certv1.CertificateSigningRequest) {
+		if err := Approve(clientset, csr, reason, message); err != nil {
+			klog.Error(err)
+		} else {
+			klog.Infof("CSR %v correctly approved", csr.Name)
+		}
 	}
-	informer := informers.NewSharedInformerFactoryWithOptions(client, resyncPeriod, informers.WithTweakListOptions(
-		func(options *metav1.ListOptions) {
-			options.FieldSelector = labels.SelectorFromSet(fieldSelector).String()
-		}))
-	csrInformer := informer.Certificates().V1().CertificateSigningRequests().Informer()
-	csrInformer.AddEventHandler(&cache.ResourceEventHandlerFuncs{
-		AddFunc: func(newObj interface{}) {
-			csrResource, ok := newObj.(*certificatesv1.CertificateSigningRequest)
-			if !ok {
-				klog.Error("Unable to cast object")
-				return
-			}
-			if len(csrResource.Status.Certificate) > 0 {
-				klog.Infof("Certificate retrieved for CSR %s", csrResource.Name)
-				crtChan <- csrResource.Status.Certificate
-			}
-		},
-		UpdateFunc: func(_, newObj interface{}) {
-			csrResource, ok := newObj.(*certificatesv1.CertificateSigningRequest)
-			if !ok {
-				klog.Error("Unable to cast object")
-				return
-			}
-			if len(csrResource.Status.Certificate) > 0 {
-				klog.Infof("Certificate retrieved for CSR %s", csrResource.Name)
-				crtChan <- csrResource.Status.Certificate
-			}
-		},
-	})
-	return csrInformer
 }

--- a/pkg/vkMachinery/csr/approve_test.go
+++ b/pkg/vkMachinery/csr/approve_test.go
@@ -11,7 +11,6 @@ import (
 )
 
 func TestApproveSigningRequest(t *testing.T) {
-	//setup
 	certificateToValidate := certificatesv1.CertificateSigningRequest{
 		TypeMeta: v1.TypeMeta{},
 		ObjectMeta: v1.ObjectMeta{
@@ -29,7 +28,7 @@ func TestApproveSigningRequest(t *testing.T) {
 	if err != nil {
 		t.Fail()
 	}
-	err = ApproveCSR(c, &certificateToValidate, "LiqoApproval", "This CSR was approved by Liqo Advertisement Operator")
+	err = Approve(c, &certificateToValidate, "LiqoApproval", "This CSR was approved by Liqo Advertisement Operator")
 	if err != nil {
 		t.Fail()
 	}

--- a/pkg/vkMachinery/csr/secret_test.go
+++ b/pkg/vkMachinery/csr/secret_test.go
@@ -1,17 +1,12 @@
 package csr
 
 import (
-	"context"
 	"os"
-	"path/filepath"
-	"testing"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-
-	"github.com/liqotech/liqo/pkg/utils/testutil"
 )
 
 const (
@@ -19,33 +14,7 @@ const (
 	namespace = "default"
 )
 
-func TestSecret(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "Secret Suite")
-}
-
 var _ = Describe("Secret", func() {
-
-	var (
-		cluster testutil.Cluster
-		err     error
-		ctx     context.Context
-		cancel  context.CancelFunc
-	)
-
-	BeforeSuite(func() {
-		ctx, cancel = context.WithCancel(context.Background())
-
-		cluster, _, err = testutil.NewTestCluster([]string{filepath.Join("..", "..", "..", "deployments", "liqo", "crds")})
-		Expect(err).To(BeNil())
-	})
-
-	AfterSuite(func() {
-		cancel()
-
-		err := cluster.GetEnv().Stop()
-		Expect(err).To(BeNil())
-	})
 
 	It("Secret Lifecycle", func() {
 

--- a/pkg/vkMachinery/csr/suite_test.go
+++ b/pkg/vkMachinery/csr/suite_test.go
@@ -1,0 +1,38 @@
+package csr
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/liqotech/liqo/pkg/utils/testutil"
+)
+
+func TestCsr(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "CSR Suite")
+}
+
+var (
+	cluster testutil.Cluster
+	err     error
+	ctx     context.Context
+	cancel  context.CancelFunc
+)
+
+var _ = BeforeSuite(func() {
+	ctx, cancel = context.WithCancel(context.Background())
+
+	cluster, _, err = testutil.NewTestCluster([]string{filepath.Join("..", "..", "..", "deployments", "liqo", "crds")})
+	Expect(err).To(BeNil())
+})
+
+var _ = AfterSuite(func() {
+	cancel()
+
+	err := cluster.GetEnv().Stop()
+	Expect(err).To(BeNil())
+})

--- a/pkg/vkMachinery/csr/watcher.go
+++ b/pkg/vkMachinery/csr/watcher.go
@@ -1,0 +1,160 @@
+package csr
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	certv1 "k8s.io/api/certificates/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/informers"
+	k8s "k8s.io/client-go/kubernetes"
+	certv1listers "k8s.io/client-go/listers/certificates/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+)
+
+// WatcherHandlerFunc represents a the function type executed once an approved CSR is observesd by the informer.
+type WatcherHandlerFunc func(*certv1.CertificateSigningRequest)
+
+// Watcher wraps the logic to be notified once a CSR change is detected.
+type Watcher struct {
+	// The un-exported type is embedded as a pointer to prevent subtle bugs occurring if the watcher struct gets copied.
+	*watcher
+}
+
+// watcher wraps the logic to be notified once a CSR change is detected.
+type watcher struct {
+	certv1listers.CertificateSigningRequestLister
+
+	starter        func(context.Context)
+	lock           sync.RWMutex
+	genericHandler WatcherHandlerFunc
+	handlerForName map[string]WatcherHandlerFunc
+
+	EventHandler func(obj interface{})
+}
+
+// NewWatcher initializes a new CSR watcher for the given label selector.
+func NewWatcher(clientset k8s.Interface, resync time.Duration, selector labels.Selector) Watcher {
+	factory := informers.NewSharedInformerFactoryWithOptions(clientset, resync, informers.WithTweakListOptions(
+		func(lo *metav1.ListOptions) { lo.LabelSelector = selector.String() },
+	))
+
+	lister := factory.Certificates().V1().CertificateSigningRequests().Lister()
+	starter := func(ctx context.Context) {
+		factory.Start(ctx.Done())
+		factory.WaitForCacheSync(ctx.Done())
+	}
+	watcher := &watcher{
+		CertificateSigningRequestLister: lister,
+
+		starter:        starter,
+		genericHandler: nil,
+		handlerForName: make(map[string]WatcherHandlerFunc),
+	}
+
+	eventHandler := func(obj interface{}) {
+		csr, ok := obj.(*certv1.CertificateSigningRequest)
+		if !ok {
+			klog.Errorf("Failed to convert object into CSR")
+			return
+		}
+
+		watcher.lock.RLock()
+		defer watcher.lock.RUnlock()
+
+		// Trigger first the specific handler for the given resource name (if set).
+		if handler, ok := watcher.handlerForName[csr.GetName()]; ok {
+			handler(csr)
+		}
+
+		// Then, trigger the generic handler (if set).
+		if watcher.genericHandler != nil {
+			watcher.genericHandler(csr)
+		}
+	}
+
+	watcher.EventHandler = eventHandler
+
+	// Setup the informer to get noticed once a CSR change is detected.
+	informer := factory.Certificates().V1().CertificateSigningRequests().Informer()
+	informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    eventHandler,
+		UpdateFunc: func(_, newObj interface{}) { eventHandler(newObj) },
+	})
+
+	return Watcher{watcher}
+}
+
+// Start starts the CSR watcher.
+func (r Watcher) Start(ctx context.Context) {
+	r.starter(ctx)
+}
+
+// RegisterHandler registers a new handler executed once a CSR change is detected.
+func (r Watcher) RegisterHandler(handler WatcherHandlerFunc) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	r.genericHandler = handler
+}
+
+// RegisterHandlerForName registers a new handler executed once a new CSR change with the given name is detected.
+func (r Watcher) RegisterHandlerForName(name string, handler WatcherHandlerFunc) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	r.handlerForName[name] = handler
+}
+
+// UnregisterHandler un-registers the handler executed once a CSR change is detected.
+func (r Watcher) UnregisterHandler() {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	r.genericHandler = nil
+}
+
+// UnregisterHandlerForName un-registers the handler executed once a CSR change with the given name is detected.
+func (r Watcher) UnregisterHandlerForName(name string) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	delete(r.handlerForName, name)
+}
+
+// RetrieveCertificate registers the appropriate handlers and waits for the certificate retrieval.
+func (r Watcher) RetrieveCertificate(ctx context.Context, csrName string) ([]byte, error) {
+	certificateChan := make(chan []byte, 1)
+
+	handler := func(csr *certv1.CertificateSigningRequest) {
+		if IsApproved(csr) {
+			select {
+			// A copy of the certificate is created to prevent mutating the cache
+			case certificateChan <- append([]byte(nil), csr.Status.Certificate...):
+			default: // Avoid to block if a certificate is already present in the channel
+			}
+		}
+	}
+
+	r.RegisterHandlerForName(csrName, handler)
+	defer r.UnregisterHandlerForName(csrName)
+
+	// Check if the certificate is already approved, in case this occurred before we registered the handler.
+	if obj, err := r.Get(csrName); err != nil {
+		handler(obj)
+	}
+
+	// Wait for the certificate, with a timeout
+	select {
+	case certificate := <-certificateChan:
+		return certificate, nil
+	case <-ctx.Done():
+		err := fmt.Errorf("context canceled before certificate retrieval")
+		return nil, err
+	}
+}
+
+// IsApproved returns whether the given CSR is approved (i.e. has a valid certificate).
+func IsApproved(csr *certv1.CertificateSigningRequest) bool {
+	return csr != nil && len(csr.Status.Certificate) > 0
+}

--- a/pkg/vkMachinery/csr/watcher_test.go
+++ b/pkg/vkMachinery/csr/watcher_test.go
@@ -1,0 +1,238 @@
+package csr
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	certv1 "k8s.io/api/certificates/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/liqotech/liqo/pkg/utils/testutil"
+)
+
+var _ = Describe("Watcher functions", func() {
+	const (
+		MatchingLabel    = "matching"
+		NotMatchingLabel = "not-matching"
+
+		MatchingName    = "foo"
+		NotMatchingName = "bar"
+	)
+
+	Describe("The csr.Watcher functions", func() {
+		var (
+			watcherCancel context.CancelFunc
+
+			client   kubernetes.Interface
+			selector labels.Selector
+
+			name, label string
+			input       *certv1.CertificateSigningRequest
+
+			watcher Watcher
+		)
+
+		CSRForger := func(name, label string) *certv1.CertificateSigningRequest {
+			req, err := testutil.FakeCSRRequest("foobar")
+			Expect(err).ToNot(HaveOccurred())
+
+			return &certv1.CertificateSigningRequest{
+				ObjectMeta: v1.ObjectMeta{Name: name, Labels: map[string]string{label: "whatever"}},
+				Spec: certv1.CertificateSigningRequestSpec{
+					SignerName: "foo.com/bar",
+					Usages:     []certv1.KeyUsage{certv1.UsageAny},
+					Request:    req,
+				},
+			}
+		}
+
+		BeforeEach(func() {
+			client = kubernetes.NewForConfigOrDie(cluster.GetCfg())
+
+			req, err := labels.NewRequirement(MatchingLabel, selection.Exists, []string{})
+			Expect(err).ToNot(HaveOccurred())
+
+			selector = labels.NewSelector().Add(*req)
+			watcher = NewWatcher(client, 0, selector)
+		})
+
+		JustBeforeEach(func() {
+			var watcherCtx context.Context
+			watcherCtx, watcherCancel = context.WithCancel(ctx)
+			watcher.Start(watcherCtx)
+
+			var err error
+			input = CSRForger(name, label)
+
+			input, err = client.CertificatesV1().CertificateSigningRequests().Create(ctx, input, v1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			// Avoid mismatches when compared.
+			input.ResourceVersion = "0"
+		})
+
+		JustAfterEach(func() {
+			watcherCancel()
+			Expect(client.CertificatesV1().CertificateSigningRequests().Delete(ctx, input.Name, v1.DeleteOptions{})).To(Succeed())
+		})
+
+		When("the RetrieveCertificate function is executed", func() {
+			var (
+				retrieveCtx context.Context
+				cancel      context.CancelFunc
+
+				certificate []byte
+				err         error
+			)
+
+			BeforeEach(func() {
+				name = MatchingName
+				label = MatchingLabel
+				retrieveCtx, cancel = context.WithTimeout(ctx, 500*time.Millisecond)
+
+				// Let run this in a goroutine, as it is blocking
+				go func() {
+					certificate, err = watcher.RetrieveCertificate(retrieveCtx, MatchingName)
+					cancel()
+				}()
+			})
+
+			JustBeforeEach(func() {
+				cert, err := testutil.FakeSelfSignedCertificate("foobar")
+				Expect(err).ToNot(HaveOccurred())
+
+				input.Status.Certificate = cert
+				input, err = client.CertificatesV1().CertificateSigningRequests().UpdateStatus(ctx, input, v1.UpdateOptions{})
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			When("the CSR matches the desired name", func() {
+				It("should succeed and retrieve the certificate", func() {
+					Eventually(retrieveCtx.Done()).Should(BeClosed())
+					Expect(err).ToNot(HaveOccurred())
+					Expect(certificate).To(Equal(input.Status.Certificate))
+				})
+			})
+
+			When("the CSR does not match the desired name", func() {
+				BeforeEach(func() { name = NotMatchingName })
+
+				It("should fail and return nil as certificate", func() {
+					Eventually(retrieveCtx.Done()).Should(BeClosed())
+					Expect(err).To(HaveOccurred())
+					Expect(certificate).To(BeNil())
+				})
+			})
+		})
+
+		When("the handlers are registered", func() {
+			var (
+				receiverGeneric chan *certv1.CertificateSigningRequest
+				receiverNamed   chan *certv1.CertificateSigningRequest
+			)
+
+			BeforeEach(func() {
+				name = MatchingName
+				label = MatchingLabel
+
+				receiverGeneric = make(chan *certv1.CertificateSigningRequest, 1)
+				receiverNamed = make(chan *certv1.CertificateSigningRequest, 1)
+
+				watcher.RegisterHandler(func(csr *certv1.CertificateSigningRequest) {
+					c := csr.DeepCopy()
+					c.ResourceVersion = "0"
+					receiverGeneric <- c
+				})
+				watcher.RegisterHandlerForName(MatchingName, func(csr *certv1.CertificateSigningRequest) {
+					c := csr.DeepCopy()
+					c.ResourceVersion = "0"
+					receiverNamed <- c
+				})
+			})
+
+			When("the CSR matches both the selector and the name constraint", func() {
+				It("the generic handler should correctly receive the CSR", func() {
+					Eventually(receiverGeneric).Should(Receive(Equal(input)))
+				})
+				It("the named handler should correctly receive the CSR", func() {
+					Eventually(receiverNamed).Should(Receive(Equal(input)))
+				})
+			})
+
+			When("the CSR matches the selector but not the name constraint", func() {
+				BeforeEach(func() { name = NotMatchingName })
+
+				It("the generic handler should correctly receive the CSR", func() {
+					Eventually(receiverGeneric).Should(Receive(Equal(input)))
+				})
+				It("the named handler should not be triggered", func() {
+					Consistently(receiverNamed).ShouldNot(Receive())
+				})
+			})
+
+			When("the CSR does not match the selector", func() {
+				BeforeEach(func() { label = NotMatchingLabel })
+
+				It("the generic handler should not be triggered", func() {
+					Consistently(receiverGeneric).ShouldNot(Receive())
+				})
+				It("the named handler should not be triggered", func() {
+					Consistently(receiverNamed).ShouldNot(Receive())
+				})
+			})
+
+			When("the handlers are then unregistered", func() {
+				BeforeEach(func() {
+					watcher.UnregisterHandler()
+					watcher.UnregisterHandlerForName(MatchingName)
+				})
+
+				It("the generic handler should not be triggered", func() {
+					Consistently(receiverGeneric).ShouldNot(Receive())
+				})
+				It("the named handler should not be triggered", func() {
+					Consistently(receiverNamed).ShouldNot(Receive())
+				})
+			})
+		})
+	})
+
+	Describe("The csr.IsApproved function", func() {
+		CSRForger := func(name string, cert []byte) *certv1.CertificateSigningRequest {
+			return &certv1.CertificateSigningRequest{
+				ObjectMeta: v1.ObjectMeta{Name: name},
+				Status:     certv1.CertificateSigningRequestStatus{Certificate: cert},
+			}
+		}
+
+		type IsApprovedCase struct {
+			input    *certv1.CertificateSigningRequest
+			expected bool
+		}
+
+		DescribeTable("should correctly return whether the CRS is approved",
+			func(c IsApprovedCase) {
+				Expect(IsApproved(c.input)).To(BeIdenticalTo(c.expected))
+			},
+			Entry("when the CSR is nil", IsApprovedCase{input: nil, expected: false}),
+			Entry("when the CSR certificate is nil", IsApprovedCase{
+				input:    &certv1.CertificateSigningRequest{},
+				expected: false,
+			}),
+			Entry("when the CSR certificate is empty", IsApprovedCase{
+				input:    CSRForger("foo", []byte{}),
+				expected: false,
+			}),
+			Entry("when the CSR certificate is present", IsApprovedCase{
+				input:    CSRForger("foo", []byte{55, 22, 57, 90}),
+				expected: true,
+			}),
+		)
+	})
+})


### PR DESCRIPTION
# Description

This PR improves the performance of the authentication service, relaxing the rate limiter configuration and using a single informer to watch CSRs, to prevent the creation/destruction overhead when performing multiple peerings in parallel. Additionally, the CSR watching logic is unified to prevent code duplication. 

The PR refactors also the IdentityManager interface, to better highlight the separate roles (@liqotech/maintainers  let me know if that looks ok to you)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Unit test (new + existing)
- [ ] E2E test (existing)
