### PR TITLE
Refactor liqonet main.go and add operator specific flags

### DIFF
--- a/cmd/liqonet/endpoint-creator-operator.go
+++ b/cmd/liqonet/endpoint-creator-operator.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"os"
+	"sync"
+	"time"
+
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	clusterConfig "github.com/liqotech/liqo/apis/config/v1alpha1"
+	"github.com/liqotech/liqo/internal/liqonet/tunnelEndpointCreator"
+	liqoconst "github.com/liqotech/liqo/pkg/consts"
+	liqonetIpam "github.com/liqotech/liqo/pkg/liqonet/ipam"
+	"github.com/liqotech/liqo/pkg/liqonet/utils"
+	"github.com/liqotech/liqo/pkg/mapperUtils"
+)
+
+func runEndpointCreatorOperator(commonFlags *liqonetCommonFlags) {
+	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+		MapperProvider:     mapperUtils.LiqoMapperProvider(scheme),
+		Scheme:             scheme,
+		MetricsBindAddress: commonFlags.metricsAddr,
+	})
+	if err != nil {
+		klog.Errorf("unable to get manager: %s", err)
+		os.Exit(1)
+	}
+	clientset := kubernetes.NewForConfigOrDie(mgr.GetConfig())
+	dynClient := dynamic.NewForConfigOrDie(mgr.GetConfig())
+	ipam := liqonetIpam.NewIPAM()
+	err = ipam.Init(liqonetIpam.Pools, dynClient, liqoconst.NetworkManagerIpamPort)
+	if err != nil {
+		klog.Errorf("cannot init IPAM:%w", err)
+	}
+	podNamespace, err := utils.GetPodNamespace()
+	if err != nil {
+		klog.Errorf("unable to get pod namespace: %v", err)
+		os.Exit(1)
+	}
+	r := &tunnelEndpointCreator.TunnelEndpointCreator{
+		Client:                     mgr.GetClient(),
+		Scheme:                     mgr.GetScheme(),
+		ClientSet:                  clientset,
+		DynClient:                  dynClient,
+		Manager:                    mgr,
+		Namespace:                  podNamespace,
+		WaitConfig:                 &sync.WaitGroup{},
+		ReservedSubnets:            make([]string, 0),
+		AdditionalPools:            make([]string, 0),
+		Configured:                 make(chan bool, 1),
+		ForeignClusterStartWatcher: make(chan bool, 1),
+		ForeignClusterStopWatcher:  make(chan struct{}),
+		IPManager:                  ipam,
+		RetryTimeout:               30 * time.Second,
+	}
+	r.WaitConfig.Add(3)
+	// starting configuration watcher
+	config, err := ctrl.GetConfig()
+	if err != nil {
+		klog.Error(err)
+		os.Exit(2)
+	}
+	r.WatchConfiguration(config, &clusterConfig.GroupVersion)
+	if err = r.SetupWithManager(mgr); err != nil {
+		klog.Errorf("unable to create controller controller TunnelEndpointCreator: %s", err)
+		os.Exit(1)
+	}
+	go r.StartForeignClusterWatcher()
+	go r.StartServiceWatcher()
+	go r.StartSecretWatcher()
+	klog.Info("starting manager as tunnelEndpointCreator-operator")
+	if err := mgr.Start(r.SetupSignalHandlerForTunEndCreator()); err != nil {
+		klog.Errorf("an error occurred while starting manager: %s", err)
+		os.Exit(1)
+	}
+}

--- a/cmd/liqonet/flags.go
+++ b/cmd/liqonet/flags.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"flag"
+
+	liqoconst "github.com/liqotech/liqo/pkg/consts"
+)
+
+type liqonetCommonFlags struct {
+	metricsAddr string
+	runAs       string
+}
+
+func addCommonFlags(liqonet *liqonetCommonFlags) {
+	flag.StringVar(&liqonet.metricsAddr, "metrics-bind-addr", ":0", "The address the metric endpoint binds to.")
+	flag.StringVar(&liqonet.runAs, "run-as", liqoconst.LiqoGatewayOperatorName,
+		"The accepted values are: liqo-gateway, liqo-route, tunnelEndpointCreator-operator. The default value is \"liqo-gateway\"")
+}

