### PR TITLE
Liqoctl Check Cluster Endpoint

### DIFF
--- a/cmd/liqoctl/cmd/install.go
+++ b/cmd/liqoctl/cmd/install.go
@@ -31,6 +31,8 @@ func newInstallCommand(ctx context.Context) *cobra.Command {
 	installCmd.Flags().BoolP("enable-lan-discovery", "", true, "Enable LAN discovery (default: true)")
 	installCmd.Flags().StringP("cluster-labels", "", "",
 		"Cluster Labels to append to Liqo Cluster, supports '='.(e.g. --cluster-labels key1=value1,key2=value2)")
+	installCmd.Flags().BoolP("disable-endpoint-check", "", false, "Disable the check that the current kubeconfig context "+
+		"contains the same endpoint retrieved from the cloud provider (AKS, EKS, GKE)")
 
 	for _, p := range providers {
 		initFunc, ok := providerInitFunc[p]

--- a/pkg/liqoctl/install/aks/provider.go
+++ b/pkg/liqoctl/install/aks/provider.go
@@ -77,7 +77,7 @@ func (k *aksProvider) ValidateCommandArguments(flags *flag.FlagSet) (err error) 
 
 // ExtractChartParameters fetches the parameters used to customize the Liqo installation on a specific cluster of a
 // given provider.
-func (k *aksProvider) ExtractChartParameters(ctx context.Context, _ *rest.Config) error {
+func (k *aksProvider) ExtractChartParameters(ctx context.Context, config *rest.Config, commonArgs *provider.CommonArguments) error {
 	authorizer, err := auth.NewAuthorizerFromCLI()
 	if err != nil {
 		return err
@@ -101,6 +101,14 @@ func (k *aksProvider) ExtractChartParameters(ctx context.Context, _ *rest.Config
 
 	if err = k.parseClusterOutput(ctx, &cluster); err != nil {
 		return err
+	}
+
+	if !commonArgs.DisableEndpointCheck {
+		if valid, err := installutils.CheckEndpoint(k.endpoint, config); err != nil {
+			return err
+		} else if !valid {
+			return fmt.Errorf("the retrieved cluster information and the cluster selected in the kubeconfig do not match")
+		}
 	}
 
 	return nil

--- a/pkg/liqoctl/install/handler.go
+++ b/pkg/liqoctl/install/handler.go
@@ -48,7 +48,7 @@ func HandleInstallCommand(ctx context.Context, cmd *cobra.Command, args []string
 		os.Exit(1)
 	}
 
-	err = providerInstance.ExtractChartParameters(ctx, config)
+	err = providerInstance.ExtractChartParameters(ctx, config, commonArgs)
 	if err != nil {
 		fmt.Printf("Unable to initialize configuration: %v", err)
 		os.Exit(1)

--- a/pkg/liqoctl/install/k3s/provider.go
+++ b/pkg/liqoctl/install/k3s/provider.go
@@ -73,7 +73,7 @@ func (k *k3sProvider) ValidateCommandArguments(flags *flag.FlagSet) (err error) 
 
 // ExtractChartParameters fetches the parameters used to customize the Liqo installation on a specific cluster of a
 // given provider.
-func (k *k3sProvider) ExtractChartParameters(ctx context.Context, config *rest.Config) error {
+func (k *k3sProvider) ExtractChartParameters(ctx context.Context, config *rest.Config, _ *provider.CommonArguments) error {
 	k8sClient, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		fmt.Printf("Unable to create client: %s", err)

--- a/pkg/liqoctl/install/kubeadm/provider.go
+++ b/pkg/liqoctl/install/kubeadm/provider.go
@@ -23,7 +23,7 @@ func (k *Kubeadm) ValidateCommandArguments(flags *flag.FlagSet) error {
 
 // ExtractChartParameters fetches the parameters used to customize the Liqo installation on a specific cluster of a
 // given provider.
-func (k *Kubeadm) ExtractChartParameters(ctx context.Context, config *rest.Config) error {
+func (k *Kubeadm) ExtractChartParameters(ctx context.Context, config *rest.Config, _ *provider.CommonArguments) error {
 	k8sClient, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		fmt.Printf("Unable to create client: %s", err)

--- a/pkg/liqoctl/install/provider/args.go
+++ b/pkg/liqoctl/install/provider/args.go
@@ -10,14 +10,15 @@ import (
 
 // CommonArguments encapsulates all the arguments common across install providers.
 type CommonArguments struct {
-	Version        string
-	Debug          bool
-	Timeout        time.Duration
-	DumpValues     bool
-	DumpValuesPath string
-	DryRun         bool
-	CommonValues   map[string]interface{}
-	Devel          bool
+	Version              string
+	Debug                bool
+	Timeout              time.Duration
+	DumpValues           bool
+	DumpValuesPath       string
+	DryRun               bool
+	CommonValues         map[string]interface{}
+	Devel                bool
+	DisableEndpointCheck bool
 }
 
 // ValidateCommonArguments validates install common arguments. If the inputs are valid, it returns a *CommonArgument
@@ -59,19 +60,24 @@ func ValidateCommonArguments(flags *flag.FlagSet) (*CommonArguments, error) {
 	if err != nil {
 		return nil, err
 	}
+	disableEndpointCheck, err := flags.GetBool("disable-endpoint-check")
+	if err != nil {
+		return nil, err
+	}
 	commonValues, err := parseCommonValues(clusterLabels, lanDiscovery)
 	if err != nil {
 		return nil, err
 	}
 	return &CommonArguments{
-		Version:        version,
-		Debug:          debug,
-		Timeout:        time.Duration(timeout) * time.Second,
-		DryRun:         dryRun,
-		DumpValues:     dumpValues,
-		DumpValuesPath: dumpValuesPath,
-		CommonValues:   commonValues,
-		Devel:          devel,
+		Version:              version,
+		Debug:                debug,
+		Timeout:              time.Duration(timeout) * time.Second,
+		DryRun:               dryRun,
+		DumpValues:           dumpValues,
+		DumpValuesPath:       dumpValuesPath,
+		CommonValues:         commonValues,
+		Devel:                devel,
+		DisableEndpointCheck: disableEndpointCheck,
 	}, nil
 }
 

--- a/pkg/liqoctl/install/provider/interface.go
+++ b/pkg/liqoctl/install/provider/interface.go
@@ -13,7 +13,7 @@ type InstallProviderInterface interface {
 	ValidateCommandArguments(*flag.FlagSet) error
 	// ExtractChartParameters retrieves the install parameters required for a correct installation. This may require
 	// instantiating extra clients to interact with cloud provider or the target cluster.
-	ExtractChartParameters(context.Context, *rest.Config) error
+	ExtractChartParameters(context.Context, *rest.Config, *CommonArguments) error
 	// UpdateChartValues patches the values map of a selected chart, modifying keys and entries to correctly install Liqo on a given
 	// provider
 	UpdateChartValues(values map[string]interface{})

--- a/pkg/liqoctl/install/utils/apiserverendpoint.go
+++ b/pkg/liqoctl/install/utils/apiserverendpoint.go
@@ -1,0 +1,49 @@
+package installutils
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"k8s.io/client-go/rest"
+)
+
+// CheckEndpoint checks if the provided endpoint end the endpoint contained in the rest.Config
+// point to the same server.
+func CheckEndpoint(endpoint string, config *rest.Config) (bool, error) {
+	configHostname, configPort, err := getHostnamePort(config.Host)
+	if err != nil {
+		return false, err
+	}
+
+	endpointHostname, endpointPort, err := getHostnamePort(endpoint)
+	if err != nil {
+		return false, err
+	}
+
+	return configHostname == endpointHostname && configPort == endpointPort, nil
+}
+
+func getHostnamePort(urlString string) (hostname, port string, err error) {
+	if !strings.HasPrefix(urlString, "https://") {
+		urlString = fmt.Sprintf("https://%v", urlString)
+	}
+
+	var parsedURL *url.URL
+	parsedURL, err = url.Parse(urlString)
+	if err != nil {
+		return "", "", err
+	}
+
+	hostname = parsedURL.Hostname()
+	port = parsedURL.Port()
+	defaultPort(&port)
+
+	return hostname, port, nil
+}
+
+func defaultPort(port *string) {
+	if port != nil && *port == "" {
+		*port = "443"
+	}
+}

--- a/pkg/liqoctl/install/utils/apiserverendpoint_test.go
+++ b/pkg/liqoctl/install/utils/apiserverendpoint_test.go
@@ -1,0 +1,107 @@
+package installutils
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/types"
+	"k8s.io/client-go/rest"
+)
+
+var _ = Describe("Test API Server Endpoint", func() {
+
+	type checkEndpointTestcase struct {
+		endpoint       string
+		config         *rest.Config
+		expectedOutput types.GomegaMatcher
+	}
+
+	DescribeTable("CheckEndpoint table",
+		func(c checkEndpointTestcase) {
+			res, err := CheckEndpoint(c.endpoint, c.config)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(res).To(c.expectedOutput)
+		},
+
+		Entry("protocol and no port, equal", checkEndpointTestcase{
+			endpoint: "https://example.com",
+			config: &rest.Config{
+				Host: "https://example.com",
+			},
+			expectedOutput: BeTrue(),
+		}),
+
+		Entry("protocol and no port, not equal", checkEndpointTestcase{
+			endpoint: "https://example.com",
+			config: &rest.Config{
+				Host: "https://example2.com",
+			},
+			expectedOutput: BeFalse(),
+		}),
+
+		Entry("protocol and port, equal", checkEndpointTestcase{
+			endpoint: "https://example.com:1234",
+			config: &rest.Config{
+				Host: "https://example.com:1234",
+			},
+			expectedOutput: BeTrue(),
+		}),
+
+		Entry("protocol and port, not equal", checkEndpointTestcase{
+			endpoint: "https://example.com:1234",
+			config: &rest.Config{
+				Host: "https://example2.com:1234",
+			},
+			expectedOutput: BeFalse(),
+		}),
+
+		Entry("protocol and port, not equal (different port)", checkEndpointTestcase{
+			endpoint: "https://example.com:1234",
+			config: &rest.Config{
+				Host: "https://example.com:123",
+			},
+			expectedOutput: BeFalse(),
+		}),
+
+		Entry("protocol and port, not equal (different port)", checkEndpointTestcase{
+			endpoint: "https://example.com:1234",
+			config: &rest.Config{
+				Host: "https://example.com",
+			},
+			expectedOutput: BeFalse(),
+		}),
+
+		Entry("protocol and port, equal", checkEndpointTestcase{
+			endpoint: "https://example.com:443",
+			config: &rest.Config{
+				Host: "https://example.com",
+			},
+			expectedOutput: BeTrue(),
+		}),
+
+		Entry("no protocol and port, equal", checkEndpointTestcase{
+			endpoint: "example.com:443",
+			config: &rest.Config{
+				Host: "example.com",
+			},
+			expectedOutput: BeTrue(),
+		}),
+
+		Entry("no protocol and port, equal", checkEndpointTestcase{
+			endpoint: "example.com:443",
+			config: &rest.Config{
+				Host: "https://example.com",
+			},
+			expectedOutput: BeTrue(),
+		}),
+
+		Entry("no protocol and port, equal", checkEndpointTestcase{
+			endpoint: "example.com",
+			config: &rest.Config{
+				Host: "https://example.com:443",
+			},
+			expectedOutput: BeTrue(),
+		}),
+	)
+
+})


### PR DESCRIPTION
# Description

This pr adds the logic in liqoctl to check if the cluster retrieved from cloud providers is the same that is the target of the kubeconfig

# How Has This Been Tested?

- [x] add unit test
