### PR TITLE
Update documentation and tutorial to liqoctl

### DIFF
--- a/docs/pages/_index.md
+++ b/docs/pages/_index.md
@@ -7,8 +7,7 @@ title: Liqo Docs
 
 # Documentation
 
-Liqo allows Kubernetes to seamlessly and securely share resources and services, enabling to run tasks on any other
-cluster available nearby.
+Liqo allows Kubernetes to seamlessly and securely share resources and services, enabling to run tasks on any other cluster available nearby.
 
 ## Why Liqo
 

--- a/docs/pages/gettingstarted/_index.md
+++ b/docs/pages/gettingstarted/_index.md
@@ -5,22 +5,24 @@ weight: 1
 
 ### Introduction
 
-Liqo enables the creation of arbitrary multi-cluster topologies, proposing a seamless multi-cluster model which dynamically allows the pods and services to be offloaded on remote clusters.
+Liqo enables the creation of arbitrary multi-cluster topologies, proposing a seamless multi-cluster model which dynamically allows the pods and services to offload on remote clusters.
 
-This section presents several tutorials that guide to the discovery and use of the most important features of Liqo.
+This section presents several tutorials that guide the discovery and use of the key Liqo features.
 
 #### System Requirements
 
-Before starting to run the following tutorials, you should have installed on your system:
+Before starting to run the following tutorials, you should have installed the following software on your system:
 
 * [**Docker**](https://docker.io), the container runtime.
-* [**Kubectl**](https://kubernetes.io/docs/tasks/tools/install-kubectl/), the command line tool for Kubernetes.
+* [**Kubectl**](https://kubernetes.io/docs/tasks/tools/install-kubectl/), the command-line tool for Kubernetes.
 * [**Helm**](https://helm.sh/docs/intro/install/), the package manager for Kubernetes.
-* **curl**, to interact with the cluster through HTTP/HTTPS. In Ubuntu it can be installed with `sudo apt update && sudo apt install -y curl`.
+* **curl**, to interact with the cluster through HTTP/HTTPS. In Ubuntu systems, you can install it via a simple `sudo apt update && sudo apt install -y curl`.
 
-The above tutorials have been tested on Linux, macOS, and Windows (through Docker Desktop).
+In addition, you should install the [**liqoctl**](/installation#liqoctl) command-line tool for Liqo. 
+
+The following tutorials were tested on Linux, macOS, and Windows (WSL2 and Docker Desktop).
 
 ### Tutorials
 
-* [Basic](./helloworld): a first _Hello World_-style tutorial to introduce basic Liqo features. In this tutorial, you will setup multiple clusters and establish the first peering among them.
-* [Advanced](./extended): a more in-depth _Dominate the world_-style tutorial showing how to use the most important features of Liqo.
+* [Basic](./helloworld): a first _Hello World_-style tutorial introducing the basic Liqo features. In this tutorial, you will set up multiple clusters and establish the first peering among them.
+* [Advanced](./extended): a more in-depth _Dominate the world_-style tutorial showing how to profit from Liqo advanced features.

--- a/docs/pages/gettingstarted/extended/dynamic_topology.md
+++ b/docs/pages/gettingstarted/extended/dynamic_topology.md
@@ -3,10 +3,11 @@ title: Dynamic topology
 weight: 8
 ---
 
-Liqo allows you to select dynamically the clusters eligible for a specific namespace. 
-If you have specified certain characteristics, all the clusters that match them will be automatically added as candidate to receive certain pods.
-Similarly, if one cluster leaves the topology, the workload will be redistributed among the remaining clusters, by destroying and recreating the pods elsewhere.
-If new clusters are peered or unpeered at runtime, you do not have to take care to configure the topology or terminate the offloading: Liqo ensures the convergence to the new set-up automatically. 
+In the previous section, you used and tested the Liqo namespace offloading mechanism and how it can prevent from an undesired scheduling.
+In this section, you will get in touch with how Liqo deals with dynamic topologies.
+More precisely, given a cluster-selector in a *NamespaceOffloading*, Liqo adds peered newcomers clusters to the schedulable set.
+Complementarily, Liqo will force the rescheduling of workloads of clusters that leave the topology.
+In a nutshell, as a system admin or devops, you do not have to care if new clusters are peered or unpeered at runtime, Liqo ensures the convergence of the toto the new set-up automatically.
 
 In this step, you will try to disable the peering with a cluster that has at least one pod inside.
 This will show you that a new replacing pod is correctly rescheduled inside another available cluster.

--- a/docs/pages/gettingstarted/extended/hard_constraints.md
+++ b/docs/pages/gettingstarted/extended/hard_constraints.md
@@ -1,29 +1,24 @@
 ---
-title: Hard constraints
+title: Scheduling Constraints 
 weight: 5
 ---
 
-The constraints enforced in the NamespaceOffloading resource must always be respected.
-Liqo can detect attempts to breach them, and react preventing the pod scheduling.
-You can test it with a simple deployment.
+In the last section, we enabled the NamespaceOffloading logic to extend a namespace across multiple clusters.
+As we discussed, the constraints enforced in the NamespaceOffloading define the extreme "borders" that constrain the pod scheduling on the cluster matching the features specified in the *clusterSelector* of the NamespaceOfflloading resource.
+In a nutshell, Liqo prevents the pod scheduling over clusters not selected in the cluster-selector.
+In this section, you can test this mechanism with the help of a simple deployment.
 
 ### Enforce a constraints violation
 
-The constraints specified for the topology were:
+At the beginning of the previous section, we described a scenario with the constraints specified for the multi-cluster topology:
 
 "*deploy pods both locally and remotely but use only remote cluster managed by the **provider-3***".
 
-You can check their enforcement deploying two pods:
-
-* The "*pod-provider-3*" compliant with the requirements.
-* The "*pod-provider-2*" in contrast with them.
- 
-{{% notice note %}}
-For the sake of clarity, we use pods instead of deployments, but the behavior would be the same.
-{{% /notice %}}
+Let us deploy a couple of pods in namespace `liqo-test`. To force the scheduling on the different nodes, we use a custom *NodeSelectorTerm* term.
+More precisely, for the second pod, the *NodeSelectorTerm* forces the "*pod-provider-2*" scheduling inside a cluster managed by *provider-2*.
 
 ```yaml
-cat << "EOF" | kubectl apply -f - -n liqo-namespace
+cat << "EOF" | kubectl apply -f - -n liqo-test
 apiVersion: v1
 kind: Pod
 metadata:
@@ -74,71 +69,17 @@ spec:
 EOF
 ```
 
-The NodeSelectorTerm forces the "*pod-provider-2*" scheduling inside a cluster managed by *provider-2*.
-The Liqo webhook denies this scheduling enforcing on the pod the NamespaceOffloading constraints.
-These are the resulting NodeSelectorTerms:
+{{% notice note %}}
+For the sake of clarity, we use pods instead of deployments, but the behavior would be the same.
+{{% /notice %}}
 
-```bash
-kubectl get pod -n liqo-test pod-provider-2 -o yaml | grep "spec:" -A 22
+The expected result is that the first pod will be correctly scheduled on the node labeled *liqo.io/provider=provider-3* and the other one will remain in a "pending" state, since it does not match the namespace-wide constraint.
+
+You can check the actual behavior by typing:
+
 ```
-
-```yaml
-spec:
-  affinity:
-    nodeAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
-        nodeSelectorTerms:
-          - matchExpressions:
-              - key: liqo.io/provider
-                operator: In
-                values:
-                  - provider-3
-              - key: liqo.io/provider
-                operator: In
-                values:
-                  - provider-2
-          - matchExpressions:
-              - key: liqo.io/type
-                operator: NotIn
-                values:
-                  - virtual-node
-              - key: liqo.io/provider
-                operator: In
-                values:
-                  - provider-2
+kubectl get pod -n liqo-test
 ```
-
-* The first MatchExpression is always False: it is impossible to have two different values for the same label. 
-  The cluster could not be managed both by provider-2 and provider-3.
-
-* The second one is usually False: the pod could be scheduled locally if a node of your cluster exposes the label `liqo.io/provider=provider-2`. 
-  This scenario would be rather unusual since this label takes on the meaning of a "*cluster label*" rather than a standard Kubernetes node label.
-
-So at the most, the pod could be scheduled locally because the admin has left this possibility specifying the requirements.
-The important thing is that pods could never be scheduled inside a remote cluster that is not allowed.
-
-You can check that this pod is *pending*:
-
-```bash
-kubectl get pod -n liqo-test pod-provider-2
-```
-```bash
-NAME             READY   STATUS    
-pod-provider-2   0/1     Pending   
-```
-  
-The "*pod-provider-3*" is compliant to the offloading constraints, so it should be correctly scheduled inside the *cluster-3*: 
-
-```bash
-export KUBECONFIG=$KUBECONFIG_3
-kubectl get pods -n $REMOTE_NAMESPACE
-```
-
-```bash
-NAME                         READY   STATUS       
-pod-provider-3-v4lk5         1/1     Running             
-```
-
 ### Clean the environment
 
 You can now delete the deployed pods: 

--- a/docs/pages/gettingstarted/extended/install.md
+++ b/docs/pages/gettingstarted/extended/install.md
@@ -10,7 +10,7 @@ In this section, you can install Liqo on the clusters just created.
 ### Define your cluster labels
 
 First, you should define the *cluster labels* that each cluster remotely exports during the peering process.
-As detailed in the [namespace replication page](#), each cluster can expose some labels meaningful, enabling the possibility to select it during the offloading configuration. 
+As detailed in the [namespace replication page](/usage/namespace_offloading/#cluster-labels-concept), each cluster can expose some labels meaningful, enabling the possibility to select it during the offloading configuration. 
 
 In this example, you export two labels for every cluster:
 
@@ -25,63 +25,41 @@ You can install Liqo on the first cluster:
 
 ```bash
 export KUBECONFIG=$KUBECONFIG_1
-helm install liqo --namespace "liqo" \
-  --set auth.config.allowEmptyToken=true \
-  --set discovery.config.clusterName="cluster-1" \
-  --set discovery.config.clusterLabels."topology\.liqo\.io/region"="eu-west" \
-  --set discovery.config.clusterLabels."liqo\.io/provider"="provider-1" \
-  --set discovery.config.autojoin=false \
-  --set networkManager.config.podCIDR="10.200.0.0/16" \
-  --set networkManager.config.serviceCIDR="10.90.0.0/12" \
-  --create-namespace
+liqoctl install kind --cluster-name cluster-1 \
+   --cluster-labels="topology.liqo.io/region"="eu-west","liqo.io/provider"="provider-1" \
+   --enable-lan-discovery=false
 ```
 
 The "**--namespace**" option sets the namespace name in which the Liqo control plane is deployed.
 
 | Key                                   | Type | Description |
 |-----                                  |------|-------------|
-| **discovery.config.clusterName**      | *string* | Set a mnemonic name for your cluster. |
-| **discovery.config.clusterLabels**    | *map*    | Set labels that will characterized the cluster when exposed remotely. |
-| **discovery.config.autojoin**         | *bool*   | If set to true, automatically join discovered cluster exposing the Authentication Service with a valid certificate. |
-| **networkManager.config.podCIDR**     | *string* | The subnet used by the cluster for the pods, in CIDR notation. |
-| **networkManager.config.serviceCIDR** | *string* | The subnet used by the cluster for the services, in CIDR notation. |
-| **auth.config.allowEmptyToken**       | *bool*   | If set to true, disable the authentication of discovered clusters. NB: use it only for testing installations |
+| **name**      | *string* | Set a mnemonic name for your cluster. |
+| **cluster-labels**    | *map*    | Set labels attached to the cluster when exposed remotely. |
+| **enable-lan-discovery**         | *bool*   | If set to true, automatically join discovered cluster exposing the Authentication Service with a valid certificate. |
 
 You can find additional details about the possible chart values by looking at [the dedicated section](/installation/chart_values#values).
  
-If you set the *autojoin* and the *allowEmptyToken* parameters to True, you automatically create a full mesh topology between your clusters.
-However, in this tutorial, the autojoin parameter is set to False because there is no need for a similar architecture. 
-You will learn how to manually enable and disable peerings according to the Liqo selective peering feature.
+If you set the *--enable-lan-discovery* to true, Liqo will automatically discover the other clusters and create a full mesh topology between them.
+However, in this tutorial, the *--enable-lan-discovery* parameter is set to False to let you discover how to manually enable and disable peerings according to the Liqo selective peering feature.
 
-Remember to install Liqo also on the other two clusters:
+You should install Liqo also on the other two clusters:
 
 ```bash
 export KUBECONFIG=$KUBECONFIG_2
-helm install liqo --namespace "liqo" \
-  --set auth.config.allowEmptyToken=true \
-  --set discovery.config.clusterName="cluster-2" \
-  --set discovery.config.clusterLabels."topology\.liqo\.io/region"="us-west" \
-  --set discovery.config.clusterLabels."liqo\.io/provider"="provider-2" \
-  --set discovery.config.autojoin=false \
-  --set networkManager.config.podCIDR="10.200.0.0/16" \
-  --set networkManager.config.serviceCIDR="10.90.0.0/12" \
-  --create-namespace
+liqoctl install kind --cluster-name cluster-2 \
+   --cluster-labels="topology.liqo.io/region"="us-west","liqo.io/provider"="provider-2" \
+   --enable-lan-discovery=false
 ```
 
 ```bash
 export KUBECONFIG=$KUBECONFIG_3
-helm install liqo --namespace "liqo" \
-  --set auth.config.allowEmptyToken=true \
-  --set discovery.config.clusterName="cluster-3" \
-  --set discovery.config.clusterLabels."topology\.liqo\.io/region"="eu-east" \
-  --set discovery.config.clusterLabels."liqo\.io/provider"="provider-3" \
-  --set discovery.config.autojoin=false \
-  --set networkManager.config.podCIDR="10.200.0.0/16" \
-  --set networkManager.config.serviceCIDR="10.90.0.0/12" \
-  --create-namespace
+liqoctl install kind --cluster-name cluster-3 \
+   --cluster-labels="topology.liqo.io/region"="eu-east","liqo.io/provider"="provider-3" \
+   --enable-lan-discovery=false
 ```
 
-Helm commands take a couple of minutes to complete. When this happens, the installation process is complete.
+liqoctl commands take a couple of minutes to complete. If liqoctl returns successfully, the installation process is complete.
 
 ## Check installation state
 

--- a/docs/pages/gettingstarted/extended/kind.md
+++ b/docs/pages/gettingstarted/extended/kind.md
@@ -8,7 +8,7 @@ weight: 1
 After having installed the [requirements](/gettingstarted#system-requirements), you can launch the clusters script:
 
 ```bash
-// script
+source <(curl -L https://raw.githubusercontent.com/liqotech/liqo/master/docs/examples/3_kind_cluster.sh)
 ```
 
 The script downloads and executes the [Kind](https://kind.sigs.k8s.io) tool to create single-node clusters. 
@@ -29,7 +29,7 @@ cluster2
 cluster3
 ```
 
-This means that three kind clusters are deployed and running on your host.
+The previous output means that three kind clusters are deployed and running on your host.
 
 You can inspect the clusters' status. 
 To do so, you can export the **KUBECONFIG** variable to specify the identity file for *kubectl* and then contact the clusters.
@@ -50,7 +50,7 @@ export KUBECONFIG=$KUBECONFIG_1
 kubectl get pods -A
 ```
 
-If each cluster provides an output similar to this, it means that the three kind clusters are correctly running on your host.
+If each cluster provides an output similar to this, you have correctly set up the three clusters on your host.
 
 ```bash
 NAMESPACE            NAME                                             READY   STATUS    

--- a/docs/pages/gettingstarted/extended/select_clusters.md
+++ b/docs/pages/gettingstarted/extended/select_clusters.md
@@ -11,19 +11,19 @@ Liqo can help you manage such a scenario by simply creating a *[Liqo namespace](
 
 ### Create the Liqo namespace
 
-As you may remember, a *Liqo namespace* is composed of: 
+As described in the [namespace offloading dedicated section](/usage/namespace_offloading/#introduction), a *Liqo namespace* is composed of: 
 
 * a local Namespace.  
 * a NamespaceOffloading resource containing the desired configuration.
 
-1. Create the local namespace called "*liqo-test* ”:
+1. You can start by creating a local namespace called, for example, "*liqo-test*":
 
 ```bash
 export KUBECONFIG=$KUBECONFIG_1
 kubectl create namespace liqo-test
 ```
 
-2. Now create the NamespaceOffloading resource inside the namespace:
+2. Now, the Liqo part: you can create an associated NamespaceOffloading resource inside the namespace to enable the offloading:
 
 ```yaml
 cat << "EOF" | kubectl apply -f -

--- a/docs/pages/gettingstarted/helloworld/install.md
+++ b/docs/pages/gettingstarted/helloworld/install.md
@@ -3,6 +3,7 @@ title: Install Liqo
 weight: 2
 ---
 
+
 ### Simple Installation (One-liner)
 
 Before installing Liqo, you have to set the right `kubeconfig` for your cluster properly. The Liqo installer leverages `kubectl`: by default kubectl refers to the default identity in `~/.kube/config` but you can override this configuration by exporting a `KUBECONFIG` variable.
@@ -18,13 +19,10 @@ You can find more details about configuring `kubectl` in the [official documenta
 Now, you can install Liqo by launching:
 
 ```bash
-curl -sL https://get.liqo.io | bash
+liqoctl install kind
 ```
 
-If you want to know more about possible customizations, you can show the help message:
-```bash
-curl -sL https://get.liqo.io | bash -s -- --help
-```
+This command will generate the adapt configuration for your Kind cluster.
 
 #### Install the second cluster
 
@@ -32,7 +30,7 @@ Similarly, as done on the first cluster, you can deploy Liqo on the second clust
 
 ```
 export KUBECONFIG=./liqo_kubeconf_2
-curl -sL https://get.liqo.io | bash
+liqoctl install kind
 ```
 
 ## Enable cluster peering

--- a/docs/pages/installation/_index.md
+++ b/docs/pages/installation/_index.md
@@ -144,7 +144,6 @@ export KUBECONFIG=/your/kubeconfig/path
 {{% /tab %}}
 
 {{% tab name="EKS" %}}
-
 ##### Supported CNIs
 
 Liqo supports EKS clusters using the default CNI:
@@ -262,11 +261,13 @@ gcloud iam service-accounts keys create ${GKE_SERVICE_ACCOUNT_PATH} \
     --iam-account=${GKE_SERVICE_ACCOUNT_ID}@${GKE_PROJECT_ID}.iam.gserviceaccount.com
 ```
 
-Now, you can export your KUBECONFIG and trigger the installation.
+Now, you can obtain the cluster kubeconfig with the following command: 
 ```bash
-export KUBECONFIG=/your/kubeconfig/path
+gcloud container clusters get-credentials ${GKE_CLUSTER_ID} --zone ${GKE_CLUSTER_ZONE} --project ${GKE_PROJECT_ID}
 ```
+The kubeconfig will be added to the current selected file (KUBECONFIG environment variable or the default path `~/.kube/config`) or created otherwise.
 
+You are ready to start the installation.
 {{% /tab %}}
 {{% tab name="K3s" %}}
 
@@ -295,40 +296,41 @@ Now, you can perform the proper Liqo installation on your cluster.
 {{< tabs groupId="provider" >}}
 {{% tab name="Kubernetes IN Docker (KIND)" %}}
 ```bash
-liqoctl install --provider kind
+liqoctl install kind
 ```
 {{% /tab %}}
 
 {{% tab name="K8s (Kubeadm)" %}}
 ```bash
-liqoctl install --provider kubeadm
+liqoctl install kubeadm
 ```
 {{% /tab %}}
 {{% tab name="EKS" %}}
 
 ```bash
-liqoctl install --provider eks --eks.region=${EKS_CLUSTER_REGION} --eks.cluster-name=${EKS_CLUSTER_NAME} 
+liqoctl install eks --region=${EKS_CLUSTER_REGION} --eks-cluster-name=${EKS_CLUSTER_NAME} 
 ```
+
 {{% /tab %}}
 {{% tab name="AKS" %}}
 ```bash
-liqoctl install --provider aks --aks.resource-group-name "${AKS_RESOURCE_GROUP}" \ 
-         --aks.resource-name "${AKS_RESOURCE_NAME}" \
-         --aks.subscription-id "${AKS_SUBSCRIPTION_ID}"
+liqoctl install aks --resource-group-name "${AKS_RESOURCE_GROUP}" \ 
+         --resource-name "${AKS_RESOURCE_NAME}" \
+         --subscription-id "${AKS_SUBSCRIPTION_ID}"
 ```
 {{% /tab %}}
 {{% tab name="GKE" %}}
 ```bash
 
-liqoctl install --provider gke --gke.project-id ${GKE_PROJECT_ID} \
-    --gke.cluster-id ${GKE_CLUSTER_ID} \
-    --gke.zone ${GKE_CLUSTER_ZONE} \
-    --gke.credentials-path ${GKE_SERVICE_ACCOUNT_PATH}
+liqoctl install gke --project-id ${GKE_PROJECT_ID} \
+    --cluster-id ${GKE_CLUSTER_ID} \
+    --zone ${GKE_CLUSTER_ZONE} \
+    --credentials-path ${GKE_SERVICE_ACCOUNT_PATH}
 ```
 {{% /tab %}}
 {{% tab name="K3s" %}}
 ```bash
-liqoctl install --provider k3s
+liqoctl install k3s
 ```
 {{% /tab %}}
 {{< /tabs >}}

--- a/pkg/liqoctl/add/consts.go
+++ b/pkg/liqoctl/add/consts.go
@@ -40,4 +40,26 @@ $ liqoctl add cluster my-cluster --auth-url https://my-cluster --id e8e3cdec-b00
 	// ClusterLiqoNamespace contains the default namespace where Liqo is installed.
 	ClusterLiqoNamespace = "liqo"
 	sameClusterError     = "the ClusterID of the adding cluster is the same of the local cluster"
+	// SuccesfulMessage is printed when ad add cluster command has scucceded.
+	SuccesfulMessage = `
+	Hooray 🎉! You have correctly added the cluster %s and activated an outgoing peering towards it.
+You can now:
+
+* Check the status of the peering to see when it is completely established. 
+Every field of the foreigncluster (but IncomingPeering) should be in "Established":
+
+kubectl get foreignclusters %s
+
+* Check if the virtual node is correctly created (this should take less than ~30s):
+
+kubectl get nodes liqo-%s
+
+* Ready to go! Let's deploy a simple application by simply typing:
+
+kubectl create ns liqo-demo # Let's create a demo namespace
+kubectl label ns liqo-demo liqo.io/enabled=true # Enable Liqo offloading on this namespace (Check out https://doc.liqo.io/usage for more details).
+kubectl apply -n liqo-demo -f https://get.liqo.io/app.yaml # Deploy a sample application in the namespace to trigger the offloading.
+
+* For more information about Liqo have a look to: https://doc.liqo.io
+`
 )

--- a/pkg/liqoctl/add/handler.go
+++ b/pkg/liqoctl/add/handler.go
@@ -60,6 +60,20 @@ func HandleAddCommand(ctx context.Context, t *ClusterArgs) {
 	if err := processAddCluster(ctx, t, clientSet, k8sClient); err != nil {
 		klog.Fatalf(err.Error())
 	}
+
+	err = printSuccesfulOutputMessage(ctx, t, k8sClient)
+	if err != nil {
+		klog.Fatalf(err.Error())
+	}
+}
+
+func printSuccesfulOutputMessage(ctx context.Context, t *ClusterArgs, k8sClient client.Client) error {
+	fc, err := foreigncluster.GetForeignClusterByID(ctx, k8sClient, t.ClusterID)
+	if err != nil {
+		return err
+	}
+	fmt.Printf(SuccesfulMessage, t.ClusterName, fc.Name, t.ClusterID)
+	return nil
 }
 
 func processAddCluster(ctx context.Context, t *ClusterArgs, clientSet kubernetes.Interface, k8sClient client.Client) error {


### PR DESCRIPTION
# Description

This PR updates the documentation, in particular w.r.t. the addition of liqoctl as preferred way to install and configure liqo.

# How Has This Been Tested?

Not applicable.