--- a/cmd/liqonet/gateway-operator.go
+++ b/cmd/liqonet/gateway-operator.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"flag"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/containernetworking/plugins/pkg/ns"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
+	"k8s.io/klog/v2"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+
+	tunneloperator "github.com/liqotech/liqo/internal/liqonet/tunnel-operator"
+	liqoconst "github.com/liqotech/liqo/pkg/consts"
+	liqonetns "github.com/liqotech/liqo/pkg/liqonet/netns"
+	tunnelwg "github.com/liqotech/liqo/pkg/liqonet/tunnel/wireguard"
+	"github.com/liqotech/liqo/pkg/liqonet/utils"
+	"github.com/liqotech/liqo/pkg/mapperUtils"
+)
+
+type gatewayOperatorFlags struct {
+	enableLeaderElection bool
+	leaseDuration        time.Duration
+	renewDeadline        time.Duration
+	retryPeriod          time.Duration
+}
+
+func addGatewayOperatorFlags(liqonet *gatewayOperatorFlags) {
+	flag.BoolVar(&liqonet.enableLeaderElection, "gateway.leader-elect", false,
+		"leader-elect enables leader election for controller manager.")
+	flag.DurationVar(&liqonet.leaseDuration, "gateway.lease-duration", 7*time.Second,
+		"lease-duration is the duration that non-leader candidates will wait to force acquire leadership")
+	flag.DurationVar(&liqonet.renewDeadline, "gateway.renew-deadline", 5*time.Second,
+		"renew-deadline is the duration that the acting control plane will retry refreshing leadership before giving up")
+	flag.DurationVar(&liqonet.retryPeriod, "gateway.retry-period", 2*time.Second,
+		"retry-period is the duration the LeaderElector clients should wait between tries of actions")
+}
+
+func runGatewayOperator(commonFlags *liqonetCommonFlags, gatewayFlags *gatewayOperatorFlags) {
+	metricsAddr := commonFlags.metricsAddr
+	enableLeaderElection := gatewayFlags.enableLeaderElection
+	leaseDuration := gatewayFlags.leaseDuration
+	renewDeadLine := gatewayFlags.renewDeadline
+	retryPeriod := gatewayFlags.retryPeriod
+
+	// Get the pod ip and parse to net.IP.
+	podIP, err := utils.GetPodIP()
+	if err != nil {
+		klog.Errorf("unable to get podIP: %v", err)
+		os.Exit(1)
+	}
+	podNamespace, err := utils.GetPodNamespace()
+	if err != nil {
+		klog.Errorf("unable to get pod namespace: %v", err)
+		os.Exit(1)
+	}
+	main, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+		MapperProvider:                mapperUtils.LiqoMapperProvider(scheme),
+		Scheme:                        scheme,
+		MetricsBindAddress:            metricsAddr,
+		LeaderElection:                enableLeaderElection,
+		LeaderElectionID:              liqoconst.GatewayLeaderElectionID,
+		LeaderElectionNamespace:       podNamespace,
+		LeaderElectionReleaseOnCancel: true,
+		LeaderElectionResourceLock:    resourcelock.LeasesResourceLock,
+		LeaseDuration:                 &leaseDuration,
+		RenewDeadline:                 &renewDeadLine,
+		RetryPeriod:                   &retryPeriod,
+		NewCache: cache.BuilderWithOptions(cache.Options{
+			SelectorsByObject: tunneloperator.LabelSelector,
+		}),
+	})
+	if err != nil {
+		klog.Errorf("unable to get main manager: %s", err)
+		os.Exit(1)
+	}
+	clientset := kubernetes.NewForConfigOrDie(main.GetConfig())
+	eventRecorder := main.GetEventRecorderFor(liqoconst.LiqoGatewayOperatorName + "." + podIP.String())
+	// This map is updated by the tunnel operator after a successful tunnel creation
+	// and is consumed by the natmapping operator to check whether the tunnel is ready or not.
+	var readyClustersMutex sync.Mutex
+	readyClusters := make(map[string]struct{})
+	// Create new network namespace for the gateway (gatewayNetns).
+	// If the namespace already exists it will be deleted and recreated.
+	// It is created here because both the tunnel-operator and the natmapping-operator
+	// need to know the namespace to configure.
+	gatewayNetns, err := liqonetns.CreateNetns(liqoconst.GatewayNetnsName)
+	if err != nil {
+		klog.Errorf("an error occurred while creating custom network namespace: %s", err.Error())
+		os.Exit(1)
+	}
+	// Get the current network namespace (hostNetns).
+	hostNetns, err := ns.GetCurrentNS()
+	if err != nil {
+		klog.Errorf("an error occurred while getting host network namespace: %s", err.Error())
+		os.Exit(1)
+	}
+	klog.Infof("created custom network namespace {%s}", liqoconst.GatewayNetnsName)
+
+	labelController := tunneloperator.NewLabelerController(podIP.String(), main.GetClient())
+	if err = labelController.SetupWithManager(main); err != nil {
+		klog.Errorf("unable to setup labeler controller: %s", err)
+		os.Exit(1)
+	}
+	tunnelController, err := tunneloperator.NewTunnelController(podIP.String(), podNamespace, eventRecorder,
+		clientset, main.GetClient(), &readyClustersMutex, readyClusters, gatewayNetns, hostNetns)
+	// If something goes wrong while creating and configuring the tunnel controller
+	// then make sure that we remove all the resources created during the create process.
+	if err != nil {
+		klog.Errorf("an error occurred while creating the tunnel controller: %v", err)
+		klog.Info("cleaning up gateway network namespace")
+		if err := liqonetns.DeleteNetns(liqoconst.GatewayNetnsName); err != nil {
+			klog.Errorf("an error occurred while deleting netns {%s}: %v", liqoconst.GatewayNetnsName, err)
+		}
+		klog.Info("cleaning up wireguard tunnel interface")
+		if err := utils.DeleteIFaceByName(tunnelwg.DeviceName); err != nil {
+			klog.Errorf("an error occurred while deleting iface {%s}: %v", tunnelwg.DriverName, err)
+		}
+		os.Exit(1)
+	}
+	if err = tunnelController.SetupWithManager(main); err != nil {
+		klog.Errorf("unable to setup tunnel controller: %s", err)
+		os.Exit(1)
+	}
+	natMappingController, err := tunneloperator.NewNatMappingController(main.GetClient(), &readyClustersMutex,
+		readyClusters, gatewayNetns)
+	if err != nil {
+		klog.Errorf("an error occurred while creating the natmapping controller: %v", err)
+		os.Exit(1)
+	}
+	if err = natMappingController.SetupWithManager(main); err != nil {
+		klog.Errorf("unable to setup natmapping controller: %s", err)
+		os.Exit(1)
+	}
+
+	klog.Info("Starting manager as Tunnel-Operator")
+	if err := main.Start(tunnelController.SetupSignalHandlerForTunnelOperator()); err != nil {
+		klog.Errorf("unable to start tunnel controller: %s", err)
+		os.Exit(1)
+	}
+}

