### PR TITLE
Improve Liqoctl Install Flags

### DIFF
--- a/cmd/liqoctl/cmd/add.go
+++ b/cmd/liqoctl/cmd/add.go
@@ -12,7 +12,9 @@ import (
 // installCmd represents the generateInstall command.
 func newAddCommand(ctx context.Context) *cobra.Command {
 	var addCmd = &cobra.Command{
-		Use: add.UseCommand,
+		Use:   add.UseCommand,
+		Short: add.LiqoctlAddShortHelp,
+		Long:  add.LiqoctlAddLongHelp,
 	}
 	addCmd.AddCommand(newAddClusterCommand(ctx))
 	return addCmd

--- a/cmd/liqoctl/cmd/install.go
+++ b/cmd/liqoctl/cmd/install.go
@@ -31,6 +31,14 @@ func newInstallCommand(ctx context.Context) *cobra.Command {
 		"Disable the check that the current kubeconfig context contains the same endpoint retrieved from the cloud provider (AKS, EKS, GKE)")
 	installCmd.PersistentFlags().String("chart-path", installutils.LiqoChartFullName,
 		"Specify a path to get the Liqo chart, instead of installing the chart from the official repository")
+	installCmd.PersistentFlags().String("cluster-name", "", "Name to assign to the Liqo Cluster")
+	installCmd.PersistentFlags().String("reserved-subnets", "", "In order to prevent IP conflicting between locally used private subnets in your "+
+		"infrastructure and private subnets belonging to remote clusters "+
+		"you need tell liqo the subnets used in your cluster. E.g if your cluster nodes belong to the 192.168.2.0/24 subnet then "+
+		"you should add that subnet to the reservedSubnets. PodCIDR and serviceCIDR used in the local cluster are automatically "+
+		"added to the reserved list. (e.g. --reserved-subnets 192.168.2.0/24,192.168.4.0/24)")
+	installCmd.PersistentFlags().String("resource-sharing-percentage", "90", "It defines the percentage of available cluster resources that "+
+		"you are willing to share with foreign clusters. It accepts [0 - 100] values.")
 
 	for _, providerName := range providers {
 		cmd, err := getCommand(ctx, providerName)

--- a/cmd/liqoctl/cmd/providers.go
+++ b/cmd/liqoctl/cmd/providers.go
@@ -20,7 +20,7 @@ const (
 	installLongHelp  = "Install Liqo on a selected %s cluster"
 )
 
-var providers = []string{"kubeadm", "k3s", "eks", "gke", "aks"}
+var providers = []string{"kubeadm", "kind", "k3s", "eks", "gke", "aks"}
 
 var providerInitFunc = map[string]func(*cobra.Command){
 	"kubeadm": kubeadm.GenerateFlags,

--- a/cmd/liqoctl/cmd/root.go
+++ b/cmd/liqoctl/cmd/root.go
@@ -19,11 +19,19 @@ func NewRootCommand(ctx context.Context) *cobra.Command {
 		Short: common.LiqoctlShortHelp,
 		Long:  common.LiqoctlLongHelp,
 	}
+
+	// since we cannot access internal klog configuration, we create a new flagset, let klog to install
+	// its flags, and we only keep the ones we are intrested in.
 	klogFlagset := flag.NewFlagSet("klog", flag.PanicOnError)
 	klog.InitFlags(klogFlagset)
+	klogFlagset.VisitAll(func(f *flag.Flag) {
+		if f.Name == "v" {
+			rootCmd.PersistentFlags().AddGoFlag(f)
+		}
+	})
+
 	rateFlagset := flag.NewFlagSet("rate-limiting", flag.PanicOnError)
 	restcfg.InitFlags(rateFlagset)
-	rootCmd.PersistentFlags().AddGoFlagSet(klogFlagset)
 	rootCmd.PersistentFlags().AddGoFlagSet(rateFlagset)
 	rootCmd.PersistentFlags().BoolP("debug", "d", false, "Enable/Disable debug mode (default: false)")
 	rootCmd.AddCommand(newInstallCommand(ctx))

--- a/pkg/liqoctl/generate/handler.go
+++ b/pkg/liqoctl/generate/handler.go
@@ -61,6 +61,12 @@ func processGenerateCommand(ctx context.Context, clientSet client.Client, liqoNa
 }
 
 func generateCommandString(commandName, authEP, clusterID, localToken, clusterName string) string {
+	// If the local cluster has not clusterName, we print the local clusterID to not leave this field empty.
+	// This can be changed bt the user when pasting this value in a remote cluster.
+	if clusterName == "" {
+		clusterName = clusterID
+	}
+
 	command := []string{commandName,
 		add.UseCommand,
 		add.ClusterResourceName,

--- a/pkg/liqoctl/install/aks/aks_test.go
+++ b/pkg/liqoctl/install/aks/aks_test.go
@@ -39,6 +39,8 @@ var _ = Describe("Extract elements from AKS", func() {
 		cmd := &cobra.Command{}
 
 		GenerateFlags(cmd)
+		cmd.Flags().String("cluster-name", "", "Name to assign to the Liqo Cluster")
+		cmd.Flags().String("reserved-subnets", "", "")
 
 		flags := cmd.Flags()
 		Expect(flags.Set("subscription-id", subscriptionID)).To(Succeed())
@@ -80,11 +82,11 @@ var _ = Describe("Extract elements from AKS", func() {
 		Expect(p.endpoint).To(Equal(endpoint))
 		Expect(p.serviceCIDR).To(Equal(serviceCIDR))
 		Expect(p.podCIDR).To(Equal(podCIDR))
-		Expect(len(p.reservedSubnets)).To(BeNumerically("==", 1))
-		Expect(p.reservedSubnets).To(ContainElement(defaultAksNodeCIDR))
-		Expect(p.clusterLabels).ToNot(BeEmpty())
-		Expect(p.clusterLabels[consts.ProviderClusterLabel]).To(Equal(providerPrefix))
-		Expect(p.clusterLabels[consts.TopologyRegionClusterLabel]).To(Equal(region))
+		Expect(len(p.ReservedSubnets)).To(BeNumerically("==", 1))
+		Expect(p.ReservedSubnets).To(ContainElement(defaultAksNodeCIDR))
+		Expect(p.ClusterLabels).ToNot(BeEmpty())
+		Expect(p.ClusterLabels[consts.ProviderClusterLabel]).To(Equal(providerPrefix))
+		Expect(p.ClusterLabels[consts.TopologyRegionClusterLabel]).To(Equal(region))
 
 	})
 

--- a/pkg/liqoctl/install/const.go
+++ b/pkg/liqoctl/install/const.go
@@ -1,7 +1,6 @@
 package install
 
 const (
-	providerFlag = "provider"
 	// LiqoctlInstallShortHelp contains the short help message for install Liqoctl command.
 	LiqoctlInstallShortHelp = "Install Liqo on a selected cluster"
 	// LiqoctlInstallLongHelp contains the long help message for install Liqoctl command.

--- a/pkg/liqoctl/install/eks/cluster.go
+++ b/pkg/liqoctl/install/eks/cluster.go
@@ -16,7 +16,7 @@ func (k *eksProvider) getClusterInfo(sess *session.Session) error {
 	eksSvc := eks.New(sess, aws.NewConfig().WithRegion(k.region))
 
 	describeCluster := &eks.DescribeClusterInput{
-		Name: aws.String(k.clusterName),
+		Name: aws.String(k.eksClusterName),
 	}
 
 	describeClusterResult, err := eksSvc.DescribeCluster(describeCluster)
@@ -49,23 +49,23 @@ func (k *eksProvider) getClusterInfo(sess *session.Session) error {
 
 func (k *eksProvider) parseClusterOutput(describeClusterResult *eks.DescribeClusterOutput) (vpcID string, err error) {
 	if describeClusterResult.Cluster.Endpoint == nil {
-		err := fmt.Errorf("the EKS cluster %v in region %v does not have a valid endpoint", k.clusterName, k.region)
+		err := fmt.Errorf("the EKS cluster %v in region %v does not have a valid endpoint", k.eksClusterName, k.region)
 		return "", err
 	}
 	k.endpoint = *describeClusterResult.Cluster.Endpoint
 
 	if describeClusterResult.Cluster.KubernetesNetworkConfig.ServiceIpv4Cidr == nil {
-		err := fmt.Errorf("the EKS cluster %v in region %v does not have a valid service CIDR", k.clusterName, k.region)
+		err := fmt.Errorf("the EKS cluster %v in region %v does not have a valid service CIDR", k.eksClusterName, k.region)
 		return "", err
 	}
 	k.serviceCIDR = *describeClusterResult.Cluster.KubernetesNetworkConfig.ServiceIpv4Cidr
 
 	if describeClusterResult.Cluster.ResourcesVpcConfig.VpcId == nil {
-		err := fmt.Errorf("the EKS cluster %v in region %v does not have a valid VPC ID", k.clusterName, k.region)
+		err := fmt.Errorf("the EKS cluster %v in region %v does not have a valid VPC ID", k.eksClusterName, k.region)
 		return "", err
 	}
 
-	k.clusterLabels[consts.TopologyRegionClusterLabel] = k.region
+	k.ClusterLabels[consts.TopologyRegionClusterLabel] = k.region
 
 	return *describeClusterResult.Cluster.ResourcesVpcConfig.VpcId, nil
 }

--- a/pkg/liqoctl/install/eks/eks_test.go
+++ b/pkg/liqoctl/install/eks/eks_test.go
@@ -40,17 +40,19 @@ var _ = Describe("Extract elements from EKS", func() {
 		cmd := &cobra.Command{}
 
 		GenerateFlags(cmd)
+		cmd.Flags().String("cluster-name", "", "Name to assign to the Liqo Cluster")
+		cmd.Flags().String("reserved-subnets", "", "")
 
 		flags := cmd.Flags()
 		Expect(flags.Set("region", region)).To(Succeed())
-		Expect(flags.Set("cluster-name", clusterName)).To(Succeed())
+		Expect(flags.Set("eks-cluster-name", clusterName)).To(Succeed())
 		Expect(flags.Set("user-name", userName)).To(Succeed())
 		Expect(flags.Set("policy-name", policyName)).To(Succeed())
 
 		Expect(p.ValidateCommandArguments(flags)).To(Succeed())
 
 		Expect(p.region).To(Equal(region))
-		Expect(p.clusterName).To(Equal(clusterName))
+		Expect(p.eksClusterName).To(Equal(clusterName))
 		Expect(p.iamLiqoUser.userName).To(Equal(userName))
 		Expect(p.iamLiqoUser.policyName).To(Equal(policyName))
 
@@ -79,9 +81,9 @@ var _ = Describe("Extract elements from EKS", func() {
 
 		Expect(p.endpoint).To(Equal(endpoint))
 		Expect(p.serviceCIDR).To(Equal(serviceCIDR))
-		Expect(p.clusterLabels).ToNot(BeEmpty())
-		Expect(p.clusterLabels[consts.ProviderClusterLabel]).To(Equal(providerPrefix))
-		Expect(p.clusterLabels[consts.TopologyRegionClusterLabel]).To(Equal(region))
+		Expect(p.ClusterLabels).ToNot(BeEmpty())
+		Expect(p.ClusterLabels[consts.ProviderClusterLabel]).To(Equal(providerPrefix))
+		Expect(p.ClusterLabels[consts.TopologyRegionClusterLabel]).To(Equal(region))
 
 		vpcOutput := &ec2.DescribeVpcsOutput{
 			Vpcs: []*ec2.Vpc{

--- a/pkg/liqoctl/install/gke/gke_test.go
+++ b/pkg/liqoctl/install/gke/gke_test.go
@@ -36,6 +36,8 @@ var _ = Describe("Extract elements from GKE", func() {
 		cmd := &cobra.Command{}
 
 		GenerateFlags(cmd)
+		cmd.Flags().String("cluster-name", "", "Name to assign to the Liqo Cluster")
+		cmd.Flags().String("reserved-subnets", "", "")
 
 		flags := cmd.Flags()
 		Expect(flags.Set("credentials-path", credentialsPath)).To(Succeed())
@@ -69,9 +71,9 @@ var _ = Describe("Extract elements from GKE", func() {
 		Expect(p.serviceCIDR).To(Equal(serviceCIDR))
 		Expect(p.podCIDR).To(Equal(podCIDR))
 
-		Expect(p.clusterLabels).ToNot(BeEmpty())
-		Expect(p.clusterLabels[consts.ProviderClusterLabel]).To(Equal(providerPrefix))
-		Expect(p.clusterLabels[consts.TopologyRegionClusterLabel]).To(Equal(zone))
+		Expect(p.ClusterLabels).ToNot(BeEmpty())
+		Expect(p.ClusterLabels[consts.ProviderClusterLabel]).To(Equal(providerPrefix))
+		Expect(p.ClusterLabels[consts.TopologyRegionClusterLabel]).To(Equal(zone))
 
 	})
 

--- a/pkg/liqoctl/install/handler.go
+++ b/pkg/liqoctl/install/handler.go
@@ -54,6 +54,8 @@ func HandleInstallCommand(ctx context.Context, cmd *cobra.Command, baseCommand, 
 		os.Exit(1)
 	}
 
-	// If the installation succeeded, let's print the add command to peer the target cluster with another one.
-	generate.HandleGenerateAddCommand(ctx, installutils.LiqoNamespace, baseCommand)
+	if !commonArgs.DumpValues && !commonArgs.DryRun {
+		// If the installation succeeded, let's print the add command to peer the target cluster with another one.
+		generate.HandleGenerateAddCommand(ctx, installutils.LiqoNamespace, baseCommand)
+	}
 }

--- a/pkg/liqoctl/install/k3s/k3s_test.go
+++ b/pkg/liqoctl/install/k3s/k3s_test.go
@@ -37,6 +37,8 @@ var _ = Describe("Extract elements from K3S", func() {
 		cmd := &cobra.Command{}
 
 		GenerateFlags(cmd)
+		cmd.Flags().String("cluster-name", "", "Name to assign to the Liqo Cluster")
+		cmd.Flags().String("reserved-subnets", "", "")
 
 		flags := cmd.Flags()
 		Expect(flags.Set("pod-cidr", podCIDR)).To(Succeed())
@@ -49,8 +51,8 @@ var _ = Describe("Extract elements from K3S", func() {
 		Expect(p.serviceCIDR).To(Equal(serviceCIDR))
 		Expect(p.apiServer).To(Equal(apiServer))
 
-		Expect(p.clusterLabels).ToNot(BeEmpty())
-		Expect(p.clusterLabels[consts.ProviderClusterLabel]).To(Equal(providerPrefix))
+		Expect(p.ClusterLabels).ToNot(BeEmpty())
+		Expect(p.ClusterLabels[consts.ProviderClusterLabel]).To(Equal(providerPrefix))
 
 	})
 

--- a/pkg/liqoctl/install/kind/provider.go
+++ b/pkg/liqoctl/install/kind/provider.go
@@ -28,13 +28,15 @@ func (k *Kind) UpdateChartValues(values map[string]interface{}) {
 	}
 	values["networkManager"] = map[string]interface{}{
 		"config": map[string]interface{}{
-			"serviceCIDR": k.ServiceCIDR,
-			"podCIDR":     k.PodCIDR,
+			"serviceCIDR":     k.ServiceCIDR,
+			"podCIDR":         k.PodCIDR,
+			"reservedSubnets": installutils.GetInterfaceSlice(k.ReservedSubnets),
 		},
 	}
 	values["discovery"] = map[string]interface{}{
 		"config": map[string]interface{}{
 			"clusterLabels": installutils.GetInterfaceMap(k.ClusterLabels),
+			"clusterName":   k.ClusterName,
 		},
 	}
 }

--- a/pkg/liqoctl/install/kubeadm/provider.go
+++ b/pkg/liqoctl/install/kubeadm/provider.go
@@ -17,15 +17,17 @@ import (
 // NewProvider initializes a new Kubeadm struct.
 func NewProvider() provider.InstallProviderInterface {
 	return &Kubeadm{
-		ClusterLabels: map[string]string{
-			consts.ProviderClusterLabel: providerPrefix,
+		GenericProvider: provider.GenericProvider{
+			ClusterLabels: map[string]string{
+				consts.ProviderClusterLabel: providerPrefix,
+			},
 		},
 	}
 }
 
 // ValidateCommandArguments validates specific arguments passed to the install command.
-func (k *Kubeadm) ValidateCommandArguments(flags *flag.FlagSet) error {
-	return nil
+func (k *Kubeadm) ValidateCommandArguments(flags *flag.FlagSet) (err error) {
+	return k.ValidateGenericCommandArguments(flags)
 }
 
 // ExtractChartParameters fetches the parameters used to customize the Liqo installation on a specific cluster of a
@@ -55,8 +57,9 @@ func (k *Kubeadm) UpdateChartValues(values map[string]interface{}) {
 	}
 	values["networkManager"] = map[string]interface{}{
 		"config": map[string]interface{}{
-			"serviceCIDR": k.ServiceCIDR,
-			"podCIDR":     k.PodCIDR,
+			"serviceCIDR":     k.ServiceCIDR,
+			"podCIDR":         k.PodCIDR,
+			"reservedSubnets": installutils.GetInterfaceSlice(k.ReservedSubnets),
 		},
 	}
 	values["discovery"] = map[string]interface{}{

--- a/pkg/liqoctl/install/kubeadm/types.go
+++ b/pkg/liqoctl/install/kubeadm/types.go
@@ -3,6 +3,8 @@ package kubeadm
 import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+
+	"github.com/liqotech/liqo/pkg/liqoctl/install/provider"
 )
 
 const (
@@ -17,10 +19,10 @@ var kubeControllerManagerLabels = map[string]string{"component": "kube-controlle
 // Kubeadm contains the parameters required to install Liqo on a kubeadm cluster and a dedicated client to fetch
 // those values.
 type Kubeadm struct {
-	APIServer     string
-	Config        *rest.Config
-	PodCIDR       string
-	ServiceCIDR   string
-	K8sClient     kubernetes.Interface
-	ClusterLabels map[string]string
+	provider.GenericProvider
+	APIServer   string
+	Config      *rest.Config
+	PodCIDR     string
+	ServiceCIDR string
+	K8sClient   kubernetes.Interface
 }

--- a/pkg/liqoctl/install/provider/generic.go
+++ b/pkg/liqoctl/install/provider/generic.go
@@ -1,0 +1,36 @@
+package provider
+
+import (
+	flag "github.com/spf13/pflag"
+
+	argsutils "github.com/liqotech/liqo/pkg/utils/args"
+)
+
+// GenericProvider includes the fields and the logic required by every install provider.
+type GenericProvider struct {
+	ReservedSubnets []string
+	ClusterLabels   map[string]string
+	ClusterName     string
+}
+
+// ValidateGenericCommandArguments validates the flags required by every install provider.
+func (p *GenericProvider) ValidateGenericCommandArguments(flags *flag.FlagSet) (err error) {
+	p.ClusterName, err = flags.GetString("cluster-name")
+	if err != nil {
+		return err
+	}
+
+	subnetString, err := flags.GetString("reserved-subnets")
+	if err != nil {
+		return err
+	}
+
+	reservedSubnets := argsutils.CIDRList{}
+	if err = reservedSubnets.Set(subnetString); err != nil {
+		return err
+	}
+
+	p.ReservedSubnets = reservedSubnets.StringList.StringList
+
+	return nil
+}

--- a/pkg/liqoctl/install/utils/map.go
+++ b/pkg/liqoctl/install/utils/map.go
@@ -24,8 +24,9 @@ func FusionMap(baseMap, patchMap map[string]interface{}) (map[string]interface{}
 
 		switch {
 		case reflect.TypeOf(v) != reflect.TypeOf(v2):
-			return nil, fmt.Errorf("the two maps have different types for the same key")
-		case reflect.TypeOf(v).String() == "string", reflect.TypeOf(v).String() == "bool", reflect.TypeOf(v).String() == "int":
+			return nil, fmt.Errorf("the two maps have different types for the same key %v %v", reflect.TypeOf(v), reflect.TypeOf(v2))
+		case reflect.TypeOf(v).String() == "string", reflect.TypeOf(v).String() == "bool",
+			reflect.TypeOf(v).String() == "int", reflect.TypeOf(v).String() == "float64":
 			resultMap[key] = v2
 		case reflect.TypeOf(v).Kind() == reflect.Slice:
 			resultMap[key] = append(v.([]interface{}), v2.([]interface{})...)

--- a/pkg/utils/args/cidrlist.go
+++ b/pkg/utils/args/cidrlist.go
@@ -1,0 +1,41 @@
+package args
+
+import (
+	"net"
+)
+
+// CIDRList implements the flag.Value interface and allows to parse stringified lists
+// in the form: "val1,val2".
+type CIDRList struct {
+	StringList StringList
+	CIDRList   []net.IPNet
+}
+
+// String returns the stringified list.
+func (cl *CIDRList) String() string {
+	return cl.StringList.String()
+}
+
+// Set parses the provided string into the []string list.
+func (cl *CIDRList) Set(str string) error {
+	if cl.CIDRList == nil {
+		cl.CIDRList = []net.IPNet{}
+	}
+	if err := cl.StringList.Set(str); err != nil {
+		return err
+	}
+
+	for _, cidr := range cl.StringList.StringList {
+		_, ipNet, err := net.ParseCIDR(cidr)
+		if err != nil {
+			return err
+		}
+		cl.CIDRList = append(cl.CIDRList, *ipNet)
+	}
+	return nil
+}
+
+// Type returns the cidrList type.
+func (cl CIDRList) Type() string {
+	return "cidrList"
+}

--- a/pkg/utils/args/percentage.go
+++ b/pkg/utils/args/percentage.go
@@ -1,0 +1,39 @@
+package args
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// Percentage implements the flag.Value interface and allows to parse stringified percentages.
+type Percentage struct {
+	Val uint64
+}
+
+// String returns the stringified percentage.
+func (p Percentage) String() string {
+	return fmt.Sprintf("%v", p.Val)
+}
+
+// Set parses the provided string into the percentage.
+func (p *Percentage) Set(str string) error {
+	if str == "" {
+		return nil
+	}
+	val, err := strconv.ParseUint(str, 10, 64)
+	if err != nil {
+		return err
+	}
+	p.Val = val
+
+	if p.Val > 100 {
+		return fmt.Errorf("invalid percentage value: %v. It has to be in range [0 - 100]", str)
+	}
+
+	return nil
+}
+
+// Type returns the percentage type.
+func (p Percentage) Type() string {
+	return "percentage"
+}


### PR DESCRIPTION
# Description

This pr includes several addition and improvements in the `liqoctl` flags. In particular:

* add `cluster-name` flag in the install command
* fix `name` in the generate add command
* disable `klog` flags, but `-v`
* extract cluster name from providers
* add reserved subnets flag
* add resource sharing percentage flag

# How Has This Been Tested?

- [x] add unit test
- [x] locally
