### PR TITLE
Fix AWS IAM Username Collision

### DIFF
--- a/pkg/identityManager/identityManager.go
+++ b/pkg/identityManager/identityManager.go
@@ -82,8 +82,9 @@ func NewIAMIdentityProvider(client kubernetes.Interface,
 	localClusterID clusterid.ClusterID, awsConfig *AwsConfig,
 	namespaceManager tenantnamespace.Manager) IdentityProvider {
 	idProvider := &iamIdentityProvider{
-		awsConfig: awsConfig,
-		client:    client,
+		awsConfig:      awsConfig,
+		client:         client,
+		localClusterID: localClusterID,
 	}
 
 	return newIdentityManager(client, localClusterID, namespaceManager, idProvider)


### PR DESCRIPTION
# Description

This pr fixes a name collision problem over the Liqo IAM usernames when multiple EKS clusters are deployed. With these changes, the name of those users is different on different clusters.

# How Has This Been Tested?

- [x] on AWS