--- a/cmd/liqonet/main.go
+++ b/cmd/liqonet/main.go
@@ -17,39 +17,14 @@ package main
 
 import (
 	"flag"
-	"os"
-	"strings"
-	"sync"
-	"time"
 
-	"github.com/containernetworking/plugins/pkg/ns"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/fields"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/selection"
-	"k8s.io/client-go/dynamic"
-	"k8s.io/client-go/kubernetes"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
-	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	"k8s.io/klog/v2"
-	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/cache"
 
-	clusterConfig "github.com/liqotech/liqo/apis/config/v1alpha1"
 	netv1alpha1 "github.com/liqotech/liqo/apis/net/v1alpha1"
-	routeoperator "github.com/liqotech/liqo/internal/liqonet/route-operator"
-	tunneloperator "github.com/liqotech/liqo/internal/liqonet/tunnel-operator"
-	"github.com/liqotech/liqo/internal/liqonet/tunnelEndpointCreator"
 	liqoconst "github.com/liqotech/liqo/pkg/consts"
-	liqonetIpam "github.com/liqotech/liqo/pkg/liqonet/ipam"
-	liqonetns "github.com/liqotech/liqo/pkg/liqonet/netns"
-	"github.com/liqotech/liqo/pkg/liqonet/overlay"
-	liqorouting "github.com/liqotech/liqo/pkg/liqonet/routing"
-	tunnelwg "github.com/liqotech/liqo/pkg/liqonet/tunnel/wireguard"
-	"github.com/liqotech/liqo/pkg/liqonet/utils"
-	"github.com/liqotech/liqo/pkg/mapperUtils"
 )
 
 const (
@@ -62,14 +37,7 @@ const (
 )
 
 var (
-	scheme      = runtime.NewScheme()
-	vxlanConfig = &overlay.VxlanDeviceAttrs{
-		Vni:      18952,
-		Name:     liqoconst.VxlanDeviceName,
-		VtepPort: 4789,
-		VtepAddr: nil,
-		Mtu:      1420,
-	}
+	scheme = runtime.NewScheme()
 )
 
 func init() {
@@ -78,290 +46,21 @@ func init() {
 }
 
 func main() {
-	var metricsAddr, runAs string
-	var enableLeaderElection bool
-	leaseDuration := 7 * time.Second
-	renewDeadLine := 5 * time.Second
-	retryPeriod := 2 * time.Second
-	flag.StringVar(&metricsAddr, "metrics-bind-addr", ":0", "The address the metric endpoint binds to.")
-	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
-		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
-	flag.StringVar(&runAs, "run-as", liqoconst.LiqoGatewayOperatorName,
-		"The accepted values are: liqo-gateway, liqo-route, tunnelEndpointCreator-operator. The default value is \"liqo-gateway\"")
-
 	klog.InitFlags(nil)
+	commonFlags := &liqonetCommonFlags{}
+	routeFlags := &routeOperatorFlags{}
+	gatewayFlags := &gatewayOperatorFlags{}
+	addCommonFlags(commonFlags)
+	addGatewayOperatorFlags(gatewayFlags)
+	addRouteOperatorFlags(routeFlags)
 	flag.Parse()
 
-	switch runAs {
+	switch commonFlags.runAs {
 	case liqoconst.LiqoRouteOperatorName:
-		mutex := &sync.RWMutex{}
-		nodeMap := map[string]string{}
-		// Get the pod ip and parse to net.IP.
-		podIP, err := utils.GetPodIP()
-		if err != nil {
-			klog.Errorf("unable to get podIP: %v", err)
-			os.Exit(1)
-		}
-		nodeName, err := utils.GetNodeName()
-		if err != nil {
-			klog.Errorf("unable to get node name: %v", err)
-			os.Exit(1)
-		}
-		podNamespace, err := utils.GetPodNamespace()
-		if err != nil {
-			klog.Errorf("unable to get pod namespace: %v", err)
-			os.Exit(1)
-		}
-		// Asking the api-server to only inform the operator for the pods running in a node different from the one
-		// where the operator is running.
-		smcFieldSelector, err := fields.ParseSelector(strings.Join([]string{"spec.nodeName", "!=", nodeName}, ""))
-		if err != nil {
-			klog.Errorf("unable to create label requirement: %v", err)
-			os.Exit(1)
-		}
-		// Asking the api-server to only inform the operator for the pods running in a node different from
-		// the virtual nodes. We want to process only the pods running on the local cluster and not the ones
-		// offloaded to a remote cluster.
-		smcLabelRequirement, err := labels.NewRequirement(liqoconst.LocalPodLabelKey, selection.DoesNotExist, []string{})
-		if err != nil {
-			klog.Errorf("unable to create label requirement: %v", err)
-			os.Exit(1)
-		}
-		smcLabelSelector := labels.NewSelector().Add(*smcLabelRequirement)
-		mainMgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
-			MapperProvider:     mapperUtils.LiqoMapperProvider(scheme),
-			Scheme:             scheme,
-			MetricsBindAddress: metricsAddr,
-			NewCache: cache.BuilderWithOptions(cache.Options{
-				SelectorsByObject: cache.SelectorsByObject{
-					&corev1.Pod{}: {
-						Field: smcFieldSelector,
-						Label: smcLabelSelector,
-					},
-				},
-			}),
-		})
-		if err != nil {
-			klog.Errorf("unable to get manager: %s", err)
-			os.Exit(1)
-		}
-		// Asking the api-server to only inform the operator for the pods that are part of the route component.
-		ovcLabelSelector := labels.SelectorFromSet(labels.Set{
-			podNameLabelKey:     routeNameLabelValue,
-			podInstanceLabelKey: routeInstanceLabelValue,
-		})
-		// This manager is used by the overlay operator and it is limited to the pods running
-		// on the same namespace as the operator.
-		overlayMgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
-			MapperProvider:     mapperUtils.LiqoMapperProvider(scheme),
-			Scheme:             scheme,
-			MetricsBindAddress: metricsAddr,
-			Namespace:          podNamespace,
-			NewCache: cache.BuilderWithOptions(cache.Options{
-				SelectorsByObject: cache.SelectorsByObject{
-					&corev1.Pod{}: {
-						Label: ovcLabelSelector,
-					},
-				},
-			}),
-		})
-		if err != nil {
-			klog.Errorf("unable to get manager: %s", err)
-			os.Exit(1)
-		}
-		vxlanConfig.VtepAddr = podIP
-		vxlanDevice, err := overlay.NewVxlanDevice(vxlanConfig)
-		if err != nil {
-			klog.Errorf("an error occurred while creating vxlan device : %v", err)
-			os.Exit(1)
-		}
-		vxlanRoutingManager, err := liqorouting.NewVxlanRoutingManager(liqoconst.RoutingTableID,
-			podIP.String(), liqoconst.OverlayNetPrefix, vxlanDevice)
-		if err != nil {
-			klog.Errorf("an error occurred while creating the vxlan routing manager: %v", err)
-			os.Exit(1)
-		}
-		eventRecorder := mainMgr.GetEventRecorderFor(liqoconst.LiqoRouteOperatorName + "." + podIP.String())
-		routeController := routeoperator.NewRouteController(podIP.String(), vxlanDevice, vxlanRoutingManager, eventRecorder, mainMgr.GetClient())
-		if err = routeController.SetupWithManager(mainMgr); err != nil {
-			klog.Errorf("unable to setup controller: %s", err)
-			os.Exit(1)
-		}
-		overlayController, err := routeoperator.NewOverlayController(podIP.String(), vxlanDevice, mutex, nodeMap, overlayMgr.GetClient())
-		if err != nil {
-			klog.Errorf("an error occurred while creating overlay controller: %v", err)
-			os.Exit(3)
-		}
-		if err = overlayController.SetupWithManager(overlayMgr); err != nil {
-			klog.Errorf("unable to setup overlay controller: %s", err)
-			os.Exit(1)
-		}
-		symmetricRoutingController, err := routeoperator.NewSymmetricRoutingOperator(nodeName,
-			liqoconst.RoutingTableID, vxlanDevice, mutex, nodeMap, mainMgr.GetClient())
-		if err != nil {
-			klog.Errorf("an error occurred while creting symmetric routing controller: %v", err)
-			os.Exit(4)
-		}
-		if err = symmetricRoutingController.SetupWithManager(mainMgr); err != nil {
-			klog.Errorf("unable to setup overlay controller: %s", err)
-			os.Exit(1)
-		}
-		if err := mainMgr.Add(overlayMgr); err != nil {
-			klog.Errorf("unable to add the overlay manager to the main manager: %s", err)
-			os.Exit(1)
-		}
-		if err := mainMgr.Start(routeController.SetupSignalHandlerForRouteOperator()); err != nil {
-			klog.Errorf("unable to start controller: %s", err)
-			os.Exit(1)
-		}
+		runRouteOperator(commonFlags, routeFlags)
 	case liqoconst.LiqoGatewayOperatorName:
-		// Get the pod ip and parse to net.IP.
-		podIP, err := utils.GetPodIP()
-		if err != nil {
-			klog.Errorf("unable to get podIP: %v", err)
-			os.Exit(1)
-		}
-		podNamespace, err := utils.GetPodNamespace()
-		if err != nil {
-			klog.Errorf("unable to get pod namespace: %v", err)
-			os.Exit(1)
-		}
-		main, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
-			MapperProvider:                mapperUtils.LiqoMapperProvider(scheme),
-			Scheme:                        scheme,
-			MetricsBindAddress:            metricsAddr,
-			LeaderElection:                enableLeaderElection,
-			LeaderElectionID:              liqoconst.GatewayLeaderElectionID,
-			LeaderElectionNamespace:       podNamespace,
-			LeaderElectionReleaseOnCancel: true,
-			LeaderElectionResourceLock:    resourcelock.LeasesResourceLock,
-			LeaseDuration:                 &leaseDuration,
-			RenewDeadline:                 &renewDeadLine,
-			RetryPeriod:                   &retryPeriod,
-			NewCache: cache.BuilderWithOptions(cache.Options{
-				SelectorsByObject: tunneloperator.LabelSelector,
-			}),
-		})
-		if err != nil {
-			klog.Errorf("unable to get main manager: %s", err)
-			os.Exit(1)
-		}
-		clientset := kubernetes.NewForConfigOrDie(main.GetConfig())
-		eventRecorder := main.GetEventRecorderFor(liqoconst.LiqoGatewayOperatorName + "." + podIP.String())
-		// This map is updated by the tunnel operator after a successful tunnel creation
-		// and is consumed by the natmapping operator to check whether the tunnel is ready or not.
-		var readyClustersMutex sync.Mutex
-		readyClusters := make(map[string]struct{})
-		// Create new network namespace for the gateway (gatewayNetns).
-		// If the namespace already exists it will be deleted and recreated.
-		// It is created here because both the tunnel-operator and the natmapping-operator
-		// need to know the namespace to configure.
-		gatewayNetns, err := liqonetns.CreateNetns(liqoconst.GatewayNetnsName)
-		if err != nil {
-			klog.Errorf("an error occurred while creating custom network namespace: %s", err.Error())
-			os.Exit(1)
-		}
-		// Get the current network namespace (hostNetns).
-		hostNetns, err := ns.GetCurrentNS()
-		if err != nil {
-			klog.Errorf("an error occurred while getting host network namespace: %s", err.Error())
-			os.Exit(1)
-		}
-		klog.Infof("created custom network namespace {%s}", liqoconst.GatewayNetnsName)
-
-		labelController := tunneloperator.NewLabelerController(podIP.String(), main.GetClient())
-		if err = labelController.SetupWithManager(main); err != nil {
-			klog.Errorf("unable to setup labeler controller: %s", err)
-			os.Exit(1)
-		}
-		tunnelController, err := tunneloperator.NewTunnelController(podIP.String(), podNamespace, eventRecorder,
-			clientset, main.GetClient(), &readyClustersMutex, readyClusters, gatewayNetns, hostNetns)
-		// If something goes wrong while creating and configuring the tunnel controller
-		// then make sure that we remove all the resources created during the create process.
-		if err != nil {
-			klog.Errorf("an error occurred while creating the tunnel controller: %v", err)
-			klog.Info("cleaning up gateway network namespace")
-			if err := liqonetns.DeleteNetns(liqoconst.GatewayNetnsName); err != nil {
-				klog.Errorf("an error occurred while deleting netns {%s}: %v", liqoconst.GatewayNetnsName, err)
-			}
-			klog.Info("cleaning up wireguard tunnel interface")
-			if err := utils.DeleteIFaceByName(tunnelwg.DeviceName); err != nil {
-				klog.Errorf("an error occurred while deleting iface {%s}: %v", tunnelwg.DriverName, err)
-			}
-			os.Exit(1)
-		}
-		if err = tunnelController.SetupWithManager(main); err != nil {
-			klog.Errorf("unable to setup tunnel controller: %s", err)
-			os.Exit(1)
-		}
-		natMappingController, err := tunneloperator.NewNatMappingController(main.GetClient(), &readyClustersMutex,
-			readyClusters, gatewayNetns)
-		if err != nil {
-			klog.Errorf("an error occurred while creating the natmapping controller: %v", err)
-			os.Exit(1)
-		}
-		if err = natMappingController.SetupWithManager(main); err != nil {
-			klog.Errorf("unable to setup natmapping controller: %s", err)
-			os.Exit(1)
-		}
-
-		klog.Info("Starting manager as Tunnel-Operator")
-		if err := main.Start(tunnelController.SetupSignalHandlerForTunnelOperator()); err != nil {
-			klog.Errorf("unable to start tunnel controller: %s", err)
-			os.Exit(1)
-		}
-	case "tunnelEndpointCreator-operator":
-		mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
-			MapperProvider:     mapperUtils.LiqoMapperProvider(scheme),
-			Scheme:             scheme,
-			MetricsBindAddress: metricsAddr,
-		})
-		if err != nil {
-			klog.Errorf("unable to get manager: %s", err)
-			os.Exit(1)
-		}
-		clientset := kubernetes.NewForConfigOrDie(mgr.GetConfig())
-		dynClient := dynamic.NewForConfigOrDie(mgr.GetConfig())
-		ipam := liqonetIpam.NewIPAM()
-		err = ipam.Init(liqonetIpam.Pools, dynClient, liqoconst.NetworkManagerIpamPort)
-		if err != nil {
-			klog.Errorf("cannot init IPAM:%w", err)
-		}
-		r := &tunnelEndpointCreator.TunnelEndpointCreator{
-			Client:                     mgr.GetClient(),
-			Scheme:                     mgr.GetScheme(),
-			ClientSet:                  clientset,
-			DynClient:                  dynClient,
-			Manager:                    mgr,
-			Namespace:                  "liqo",
-			WaitConfig:                 &sync.WaitGroup{},
-			ReservedSubnets:            make([]string, 0),
-			AdditionalPools:            make([]string, 0),
-			Configured:                 make(chan bool, 1),
-			ForeignClusterStartWatcher: make(chan bool, 1),
-			ForeignClusterStopWatcher:  make(chan struct{}),
-			IPManager:                  ipam,
-			RetryTimeout:               30 * time.Second,
-		}
-		r.WaitConfig.Add(3)
-		//starting configuration watcher
-		config, err := ctrl.GetConfig()
-		if err != nil {
-			klog.Error(err)
-			os.Exit(2)
-		}
-		r.WatchConfiguration(config, &clusterConfig.GroupVersion)
-		if err = r.SetupWithManager(mgr); err != nil {
-			klog.Errorf("unable to create controller controller TunnelEndpointCreator: %s", err)
-			os.Exit(1)
-		}
-		go r.StartForeignClusterWatcher()
-		go r.StartServiceWatcher()
-		go r.StartSecretWatcher()
-		klog.Info("starting manager as tunnelEndpointCreator-operator")
-		if err := mgr.Start(r.SetupSignalHandlerForTunEndCreator()); err != nil {
-			klog.Errorf("an error occurred while starting manager: %s", err)
-			os.Exit(1)
-		}
+		runGatewayOperator(commonFlags, gatewayFlags)
+	case liqoconst.LiqoNetworkManagerName:
+		runEndpointCreatorOperator(commonFlags)
 	}
 }

