### PR TITLE
Change auth-service listening port from 443 to 8443

### DIFF
--- a/deployments/liqo/templates/liqo-auth-deployment.yaml
+++ b/deployments/liqo/templates/liqo-auth-deployment.yaml
@@ -26,11 +26,17 @@ spec:
         {{- toYaml .Values.auth.pod.annotations | nindent 8 }}
       {{- end }}
     spec:
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
       serviceAccountName: {{ include "liqo.prefixedName" $authConfig }}
       {{- if .Values.auth.tls }}
       initContainers:
         - name: {{ $authConfig.containerName }}
           imagePullPolicy: {{ .Values.pullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
           image: {{ .Values.auth.initContainer.imageName }}{{ include "liqo.suffix" $authConfig }}:{{ include "liqo.version" $authConfig }}
           volumeMounts:
             - mountPath: '/certs'
@@ -57,6 +63,8 @@ spec:
       {{- end }}
       containers:
         - image: {{ .Values.auth.imageName }}{{ include "liqo.suffix" $authConfig }}:{{ include "liqo.version" $authConfig }}
+          securityContext:
+            allowPrivilegeEscalation: false
           name: {{ $authConfig.name }}
           imagePullPolicy: {{ .Values.pullPolicy }}
           command: ["/usr/bin/auth-service"]
@@ -78,7 +86,7 @@ spec:
           {{- if not .Values.auth.tls}}
           - --listeningPort=5000
           {{- else }}
-          - --listeningPort=443
+          - --listeningPort=8443
           - --useTls
           {{- end }}
           {{- if .Values.auth.pod.extraArgs }}

--- a/deployments/liqo/templates/liqo-auth-service.yaml
+++ b/deployments/liqo/templates/liqo-auth-service.yaml
@@ -25,5 +25,5 @@ spec:
       targetPort: 5000
       {{- else }}
       port: 443
-      targetPort: 443
+      targetPort: 8443
       {{- end }}


### PR DESCRIPTION
# Description

This PR includes a port change for the authentication service. More precisely, auth service now binds on unprivileged instead of binding on 443 and executed with an unprivileged user.

# How Has This Been Tested?

- [ ] E2E
