### PR TITLE
Fix issue in init-virtual-kubelet

### DIFF
--- a/cmd/init-virtual-kubelet/main.go
+++ b/cmd/init-virtual-kubelet/main.go
@@ -69,7 +69,7 @@ func main() {
 	_, hasCertificate, err := csr.GetCSRSecret(ctx, client, nodeName, namespace)
 	if !apierrors.IsNotFound(err) && !hasCertificate {
 		if err != nil {
-			klog.Error(err)
+			klog.Fatal(err)
 		} else {
 			klog.Info("Certificate already present for this nodeName. Skipping")
 		}
@@ -88,8 +88,7 @@ func main() {
 	cancel()
 
 	if err != nil {
-		klog.Error("Unable to get certificate: %w", err)
-		return
+		klog.Fatalf("Unable to get certificate: %w", err)
 	}
 
 	if err := csr.StoreCertificate(ctx, client, cert, namespace, nodeName); err != nil {

--- a/cmd/liqo-controller-manager/main.go
+++ b/cmd/liqo-controller-manager/main.go
@@ -81,6 +81,7 @@ func main() {
 	var enableLeaderElection bool
 	var enablePanic bool
 	var liqoNamespace, kubeletImage, initKubeletImage string
+	var disableKubeletCertGeneration bool
 	var resyncPeriod int64
 	var offloadingStatusControllerRequeueTime int64
 	var offerUpdateThreshold uint64
@@ -108,6 +109,9 @@ func main() {
 	flag.StringVar(&initKubeletImage,
 		"init-kubelet-image", defaultInitVKImage,
 		"The image of the virtual kubelet init container to be deployed")
+	flag.BoolVar(&disableKubeletCertGeneration,
+		"disable-kubelet-certificate-generation", false,
+		"Whether to disable the virtual kubelet certificate generation by means of an init container (used for logs/exec capabilities)")
 
 	klog.InitFlags(nil)
 	flag.Parse()
@@ -189,7 +193,7 @@ func main() {
 	}
 
 	resourceOfferReconciler := resourceoffercontroller.NewResourceOfferController(
-		mgr, clusterID, time.Duration(resyncPeriod), kubeletImage, initKubeletImage, liqoNamespace)
+		mgr, clusterID, time.Duration(resyncPeriod), kubeletImage, initKubeletImage, liqoNamespace, disableKubeletCertGeneration)
 	if err = resourceOfferReconciler.SetupWithManager(mgr); err != nil {
 		klog.Fatal(err)
 	}

--- a/pkg/liqo-controller-manager/resourceoffer-controller/controller_config.go
+++ b/pkg/liqo-controller-manager/resourceoffer-controller/controller_config.go
@@ -6,13 +6,15 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	"github.com/liqotech/liqo/pkg/clusterid"
+	"github.com/liqotech/liqo/pkg/vkMachinery/forge"
 )
 
 // NewResourceOfferController creates and returns a new reconciler for the ResourceOffers.
 func NewResourceOfferController(
 	mgr manager.Manager, clusterID clusterid.ClusterID,
 	resyncPeriod time.Duration, virtualKubeletImage,
-	initVirtualKubeletImage, liqoNamespace string) *ResourceOfferReconciler {
+	initVirtualKubeletImage, liqoNamespace string,
+	disableKubeletCertGeneration bool) *ResourceOfferReconciler {
 	return &ResourceOfferReconciler{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
@@ -22,8 +24,11 @@ func NewResourceOfferController(
 
 		liqoNamespace: liqoNamespace,
 
-		virtualKubeletImage:     virtualKubeletImage,
-		initVirtualKubeletImage: initVirtualKubeletImage,
+		virtualKubeletOpts: forge.VirtualKubeletOpts{
+			ContainerImage:        virtualKubeletImage,
+			InitContainerImage:    initVirtualKubeletImage,
+			DisableCertGeneration: disableKubeletCertGeneration,
+		},
 
 		resyncPeriod: resyncPeriod,
 	}

--- a/pkg/liqo-controller-manager/resourceoffer-controller/resourceoffer_controller.go
+++ b/pkg/liqo-controller-manager/resourceoffer-controller/resourceoffer_controller.go
@@ -45,6 +45,7 @@ import (
 	crdreplicator "github.com/liqotech/liqo/internal/crdReplicator"
 	"github.com/liqotech/liqo/pkg/clusterid"
 	"github.com/liqotech/liqo/pkg/vkMachinery"
+	"github.com/liqotech/liqo/pkg/vkMachinery/forge"
 )
 
 const resourceOfferAnnotation = "liqo.io/resourceoffer"
@@ -59,8 +60,7 @@ type ResourceOfferReconciler struct {
 
 	liqoNamespace string
 
-	virtualKubeletImage     string
-	initVirtualKubeletImage string
+	virtualKubeletOpts forge.VirtualKubeletOpts
 
 	resyncPeriod       time.Duration
 	configuration      *configv1alpha1.ClusterConfig

--- a/pkg/liqo-controller-manager/resourceoffer-controller/resourceoffer_controller_methods.go
+++ b/pkg/liqo-controller-manager/resourceoffer-controller/resourceoffer_controller_methods.go
@@ -139,8 +139,8 @@ func (r *ResourceOfferReconciler) createVirtualKubeletDeployment(
 
 	// forge the virtual Kubelet
 	vkDeployment, err := forge.VirtualKubeletDeployment(
-		remoteClusterID, name, namespace, r.liqoNamespace, r.virtualKubeletImage,
-		r.initVirtualKubeletImage, nodeName, r.clusterID.GetClusterID())
+		remoteClusterID, name, namespace, r.liqoNamespace,
+		nodeName, r.clusterID.GetClusterID(), r.virtualKubeletOpts)
 	if err != nil {
 		klog.Error(err)
 		return err

--- a/pkg/liqo-controller-manager/resourceoffer-controller/resourceoffer_controller_test.go
+++ b/pkg/liqo-controller-manager/resourceoffer-controller/resourceoffer_controller_test.go
@@ -91,7 +91,7 @@ var _ = Describe("ResourceOffer Controller", func() {
 
 		clusterID := clusterid.NewStaticClusterID("remote-id")
 
-		controller = NewResourceOfferController(mgr, clusterID, 10*time.Second, virtualKubeletImage, initVirtualKubeletImage, testNamespace)
+		controller = NewResourceOfferController(mgr, clusterID, 10*time.Second, virtualKubeletImage, initVirtualKubeletImage, testNamespace, false)
 		if err := controller.SetupWithManager(mgr); err != nil {
 			By(err.Error())
 			os.Exit(1)

--- a/pkg/liqoctl/install/eks/provider.go
+++ b/pkg/liqoctl/install/eks/provider.go
@@ -149,6 +149,11 @@ func (k *eksProvider) UpdateChartValues(values map[string]interface{}) {
 			"clusterLabels": installutils.GetInterfaceMap(k.clusterLabels),
 		},
 	}
+	values["controllerManager"] = map[string]interface{}{
+		"pod": map[string]interface{}{
+			"extraArgs": []interface{}{"--disable-kubelet-certificate-generation=true"},
+		},
+	}
 }
 
 // GenerateFlags generates the set of specific subpath and flags are accepted for a specific provider.

--- a/pkg/vkMachinery/csr/secret.go
+++ b/pkg/vkMachinery/csr/secret.go
@@ -22,7 +22,6 @@ func GetCSRSecret(ctx context.Context,
 	clientset kubernetes.Interface, nodeName, namespace string) (secret *v1.Secret, hasCertificate bool, err error) {
 	secret, err = clientset.CoreV1().Secrets(namespace).Get(ctx, nodeName, metav1.GetOptions{})
 	if err != nil {
-		klog.Error(err)
 		return nil, false, err
 	}
 

--- a/pkg/vkMachinery/csr/watcher.go
+++ b/pkg/vkMachinery/csr/watcher.go
@@ -140,7 +140,7 @@ func (r Watcher) RetrieveCertificate(ctx context.Context, csrName string) ([]byt
 	defer r.UnregisterHandlerForName(csrName)
 
 	// Check if the certificate is already approved, in case this occurred before we registered the handler.
-	if obj, err := r.Get(csrName); err != nil {
+	if obj, err := r.Get(csrName); err == nil {
 		handler(obj)
 	}
 

--- a/pkg/vkMachinery/forge/creation.go
+++ b/pkg/vkMachinery/forge/creation.go
@@ -11,8 +11,8 @@ import (
 )
 
 // VirtualKubeletDeployment forges the deployment for a virtual-kubelet.
-func VirtualKubeletDeployment(remoteClusterID,
-	vkName, vkNamespace, liqoNamespace, vkImage, initVKImage, nodeName, homeClusterID string) (*appsv1.Deployment, error) {
+func VirtualKubeletDeployment(remoteClusterID, vkName, vkNamespace, liqoNamespace,
+	nodeName, homeClusterID string, opts VirtualKubeletOpts) (*appsv1.Deployment, error) {
 	vkLabels := VirtualKubeletLabels(remoteClusterID)
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -29,7 +29,7 @@ func VirtualKubeletDeployment(remoteClusterID,
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: vkLabels,
 				},
-				Spec: forgeVKPodSpec(vkName, vkNamespace, liqoNamespace, homeClusterID, remoteClusterID, initVKImage, nodeName, vkImage),
+				Spec: forgeVKPodSpec(vkName, vkNamespace, liqoNamespace, homeClusterID, remoteClusterID, nodeName, opts),
 			},
 		},
 	}, nil

--- a/pkg/vkMachinery/forge/forge.go
+++ b/pkg/vkMachinery/forge/forge.go
@@ -47,12 +47,16 @@ func forgeVKVolumes() []v1.Volume {
 	return volumes
 }
 
-func forgeVKInitContainers(nodeName, initVKImage string) []v1.Container {
+func forgeVKInitContainers(nodeName string, opts VirtualKubeletOpts) []v1.Container {
+	if opts.DisableCertGeneration {
+		return []v1.Container{}
+	}
+
 	return []v1.Container{
 		{
 			Resources: forgeVKResources(),
 			Name:      "crt-generator",
-			Image:     initVKImage,
+			Image:     opts.InitContainerImage,
 			Command: []string{
 				"/usr/bin/init-virtual-kubelet",
 			},
@@ -149,11 +153,11 @@ func forgeVKContainers(
 
 func forgeVKPodSpec(
 	vkName, vkNamespace, liqoNamespace, homeClusterID string,
-	remoteClusterID, initVKImage, nodeName, vkImage string) v1.PodSpec {
+	remoteClusterID, nodeName string, opts VirtualKubeletOpts) v1.PodSpec {
 	return v1.PodSpec{
 		Volumes:        forgeVKVolumes(),
-		InitContainers: forgeVKInitContainers(nodeName, initVKImage),
-		Containers: forgeVKContainers(vkImage, remoteClusterID,
+		InitContainers: forgeVKInitContainers(nodeName, opts),
+		Containers: forgeVKContainers(opts.ContainerImage, remoteClusterID,
 			nodeName, vkNamespace, liqoNamespace, homeClusterID),
 		ServiceAccountName: vkName,
 		Affinity:           forgeVKAffinity(),

--- a/pkg/vkMachinery/forge/type.go
+++ b/pkg/vkMachinery/forge/type.go
@@ -1,0 +1,12 @@
+package forge
+
+// VirtualKubeletOpts defines the custom options associated with the virtual kubelet deployment forging.
+type VirtualKubeletOpts struct {
+	// ContainerImage contains the virtual kubelet image name and tag.
+	ContainerImage string
+	// InitContainerImage contains the virtual kubelet init-container image name and tag.
+	InitContainerImage string
+	// DisableCertGeneration allows to disable the virtual kubelet certificate generation by means
+	// of the init container (used for logs/exec capabilities).
+	DisableCertGeneration bool
+}


### PR DESCRIPTION
# Description

This PR fixes an issue in the CSR watching logic, which caused the init-virtual-kubelet code to take longer than expected to complete. Additionally, it introduces a flag in the controller manager to disable the creation of the init container, which is set when installed on EKS (as currently not working).

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Unit testing (existing + ad hoc)
- [x] E2E testing
- [X] Manual testing to ensure correct init-container configuration
