### PR TITLE
Exclude Node CIDR Network

### DIFF
--- a/pkg/liqoctl/install/aks/aks_test.go
+++ b/pkg/liqoctl/install/aks/aks_test.go
@@ -59,6 +59,11 @@ var _ = Describe("Extract elements from AKS", func() {
 					PodCidr:       pointer.StringPtr(podCIDR),
 					ServiceCidr:   pointer.StringPtr(serviceCIDR),
 				},
+				AgentPoolProfiles: &[]containerservice.ManagedClusterAgentPoolProfile{
+					{
+						VnetSubnetID: nil,
+					},
+				},
 			},
 		}
 
@@ -69,6 +74,8 @@ var _ = Describe("Extract elements from AKS", func() {
 		Expect(p.endpoint).To(Equal(endpoint))
 		Expect(p.serviceCIDR).To(Equal(serviceCIDR))
 		Expect(p.podCIDR).To(Equal(podCIDR))
+		Expect(len(p.reservedSubnets)).To(BeNumerically("==", 1))
+		Expect(p.reservedSubnets).To(ContainElement(defaultAksNodeCIDR))
 
 	})
 

--- a/pkg/liqoctl/install/utils/map.go
+++ b/pkg/liqoctl/install/utils/map.go
@@ -27,6 +27,8 @@ func FusionMap(baseMap, patchMap map[string]interface{}) (map[string]interface{}
 			return nil, fmt.Errorf("the two maps have different types for the same key")
 		case reflect.TypeOf(v).String() == "string", reflect.TypeOf(v).String() == "bool", reflect.TypeOf(v).String() == "int":
 			resultMap[key] = v2
+		case reflect.TypeOf(v).Kind() == reflect.Slice:
+			resultMap[key] = append(v.([]interface{}), v2.([]interface{})...)
 		default:
 			resultMap[key], err = FusionMap(baseMap[key].(map[string]interface{}), patchMap[key].(map[string]interface{}))
 			if err != nil {

--- a/pkg/liqoctl/install/utils/map_test.go
+++ b/pkg/liqoctl/install/utils/map_test.go
@@ -23,6 +23,7 @@ var m1 = map[string]interface{}{
 				"i": "i1",
 			},
 		},
+		"slice": []interface{}{},
 	},
 }
 
@@ -42,6 +43,7 @@ var m2 = map[string]interface{}{
 				"h2": "e2",
 			},
 		},
+		"slice": []interface{}{"str1", "str2"},
 	},
 }
 
@@ -67,6 +69,7 @@ var expectedResultMap = map[string]interface{}{
 				"i": "i1",
 			},
 		},
+		"slice": []interface{}{"str1", "str2"},
 	},
 }
 

--- a/pkg/liqoctl/install/utils/slice.go
+++ b/pkg/liqoctl/install/utils/slice.go
@@ -1,0 +1,10 @@
+package installutils
+
+// GetInterfaceSlice casts a slice of string to a slice in interface{}.
+func GetInterfaceSlice(in []string) []interface{} {
+	out := make([]interface{}, len(in))
+	for i := range in {
+		out[i] = in[i]
+	}
+	return out
+}


### PR DESCRIPTION
# Description

This pr includes the logic in the liqoctl command to exclude the node CIDR network from the available networks for cluster remappings

This logic has been added for:
* AKS kubenet clusters
* GKE clusters

It is not necessary for AKS Azure CNI clusters and for EKS clusters, since the cluster nodes IPs are contained in the pod CIDR

# How Has This Been Tested?

- [x] on AKS installation
- [x] on GKE installation
- [x] improve unit test
