### PR TITLE
Fix Race Condition in ResourceRequest Phase Test

### DIFF
--- a/pkg/liqo-controller-manager/resource-request-controller/resourceRequestPhase_test.go
+++ b/pkg/liqo-controller-manager/resource-request-controller/resourceRequestPhase_test.go
@@ -61,9 +61,12 @@ var _ = Describe("Resource Phase", func() {
 
 				Expect(controller.Create(ctx, foreignCluster)).To(Succeed())
 
-				phase, err := controller.getResourceRequestPhase(ctx, c.resourceRequest)
-				Expect(err).To(Succeed())
-				Expect(phase).To(c.expectedResult)
+				// this eventually fixes a cache race condition
+				Eventually(func() resourceRequestPhase {
+					phase, err := controller.getResourceRequestPhase(ctx, c.resourceRequest)
+					Expect(err).ToNot(HaveOccurred())
+					return phase
+				}, timeout, interval).Should(c.expectedResult)
 
 				Expect(controller.Delete(ctx, foreignCluster)).To(Succeed())
 			},


### PR DESCRIPTION
# Description

This pr fixes a race condition that could happen during the ResourceRequest Phase unit tests

# How Has This Been Tested?

- [x] locally
- [x] on github actions