--- a/cmd/liqonet/route-operator.go
+++ b/cmd/liqonet/route-operator.go
@@ -1,0 +1,167 @@
+package main
+
+import (
+	"flag"
+	"os"
+	"strings"
+	"sync"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/klog/v2"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+
+	routeoperator "github.com/liqotech/liqo/internal/liqonet/route-operator"
+	liqoconst "github.com/liqotech/liqo/pkg/consts"
+	"github.com/liqotech/liqo/pkg/liqonet/overlay"
+	liqorouting "github.com/liqotech/liqo/pkg/liqonet/routing"
+	"github.com/liqotech/liqo/pkg/liqonet/utils"
+	"github.com/liqotech/liqo/pkg/mapperUtils"
+)
+
+type routeOperatorFlags struct {
+	vni      int
+	mtu      int
+	vtepPort int
+}
+
+func addRouteOperatorFlags(liqonet *routeOperatorFlags) {
+	flag.IntVar(&liqonet.vni, "route.vxlan-vni", 18952, "VXLAN Virtual Network Identifier (VNI) for the Liqonet intra-cluster overlay network")
+	flag.IntVar(&liqonet.mtu, "route.vxlan-mtu", 1420, "VXLAN Max Transmit Unit (MTU) for the Liqonet intra-cluster overlay network")
+	flag.IntVar(&liqonet.vtepPort, "route.vxlan-vtep-port", 4879,
+		"VXLAN Virtual Tunnel Endpoints (VTEP) port for the Liqonet intra-cluster overlay network")
+}
+
+func runRouteOperator(commonFlags *liqonetCommonFlags, routeFlags *routeOperatorFlags) {
+	vxlanConfig := &overlay.VxlanDeviceAttrs{
+		Vni:      routeFlags.vni,
+		Name:     liqoconst.VxlanDeviceName,
+		VtepPort: routeFlags.vtepPort,
+		VtepAddr: nil,
+		MTU:      routeFlags.mtu,
+	}
+
+	mutex := &sync.RWMutex{}
+	nodeMap := map[string]string{}
+	// Get the pod ip and parse to net.IP.
+	podIP, err := utils.GetPodIP()
+	if err != nil {
+		klog.Errorf("unable to get podIP: %v", err)
+		os.Exit(1)
+	}
+	nodeName, err := utils.GetNodeName()
+	if err != nil {
+		klog.Errorf("unable to get node name: %v", err)
+		os.Exit(1)
+	}
+	podNamespace, err := utils.GetPodNamespace()
+	if err != nil {
+		klog.Errorf("unable to get pod namespace: %v", err)
+		os.Exit(1)
+	}
+	// Asking the api-server to only inform the operator for the pods running in a node different from the one
+	// where the operator is running.
+	smcFieldSelector, err := fields.ParseSelector(strings.Join([]string{"spec.nodeName", "!=", nodeName}, ""))
+	if err != nil {
+		klog.Errorf("unable to create label requirement: %v", err)
+		os.Exit(1)
+	}
+	// Asking the api-server to only inform the operator for the pods running in a node different from
+	// the virtual nodes. We want to process only the pods running on the local cluster and not the ones
+	// offloaded to a remote cluster.
+	smcLabelRequirement, err := labels.NewRequirement(liqoconst.LocalPodLabelKey, selection.DoesNotExist, []string{})
+	if err != nil {
+		klog.Errorf("unable to create label requirement: %v", err)
+		os.Exit(1)
+	}
+	smcLabelSelector := labels.NewSelector().Add(*smcLabelRequirement)
+	mainMgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+		MapperProvider:     mapperUtils.LiqoMapperProvider(scheme),
+		Scheme:             scheme,
+		MetricsBindAddress: commonFlags.metricsAddr,
+		NewCache: cache.BuilderWithOptions(cache.Options{
+			SelectorsByObject: cache.SelectorsByObject{
+				&corev1.Pod{}: {
+					Field: smcFieldSelector,
+					Label: smcLabelSelector,
+				},
+			},
+		}),
+	})
+	if err != nil {
+		klog.Errorf("unable to get manager: %s", err)
+		os.Exit(1)
+	}
+	// Asking the api-server to only inform the operator for the pods that are part of the route component.
+	ovcLabelSelector := labels.SelectorFromSet(labels.Set{
+		podNameLabelKey:     routeNameLabelValue,
+		podInstanceLabelKey: routeInstanceLabelValue,
+	})
+	// This manager is used by the overlay operator and it is limited to the pods running
+	// on the same namespace as the operator.
+	overlayMgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+		MapperProvider:     mapperUtils.LiqoMapperProvider(scheme),
+		Scheme:             scheme,
+		MetricsBindAddress: ":0",
+		Namespace:          podNamespace,
+		NewCache: cache.BuilderWithOptions(cache.Options{
+			SelectorsByObject: cache.SelectorsByObject{
+				&corev1.Pod{}: {
+					Label: ovcLabelSelector,
+				},
+			},
+		}),
+	})
+	if err != nil {
+		klog.Errorf("unable to get manager: %s", err)
+		os.Exit(1)
+	}
+	vxlanConfig.VtepAddr = podIP
+	vxlanDevice, err := overlay.NewVxlanDevice(vxlanConfig)
+	if err != nil {
+		klog.Errorf("an error occurred while creating vxlan device : %v", err)
+		os.Exit(1)
+	}
+	vxlanRoutingManager, err := liqorouting.NewVxlanRoutingManager(liqoconst.RoutingTableID,
+		podIP.String(), liqoconst.OverlayNetPrefix, vxlanDevice)
+	if err != nil {
+		klog.Errorf("an error occurred while creating the vxlan routing manager: %v", err)
+		os.Exit(1)
+	}
+	eventRecorder := mainMgr.GetEventRecorderFor(liqoconst.LiqoRouteOperatorName + "." + podIP.String())
+	routeController := routeoperator.NewRouteController(podIP.String(), vxlanDevice, vxlanRoutingManager, eventRecorder, mainMgr.GetClient())
+	if err = routeController.SetupWithManager(mainMgr); err != nil {
+		klog.Errorf("unable to setup controller: %s", err)
+		os.Exit(1)
+	}
+	overlayController, err := routeoperator.NewOverlayController(podIP.String(), vxlanDevice, mutex, nodeMap, overlayMgr.GetClient())
+	if err != nil {
+		klog.Errorf("an error occurred while creating overlay controller: %v", err)
+		os.Exit(3)
+	}
+	if err = overlayController.SetupWithManager(overlayMgr); err != nil {
+		klog.Errorf("unable to setup overlay controller: %s", err)
+		os.Exit(1)
+	}
+	symmetricRoutingController, err := routeoperator.NewSymmetricRoutingOperator(nodeName,
+		liqoconst.RoutingTableID, vxlanDevice, mutex, nodeMap, mainMgr.GetClient())
+	if err != nil {
+		klog.Errorf("an error occurred while creting symmetric routing controller: %v", err)
+		os.Exit(4)
+	}
+	if err = symmetricRoutingController.SetupWithManager(mainMgr); err != nil {
+		klog.Errorf("unable to setup overlay controller: %s", err)
+		os.Exit(1)
+	}
+	if err := mainMgr.Add(overlayMgr); err != nil {
+		klog.Errorf("unable to add the overlay manager to the main manager: %s", err)
+		os.Exit(1)
+	}
+	if err := mainMgr.Start(routeController.SetupSignalHandlerForRouteOperator()); err != nil {
+		klog.Errorf("unable to start controller: %s", err)
+		os.Exit(1)
+	}
+}

