### PR TITLE
ResourceRequest: prevent race condition

### DIFF
--- a/internal/discovery/foreign-cluster-operator/auth.go
+++ b/internal/discovery/foreign-cluster-operator/auth.go
@@ -127,7 +127,7 @@ func sendIdentityRequest(request auth.IdentityRequest, fc *discoveryv1alpha1.For
 		klog.Error(err)
 		return nil, err
 	}
-	klog.V(4).Infof("[%v] Sending json request: %v", fc.Spec.ClusterIdentity.ClusterID, string(jsonRequest))
+	klog.V(8).Infof("[%v] Sending json request: %v", fc.Spec.ClusterIdentity.ClusterID, string(jsonRequest))
 
 	resp, err := sendRequest(
 		fmt.Sprintf("%s%s", fc.Spec.ForeignAuthURL, request.GetPath()),

--- a/pkg/liqo-controller-manager/resource-request-controller/resourceRequestPhase.go
+++ b/pkg/liqo-controller-manager/resource-request-controller/resourceRequestPhase.go
@@ -1,10 +1,6 @@
 package resourcerequestoperator
 
 import (
-	"context"
-
-	"k8s.io/klog/v2"
-
 	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
 	foreignclusterutils "github.com/liqotech/liqo/pkg/utils/foreignCluster"
 )
@@ -17,20 +13,15 @@ const (
 	deletingResourceRequestPhase resourceRequestPhase = "Deleting"
 )
 
-// getResourceRequestPhase returns the resourceRequestPhase of a resource request. It is:
-// * "Deleting" if the deleteion timestamp is set or the related offer has been withdrawn.
-// * "Allow" if the incoming peering is enabled for ForeignCluster o by the ClusterConfig.
+// getResourceRequestPhase returns the phase associated with a resource request. It is:
+// * "Deleting" if the deletion timestamp is set or the related offer has been withdrawn.
+// * "Allow" if the incoming peering is enabled in the ForeignCluster or by the ClusterConfig.
 // * "Deny" in the other cases (no ForeignCluster, incoming peering disabled, ...)
-func (r *ResourceRequestReconciler) getResourceRequestPhase(ctx context.Context,
+func (r *ResourceRequestReconciler) getResourceRequestPhase(
+	foreignCluster *discoveryv1alpha1.ForeignCluster,
 	resourceRequest *discoveryv1alpha1.ResourceRequest) (resourceRequestPhase, error) {
 	if !resourceRequest.GetDeletionTimestamp().IsZero() || !resourceRequest.Spec.WithdrawalTimestamp.IsZero() {
 		return deletingResourceRequestPhase, nil
-	}
-
-	foreignCluster, err := foreignclusterutils.GetForeignClusterByID(ctx, r.Client, resourceRequest.Spec.ClusterIdentity.ClusterID)
-	if err != nil {
-		klog.Error(err)
-		return denyResourceRequestPhase, err
 	}
 
 	if foreignclusterutils.AllowIncomingPeering(foreignCluster, r.Broadcaster.GetConfig()) {

--- a/pkg/liqo-controller-manager/resource-request-controller/resourceRequestPhase_test.go
+++ b/pkg/liqo-controller-manager/resource-request-controller/resourceRequestPhase_test.go
@@ -59,16 +59,9 @@ var _ = Describe("Resource Phase", func() {
 					},
 				}
 
-				Expect(controller.Create(ctx, foreignCluster)).To(Succeed())
-
-				// this eventually fixes a cache race condition
-				Eventually(func() resourceRequestPhase {
-					phase, err := controller.getResourceRequestPhase(ctx, c.resourceRequest)
-					Expect(err).ToNot(HaveOccurred())
-					return phase
-				}, timeout, interval).Should(c.expectedResult)
-
-				Expect(controller.Delete(ctx, foreignCluster)).To(Succeed())
+				phase, err := controller.getResourceRequestPhase(foreignCluster, c.resourceRequest)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(phase).To(c.expectedResult)
 			},
 
 			Entry("deleted resource request", getResourceRequestPhaseTestcase{

--- a/pkg/liqo-controller-manager/resource-request-controller/utils_test.go
+++ b/pkg/liqo-controller-manager/resource-request-controller/utils_test.go
@@ -1,0 +1,90 @@
+package resourcerequestoperator
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
+)
+
+var _ = Describe("Utility functions", func() {
+
+	Describe("The ensureControllerReference function", func() {
+		var (
+			r ResourceRequestReconciler
+
+			foreignCluster  discoveryv1alpha1.ForeignCluster
+			resourceRequest discoveryv1alpha1.ResourceRequest
+
+			update bool
+			err    error
+		)
+
+		BeforeEach(func() {
+			r = ResourceRequestReconciler{Scheme: scheme.Scheme}
+			foreignCluster = discoveryv1alpha1.ForeignCluster{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: discoveryv1alpha1.GroupVersion.String(),
+					Kind:       "ForeignCluster",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "foreign-cluster",
+					UID:  "8a402261-9cf4-402e-89e8-4d743fb315fb",
+				},
+			}
+			resourceRequest = discoveryv1alpha1.ResourceRequest{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: discoveryv1alpha1.GroupVersion.String(),
+					Kind:       "ResourceRequest",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "resource-request",
+					Namespace: "foo",
+				},
+			}
+		})
+
+		JustBeforeEach(func() {
+			update, err = r.ensureControllerReference(&foreignCluster, &resourceRequest)
+		})
+
+		When("The resource request has not a controller reference", func() {
+			It("Should not return an error", func() { Expect(err).NotTo(HaveOccurred()) })
+			It("Should return that an update is needed", func() { Expect(update).To(BeTrue()) })
+			It("Should set the correct controller reference", func() {
+				Expect(metav1.GetControllerOf(&resourceRequest).Kind).To(Equal(foreignCluster.Kind))
+				Expect(metav1.GetControllerOf(&resourceRequest).APIVersion).To(Equal(foreignCluster.APIVersion))
+				Expect(metav1.GetControllerOf(&resourceRequest).Name).To(Equal(foreignCluster.GetName()))
+				Expect(metav1.GetControllerOf(&resourceRequest).UID).To(Equal(foreignCluster.GetUID()))
+			})
+		})
+
+		When("The resource request has already a controller reference", func() {
+			var controller discoveryv1alpha1.ForeignCluster
+
+			BeforeEach(func() {
+				controller = discoveryv1alpha1.ForeignCluster{
+					TypeMeta: foreignCluster.TypeMeta,
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "foreign-cluster-controller",
+						UID:  "1d392296-3798-47d2-8e8d-73dc3f65ffc8",
+					},
+				}
+
+				Expect(controllerutil.SetControllerReference(&controller, &resourceRequest, r.Scheme)).To(Succeed())
+			})
+
+			It("Should not return an error", func() { Expect(err).NotTo(HaveOccurred()) })
+			It("Should return that an update is not needed", func() { Expect(update).To(BeFalse()) })
+			It("Should not modify the controller reference", func() {
+				Expect(metav1.GetControllerOf(&resourceRequest).Kind).To(Equal(controller.Kind))
+				Expect(metav1.GetControllerOf(&resourceRequest).APIVersion).To(Equal(controller.APIVersion))
+				Expect(metav1.GetControllerOf(&resourceRequest).Name).To(Equal(controller.GetName()))
+				Expect(metav1.GetControllerOf(&resourceRequest).UID).To(Equal(controller.GetUID()))
+			})
+		})
+	})
+})


### PR DESCRIPTION
# Description

This PR fixes a race condition in the resource request controller, which could cause the failure to retrieve a foreign cluster just created (during an incoming peering), missing at the same time the configuration of the appropriate controller reference. Additionally, it makes the controller reference configuration idempotent.


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Unit testing (existing + new)
- [x] E2E testing (existing)
