### PR TITLE
Add Extra Annotation and Labels on Virtual Kubelet and Virtual Node

### DIFF
--- a/cmd/virtual-kubelet/root/flag.go
+++ b/cmd/virtual-kubelet/root/flag.go
@@ -44,6 +44,9 @@ func InstallFlags(flags *pflag.FlagSet, c *Opts) {
 		"connect to in order to contact the IPAM module")
 	flags.BoolVar(&c.Profiling, "enable-profiling", c.Profiling, "Enable pprof profiling")
 
+	flags.Var(&c.NodeExtraAnnotations, "node-extra-annotations", "Extra annotations to add to the Virtual Node")
+	flags.Var(&c.NodeExtraLabels, "node-extra-labels", "Extra labels to add to the Virtual Node")
+
 	flagset := flag.NewFlagSet("klog", flag.PanicOnError)
 	klog.InitFlags(flagset)
 	flagset.VisitAll(func(f *flag.Flag) {

--- a/cmd/virtual-kubelet/root/opts.go
+++ b/cmd/virtual-kubelet/root/opts.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/liqotech/liqo/pkg/consts"
+	argsutils "github.com/liqotech/liqo/pkg/utils/args"
 )
 
 // Defaults for root command options.
@@ -82,6 +83,9 @@ type Opts struct {
 
 	Version   string
 	Profiling bool
+
+	NodeExtraAnnotations argsutils.StringMap
+	NodeExtraLabels      argsutils.StringMap
 }
 
 // SetDefaultOpts sets default options for unset values on the passed in option struct.

--- a/cmd/virtual-kubelet/root/root.go
+++ b/cmd/virtual-kubelet/root/root.go
@@ -143,7 +143,8 @@ func runRootCommand(ctx context.Context, s *provider.Store, c *Opts) error {
 
 	var nodeRunner *node.NodeController
 
-	pNode, err := NodeFromProvider(ctx, c.NodeName, p, c.Version, []metav1.OwnerReference{})
+	pNode, err := NodeFromProvider(ctx, c.NodeName, p, c.Version, []metav1.OwnerReference{},
+		c.NodeExtraAnnotations.StringMap, c.NodeExtraLabels.StringMap)
 	if err != nil {
 		klog.Fatal(err)
 	}

--- a/deployments/liqo/README.md
+++ b/deployments/liqo/README.md
@@ -68,8 +68,13 @@
 | route.pod.extraArgs | list | `[]` | route pod extra arguments |
 | route.pod.labels | object | `{}` | route pod labels |
 | tag | string | `""` | Images' tag to select a development version of liqo instead of a release |
+| virtualKubelet.extra.annotations | object | `{}` | virtual kubelet pod extra annotations |
+| virtualKubelet.extra.args | list | `[]` | virtual kubelet pod extra arguments |
+| virtualKubelet.extra.labels | object | `{}` | virtual kubelet pod extra labels |
 | virtualKubelet.imageName | string | `"liqo/virtual-kubelet"` | virtual kubelet image repository |
 | virtualKubelet.initContainer.imageName | string | `"liqo/init-virtual-kubelet"` | virtual kubelet init container image repository |
+| virtualKubelet.virtualNode.extra.annotations | object | `{}` | virtual node extra annotations |
+| virtualKubelet.virtualNode.extra.labels | object | `{}` | virtual node extra labels |
 | webhook.imageName | string | `"liqo/liqo-webhook"` | webhook image repository |
 | webhook.initContainer.imageName | string | `"liqo/webhook-configuration"` | webhook init container image repository |
 | webhook.mutatingWebhookConfiguration.annotations | object | `{}` | mutatingWebhookConfiguration annotations |

--- a/deployments/liqo/templates/_helpers.tpl
+++ b/deployments/liqo/templates/_helpers.tpl
@@ -140,3 +140,25 @@ Pre-delete hook Annotations
 "helm.sh/hook-weight": "-5"
 "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 {{- end }}
+
+{{/*
+Concatenates a values dictionary into a string in the form "--commandName=key1=val1,key2=val2"
+*/}}
+{{- define "liqo.concatenateMap" -}}
+{{- $res := print .commandName "=" -}}
+{{- range $key, $val := .dictionary -}}
+{{- $res = print $res $key "=" $val "," -}}
+{{- end -}}
+- {{ trimSuffix "," $res }}
+{{- end -}}
+
+{{/*
+Concatenates a values list into a string in the form "--commandName=val1,val2"
+*/}}
+{{- define "liqo.concatenateList" -}}
+{{- $res := print .commandName "=" -}}
+{{- range $val := .list -}}
+{{- $res = print $res $val "," -}}
+{{- end -}}
+- {{ trimSuffix "," $res }}
+{{- end -}}

--- a/deployments/liqo/templates/liqo-controller-manager.yaml
+++ b/deployments/liqo/templates/liqo-controller-manager.yaml
@@ -35,6 +35,26 @@ spec:
           - --liqo-namespace=$(POD_NAMESPACE)
           - --kubelet-image={{ .Values.virtualKubelet.imageName }}{{ include "liqo.suffix" $ctrlManagerConfig }}:{{ include "liqo.version" $ctrlManagerConfig }}
           - --init-kubelet-image={{ .Values.virtualKubelet.initContainer.imageName }}{{ include "liqo.suffix" $ctrlManagerConfig }}:{{ include "liqo.version" $ctrlManagerConfig }}
+          {{- if .Values.virtualKubelet.extra.annotations }}
+          {{- $d := dict "commandName" "--kubelet-extra-annotations" "dictionary" .Values.virtualKubelet.extra.annotations }}
+          {{- include "liqo.concatenateMap" $d | nindent 10 }}
+          {{- end }}
+          {{- if .Values.virtualKubelet.extra.labels }}
+          {{- $d := dict "commandName" "--kubelet-extra-labels" "dictionary" .Values.virtualKubelet.extra.labels }}
+          {{- include "liqo.concatenateMap" $d | nindent 10 }}
+          {{- end }}
+          {{- if .Values.virtualKubelet.extra.args }}
+          {{- $d := dict "commandName" "--kubelet-extra-args" "list" .Values.virtualKubelet.extra.args }}
+          {{- include "liqo.concatenateList" $d | nindent 10 }}
+          {{- end }}
+          {{- if .Values.virtualKubelet.virtualNode.extra.annotations }}
+          {{- $d := dict "commandName" "--node-extra-annotations" "dictionary" .Values.virtualKubelet.virtualNode.extra.annotations }}
+          {{- include "liqo.concatenateMap" $d | nindent 10 }}
+          {{- end }}
+          {{- if .Values.virtualKubelet.virtualNode.extra.labels }}
+          {{- $d := dict "commandName" "--node-extra-labels" "dictionary" .Values.virtualKubelet.virtualNode.extra.labels }}
+          {{- include "liqo.concatenateMap" $d | nindent 10 }}
+          {{- end }}
           {{- if .Values.controllerManager.pod.extraArgs }}
           {{- toYaml .Values.controllerManager.pod.extraArgs | nindent 10 }}
           {{- end }}

--- a/deployments/liqo/values.yaml
+++ b/deployments/liqo/values.yaml
@@ -184,6 +184,20 @@ virtualKubelet:
   initContainer:
     # -- virtual kubelet init container image repository
     imageName: "liqo/init-virtual-kubelet"
+  # add additional values for this fields to add to virtual kubelet deployments and pods
+  extra:
+    # -- virtual kubelet pod extra annotations
+    annotations: {}
+    # -- virtual kubelet pod extra labels
+    labels: {}
+    # -- virtual kubelet pod extra arguments
+    args: []
+  virtualNode:
+    extra:
+      # -- virtual node extra annotations
+      annotations: {}
+      # -- virtual node extra labels
+      labels: {}
 
 # -- liqo name override
 nameOverride: ""

--- a/docs/pages/installation/chart_values.md
+++ b/docs/pages/installation/chart_values.md
@@ -73,8 +73,13 @@ weight: 5
 | route.pod.extraArgs | list | `[]` | route pod extra arguments |
 | route.pod.labels | object | `{}` | route pod labels |
 | tag | string | `""` | Images' tag to select a development version of liqo instead of a release |
+| virtualKubelet.extra.annotations | object | `{}` | virtual kubelet pod extra annotations |
+| virtualKubelet.extra.args | list | `[]` | virtual kubelet pod extra arguments |
+| virtualKubelet.extra.labels | object | `{}` | virtual kubelet pod extra labels |
 | virtualKubelet.imageName | string | `"liqo/virtual-kubelet"` | virtual kubelet image repository |
 | virtualKubelet.initContainer.imageName | string | `"liqo/init-virtual-kubelet"` | virtual kubelet init container image repository |
+| virtualKubelet.virtualNode.extra.annotations | object | `{}` | virtual node extra annotations |
+| virtualKubelet.virtualNode.extra.labels | object | `{}` | virtual node extra labels |
 | webhook.imageName | string | `"liqo/liqo-webhook"` | webhook image repository |
 | webhook.initContainer.imageName | string | `"liqo/webhook-configuration"` | webhook init container image repository |
 | webhook.mutatingWebhookConfiguration.annotations | object | `{}` | mutatingWebhookConfiguration annotations |

--- a/pkg/liqo-controller-manager/resourceoffer-controller/controller_config.go
+++ b/pkg/liqo-controller-manager/resourceoffer-controller/controller_config.go
@@ -12,9 +12,8 @@ import (
 // NewResourceOfferController creates and returns a new reconciler for the ResourceOffers.
 func NewResourceOfferController(
 	mgr manager.Manager, clusterID clusterid.ClusterID,
-	resyncPeriod time.Duration, virtualKubeletImage,
-	initVirtualKubeletImage, liqoNamespace string,
-	disableKubeletCertGeneration bool) *ResourceOfferReconciler {
+	resyncPeriod time.Duration, liqoNamespace string,
+	virtualKubeletOpts *forge.VirtualKubeletOpts) *ResourceOfferReconciler {
 	return &ResourceOfferReconciler{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
@@ -24,11 +23,7 @@ func NewResourceOfferController(
 
 		liqoNamespace: liqoNamespace,
 
-		virtualKubeletOpts: forge.VirtualKubeletOpts{
-			ContainerImage:        virtualKubeletImage,
-			InitContainerImage:    initVirtualKubeletImage,
-			DisableCertGeneration: disableKubeletCertGeneration,
-		},
+		virtualKubeletOpts: virtualKubeletOpts,
 
 		resyncPeriod: resyncPeriod,
 	}

--- a/pkg/liqo-controller-manager/resourceoffer-controller/resourceoffer_controller.go
+++ b/pkg/liqo-controller-manager/resourceoffer-controller/resourceoffer_controller.go
@@ -60,7 +60,7 @@ type ResourceOfferReconciler struct {
 
 	liqoNamespace string
 
-	virtualKubeletOpts forge.VirtualKubeletOpts
+	virtualKubeletOpts *forge.VirtualKubeletOpts
 
 	resyncPeriod       time.Duration
 	configuration      *configv1alpha1.ClusterConfig

--- a/pkg/liqo-controller-manager/resourceoffer-controller/resourceoffer_controller_methods.go
+++ b/pkg/liqo-controller-manager/resourceoffer-controller/resourceoffer_controller_methods.go
@@ -148,6 +148,9 @@ func (r *ResourceOfferReconciler) createVirtualKubeletDeployment(
 
 	op, err = controllerutil.CreateOrUpdate(ctx, r.Client, vkDeployment, func() error {
 		// set the "owner" object name in the annotation to be able to reconcile deployment changes
+		if vkDeployment.Annotations == nil {
+			vkDeployment.Annotations = map[string]string{}
+		}
 		vkDeployment.Annotations[resourceOfferAnnotation] = resourceOffer.GetName()
 		return nil
 	})
@@ -208,7 +211,7 @@ func (r *ResourceOfferReconciler) deleteClusterRoleBinding(
 func (r *ResourceOfferReconciler) getVirtualKubeletDeployment(
 	ctx context.Context, resourceOffer *sharingv1alpha1.ResourceOffer) (*appsv1.Deployment, error) {
 	var deployList appsv1.DeploymentList
-	labels := forge.VirtualKubeletLabels(resourceOffer.Spec.ClusterId)
+	labels := forge.VirtualKubeletLabels(resourceOffer.Spec.ClusterId, r.virtualKubeletOpts)
 	if err := r.Client.List(ctx, &deployList, client.MatchingLabels(labels)); err != nil {
 		klog.Error(err)
 		return nil, err

--- a/pkg/liqo-controller-manager/resourceoffer-controller/resourceoffer_controller_test.go
+++ b/pkg/liqo-controller-manager/resourceoffer-controller/resourceoffer_controller_test.go
@@ -91,7 +91,12 @@ var _ = Describe("ResourceOffer Controller", func() {
 
 		clusterID := clusterid.NewStaticClusterID("remote-id")
 
-		controller = NewResourceOfferController(mgr, clusterID, 10*time.Second, virtualKubeletImage, initVirtualKubeletImage, testNamespace, false)
+		kubeletOpts := &forge.VirtualKubeletOpts{
+			ContainerImage:     virtualKubeletImage,
+			InitContainerImage: initVirtualKubeletImage,
+		}
+
+		controller = NewResourceOfferController(mgr, clusterID, 10*time.Second, testNamespace, kubeletOpts)
 		if err := controller.SetupWithManager(mgr); err != nil {
 			By(err.Error())
 			os.Exit(1)

--- a/pkg/liqoctl/install/aks/provider.go
+++ b/pkg/liqoctl/install/aks/provider.go
@@ -137,6 +137,15 @@ func (k *aksProvider) UpdateChartValues(values map[string]interface{}) {
 			"clusterLabels": installutils.GetInterfaceMap(k.clusterLabels),
 		},
 	}
+	values["virtualKubelet"] = map[string]interface{}{
+		"virtualNode": map[string]interface{}{
+			"extra": map[string]interface{}{
+				"labels": map[string]interface{}{
+					"kubernetes.azure.com/managed": "false",
+				},
+			},
+		},
+	}
 }
 
 // GenerateFlags generates the set of specific subpath and flags are accepted for a specific provider.

--- a/pkg/utils/args/args_test.go
+++ b/pkg/utils/args/args_test.go
@@ -1,0 +1,109 @@
+package args
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+)
+
+func TestParseArguments(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "ParseArguments Suite")
+}
+
+var _ = Describe("ParseArguments", func() {
+
+	Context("StringMap", func() {
+
+		type parseMapTestcase struct {
+			str           string
+			expectedError OmegaMatcher
+			expectedMap   map[string]string
+		}
+
+		DescribeTable("StringMap table",
+
+			func(c parseMapTestcase) {
+				sm := StringMap{}
+				err := sm.Set(c.str)
+				Expect(err).To(c.expectedError)
+				Expect(sm.StringMap).To(Equal(c.expectedMap))
+				if err == nil {
+					Expect(sm.String()).To(Equal(c.str))
+				}
+			},
+
+			Entry("empty string", parseMapTestcase{
+				str:           "",
+				expectedError: Not(HaveOccurred()),
+				expectedMap:   map[string]string{},
+			}),
+
+			Entry("single value map", parseMapTestcase{
+				str:           "key1=val1",
+				expectedError: Not(HaveOccurred()),
+				expectedMap: map[string]string{
+					"key1": "val1",
+				},
+			}),
+
+			Entry("multi values map", parseMapTestcase{
+				str:           "key1=val1,key2=val2",
+				expectedError: Not(HaveOccurred()),
+				expectedMap: map[string]string{
+					"key1": "val1",
+					"key2": "val2",
+				},
+			}),
+
+			Entry("invalid map", parseMapTestcase{
+				str:           "key1,key2=val2",
+				expectedError: HaveOccurred(),
+				expectedMap:   map[string]string{},
+			}),
+		)
+
+	})
+
+	Context("StringList", func() {
+
+		type parseListTestcase struct {
+			str          string
+			expectedList []string
+		}
+
+		DescribeTable("StringList table",
+
+			func(c parseListTestcase) {
+				sl := StringList{}
+				Expect(sl.Set(c.str)).To(Succeed())
+				Expect(sl.StringList).To(Equal(c.expectedList))
+				Expect(sl.String()).To(Equal(c.str))
+			},
+
+			Entry("empty string", parseListTestcase{
+				str:          "",
+				expectedList: []string{},
+			}),
+
+			Entry("single value list", parseListTestcase{
+				str: "val1",
+				expectedList: []string{
+					"val1",
+				},
+			}),
+
+			Entry("multi values list", parseListTestcase{
+				str: "val1,val2",
+				expectedList: []string{
+					"val1",
+					"val2",
+				},
+			}),
+		)
+
+	})
+
+})

--- a/pkg/utils/args/doc.go
+++ b/pkg/utils/args/doc.go
@@ -1,0 +1,3 @@
+// Package args contains shared utility methods for
+// argument parsing and validation.
+package args

--- a/pkg/utils/args/stringlist.go
+++ b/pkg/utils/args/stringlist.go
@@ -1,0 +1,40 @@
+package args
+
+import (
+	"strings"
+)
+
+// StringList implements the flag.Value interface and allows to parse stringified lists
+// in the form: "val1,val2".
+type StringList struct {
+	StringList []string
+}
+
+// String returns the stringified list.
+func (sl StringList) String() string {
+	if sl.StringList == nil {
+		return ""
+	}
+	return strings.Join(sl.StringList, ",")
+}
+
+// Set parses the provided string into the []string list.
+func (sl *StringList) Set(str string) error {
+	if sl.StringList == nil {
+		sl.StringList = []string{}
+	}
+	if str == "" {
+		return nil
+	}
+	chunks := strings.Split(str, ",")
+	for i := range chunks {
+		chunk := chunks[i]
+		sl.StringList = append(sl.StringList, chunk)
+	}
+	return nil
+}
+
+// Type returns the stringList type.
+func (sl StringList) Type() string {
+	return "stringList"
+}

--- a/pkg/utils/args/stringmap.go
+++ b/pkg/utils/args/stringmap.go
@@ -1,0 +1,52 @@
+package args
+
+import (
+	"fmt"
+	"strings"
+)
+
+// StringMap implements the flag.Value interface and allows to parse stringified maps
+// in the form: "key1=val1,key2=val2".
+type StringMap struct {
+	StringMap map[string]string
+}
+
+// String returns the stringified map.
+func (sm StringMap) String() string {
+	if sm.StringMap == nil {
+		return ""
+	}
+
+	strs := make([]string, len(sm.StringMap))
+	i := 0
+	for k, v := range sm.StringMap {
+		strs[i] = fmt.Sprintf("%s=%s", k, v)
+		i++
+	}
+	return strings.Join(strs, ",")
+}
+
+// Set parses the provided string into the map[string]string map.
+func (sm *StringMap) Set(str string) error {
+	if sm.StringMap == nil {
+		sm.StringMap = map[string]string{}
+	}
+	if str == "" {
+		return nil
+	}
+	chunks := strings.Split(str, ",")
+	for i := range chunks {
+		chunk := chunks[i]
+		strs := strings.Split(chunk, "=")
+		if len(strs) != 2 {
+			return fmt.Errorf("invalid value %v", chunk)
+		}
+		sm.StringMap[strs[0]] = strs[1]
+	}
+	return nil
+}
+
+// Type returns the stringMap type.
+func (sm StringMap) Type() string {
+	return "stringMap"
+}

--- a/pkg/vkMachinery/forge/type.go
+++ b/pkg/vkMachinery/forge/type.go
@@ -1,5 +1,9 @@
 package forge
 
+import (
+	argsutils "github.com/liqotech/liqo/pkg/utils/args"
+)
+
 // VirtualKubeletOpts defines the custom options associated with the virtual kubelet deployment forging.
 type VirtualKubeletOpts struct {
 	// ContainerImage contains the virtual kubelet image name and tag.
@@ -9,4 +13,9 @@ type VirtualKubeletOpts struct {
 	// DisableCertGeneration allows to disable the virtual kubelet certificate generation by means
 	// of the init container (used for logs/exec capabilities).
 	DisableCertGeneration bool
+	ExtraAnnotations      map[string]string
+	ExtraLabels           map[string]string
+	ExtraArgs             []string
+	NodeExtraAnnotations  argsutils.StringMap
+	NodeExtraLabels       argsutils.StringMap
 }


### PR DESCRIPTION
# Description

This pr adds the possibility to add additional fields for the Virtual Kubelets and the Virtual Nodes in the helm values file, in particular:

* additional extra annotation on Virtual Kubelet Deployment/Pod
* additional extra labels on Virtual Kubelet Deployment/Pod
* additional extra arguments on Virtual Kubelet Deployment/Pod
* additional extra annotations on Virtual Node
* additional extra labels on Virtual Node

Now `liqoctl` adds the `kubernetes.azure.com/managed=false` label on the Virtual Nodes when deploying on Azure, allowing these nodes to not be reconciled by the Azure controllers and avoiding conflicts.

# How Has This Been Tested?

- [x] add unit test
- [x] locally on KinD
- [x] on AKS clusters