--- a/deployments/liqo/templates/liqo-gateway-deployment.yaml
+++ b/deployments/liqo/templates/liqo-gateway-deployment.yaml
@@ -36,7 +36,7 @@ spec:
           command: ["/usr/bin/liqonet"]
           args:
           - --run-as=liqo-gateway
-          - --leader-elect=true
+          - --gateway.leader-elect=true
           {{- if .Values.gateway.pod.extraArgs }}
           {{- toYaml .Values.gateway.pod.extraArgs | nindent 10 }}
           {{- end }}

--- a/deployments/liqo/templates/liqo-network-manager-deployment.yaml
+++ b/deployments/liqo/templates/liqo-network-manager-deployment.yaml
@@ -37,6 +37,11 @@ spec:
             {{- if .Values.networkManager.pod.extraArgs }}
             {{- toYaml .Values.networkManager.pod.extraArgs | nindent 12 }}
             {{- end }}
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           resources:
             requests:
               cpu: 50m

--- a/internal/liqonet/route-operator/route_operator_suite_test.go
+++ b/internal/liqonet/route-operator/route_operator_suite_test.go
@@ -18,7 +18,7 @@ var (
 		Name:     "vxlan.route",
 		VtepPort: 4789,
 		VtepAddr: nil,
-		Mtu:      1450,
+		MTU:      1450,
 	}
 	vxlanDevice   = new(overlay.VxlanDevice)
 	vxlanDeviceIP = "240.0.0.1/8"
