### PR TITLE
Propagate Tolerations when forging foreign Pods

### DIFF
--- a/pkg/virtualKubelet/forge/forge_test.go
+++ b/pkg/virtualKubelet/forge/forge_test.go
@@ -39,3 +39,34 @@ var _ = Describe("Virtual Kubelet labels test", func() {
 	})
 
 })
+
+var _ = Describe("Forge toleration test", func() {
+	var (
+		tol1 corev1.Toleration
+		tol2 corev1.Toleration
+	)
+
+	Context("Tolerations", func() {
+		BeforeEach(func() {
+			tol1 = corev1.Toleration{
+				Key:      "virtual-node.liqo.io/not-allowed",
+				Operator: "Exist",
+				Effect:   "NoExecute",
+			}
+			tol2 = corev1.Toleration{
+				Key:      "node.kubernetes.io/not-ready",
+				Operator: "Exist",
+				Effect:   "NoExecute",
+			}
+
+		})
+
+		It("Filtering tolerations", func() {
+			input := []corev1.Toleration{tol1, tol2}
+			expected := []corev1.Toleration{tol2}
+			output := forgeTolerations(input)
+			Expect(output).To(Equal(expected))
+		})
+
+	})
+})

--- a/pkg/virtualKubelet/forge/pods.go
+++ b/pkg/virtualKubelet/forge/pods.go
@@ -130,8 +130,23 @@ func (f *apiForger) forgePodSpec(inputPodSpec corev1.PodSpec) corev1.PodSpec {
 	outputPodSpec.Volumes = forgeVolumes(inputPodSpec.Volumes)
 	outputPodSpec.InitContainers = forgeContainers(inputPodSpec.InitContainers, outputPodSpec.Volumes)
 	outputPodSpec.Containers = forgeContainers(inputPodSpec.Containers, outputPodSpec.Volumes)
+	outputPodSpec.Tolerations = forgeTolerations(inputPodSpec.Tolerations)
 
 	return outputPodSpec
+}
+
+func forgeTolerations(inputTolerations []corev1.Toleration) []corev1.Toleration {
+	tolerations := make([]corev1.Toleration, 0)
+
+	for _, toleration := range inputTolerations {
+		// copy all tolerations except the one for the virtual node.
+		// This prevents by default the possibility of "recursive" scheduling on virtual nodes on the target cluster.
+		if toleration.Key != liqoconst.VirtualNodeTolerationKey {
+			tolerations = append(tolerations, toleration)
+		}
+	}
+
+	return tolerations
 }
 
 func forgeContainers(inputContainers []corev1.Container, inputVolumes []corev1.Volume) []corev1.Container {


### PR DESCRIPTION
# Description

This PR aims to propagate Tolerations of the home pod on the foreign pod, except the one related to the virtual node.

Fixes #(issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Locally on Kind
- [x] Unit test
