### PR TITLE
Add docs command to liqoctl tool

### DIFF
--- a/cmd/liqoctl/cmd/docs.go
+++ b/cmd/liqoctl/cmd/docs.go
@@ -1,0 +1,44 @@
+// Copyright 2019-2021 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+	"helm.sh/helm/v3/cmd/helm/require"
+
+	"github.com/liqotech/liqo/pkg/liqoctl/docs"
+)
+
+func newDocsCommand(ctx context.Context) *cobra.Command {
+	docsArgs := docs.Args{}
+	cmd := &cobra.Command{
+		Use:   docs.UseCommand,
+		Short: docs.ShortHelp,
+		Long:  docs.LongHelp,
+		Args:  require.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			docsArgs.TopCmd = cmd.Root()
+			return docsArgs.Handler(ctx)
+		},
+		Hidden: true,
+	}
+	flags := cmd.Flags()
+	flags.StringVar(&docsArgs.Dest, docs.OutputDir, "./", "directory to which documentation is written")
+	flags.StringVar(&docsArgs.DocTypeString, docs.DocType, "markdown", "the type of documentation to generate (markdown, man)")
+	flags.BoolVar(&docsArgs.GenerateHeaders, docs.GenerateHeaders, false, "generate standard headers for markdown files")
+	return cmd
+}

--- a/cmd/liqoctl/cmd/root.go
+++ b/cmd/liqoctl/cmd/root.go
@@ -51,5 +51,6 @@ func NewRootCommand(ctx context.Context) *cobra.Command {
 	rootCmd.AddCommand(newInstallCommand(ctx))
 	rootCmd.AddCommand(newAddCommand(ctx))
 	rootCmd.AddCommand(newGenerateAddCommand(ctx))
+	rootCmd.AddCommand(newDocsCommand(ctx))
 	return rootCmd
 }

--- a/pkg/liqoctl/docs/consts.go
+++ b/pkg/liqoctl/docs/consts.go
@@ -1,0 +1,37 @@
+// Copyright 2019-2021 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package docs
+
+const (
+	// ShortHelp contains the short help string for liqoctl docs command.
+	ShortHelp = "Generate documentation as markdown"
+	// LongHelp contains the Long help string for liqoctl docs command.
+	LongHelp = `
+Generate documentation files for liqoctl.
+
+This command can generate documentation for liqoctl in the following formats:
+- Markdown
+
+$ liqoctl docs --dir path-to-desired-folder
+`
+	// UseCommand contains the name of the command.
+	UseCommand = "docs"
+	// OutputDir contains the name of dir flag.
+	OutputDir = "dir"
+	// DocType contains the name of type flag.
+	DocType = "type"
+	// GenerateHeaders contains the name of generate-headers.
+	GenerateHeaders = "generate-headers"
+)

--- a/pkg/liqoctl/docs/doc.go
+++ b/pkg/liqoctl/docs/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2019-2021 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package docs contains the logic that handle the docs command in liqoctl
+package docs

--- a/pkg/liqoctl/docs/handler.go
+++ b/pkg/liqoctl/docs/handler.go
@@ -1,0 +1,60 @@
+// Copyright 2019-2021 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package docs
+
+import (
+	"context"
+	"fmt"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"github.com/spf13/cobra/doc"
+)
+
+// Args holds the necessary flags for the docs command.
+type Args struct {
+	Dest            string
+	DocTypeString   string
+	TopCmd          *cobra.Command
+	GenerateHeaders bool
+}
+
+// Handler implement the logic of the docs command.
+func (o *Args) Handler(ctx context.Context) error {
+	switch o.DocTypeString {
+	case "markdown":
+		if o.GenerateHeaders {
+			standardLinks := func(s string) string { return s }
+
+			hdrFunc := func(filename string) string {
+				base := filepath.Base(filename)
+				name := strings.TrimSuffix(base, path.Ext(base))
+				title := strings.Title(strings.ReplaceAll(name, "_", " "))
+				return fmt.Sprintf("---\ntitle: \"%s\"\n---\n\n", title)
+			}
+
+			return doc.GenMarkdownTreeCustom(o.TopCmd, o.Dest, hdrFunc, standardLinks)
+		}
+		return doc.GenMarkdownTree(o.TopCmd, o.Dest)
+	case "man":
+		manHdr := &doc.GenManHeader{Title: "LIQOCTL", Section: "1"}
+		return doc.GenManTree(o.TopCmd, manHdr, o.Dest)
+	default:
+		return errors.Errorf("unknown doc type %q. Try 'markdown' or 'man'", o.DocTypeString)
+	}
+}


### PR DESCRIPTION
# Description

Liqoctl now has a new command named `docs` used to generate the reference documentation of the tool itself. The command is hidden from the final user meaning that it does not show up in the list of available commands. The `docs` command is thought to be used only to generate the reference documentation when new commands are added or existing ones are modified.

```
Usage:
  liqoctl docs [flags]

Flags:
      --dir string         directory to which documentation is written (default "./")
      --generate-headers   generate standard headers for markdown files
  -h, --help               help for docs
      --type string        the type of documentation to generate (markdown, man) (default "markdown")

```

