### PR TITLE
Cache IAM Credentials in Liqoctl EKS Provider

### DIFF
--- a/pkg/liqoctl/install/eks/iamkeycache.go
+++ b/pkg/liqoctl/install/eks/iamkeycache.go
@@ -1,0 +1,98 @@
+package eks
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+	"k8s.io/klog/v2"
+)
+
+type iamUserCredential struct {
+	AccessKeyID     string `yaml:"accessKeyID"`
+	SecretAccessKey string `yaml:"secretAccessKey"`
+}
+
+type iamUserCredentialCache map[string]iamUserCredential
+
+const (
+	liqoIamCredentialsFile = "iam-credentials.yaml"
+	liqoDirName            = ".liqo"
+)
+
+var (
+	liqoDirPath string
+)
+
+func init() {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		klog.Error(err)
+		os.Exit(1)
+	}
+	liqoDirPath = filepath.Join(homeDir, liqoDirName)
+}
+
+func storeIamAccessKey(iamUserName, accessKeyID, secretAccessKey string) error {
+	cache, err := readCache()
+	if err != nil {
+		return err
+	}
+
+	cache[iamUserName] = iamUserCredential{
+		AccessKeyID:     accessKeyID,
+		SecretAccessKey: secretAccessKey,
+	}
+
+	data, err := yaml.Marshal(cache)
+	if err != nil {
+		return err
+	}
+
+	fileName := filepath.Join(liqoDirPath, liqoIamCredentialsFile)
+	if err = ioutil.WriteFile(fileName, data, 0600); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func retrieveIamAccessKey(iamUserName string) (accessKeyID, secretAccessKey string, err error) {
+	cache, err := readCache()
+	if err != nil {
+		return "", "", err
+	}
+
+	key, ok := cache[iamUserName]
+	if !ok {
+		return "", "", nil
+	}
+
+	return key.AccessKeyID, key.SecretAccessKey, nil
+}
+
+func readCache() (iamUserCredentialCache, error) {
+	// ensure the directory existence
+	err := os.MkdirAll(liqoDirPath, 0700)
+	if err != nil {
+		return nil, err
+	}
+
+	fileName := filepath.Join(liqoDirPath, liqoIamCredentialsFile)
+	if _, err := os.Stat(fileName); err != nil {
+		return iamUserCredentialCache{}, nil
+	}
+
+	data, err := ioutil.ReadFile(filepath.Clean(fileName))
+	if err != nil {
+		return nil, err
+	}
+
+	var cache iamUserCredentialCache
+	if err = yaml.Unmarshal(data, &cache); err != nil {
+		return nil, err
+	}
+
+	return cache, nil
+}

--- a/pkg/liqoctl/install/eks/iamkeycache_test.go
+++ b/pkg/liqoctl/install/eks/iamkeycache_test.go
@@ -1,0 +1,46 @@
+package eks
+
+import (
+	"os"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("IAM Key Cache Test", func() {
+
+	const (
+		iamUsername        = "user-123"
+		unknownIamUsername = "user-1234"
+		accessKeyID        = "key-id"
+		secretAccessKey    = "secret-key"
+	)
+
+	BeforeEach(func() {
+		Expect(os.RemoveAll(liqoDirPath)).To(Succeed())
+	})
+
+	AfterEach(func() {
+		Expect(os.RemoveAll(liqoDirPath)).To(Succeed())
+	})
+
+	It("key lifecycle", func() {
+
+		By("store the keys")
+		Expect(storeIamAccessKey(iamUsername, accessKeyID, secretAccessKey)).To(Succeed())
+
+		By("retrieve the keys")
+		aKey, sKey, err := retrieveIamAccessKey(iamUsername)
+		Expect(err).To(Succeed())
+		Expect(aKey).To(Equal(accessKeyID))
+		Expect(sKey).To(Equal(secretAccessKey))
+
+		By("read unknown user")
+		aKey, sKey, err = retrieveIamAccessKey(unknownIamUsername)
+		Expect(err).To(Succeed())
+		Expect(aKey).To(BeEmpty())
+		Expect(sKey).To(BeEmpty())
+
+	})
+
+})

--- a/pkg/liqoctl/install/eks/provider.go
+++ b/pkg/liqoctl/install/eks/provider.go
@@ -78,6 +78,18 @@ func (k *eksProvider) ValidateCommandArguments(flags *flag.FlagSet) (err error) 
 		return err
 	}
 
+	storedAccessKeyID, storedSecretAccessKey, err := retrieveIamAccessKey(k.iamLiqoUser.userName)
+	if err != nil {
+		return err
+	}
+
+	if storedAccessKeyID != "" && k.iamLiqoUser.accessKeyID == "" {
+		k.iamLiqoUser.accessKeyID = storedAccessKeyID
+	}
+	if storedSecretAccessKey != "" && k.iamLiqoUser.secretAccessKey == "" {
+		k.iamLiqoUser.secretAccessKey = storedSecretAccessKey
+	}
+
 	return nil
 }
 
@@ -129,8 +141,10 @@ func GenerateFlags(flags *flag.FlagSet) {
 	subFlag.String("region", "", "The EKS region where your cluster is running")
 	subFlag.String("cluster-name", "", "The EKS clusterName of your cluster")
 
-	subFlag.String("user-name", "", "The username to assign to the Liqo user")
-	subFlag.String("policy-name", "", "The name of the policy to assign to the Liqo user")
+	subFlag.String("user-name", "liqo-cluster-user", "The username to assign to the Liqo user. "+
+		"This user will be created if no access keys have been provided, "+
+		"otherwise liqoctl assumes that the provided keys are related to this user (optional)")
+	subFlag.String("policy-name", "liqo-cluster-policy", "The name of the policy to assign to the Liqo user (optional)")
 
 	subFlag.String("access-key-id", "", "The IAM accessKeyID for the Liqo user (optional)")
 	subFlag.String("secret-access-key", "", "The IAM secretAccessKey for the Liqo user (optional)")


### PR DESCRIPTION
# Description

This pr adds a cache for the Liqo IAM user credentials

# How Has This Been Tested?

- [x] add unit test
- [x] on AWS