@@ -74,7 +74,7 @@ func setUpVxlanLink(attrs *overlay.VxlanDeviceAttrs) (netlink.Link, error) {
 	err := netlink.LinkAdd(&netlink.Vxlan{
 		LinkAttrs: netlink.LinkAttrs{
 			Name:  attrs.Name,
-			MTU:   attrs.Mtu,
+			MTU:   attrs.MTU,
 			Flags: net.FlagUp,
 		},
 		VxlanId:  attrs.Vni,

--- a/pkg/consts/liqonet.go
+++ b/pkg/consts/liqonet.go
@@ -37,6 +37,8 @@ const (
 	LiqoRouteOperatorName = "liqo-route"
 	// LiqoGatewayOperatorName name of the operator.
 	LiqoGatewayOperatorName = "liqo-gateway"
+	// LiqoNetworkManagerName name of the operator.
+	LiqoNetworkManagerName = "tunnelEndpointCreator-operator"
 	// GatewayLeaderElectionID used as name for the lease.coordination.k8s.io resource.
 	GatewayLeaderElectionID = "1d5hml1.gateway.net.liqo.io"
 	// GatewayNetnsName name of the custom network namespace used by liqo-gateway.

--- a/pkg/liqonet/overlay/vxlan.go
+++ b/pkg/liqonet/overlay/vxlan.go
@@ -20,7 +20,7 @@ type VxlanDeviceAttrs struct {
 	Name     string
 	VtepPort int
 	VtepAddr net.IP
-	Mtu      int
+	MTU      int
 }
 
 // VxlanDevice struct that holds a vxlan link.
@@ -39,7 +39,7 @@ func NewVxlanDevice(devAttrs *VxlanDeviceAttrs) (*VxlanDevice, error) {
 	link := &netlink.Vxlan{
 		LinkAttrs: netlink.LinkAttrs{
 			Name:  devAttrs.Name,
-			MTU:   devAttrs.Mtu,
+			MTU:   devAttrs.MTU,
 			Flags: net.FlagUp,
 		},
 		VxlanId:  devAttrs.Vni,

--- a/pkg/liqonet/overlay/vxlan_test.go
+++ b/pkg/liqonet/overlay/vxlan_test.go
@@ -20,7 +20,7 @@ func createLink(attrs *VxlanDeviceAttrs) (netlink.Link, error) {
 	err := netlink.LinkAdd(&netlink.Vxlan{
 		LinkAttrs: netlink.LinkAttrs{
 			Name:  vxlanOld.Name,
-			MTU:   vxlanOld.Mtu,
+			MTU:   vxlanOld.MTU,
 			Flags: net.FlagUp,
 		},
 		VxlanId:  vxlanOld.Vni,
@@ -74,7 +74,7 @@ func containsFdbEntry(fdbs []netlink.Neigh, n Neighbor) bool {
 
 func checkConfig(vxlanDev *VxlanDevice, vxlanOld *VxlanDeviceAttrs) {
 	Expect(vxlanDev.Link.VxlanId).Should(BeNumerically("==", vxlanOld.Vni))
-	Expect(vxlanDev.Link.MTU).Should(BeNumerically("==", vxlanOld.Mtu))
+	Expect(vxlanDev.Link.MTU).Should(BeNumerically("==", vxlanOld.MTU))
 	Expect(vxlanDev.Link.Port).Should(BeNumerically("==", vxlanOld.VtepPort))
 	Expect(vxlanDev.Link.SrcAddr).Should(Equal(vxlanOld.VtepAddr))
 	Expect(vxlanDev.Link.Name).Should(Equal(vxlanOld.Name))
@@ -88,14 +88,14 @@ var _ = Describe("Vxlan", func() {
 			Name:     "vxlan.test",
 			VtepPort: 4789,
 			VtepAddr: defaultIfaceIP,
-			Mtu:      1450,
+			MTU:      1450,
 		}
 		vxlanOld = &VxlanDeviceAttrs{
 			Vni:      18953,
 			Name:     "vxlan.old",
 			VtepAddr: defaultIfaceIP,
 			VtepPort: 4789,
-			Mtu:      1450,
+			MTU:      1450,
 		}
 		vxlanOldLink, err = createLink(vxlanOld)
 		vxlanDev = VxlanDevice{Link: vxlanOldLink.(*netlink.Vxlan)}

--- a/pkg/liqonet/routing/vxlanRouting_test.go
+++ b/pkg/liqonet/routing/vxlanRouting_test.go
@@ -37,7 +37,7 @@ var (
 		Name:     "vxlan.test",
 		VtepPort: 4789,
 		VtepAddr: nil,
-		Mtu:      1450,
+		MTU:      1450,
 	}
 	tepVRM            netv1alpha1.TunnelEndpoint
 	existingRoutesVRM []*netlink.Route
@@ -48,7 +48,7 @@ func setUpVxlanLink(attrs *overlay.VxlanDeviceAttrs) (netlink.Link, error) {
 	err := netlink.LinkAdd(&netlink.Vxlan{
 		LinkAttrs: netlink.LinkAttrs{
 			Name:  attrs.Name,
-			MTU:   attrs.Mtu,
+			MTU:   attrs.MTU,
 			Flags: net.FlagUp,
 		},
 		VxlanId:  attrs.Vni,


### PR DESCRIPTION
# Description

This PR increases the number of flags supported by liqonet route operator, in order to configure the VXLAN overlay network parameters.

# How Has This Been Tested?

- [ ] Manually
- [x] E2E
