### PR TITLE
New Liqoctl Remove Command

### DIFF
--- a/cmd/liqoctl/cmd/remove.go
+++ b/cmd/liqoctl/cmd/remove.go
@@ -1,0 +1,50 @@
+// Copyright 2019-2021 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+
+	"github.com/liqotech/liqo/pkg/liqoctl/remove"
+)
+
+// removeCmd represents the remove command.
+func newRemoveCommand(ctx context.Context) *cobra.Command {
+	var removeCmd = &cobra.Command{
+		Use:   remove.UseCommand,
+		Short: remove.LiqoctlRemoveShortHelp,
+		Long:  remove.LiqoctlRemoveLongHelp,
+	}
+	removeCmd.AddCommand(newRemoveClusterCommand(ctx))
+	return removeCmd
+}
+
+func newRemoveClusterCommand(ctx context.Context) *cobra.Command {
+	removeArgs := &remove.ClusterArgs{}
+	var removeClusterCmd = &cobra.Command{
+		Use:   remove.ClusterResourceName,
+		Short: remove.LiqoctlRemoveShortHelp,
+		Long:  remove.LiqoctlRemoveLongHelp,
+		Args:  cobra.MinimumNArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			removeArgs.ClusterName = args[0]
+			remove.HandleRemoveCommand(ctx, removeArgs)
+		},
+	}
+
+	return removeClusterCmd
+}

--- a/cmd/liqoctl/cmd/root.go
+++ b/cmd/liqoctl/cmd/root.go
@@ -49,6 +49,7 @@ func NewRootCommand(ctx context.Context) *cobra.Command {
 	rootCmd.PersistentFlags().BoolP("debug", "d", false, "Enable/Disable debug mode (default: false)")
 	rootCmd.AddCommand(newInstallCommand(ctx))
 	rootCmd.AddCommand(newAddCommand(ctx))
+	rootCmd.AddCommand(newRemoveCommand(ctx))
 	rootCmd.AddCommand(newGenerateAddCommand(ctx))
 	rootCmd.AddCommand(newDocsCommand(ctx))
 	rootCmd.AddCommand(newVersionCommand())

--- a/pkg/liqoctl/add/consts.go
+++ b/pkg/liqoctl/add/consts.go
@@ -40,8 +40,8 @@ $ liqoctl add cluster my-cluster --auth-url https://my-cluster --id e8e3cdec-b00
 	// ClusterLiqoNamespace contains the default namespace where Liqo is installed.
 	ClusterLiqoNamespace = "liqo"
 	sameClusterError     = "the ClusterID of the adding cluster is the same of the local cluster"
-	// SuccesfulMessage is printed when ad add cluster command has scucceded.
-	SuccesfulMessage = `
+	// SuccessfulMessage is printed when ad add cluster command has succeeded.
+	SuccessfulMessage = `
 Hooray 🎉! You have correctly added the cluster %s and activated an outgoing peering towards it.
 You can now:
 

--- a/pkg/liqoctl/add/handler.go
+++ b/pkg/liqoctl/add/handler.go
@@ -63,19 +63,19 @@ func HandleAddCommand(ctx context.Context, t *ClusterArgs) error {
 		return err
 	}
 
-	err = printSuccesfulOutputMessage(ctx, t, k8sClient)
+	err = printSuccessfulOutputMessage(ctx, t, k8sClient)
 	if err != nil {
 		return err
 	}
 	return nil
 }
 
