### PR TITLE
Liqoctl Add Cluster Labels

### DIFF
--- a/pkg/consts/clusterlabels.go
+++ b/pkg/consts/clusterlabels.go
@@ -1,0 +1,8 @@
+package consts
+
+const (
+	// ProviderClusterLabel is the cluster label used to indicate the cluster provider.
+	ProviderClusterLabel = "liqo.io/provider"
+	// TopologyRegionClusterLabel is the cluster label used to indicate the cluster region.
+	TopologyRegionClusterLabel = "topology.kubernetes.io/region"
+)

--- a/pkg/liqoctl/install/aks/aks_test.go
+++ b/pkg/liqoctl/install/aks/aks_test.go
@@ -9,6 +9,8 @@ import (
 	. "github.com/onsi/gomega"
 	flag "github.com/spf13/pflag"
 	"k8s.io/utils/pointer"
+
+	"github.com/liqotech/liqo/pkg/consts"
 )
 
 func TestFetchingParameters(t *testing.T) {
@@ -24,6 +26,8 @@ const (
 	subscriptionID    = "subID"
 	resourceGroupName = "test"
 	resourceName      = "liqo"
+
+	region = "region"
 )
 
 var _ = Describe("Extract elements from AKS", func() {
@@ -52,6 +56,7 @@ var _ = Describe("Extract elements from AKS", func() {
 		ctx := context.TODO()
 
 		clusterOutput := &containerservice.ManagedCluster{
+			Location: pointer.StringPtr(region),
 			ManagedClusterProperties: &containerservice.ManagedClusterProperties{
 				Fqdn: pointer.StringPtr(endpoint),
 				NetworkProfile: &containerservice.NetworkProfile{
@@ -76,6 +81,9 @@ var _ = Describe("Extract elements from AKS", func() {
 		Expect(p.podCIDR).To(Equal(podCIDR))
 		Expect(len(p.reservedSubnets)).To(BeNumerically("==", 1))
 		Expect(p.reservedSubnets).To(ContainElement(defaultAksNodeCIDR))
+		Expect(p.clusterLabels).ToNot(BeEmpty())
+		Expect(p.clusterLabels[consts.ProviderClusterLabel]).To(Equal(providerPrefix))
+		Expect(p.clusterLabels[consts.TopologyRegionClusterLabel]).To(Equal(region))
 
 	})
 

--- a/pkg/liqoctl/install/eks/cluster.go
+++ b/pkg/liqoctl/install/eks/cluster.go
@@ -7,6 +7,8 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/eks"
+
+	"github.com/liqotech/liqo/pkg/consts"
 )
 
 // getClusterInfo retrieved information from the EKS cluster.
@@ -62,6 +64,8 @@ func (k *eksProvider) parseClusterOutput(describeClusterResult *eks.DescribeClus
 		err := fmt.Errorf("the EKS cluster %v in region %v does not have a valid VPC ID", k.clusterName, k.region)
 		return "", err
 	}
+
+	k.clusterLabels[consts.TopologyRegionClusterLabel] = k.region
 
 	return *describeClusterResult.Cluster.ResourcesVpcConfig.VpcId, nil
 }

--- a/pkg/liqoctl/install/eks/eks_test.go
+++ b/pkg/liqoctl/install/eks/eks_test.go
@@ -9,6 +9,8 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	flag "github.com/spf13/pflag"
+
+	"github.com/liqotech/liqo/pkg/consts"
 )
 
 func TestFetchingParameters(t *testing.T) {
@@ -68,6 +70,7 @@ var _ = Describe("Extract elements from EKS", func() {
 		}
 
 		p := NewProvider().(*eksProvider)
+		p.region = region
 
 		resVpcID, err := p.parseClusterOutput(clusterOutput)
 		Expect(err).To(Succeed())
@@ -75,6 +78,9 @@ var _ = Describe("Extract elements from EKS", func() {
 
 		Expect(p.endpoint).To(Equal(endpoint))
 		Expect(p.serviceCIDR).To(Equal(serviceCIDR))
+		Expect(p.clusterLabels).ToNot(BeEmpty())
+		Expect(p.clusterLabels[consts.ProviderClusterLabel]).To(Equal(providerPrefix))
+		Expect(p.clusterLabels[consts.TopologyRegionClusterLabel]).To(Equal(region))
 
 		vpcOutput := &ec2.DescribeVpcsOutput{
 			Vpcs: []*ec2.Vpc{

--- a/pkg/liqoctl/install/eks/provider.go
+++ b/pkg/liqoctl/install/eks/provider.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
 
+	"github.com/liqotech/liqo/pkg/consts"
 	"github.com/liqotech/liqo/pkg/liqoctl/install/provider"
 	installutils "github.com/liqotech/liqo/pkg/liqoctl/install/utils"
 )
@@ -25,7 +26,8 @@ type eksProvider struct {
 	serviceCIDR string
 	podCIDR     string
 
-	iamLiqoUser iamLiqoUser
+	iamLiqoUser   iamLiqoUser
+	clusterLabels map[string]string
 }
 
 type iamLiqoUser struct {
@@ -38,7 +40,11 @@ type iamLiqoUser struct {
 
 // NewProvider initializes a new EKS provider struct.
 func NewProvider() provider.InstallProviderInterface {
-	return &eksProvider{}
+	return &eksProvider{
+		clusterLabels: map[string]string{
+			consts.ProviderClusterLabel: providerPrefix,
+		},
+	}
 }
 
 // ValidateCommandArguments validates specific arguments passed to the install command.
@@ -137,6 +143,11 @@ func (k *eksProvider) UpdateChartValues(values map[string]interface{}) {
 		"secretAccessKey": k.iamLiqoUser.secretAccessKey,
 		"region":          k.region,
 		"clusterName":     k.clusterName,
+	}
+	values["discovery"] = map[string]interface{}{
+		"config": map[string]interface{}{
+			"clusterLabels": installutils.GetInterfaceMap(k.clusterLabels),
+		},
 	}
 }
 

--- a/pkg/liqoctl/install/gke/gke_test.go
+++ b/pkg/liqoctl/install/gke/gke_test.go
@@ -7,6 +7,8 @@ import (
 	. "github.com/onsi/gomega"
 	flag "github.com/spf13/pflag"
 	"google.golang.org/api/container/v1"
+
+	"github.com/liqotech/liqo/pkg/consts"
 )
 
 func TestFetchingParameters(t *testing.T) {
@@ -55,6 +57,7 @@ var _ = Describe("Extract elements from GKE", func() {
 			Endpoint:         endpoint,
 			ServicesIpv4Cidr: serviceCIDR,
 			ClusterIpv4Cidr:  podCIDR,
+			Location:         zone,
 		}
 
 		p := NewProvider().(*gkeProvider)
@@ -64,6 +67,10 @@ var _ = Describe("Extract elements from GKE", func() {
 		Expect(p.endpoint).To(Equal(endpoint))
 		Expect(p.serviceCIDR).To(Equal(serviceCIDR))
 		Expect(p.podCIDR).To(Equal(podCIDR))
+
+		Expect(p.clusterLabels).ToNot(BeEmpty())
+		Expect(p.clusterLabels[consts.ProviderClusterLabel]).To(Equal(providerPrefix))
+		Expect(p.clusterLabels[consts.TopologyRegionClusterLabel]).To(Equal(zone))
 
 	})
 

--- a/pkg/liqoctl/install/k3s/k3s_test.go
+++ b/pkg/liqoctl/install/k3s/k3s_test.go
@@ -48,6 +48,9 @@ var _ = Describe("Extract elements from K3S", func() {
 		Expect(p.serviceCIDR).To(Equal(serviceCIDR))
 		Expect(p.apiServer).To(Equal(apiServer))
 
+		Expect(p.clusterLabels).ToNot(BeEmpty())
+		Expect(p.clusterLabels[consts.ProviderClusterLabel]).To(Equal(providerPrefix))
+
 	})
 
 	Context("test api server validation", func() {

--- a/pkg/liqoctl/install/k3s/provider.go
+++ b/pkg/liqoctl/install/k3s/provider.go
@@ -39,11 +39,17 @@ type k3sProvider struct {
 	apiServer   string
 	serviceCIDR string
 	podCIDR     string
+
+	clusterLabels map[string]string
 }
 
 // NewProvider initializes a new K3S provider struct.
 func NewProvider() provider.InstallProviderInterface {
-	return &k3sProvider{}
+	return &k3sProvider{
+		clusterLabels: map[string]string{
+			consts.ProviderClusterLabel: providerPrefix,
+		},
+	}
 }
 
 // ValidateCommandArguments validates specific arguments passed to the install command.
@@ -111,6 +117,11 @@ func (k *k3sProvider) UpdateChartValues(values map[string]interface{}) {
 		"config": map[string]interface{}{
 			"serviceCIDR": k.serviceCIDR,
 			"podCIDR":     k.podCIDR,
+		},
+	}
+	values["discovery"] = map[string]interface{}{
+		"config": map[string]interface{}{
+			"clusterLabels": installutils.GetInterfaceMap(k.clusterLabels),
 		},
 	}
 }

--- a/pkg/liqoctl/install/kind/provider.go
+++ b/pkg/liqoctl/install/kind/provider.go
@@ -2,6 +2,7 @@ package kind
 
 import (
 	"github.com/liqotech/liqo/pkg/liqoctl/install/provider"
+	installutils "github.com/liqotech/liqo/pkg/liqoctl/install/utils"
 )
 
 // NewProvider initializes a new Kind struct.
@@ -29,6 +30,11 @@ func (k *Kind) UpdateChartValues(values map[string]interface{}) {
 		"config": map[string]interface{}{
 			"serviceCIDR": k.ServiceCIDR,
 			"podCIDR":     k.PodCIDR,
+		},
+	}
+	values["discovery"] = map[string]interface{}{
+		"config": map[string]interface{}{
+			"clusterLabels": installutils.GetInterfaceMap(k.ClusterLabels),
 		},
 	}
 }

--- a/pkg/liqoctl/install/kubeadm/provider.go
+++ b/pkg/liqoctl/install/kubeadm/provider.go
@@ -8,12 +8,18 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 
+	"github.com/liqotech/liqo/pkg/consts"
 	"github.com/liqotech/liqo/pkg/liqoctl/install/provider"
+	installutils "github.com/liqotech/liqo/pkg/liqoctl/install/utils"
 )
 
 // NewProvider initializes a new Kubeadm struct.
 func NewProvider() provider.InstallProviderInterface {
-	return &Kubeadm{}
+	return &Kubeadm{
+		ClusterLabels: map[string]string{
+			consts.ProviderClusterLabel: providerPrefix,
+		},
+	}
 }
 
 // ValidateCommandArguments validates specific arguments passed to the install command.
@@ -50,6 +56,11 @@ func (k *Kubeadm) UpdateChartValues(values map[string]interface{}) {
 		"config": map[string]interface{}{
 			"serviceCIDR": k.ServiceCIDR,
 			"podCIDR":     k.PodCIDR,
+		},
+	}
+	values["discovery"] = map[string]interface{}{
+		"config": map[string]interface{}{
+			"clusterLabels": installutils.GetInterfaceMap(k.ClusterLabels),
 		},
 	}
 }

--- a/pkg/liqoctl/install/kubeadm/types.go
+++ b/pkg/liqoctl/install/kubeadm/types.go
@@ -17,9 +17,10 @@ var kubeControllerManagerLabels = map[string]string{"component": "kube-controlle
 // Kubeadm contains the parameters required to install Liqo on a kubeadm cluster and a dedicated client to fetch
 // those values.
 type Kubeadm struct {
-	APIServer   string
-	Config      *rest.Config
-	PodCIDR     string
-	ServiceCIDR string
-	K8sClient   kubernetes.Interface
+	APIServer     string
+	Config        *rest.Config
+	PodCIDR       string
+	ServiceCIDR   string
+	K8sClient     kubernetes.Interface
+	ClusterLabels map[string]string
 }

--- a/pkg/liqoctl/install/utils/slice.go
+++ b/pkg/liqoctl/install/utils/slice.go
@@ -8,3 +8,12 @@ func GetInterfaceSlice(in []string) []interface{} {
 	}
 	return out
 }
+
+// GetInterfaceMap casts a map of [string]string to a map of [string]interface{}.
+func GetInterfaceMap(in map[string]string) map[string]interface{} {
+	out := make(map[string]interface{}, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}


### PR DESCRIPTION
# Description

This pr adds a simple logic to add some cluster labels to the `liqoctl` installed clusters.

It adds the `liqo.io/provider` label with the provider name as value, and (on managed clusters, i.e. AKS, EKS, GKE) it adds the `topology.kubernetes.io/zone` and the `topology.kubernetes.io/region` basing on the cluster zone/region retrieved from the cloud provider APIs. In that way, the virtual node is now compliant with the [topology keys](https://kubernetes.io/docs/concepts/services-networking/service-topology/) and with the [topology aware hints](https://kubernetes.io/docs/concepts/services-networking/topology-aware-hints/) labeling system.