### PR TITLE
Add liqoctl install custom output

### DIFF
--- a/cmd/liqoctl/cmd/add.go
+++ b/cmd/liqoctl/cmd/add.go
@@ -37,13 +37,14 @@ func newAddCommand(ctx context.Context) *cobra.Command {
 func newAddClusterCommand(ctx context.Context) *cobra.Command {
 	installArgs := &add.ClusterArgs{}
 	var addClusterCmd = &cobra.Command{
-		Use:   add.ClusterResourceName,
-		Short: add.LiqoctlAddShortHelp,
-		Long:  add.LiqoctlAddLongHelp,
-		Args:  cobra.MinimumNArgs(1),
-		Run: func(cmd *cobra.Command, args []string) {
+		Use:          add.ClusterResourceName,
+		Short:        add.LiqoctlAddShortHelp,
+		Long:         add.LiqoctlAddLongHelp,
+		Args:         cobra.MinimumNArgs(1),
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
 			installArgs.ClusterName = args[0]
-			add.HandleAddCommand(ctx, installArgs)
+			return add.HandleAddCommand(ctx, installArgs)
 		},
 	}
 	addClusterCmd.Flags().StringVar(&installArgs.ClusterAuthURL, add.AuthURLFlagName, "",

--- a/cmd/liqoctl/cmd/generate-add.go
+++ b/cmd/liqoctl/cmd/generate-add.go
@@ -31,8 +31,8 @@ func newGenerateAddCommand(ctx context.Context) *cobra.Command {
 		Use:   generate.LiqoctlGenerateAddCommand,
 		Short: generate.LiqoctlGenerateShortHelp,
 		Long:  generate.LiqoctlGenerateLongHelp,
-		Run: func(cmd *cobra.Command, args []string) {
-			generate.HandleGenerateAddCommand(ctx, liqoNamespace, os.Args[0])
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return generate.HandleGenerateAddCommand(ctx, liqoNamespace, os.Args[0])
 		},
 	}
 	addCmd.Flags().StringVar(&liqoNamespace, "namespace", add.ClusterLiqoNamespace,

--- a/cmd/liqoctl/cmd/install.go
+++ b/cmd/liqoctl/cmd/install.go
@@ -30,7 +30,6 @@ func newInstallCommand(ctx context.Context) *cobra.Command {
 		Short: installutils.LiqoctlInstallShortHelp,
 		Long:  installutils.LiqoctlInstallLongHelp,
 	}
-
 	installCmd.PersistentFlags().IntP("timeout", "t", 600, "Configure the timeout for the installation process in seconds")
 	installCmd.PersistentFlags().StringP("version", "", "", "Select the Liqo version (default: latest stable release)")
 	installCmd.PersistentFlags().BoolP("devel", "", false,

--- a/cmd/liqoctl/cmd/providers.go
+++ b/cmd/liqoctl/cmd/providers.go
@@ -47,11 +47,12 @@ var providerInitFunc = map[string]func(*cobra.Command){
 
 func getCommand(ctx context.Context, provider string) (*cobra.Command, error) {
 	cmd := &cobra.Command{
-		Use:   provider,
-		Short: fmt.Sprintf(installShortHelp, provider),
-		Long:  fmt.Sprintf(installLongHelp, provider),
-		Run: func(cmd *cobra.Command, args []string) {
-			install.HandleInstallCommand(ctx, cmd, os.Args[0], provider)
+		Use:          provider,
+		Short:        fmt.Sprintf(installShortHelp, provider),
+		Long:         fmt.Sprintf(installLongHelp, provider),
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return install.HandleInstallCommand(ctx, cmd, os.Args[0], provider)
 		},
 	}
 

--- a/cmd/liqoctl/cmd/root.go
+++ b/cmd/liqoctl/cmd/root.go
@@ -43,7 +43,6 @@ func NewRootCommand(ctx context.Context) *cobra.Command {
 			rootCmd.PersistentFlags().AddGoFlag(f)
 		}
 	})
-
 	rateFlagset := flag.NewFlagSet("rate-limiting", flag.PanicOnError)
 	restcfg.InitFlags(rateFlagset)
 	rootCmd.PersistentFlags().AddGoFlagSet(rateFlagset)

--- a/pkg/liqoctl/add/consts.go
+++ b/pkg/liqoctl/add/consts.go
@@ -42,19 +42,19 @@ $ liqoctl add cluster my-cluster --auth-url https://my-cluster --id e8e3cdec-b00
 	sameClusterError     = "the ClusterID of the adding cluster is the same of the local cluster"
 	// SuccesfulMessage is printed when ad add cluster command has scucceded.
 	SuccesfulMessage = `
-	Hooray 🎉! You have correctly added the cluster %s and activated an outgoing peering towards it.
+Hooray 🎉! You have correctly added the cluster %s and activated an outgoing peering towards it.
 You can now:
 
-* Check the status of the peering to see when it is completely established. 
+* Check the status of the peering to see when it is completely established 👓.
 Every field of the foreigncluster (but IncomingPeering) should be in "Established":
 
 kubectl get foreignclusters %s
 
-* Check if the virtual node is correctly created (this should take less than ~30s):
+* Check if the virtual node is correctly created (this should take less than ~30s) 📦:
 
 kubectl get nodes liqo-%s
 
-* Ready to go! Let's deploy a simple application by simply typing:
+* Ready to go! Let's deploy a simple cross-cluster application using Liqo 🚜:
 
 kubectl create ns liqo-demo # Let's create a demo namespace
 kubectl label ns liqo-demo liqo.io/enabled=true # Enable Liqo offloading on this namespace (Check out https://doc.liqo.io/usage for more details).

--- a/pkg/liqoctl/add/handler.go
+++ b/pkg/liqoctl/add/handler.go
@@ -44,27 +44,30 @@ type ClusterArgs struct {
 }
 
 // HandleAddCommand handles the add command, configuring all the resources required to configure an outgoing peering.
-func HandleAddCommand(ctx context.Context, t *ClusterArgs) {
+func HandleAddCommand(ctx context.Context, t *ClusterArgs) error {
 	restConfig := common.GetLiqoctlRestConfOrDie()
 
+	klog.Info("* Initializing 🔌... ")
 	clientSet, err := kubernetes.NewForConfig(restConfig)
 	if err != nil {
-		klog.Fatalf(err.Error())
+		return err
 	}
 
 	k8sClient, err := client.New(restConfig, client.Options{})
 	if err != nil {
-		klog.Fatalf(err.Error())
+		return err
 	}
 
+	klog.Info("* Processing Cluster Addition 🔧... ")
 	if err := processAddCluster(ctx, t, clientSet, k8sClient); err != nil {
-		klog.Fatalf(err.Error())
+		return err
 	}
 
 	err = printSuccesfulOutputMessage(ctx, t, k8sClient)
 	if err != nil {
-		klog.Fatalf(err.Error())
+		return err
 	}
+	return nil
 }
 
 func printSuccesfulOutputMessage(ctx context.Context, t *ClusterArgs, k8sClient client.Client) error {

--- a/pkg/liqoctl/generate/handler.go
+++ b/pkg/liqoctl/generate/handler.go
@@ -34,18 +34,19 @@ import (
 )
 
 // HandleGenerateAddCommand outputs the liqoctl add command to use to add the target cluster.
-func HandleGenerateAddCommand(ctx context.Context, liqoNamespace, commandName string) {
+func HandleGenerateAddCommand(ctx context.Context, liqoNamespace, commandName string) error {
 	restConfig := common.GetLiqoctlRestConfOrDie()
 
 	clientSet, err := client.New(restConfig, client.Options{})
 	if err != nil {
-		klog.Fatalf(err.Error())
+		return err
 	}
 
 	commandString := processGenerateCommand(ctx, clientSet, liqoNamespace, commandName)
 
-	fmt.Printf("\nUse this command to peer with this cluster:\n\n")
-	fmt.Printf("%s\n", commandString)
+	fmt.Printf("\nUse this command on a DIFFERENT cluster to enable an outgoing peering WITH THE CURRENT cluster 🛠:\n\n")
+	fmt.Printf("%s\n\n", commandString)
+	return nil
 }
 
 func processGenerateCommand(ctx context.Context, clientSet client.Client, liqoNamespace, commandName string) string {


### PR DESCRIPTION
# Description

This PR updates the output of liqoctl install.

Example Command:

```liqoctl install kind```

Sample Output:

* Initializing installer... :electric_plug: 
* Retrieving cluster configuration from Provider... :scroll:  
* Installing or Upgrading Liqo... (this may take few minutes) :hourglass_flowing_sand: 
2021/09/11 13:23:41 release upgrade successfully: liqo/liqo-v0.3.0-rc.6
* All Set! You can use Liqo now! :rocket:

Use this command on a DIFFERENT cluster to enable an outgoing peering WITH THE CURRENT cluster 🛠:

./liqoctl add cluster 00ed2e34-e122-4976-ad10-1c46eb206d78 --auth-url https://172.18.0.3:31577 --id 00ed2e34-e122-4976-ad10-1c46eb206d78 --token 919071f73b0d88fc98d72ee3ad9652109f41f087e1eb230797c903af982fdece63cb2716123d5fd608361832e2e7408f6629ee7fbf57c22975c38454a4b78df6

# How Has This Been Tested?

- [x] Manually