-func printSuccesfulOutputMessage(ctx context.Context, t *ClusterArgs, k8sClient client.Client) error {
+func printSuccessfulOutputMessage(ctx context.Context, t *ClusterArgs, k8sClient client.Client) error {
 	fc, err := foreigncluster.GetForeignClusterByID(ctx, k8sClient, t.ClusterID)
 	if err != nil {
 		return err
 	}
-	fmt.Printf(SuccesfulMessage, t.ClusterName, fc.Name, t.ClusterID)
+	fmt.Printf(SuccessfulMessage, t.ClusterName, fc.Name, t.ClusterID)
 	return nil
 }
 

--- a/pkg/liqoctl/remove/consts.go
+++ b/pkg/liqoctl/remove/consts.go
@@ -1,0 +1,42 @@
+// Copyright 2019-2021 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package remove
+
+const (
+	// LiqoctlRemoveShortHelp contains the short help string for liqoctl remove command.
+	LiqoctlRemoveShortHelp = "Disable a peering with a remote cluster"
+	// LiqoctlRemoveLongHelp contains the Long help string for liqoctl remove command.
+	LiqoctlRemoveLongHelp = `Disable a peering with a remote cluster
+
+$ liqoctl remove cluster my-cluster
+
+`
+	// UseCommand contains the verb of the remove command.
+	UseCommand = "remove"
+	// ClusterResourceName contains the name of the resource removed in liqoctl remove.
+	ClusterResourceName = "cluster"
+	// SuccessfulMessage is printed when a remove cluster command has scucceded.
+	SuccessfulMessage = `
+	Success 👌! You have correctly removed the cluster %s and disabled an outgoing peering towards it.
+You can now:
+
+* Check the status of the peering to see when it is completely disabled. 
+The field OutgoingPeering of the foreigncluster should be in "None":
+
+kubectl get foreignclusters %s
+
+* For more information about Liqo have a look to: https://doc.liqo.io
+`
+)

--- a/pkg/liqoctl/remove/doc.go
+++ b/pkg/liqoctl/remove/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2019-2021 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package remove contains the logic to terminate an outgoing peering to a remote cluster
+package remove

--- a/pkg/liqoctl/remove/handler.go
+++ b/pkg/liqoctl/remove/handler.go
@@ -1,0 +1,84 @@
+// Copyright 2019-2021 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package remove
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
+	"github.com/liqotech/liqo/pkg/liqoctl/common"
+	foreigncluster "github.com/liqotech/liqo/pkg/utils/foreignCluster"
+)
+
+// ClusterArgs encapsulates arguments required to disable an outgoing peering to a remote cluster.
+type ClusterArgs struct {
+	ClusterName string
+	ClusterID   string
+}
+
+// HandleRemoveCommand handles the remove command, configuring all the resources required to disable an outgoing peering.
+func HandleRemoveCommand(ctx context.Context, t *ClusterArgs) {
+	restConfig := common.GetLiqoctlRestConfOrDie()
+
+	k8sClient, err := client.New(restConfig, client.Options{})
+	if err != nil {
+		klog.Fatalf(err.Error())
+	}
+
+	if err := processRemoveCluster(ctx, t, k8sClient); err != nil {
+		klog.Fatalf(err.Error())
+	}
+
+	err = printSuccessfulOutputMessage(ctx, t, k8sClient)
+	if err != nil {
+		klog.Fatalf(err.Error())
+	}
+}
+
+func printSuccessfulOutputMessage(ctx context.Context, t *ClusterArgs, k8sClient client.Client) error {
+	fc, err := foreigncluster.GetForeignClusterByID(ctx, k8sClient, t.ClusterID)
+	if err != nil {
+		return err
+	}
+	fmt.Printf(SuccessfulMessage, t.ClusterName, fc.Name)
+	return nil
+}
+
+func processRemoveCluster(ctx context.Context, t *ClusterArgs, k8sClient client.Client) error {
+	err := enforceForeignCluster(ctx, k8sClient, t)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func enforceForeignCluster(ctx context.Context, cl client.Client, t *ClusterArgs) error {
+	// Get ForeignCluster
+	var foreignCluster discoveryv1alpha1.ForeignCluster
+	if err := cl.Get(ctx, types.NamespacedName{Name: t.ClusterName}, &foreignCluster); err != nil {
+		return err
+	}
+
+	t.ClusterID = foreignCluster.Spec.ClusterIdentity.ClusterID
+
+	// Update ForeignCluster
+	foreignCluster.Spec.OutgoingPeeringEnabled = discoveryv1alpha1.PeeringEnabledNo
+	return cl.Update(ctx, &foreignCluster)
+}

--- a/pkg/liqoctl/remove/remove_test.go
+++ b/pkg/liqoctl/remove/remove_test.go
@@ -1,0 +1,117 @@
+// Copyright 2019-2021 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package remove
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/types"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	machinerytypes "k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
+)
+
+const (
+	foreignClusterName        = "foreign-cluster-1"
+	invalidForeignClusterName = "foreign-cluster-2"
+
+	timeout  = time.Second * 30
+	interval = time.Millisecond * 250
+)
+
+var (
+	k8sClient client.Client
+)
+
+func TestRemoveCommand(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Test Remove Command")
+}
+
+var _ = BeforeSuite(func() {
+	utilruntime.Must(discoveryv1alpha1.AddToScheme(scheme.Scheme))
+})
+
+var _ = Describe("Test Remove Command", func() {
+
+	BeforeEach(func() {
+		k8sClient = setUpEnvironment()
+	})
+
+	When("Disable the outgoing peering fore a ForeignCluster", func() {
+
+		type removeTestcase struct {
+			clusterName   string
+			expectedError types.GomegaMatcher
+			expectedFlag  types.GomegaMatcher
+		}
+
+		DescribeTable("Credential Validator table",
+			func(c removeTestcase) {
+				ctx := context.TODO()
+
+				err := processRemoveCluster(ctx, &ClusterArgs{
+					ClusterName: c.clusterName,
+				}, k8sClient)
+				Expect(err).To(c.expectedError)
+
+				Eventually(func() discoveryv1alpha1.PeeringEnabledType {
+					var foreignCluster discoveryv1alpha1.ForeignCluster
+					Expect(k8sClient.Get(ctx, machinerytypes.NamespacedName{Name: foreignClusterName}, &foreignCluster)).To(Succeed())
+
+					return foreignCluster.Spec.OutgoingPeeringEnabled
+				}, timeout, interval).Should(c.expectedFlag)
+			},
+
+			Entry("valid foreign cluster name", removeTestcase{
+				clusterName:   foreignClusterName,
+				expectedError: Not(HaveOccurred()),
+				expectedFlag:  Equal(discoveryv1alpha1.PeeringEnabledNo),
+			}),
+
+			Entry("invalid foreign cluster name", removeTestcase{
+				clusterName:   invalidForeignClusterName,
+				expectedError: HaveOccurred(),
+				expectedFlag:  Equal(discoveryv1alpha1.PeeringEnabledYes),
+			}),
+		)
+
+	})
+
+})
+
+func setUpEnvironment() client.Client {
+	foreignCluster := &discoveryv1alpha1.ForeignCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: foreignClusterName,
+		},
+		Spec: discoveryv1alpha1.ForeignClusterSpec{
+			OutgoingPeeringEnabled: discoveryv1alpha1.PeeringEnabledYes,
+		},
+	}
+
+	k8sClient := ctrlfake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(foreignCluster).Build()
+	return k8sClient
+}


### PR DESCRIPTION
# Description

This pr adds a new command to `liqoctl` to allow the user to disable the peering with a remote cluster

# How Has This Been Tested?

- [x] add init test
- [x] locally
