### PR TITLE
Setup a global context in liqoctl

### DIFF
--- a/cmd/liqoctl/cmd/install.go
+++ b/cmd/liqoctl/cmd/install.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"context"
+
 	"github.com/spf13/cobra"
 	"k8s.io/klog/v2"
 
@@ -8,17 +10,19 @@ import (
 )
 
 // installCmd represents the generateInstall command.
-var installCmd = &cobra.Command{
-	Use:   "install",
-	Short: "Install Liqo on a selected cluster",
-	Long:  `Install Liqo on a selected cluster.`,
-	Run:   install.HandleInstallCommand,
-}
+func newInstallCommand(ctx context.Context) *cobra.Command {
+	var installCmd = &cobra.Command{
+		Use:   "install",
+		Short: install.LiqoctlInstallShortHelp,
+		Long:  install.LiqoctlInstallLongHelp,
+		Run: func(cmd *cobra.Command, args []string) {
+			install.HandleInstallCommand(ctx, cmd, args)
+		},
+	}
 
-func init() {
-	rootCmd.AddCommand(installCmd)
-
-	installCmd.Flags().StringP("provider", "p", "kubeadm", "The provider for the cluster")
+	installCmd.Flags().StringP("provider", "p", "kubeadm", "Select the cluster provider type")
+	installCmd.Flags().IntP("timeout", "t", 600, "Configure the timeout for the installation process in seconds (default: 600)")
+	installCmd.Flags().StringP("version", "", "", "Select the Liqo version (default: latest stable release)")
 
 	for _, p := range providers {
 		initFunc, ok := providerInitFunc[p]
@@ -27,4 +31,5 @@ func init() {
 		}
 		initFunc(installCmd.Flags())
 	}
+	return installCmd
 }

--- a/cmd/liqoctl/cmd/root.go
+++ b/cmd/liqoctl/cmd/root.go
@@ -1,34 +1,27 @@
 package cmd
 
 import (
+	"context"
 	"flag"
 
 	"github.com/spf13/cobra"
 	"k8s.io/klog/v2"
+
+	"github.com/liqotech/liqo/pkg/liqoctl/common"
 )
 
-// rootCmd represents the base command when called without any subcommands.
-var rootCmd = &cobra.Command{
-	Use:   "liqoctl",
-	Short: "liqoctl - the Liqo Command Line Interface",
-	Long: `liqoctl is a CLI tool to install and manage Liqo-enabled clusters.
-
-Liqo is a platform to enable dynamic and decentralized resource sharing across Kubernetes clusters. 
-Liqo allows to run pods on a remote cluster seamlessly and without any modification of 
-Kubernetes and the applications. 
-With Liqo it is possible to extend the control plane of a Kubernetes cluster across the cluster's boundaries, 
-making multi-cluster native and transparent: collapse an entire remote cluster to a virtual local node, 
-by allowing workloads offloading and resource management compliant with the standard Kubernetes approach.`,
-}
-
-// Execute adds all child commands to the root command and sets flags appropriately.
-// This is called by main.main(). It only needs to happen once to the rootCmd.
-func Execute() {
-	cobra.CheckErr(rootCmd.Execute())
-}
-
-func init() {
+// NewRootCommand initializes the tree of commands.
+func NewRootCommand(ctx context.Context) *cobra.Command {
+	// rootCmd represents the base command when called without any subcommands.
+	var rootCmd = &cobra.Command{
+		Use:   "liqoctl",
+		Short: common.LiqoctlShortHelp,
+		Long:  common.LiqoctlLongHelp,
+	}
 	flagset := flag.NewFlagSet("klog", flag.PanicOnError)
 	klog.InitFlags(flagset)
 	rootCmd.PersistentFlags().AddGoFlagSet(flagset)
+	rootCmd.PersistentFlags().BoolP("debug", "d", false, "Enable/Disable debug mode (default: false)")
+	rootCmd.AddCommand(newInstallCommand(ctx))
+	return rootCmd
 }

--- a/cmd/liqoctl/main.go
+++ b/cmd/liqoctl/main.go
@@ -1,7 +1,24 @@
 package main
 
-import "github.com/liqotech/liqo/cmd/liqoctl/cmd"
+import (
+	"context"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/spf13/cobra"
+
+	liqocmd "github.com/liqotech/liqo/cmd/liqoctl/cmd"
+)
 
 func main() {
-	cmd.Execute()
+	ctx, cancel := context.WithCancel(context.Background())
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		<-sig
+		cancel()
+	}()
+	cmd := liqocmd.NewRootCommand(ctx)
+	cobra.CheckErr(cmd.Execute())
 }

--- a/pkg/liqoctl/common/const.go
+++ b/pkg/liqoctl/common/const.go
@@ -1,0 +1,14 @@
+package common
+
+// LiqoctlShortHelp contains the short help message for root Liqoctl command.
+const LiqoctlShortHelp = "liqoctl - the Liqo Command Line Interface"
+
+// LiqoctlLongHelp contains the long help message for root Liqoctl command.
+const LiqoctlLongHelp = `liqoctl is a CLI tool to install and manage Liqo-enabled clusters.
+
+Liqo is a platform to enable dynamic and decentralized resource sharing across Kubernetes clusters. 
+Liqo allows to run pods on a remote cluster seamlessly and without any modification of 
+Kubernetes and the applications. 
+With Liqo it is possible to extend the control plane of a Kubernetes cluster across the cluster's boundaries, 
+making multi-cluster native and transparent: collapse an entire remote cluster to a virtual local node, 
+by allowing workloads offloading and resource management compliant with the standard Kubernetes approach.`

--- a/pkg/liqoctl/common/doc.go
+++ b/pkg/liqoctl/common/doc.go
@@ -1,0 +1,2 @@
+// Package common contains common definition and utils used across liqoctl
+package common

--- a/pkg/liqoctl/install/const.go
+++ b/pkg/liqoctl/install/const.go
@@ -1,0 +1,9 @@
+package install
+
+const (
+	providerFlag = "provider"
+	// LiqoctlInstallShortHelp contains the short help message for install Liqoctl command.
+	LiqoctlInstallShortHelp = "Install Liqo on a selected cluster"
+	// LiqoctlInstallLongHelp contains the long help message for install Liqoctl command.
+	LiqoctlInstallLongHelp = `Install Liqo on a selected cluster`
+)

--- a/pkg/liqoctl/install/helm/const.go
+++ b/pkg/liqoctl/install/helm/const.go
@@ -4,6 +4,7 @@ const liqoRepo = "https://helm.liqo.io/"
 
 // LiqoNamespace contains the default namespace for Liqo installation.
 const LiqoNamespace = "liqo"
+const liqoChartName = "liqo"
 const liqoHelmConfigPath = "/tmp/.helmrepo"
 const liqoHelmCachePath = "/tmp/.helmcache"
 

--- a/pkg/liqoctl/install/helm/init.go
+++ b/pkg/liqoctl/install/helm/init.go
@@ -4,16 +4,18 @@ import (
 	helm "github.com/mittwald/go-helm-client"
 	"helm.sh/helm/v3/pkg/repo"
 	"k8s.io/client-go/rest"
+
+	"github.com/liqotech/liqo/pkg/liqoctl/install/provider"
 )
 
 // InitializeHelmClientWithRepo initiliazes an helm client for a given *rest.Config and adds the Liqo repository.
-func InitializeHelmClientWithRepo(config *rest.Config) (*helm.HelmClient, error) {
+func InitializeHelmClientWithRepo(config *rest.Config, commonArgs *provider.CommonArguments) (*helm.HelmClient, error) {
 	opt := &helm.RestConfClientOptions{
 		Options: &helm.Options{
 			Namespace:        LiqoNamespace,
 			RepositoryConfig: liqoHelmConfigPath,
 			RepositoryCache:  liqoHelmCachePath,
-			DebugLog:         nil,
+			Debug:            commonArgs.Debug,
 		},
 		RestConfig: config,
 	}
@@ -33,8 +35,8 @@ func InitializeHelmClientWithRepo(config *rest.Config) (*helm.HelmClient, error)
 func initLiqoRepo(helmClient helm.Client) error {
 	// Define a public chart repository
 	chartRepo := repo.Entry{
-		Name: "liqo",
 		URL:  liqoRepo,
+		Name: liqoChartName,
 	}
 
 	if err := helmClient.AddOrUpdateChartRepo(chartRepo); err != nil {

--- a/pkg/liqoctl/install/provider/args.go
+++ b/pkg/liqoctl/install/provider/args.go
@@ -1,0 +1,36 @@
+package provider
+
+import (
+	"time"
+
+	flag "github.com/spf13/pflag"
+)
+
+// CommonArguments encapsulates all the arguments common across install providers.
+type CommonArguments struct {
+	Version string
+	Debug   bool
+	Timeout time.Duration
+}
+
+// ValidateCommonArguments validates install common arguments. If the inputs are valid, it returns a *CommonArgument
+// with all the parameters contents.
+func ValidateCommonArguments(flags *flag.FlagSet) (*CommonArguments, error) {
+	version, err := flags.GetString("version")
+	if err != nil {
+		return nil, err
+	}
+	debug, err := flags.GetBool("debug")
+	if err != nil {
+		return nil, err
+	}
+	timeout, err := flags.GetInt("timeout")
+	if err != nil {
+		return nil, err
+	}
+	return &CommonArguments{
+		Version: version,
+		Debug:   debug,
+		Timeout: time.Duration(timeout) * time.Second,
+	}, nil
+}

--- a/pkg/liqoctl/install/utils.go
+++ b/pkg/liqoctl/install/utils.go
@@ -32,8 +32,8 @@ func getProviderInstance(providerType string) provider.InstallProviderInterface 
 	}
 }
 
-func initHelmClient(config *rest.Config) (*helm.HelmClient, error) {
-	helmClient, err := helmutils.InitializeHelmClientWithRepo(config)
+func initHelmClient(config *rest.Config, arguments *provider.CommonArguments) (*helm.HelmClient, error) {
+	helmClient, err := helmutils.InitializeHelmClientWithRepo(config, arguments)
 	if err != nil {
 		fmt.Printf("Unable to create helmClient: %s", err)
 		return nil, err
@@ -41,8 +41,10 @@ func initHelmClient(config *rest.Config) (*helm.HelmClient, error) {
 	return helmClient, nil
 }
 
-func installOrUpdate(ctx context.Context, helmClient *helm.HelmClient, k provider.InstallProviderInterface) error {
-	output, _, err := helmutils.GetChart(helmutils.LiqoChartFullName, &action.ChartPathOptions{}, helmClient.Settings)
+func installOrUpdate(ctx context.Context, helmClient *helm.HelmClient, k provider.InstallProviderInterface, cArgs *provider.CommonArguments) error {
+	output, _, err := helmutils.GetChart(helmutils.LiqoChartFullName, &action.ChartPathOptions{
+		Version: cArgs.Version,
+	}, helmClient.Settings)
 	if err != nil {
 		return err
 	}
@@ -60,7 +62,7 @@ func installOrUpdate(ctx context.Context, helmClient *helm.HelmClient, k provide
 		Namespace:        helmutils.LiqoNamespace,
 		ValuesYaml:       string(raw),
 		DependencyUpdate: true,
-		Timeout:          600,
+		Timeout:          cArgs.Timeout,
 		GenerateName:     false,
 	}
 


### PR DESCRIPTION
# Description

This PR refactors `liqoctl` to add:

* [x] Common context for subcommands
* [x] Several flags:
	* [x] Timeout
	* [x] Debug
	* [x] Version

# How Has This Been Tested?

- [ ] Unit Testing
