### PR TITLE
Add liqoctl version command

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -213,7 +213,10 @@ jobs:
           persist-credentials: false
 
       - name: Build Liqoctl
-        run: go build -o liqoctl-${{ matrix.goos }}-${{ matrix.goarch }} -ldflags="-s -w" ./cmd/liqoctl
+        run: >
+          go build -o liqoctl-${{ matrix.goos }}-${{ matrix.goarch }} 
+          -ldflags="-s -w -X 'github.com/liqotech/liqo/pkg/liqoctl/version.liqoctlVersion=${{ needs.configure.outputs.commit-ref }}'" 
+          ./cmd/liqoctl
         env:
           CGO_ENABLED: 0
           GOOS: ${{ matrix.goos }}

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ externalcrds
 
 # directory where liqo stores the bearer tokens got by identity providers (i.e. Amazon IAM)
 token
+
+# to ease the local development of liqoctl
+/liqoctl

--- a/cmd/liqoctl/cmd/root.go
+++ b/cmd/liqoctl/cmd/root.go
@@ -52,5 +52,6 @@ func NewRootCommand(ctx context.Context) *cobra.Command {
 	rootCmd.AddCommand(newAddCommand(ctx))
 	rootCmd.AddCommand(newGenerateAddCommand(ctx))
 	rootCmd.AddCommand(newDocsCommand(ctx))
+	rootCmd.AddCommand(newVersionCommand())
 	return rootCmd
 }

--- a/cmd/liqoctl/cmd/version.go
+++ b/cmd/liqoctl/cmd/version.go
@@ -1,0 +1,34 @@
+// Copyright 2019-2021 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/liqotech/liqo/pkg/liqoctl/version"
+)
+
+// installCmd represents the generateInstall command.
+func newVersionCommand() *cobra.Command {
+	var verCmd = &cobra.Command{
+		Use:   version.LiqoctlVersionCommand,
+		Short: version.LiqoctlVersionShortHelp,
+		Long:  version.LiqoctlVersionLongHelp,
+		Run: func(cmd *cobra.Command, args []string) {
+			version.HandleVersionCommand()
+		},
+	}
+	return verCmd
+}

--- a/pkg/liqoctl/version/consts.go
+++ b/pkg/liqoctl/version/consts.go
@@ -1,0 +1,24 @@
+// Copyright 2019-2021 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package version
+
+// LiqoctlVersionShortHelp contains the short help message for the version Liqoctl command.
+const LiqoctlVersionShortHelp = "Print current liqoctl client version"
+
+// LiqoctlVersionLongHelp contains the short help message for the version Liqoctl command.
+const LiqoctlVersionLongHelp = "Print current liqoctl client version"
+
+// LiqoctlVersionCommand contains the use command for the version Liqoctl command.
+const LiqoctlVersionCommand = "version"

--- a/pkg/liqoctl/version/doc.go
+++ b/pkg/liqoctl/version/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2019-2021 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package version contains the logic that handle the version command in liqoctl
+package version

--- a/pkg/liqoctl/version/handler.go
+++ b/pkg/liqoctl/version/handler.go
@@ -1,0 +1,32 @@
+// Copyright 2019-2021 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package version
+
+import (
+	"fmt"
+)
+
+// if you need to rename the following variables, change also the build command for liqoctl.
+var liqoctlVersion = "development"
+var liqoctlSHA = ""
+
+// HandleVersionCommand outputs the liqoctl add command to use to add the target cluster.
+func HandleVersionCommand() {
+	fmt.Println()
+	fmt.Printf("Current Liqoctl client version: %s\n\n", liqoctlVersion)
+	if liqoctlSHA != "" {
+		fmt.Printf("Current Liqoctl client commit SHA: %s\n\n", liqoctlSHA)
+	}
+}


### PR DESCRIPTION
# Description

This PR is adds the `version` command to `liqoctl`. It uses the linker flags to provide a value for a variable at build time

# How Has This Been Tested?

Since this is a very simple addition from a golang execution perspective, no test useful tests can be performed. It could be useful to do a build test
