### PR TITLE
Move Liqoctl Providers to Subcommands

### DIFF
--- a/cmd/liqoctl/cmd/install.go
+++ b/cmd/liqoctl/cmd/install.go
@@ -2,12 +2,10 @@ package cmd
 
 import (
 	"context"
-	"os"
 
 	"github.com/spf13/cobra"
 	"k8s.io/klog/v2"
 
-	"github.com/liqotech/liqo/pkg/liqoctl/install"
 	installutils "github.com/liqotech/liqo/pkg/liqoctl/install/utils"
 )
 
@@ -17,33 +15,30 @@ func newInstallCommand(ctx context.Context) *cobra.Command {
 		Use:   installutils.LiqoctlInstallCommand,
 		Short: installutils.LiqoctlInstallShortHelp,
 		Long:  installutils.LiqoctlInstallLongHelp,
-		Run: func(cmd *cobra.Command, args []string) {
-			install.HandleInstallCommand(ctx, cmd, os.Args[0])
-		},
 	}
 
-	installCmd.Flags().StringP("provider", "p", "kubeadm", "Select the cluster provider type")
-	installCmd.Flags().IntP("timeout", "t", 600, "Configure the timeout for the installation process in seconds")
-	installCmd.Flags().StringP("version", "", "", "Select the Liqo version (default: latest stable release)")
-	installCmd.Flags().BoolP("devel", "", false,
+	installCmd.PersistentFlags().IntP("timeout", "t", 600, "Configure the timeout for the installation process in seconds")
+	installCmd.PersistentFlags().StringP("version", "", "", "Select the Liqo version (default: latest stable release)")
+	installCmd.PersistentFlags().BoolP("devel", "", false,
 		"Enable use development versions, too. Equivalent to version '>0.0.0-0'. If --version is set, this is ignored")
-	installCmd.Flags().BoolP("only-output-values", "", false, "Generate a values file for further customization")
-	installCmd.Flags().StringP("dump-values-path", "", "./values.yaml", "Path for the output value file")
-	installCmd.Flags().BoolP("dry-run", "", false, "Simulate an install")
-	installCmd.Flags().BoolP("enable-lan-discovery", "", true, "Enable LAN discovery")
-	installCmd.Flags().StringP("cluster-labels", "", "",
+	installCmd.PersistentFlags().BoolP("only-output-values", "", false, "Generate a values file for further customization")
+	installCmd.PersistentFlags().StringP("dump-values-path", "", "./values.yaml", "Path for the output value file")
+	installCmd.PersistentFlags().BoolP("dry-run", "", false, "Simulate an install")
+	installCmd.PersistentFlags().BoolP("enable-lan-discovery", "", true, "Enable LAN discovery")
+	installCmd.PersistentFlags().StringP("cluster-labels", "", "",
 		"Cluster Labels to append to Liqo Cluster, supports '='.(e.g. --cluster-labels key1=value1,key2=value2)")
-	installCmd.Flags().BoolP("disable-endpoint-check", "", false,
+	installCmd.PersistentFlags().BoolP("disable-endpoint-check", "", false,
 		"Disable the check that the current kubeconfig context contains the same endpoint retrieved from the cloud provider (AKS, EKS, GKE)")
-	installCmd.Flags().String("chart-path", installutils.LiqoChartFullName,
+	installCmd.PersistentFlags().String("chart-path", installutils.LiqoChartFullName,
 		"Specify a path to get the Liqo chart, instead of installing the chart from the official repository")
 
-	for _, p := range providers {
-		initFunc, ok := providerInitFunc[p]
-		if !ok {
-			klog.Fatalf("unknown provider: %v", p)
+	for _, providerName := range providers {
+		cmd, err := getCommand(ctx, providerName)
+		if err != nil {
+			klog.Fatal(err)
 		}
-		initFunc(installCmd.Flags())
+
+		installCmd.AddCommand(cmd)
 	}
 	return installCmd
 }

--- a/cmd/liqoctl/cmd/providers.go
+++ b/cmd/liqoctl/cmd/providers.go
@@ -1,8 +1,13 @@
 package cmd
 
 import (
-	flag "github.com/spf13/pflag"
+	"context"
+	"fmt"
+	"os"
 
+	"github.com/spf13/cobra"
+
+	"github.com/liqotech/liqo/pkg/liqoctl/install"
 	"github.com/liqotech/liqo/pkg/liqoctl/install/aks"
 	"github.com/liqotech/liqo/pkg/liqoctl/install/eks"
 	"github.com/liqotech/liqo/pkg/liqoctl/install/gke"
@@ -10,13 +15,38 @@ import (
 	"github.com/liqotech/liqo/pkg/liqoctl/install/kubeadm"
 )
 
+const (
+	installShortHelp = "Install Liqo on a selected %s cluster"
+	installLongHelp  = "Install Liqo on a selected %s cluster"
+)
+
 var providers = []string{"kubeadm", "k3s", "eks", "gke", "aks"}
 
-var providerInitFunc = map[string]func(*flag.FlagSet){
+var providerInitFunc = map[string]func(*cobra.Command){
 	"kubeadm": kubeadm.GenerateFlags,
 	"kind":    kubeadm.GenerateFlags,
 	"k3s":     k3s.GenerateFlags,
 	"eks":     eks.GenerateFlags,
 	"gke":     gke.GenerateFlags,
 	"aks":     aks.GenerateFlags,
+}
+
+func getCommand(ctx context.Context, provider string) (*cobra.Command, error) {
+	cmd := &cobra.Command{
+		Use:   provider,
+		Short: fmt.Sprintf(installShortHelp, provider),
+		Long:  fmt.Sprintf(installLongHelp, provider),
+		Run: func(cmd *cobra.Command, args []string) {
+			install.HandleInstallCommand(ctx, cmd, os.Args[0], provider)
+		},
+	}
+
+	initFunc, ok := providerInitFunc[provider]
+	if !ok {
+		return nil, fmt.Errorf("initFunc not found for provider %s not found", provider)
+	}
+
+	initFunc(cmd)
+
+	return cmd, nil
 }

--- a/pkg/liqoctl/install/aks/aks_test.go
+++ b/pkg/liqoctl/install/aks/aks_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2021-07-01/containerservice"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	flag "github.com/spf13/pflag"
+	"github.com/spf13/cobra"
 	"k8s.io/utils/pointer"
 
 	"github.com/liqotech/liqo/pkg/consts"
@@ -36,13 +36,14 @@ var _ = Describe("Extract elements from AKS", func() {
 
 		p := NewProvider().(*aksProvider)
 
-		flags := flag.NewFlagSet("test", flag.PanicOnError)
+		cmd := &cobra.Command{}
 
-		GenerateFlags(flags)
+		GenerateFlags(cmd)
 
-		Expect(flags.Set("aks.subscription-id", subscriptionID)).To(Succeed())
-		Expect(flags.Set("aks.resource-group-name", resourceGroupName)).To(Succeed())
-		Expect(flags.Set("aks.resource-name", resourceName)).To(Succeed())
+		flags := cmd.Flags()
+		Expect(flags.Set("subscription-id", subscriptionID)).To(Succeed())
+		Expect(flags.Set("resource-group-name", resourceGroupName)).To(Succeed())
+		Expect(flags.Set("resource-name", resourceName)).To(Succeed())
 
 		Expect(p.ValidateCommandArguments(flags)).To(Succeed())
 

--- a/pkg/liqoctl/install/eks/eks_test.go
+++ b/pkg/liqoctl/install/eks/eks_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/eks"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	flag "github.com/spf13/pflag"
+	"github.com/spf13/cobra"
 
 	"github.com/liqotech/liqo/pkg/consts"
 )
@@ -37,14 +37,15 @@ var _ = Describe("Extract elements from EKS", func() {
 
 		p := NewProvider().(*eksProvider)
 
-		flags := flag.NewFlagSet("test", flag.PanicOnError)
+		cmd := &cobra.Command{}
 
-		GenerateFlags(flags)
+		GenerateFlags(cmd)
 
-		Expect(flags.Set("eks.region", region)).To(Succeed())
-		Expect(flags.Set("eks.cluster-name", clusterName)).To(Succeed())
-		Expect(flags.Set("eks.user-name", userName)).To(Succeed())
-		Expect(flags.Set("eks.policy-name", policyName)).To(Succeed())
+		flags := cmd.Flags()
+		Expect(flags.Set("region", region)).To(Succeed())
+		Expect(flags.Set("cluster-name", clusterName)).To(Succeed())
+		Expect(flags.Set("user-name", userName)).To(Succeed())
+		Expect(flags.Set("policy-name", policyName)).To(Succeed())
 
 		Expect(p.ValidateCommandArguments(flags)).To(Succeed())
 

--- a/pkg/liqoctl/install/gke/gke_test.go
+++ b/pkg/liqoctl/install/gke/gke_test.go
@@ -5,7 +5,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	flag "github.com/spf13/pflag"
+	"github.com/spf13/cobra"
 	"google.golang.org/api/container/v1"
 
 	"github.com/liqotech/liqo/pkg/consts"
@@ -33,14 +33,15 @@ var _ = Describe("Extract elements from GKE", func() {
 
 		p := NewProvider().(*gkeProvider)
 
-		flags := flag.NewFlagSet("test", flag.PanicOnError)
+		cmd := &cobra.Command{}
 
-		GenerateFlags(flags)
+		GenerateFlags(cmd)
 
-		Expect(flags.Set("gke.credentials-path", credentialsPath)).To(Succeed())
-		Expect(flags.Set("gke.project-id", projectID)).To(Succeed())
-		Expect(flags.Set("gke.zone", zone)).To(Succeed())
-		Expect(flags.Set("gke.cluster-id", clusterID)).To(Succeed())
+		flags := cmd.Flags()
+		Expect(flags.Set("credentials-path", credentialsPath)).To(Succeed())
+		Expect(flags.Set("project-id", projectID)).To(Succeed())
+		Expect(flags.Set("zone", zone)).To(Succeed())
+		Expect(flags.Set("cluster-id", clusterID)).To(Succeed())
 
 		Expect(p.ValidateCommandArguments(flags)).To(Succeed())
 

--- a/pkg/liqoctl/install/handler.go
+++ b/pkg/liqoctl/install/handler.go
@@ -15,12 +15,8 @@ import (
 
 // HandleInstallCommand implements the "install" command. It detects which provider has to be used, generates the chart
 // with provider-specific values. Finally, it performs the installation on the target cluster.
-func HandleInstallCommand(ctx context.Context, cmd *cobra.Command, baseCommand string) {
+func HandleInstallCommand(ctx context.Context, cmd *cobra.Command, baseCommand, providerName string) {
 	config := common.GetLiqoctlRestConfOrDie()
-	providerName, err := cmd.Flags().GetString(providerFlag)
-	if err != nil {
-		return
-	}
 	providerInstance := getProviderInstance(providerName)
 
 	if providerInstance == nil {

--- a/pkg/liqoctl/install/k3s/k3s_test.go
+++ b/pkg/liqoctl/install/k3s/k3s_test.go
@@ -8,7 +8,7 @@ import (
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
-	flag "github.com/spf13/pflag"
+	"github.com/spf13/cobra"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -34,13 +34,14 @@ var _ = Describe("Extract elements from K3S", func() {
 
 		p := NewProvider().(*k3sProvider)
 
-		flags := flag.NewFlagSet("test", flag.PanicOnError)
+		cmd := &cobra.Command{}
 
-		GenerateFlags(flags)
+		GenerateFlags(cmd)
 
-		Expect(flags.Set("k3s.pod-cidr", podCIDR)).To(Succeed())
-		Expect(flags.Set("k3s.service-cidr", serviceCIDR)).To(Succeed())
-		Expect(flags.Set("k3s.api-server", apiServer)).To(Succeed())
+		flags := cmd.Flags()
+		Expect(flags.Set("pod-cidr", podCIDR)).To(Succeed())
+		Expect(flags.Set("service-cidr", serviceCIDR)).To(Succeed())
+		Expect(flags.Set("api-server", apiServer)).To(Succeed())
 
 		Expect(p.ValidateCommandArguments(flags)).To(Succeed())
 

--- a/pkg/liqoctl/install/kubeadm/provider.go
+++ b/pkg/liqoctl/install/kubeadm/provider.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/spf13/cobra"
 	flag "github.com/spf13/pflag"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -66,11 +67,5 @@ func (k *Kubeadm) UpdateChartValues(values map[string]interface{}) {
 }
 
 // GenerateFlags generates the set of specific subpath and flags are accepted for a specific provider.
-func GenerateFlags(flags *flag.FlagSet) {
-	subFlag := flag.NewFlagSet(providerPrefix, flag.ExitOnError)
-	subFlag.SetNormalizeFunc(func(f *flag.FlagSet, name string) flag.NormalizedName {
-		return flag.NormalizedName(providerPrefix + "." + name)
-	})
-
-	flags.AddFlagSet(subFlag)
+func GenerateFlags(command *cobra.Command) {
 }

--- a/pkg/liqoctl/install/utils/flags.go
+++ b/pkg/liqoctl/install/utils/flags.go
@@ -6,19 +6,14 @@ import (
 	flag "github.com/spf13/pflag"
 )
 
-// PrefixedName returns the paramenter name with the providerPrefix.
-func PrefixedName(providerPrefix, name string) string {
-	return fmt.Sprintf("%v.%v", providerPrefix, name)
-}
-
 // CheckStringFlagIsSet checks that a string flag is set and returns its value.
-func CheckStringFlagIsSet(flags *flag.FlagSet, providerPrefix, name string) (string, error) {
-	value, err := flags.GetString(PrefixedName(providerPrefix, name))
+func CheckStringFlagIsSet(flags *flag.FlagSet, name string) (string, error) {
+	value, err := flags.GetString(name)
 	if err != nil {
 		return "", err
 	}
 	if value == "" {
-		err := fmt.Errorf("--%v.%v not provided", providerPrefix, name)
+		err := fmt.Errorf("--%v not provided", name)
 		return "", err
 	}
 	return value, nil


### PR DESCRIPTION
# Description

This pr adds a new subcommand for each provider in the `liqoctl install` command.

* provider-specific flags no longer require a prefix
* the flags that are shown by the --help command ar enow specific to the provider
* automatic flag validation (by cobra)

# How Has This Been Tested?

- [x] locally