### PR TITLE
Set Liqoctl Install Verbosity and Handle Signals

### DIFF
--- a/cmd/liqoctl/cmd/install.go
+++ b/cmd/liqoctl/cmd/install.go
@@ -39,6 +39,7 @@ func newInstallCommand(ctx context.Context) *cobra.Command {
 		"added to the reserved list. (e.g. --reserved-subnets 192.168.2.0/24,192.168.4.0/24)")
 	installCmd.PersistentFlags().String("resource-sharing-percentage", "90", "It defines the percentage of available cluster resources that "+
 		"you are willing to share with foreign clusters. It accepts [0 - 100] values.")
+	installCmd.PersistentFlags().Bool("enable-ha", false, "Enable the gateway component support active/passive high availability.")
 
 	for _, providerName := range providers {
 		cmd, err := getCommand(ctx, providerName)

--- a/deployments/liqo/README.md
+++ b/deployments/liqo/README.md
@@ -51,6 +51,7 @@
 | gateway.pod.annotations | object | `{}` | gateway pod annotations |
 | gateway.pod.extraArgs | list | `[]` | gateway pod extra arguments |
 | gateway.pod.labels | object | `{}` | gateway pod labels |
+| gateway.replicas | int | `1` | The number of gateway instances to run. The gateway component supports active/passive high availability. Make sure that there are enough nodes to accommodate the replicas, because being the instances in host network no more than one replica can be scheduled on a given node. |
 | gateway.service.annotations | object | `{}` |  |
 | gateway.service.type | string | `"LoadBalancer"` | If you plan to use liqo over the Internet consider to change this field to "LoadBalancer". More generally, if your cluster nodes are directly reachable by the cluster to whom you are peering, you may change it to "NodePort". |
 | nameOverride | string | `""` | liqo name override |

--- a/deployments/liqo/templates/liqo-gateway-deployment.yaml
+++ b/deployments/liqo/templates/liqo-gateway-deployment.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   strategy:
     type: Recreate
-  replicas: 1
+  replicas: {{ .Values.gateway.replicas }}
   selector:
     matchLabels:
       {{- include "liqo.selectorLabels" $gatewayConfig | nindent 6 }}

--- a/deployments/liqo/values.yaml
+++ b/deployments/liqo/values.yaml
@@ -38,6 +38,11 @@ route:
   imageName: "liqo/liqonet"
 
 gateway:
+  # -- The number of gateway instances to run.
+  # The gateway component supports active/passive high availability.
+  # Make sure that there are enough nodes to accommodate the replicas, because being the instances in host network no more
+  # than one replica can be scheduled on a given node.
+  replicas: 1
   pod:
     # -- gateway pod annotations
     annotations: {}

--- a/docs/pages/installation/chart_values.md
+++ b/docs/pages/installation/chart_values.md
@@ -56,6 +56,7 @@ weight: 5
 | gateway.pod.annotations | object | `{}` | gateway pod annotations |
 | gateway.pod.extraArgs | list | `[]` | gateway pod extra arguments |
 | gateway.pod.labels | object | `{}` | gateway pod labels |
+| gateway.replicas | int | `1` | The number of gateway instances to run. The gateway component supports active/passive high availability. Make sure that there are enough nodes to accommodate the replicas, because being the instances in host network no more than one replica can be scheduled on a given node. |
 | gateway.service.annotations | object | `{}` |  |
 | gateway.service.type | string | `"LoadBalancer"` | If you plan to use liqo over the Internet consider to change this field to "LoadBalancer". More generally, if your cluster nodes are directly reachable by the cluster to whom you are peering, you may change it to "NodePort". |
 | nameOverride | string | `""` | liqo name override |

--- a/pkg/liqoctl/generate/handler.go
+++ b/pkg/liqoctl/generate/handler.go
@@ -29,7 +29,7 @@ func HandleGenerateAddCommand(ctx context.Context, liqoNamespace, commandName st
 
 	commandString := processGenerateCommand(ctx, clientSet, liqoNamespace, commandName)
 
-	fmt.Printf("Use this command to peer with this cluster:\n\n")
+	fmt.Printf("\nUse this command to peer with this cluster:\n\n")
 	fmt.Printf("%s\n", commandString)
 }
 

--- a/pkg/liqoctl/install/helm.go
+++ b/pkg/liqoctl/install/helm.go
@@ -4,6 +4,7 @@ import (
 	helm "github.com/mittwald/go-helm-client"
 	"helm.sh/helm/v3/pkg/repo"
 	"k8s.io/client-go/rest"
+	"k8s.io/klog/v2"
 
 	"github.com/liqotech/liqo/pkg/liqoctl/install/provider"
 	installutils "github.com/liqotech/liqo/pkg/liqoctl/install/utils"
@@ -18,7 +19,7 @@ func InitializeHelmClientWithRepo(config *rest.Config, commonArgs *provider.Comm
 			RepositoryCache:  liqoHelmCachePath,
 			Debug:            commonArgs.Debug,
 			Linting:          false,
-			DebugLog:         nil,
+			DebugLog:         klog.V(4).Infof,
 		},
 		RestConfig: config,
 	}

--- a/pkg/liqoctl/install/provider/args.go
+++ b/pkg/liqoctl/install/provider/args.go
@@ -74,7 +74,11 @@ func ValidateCommonArguments(flags *flag.FlagSet) (*CommonArguments, error) {
 	if err != nil {
 		return nil, err
 	}
-	commonValues, err := parseCommonValues(clusterLabels, chartPath, version, resourceSharingPercentage, lanDiscovery)
+	enableHa, err := flags.GetBool("enable-ha")
+	if err != nil {
+		return nil, err
+	}
+	commonValues, err := parseCommonValues(clusterLabels, chartPath, version, resourceSharingPercentage, lanDiscovery, enableHa)
 	if err != nil {
 		return nil, err
 	}
@@ -92,7 +96,8 @@ func ValidateCommonArguments(flags *flag.FlagSet) (*CommonArguments, error) {
 	}, nil
 }
 
-func parseCommonValues(clusterLabels, chartPath, version, resourceSharingPercentage string, lanDiscovery bool) (map[string]interface{}, error) {
+func parseCommonValues(clusterLabels, chartPath, version, resourceSharingPercentage string,
+	lanDiscovery, enableHa bool) (map[string]interface{}, error) {
 	clusterLabelsVar := argsutils.StringMap{}
 	if err := clusterLabelsVar.Set(clusterLabels); err != nil {
 		return map[string]interface{}{}, err
@@ -111,6 +116,11 @@ func parseCommonValues(clusterLabels, chartPath, version, resourceSharingPercent
 		return map[string]interface{}{}, err
 	}
 
+	gatewayReplicas := 1
+	if enableHa {
+		gatewayReplicas = 2
+	}
+
 	return map[string]interface{}{
 		"tag": tag,
 		"discovery": map[string]interface{}{
@@ -124,6 +134,9 @@ func parseCommonValues(clusterLabels, chartPath, version, resourceSharingPercent
 			"config": map[string]interface{}{
 				"resourceSharingPercentage": float64(resourceSharingPercentageVal.Val),
 			},
+		},
+		"gateway": map[string]interface{}{
+			"replicas": float64(gatewayReplicas),
 		},
 	}, nil
 }


### PR DESCRIPTION
# Description

This pr includes some improvements to the liqoctl tool:

* reduce the verbosity of the install command
* handle SIGINT and SIGTERM signals
* add the enable-ha flag to enable liqo-gateway multiple replicas
