### PR TITLE
Adding status command to liqoctl tool.

### DIFF
--- a/cmd/liqoctl/cmd/root.go
+++ b/cmd/liqoctl/cmd/root.go
@@ -54,5 +54,6 @@ func NewRootCommand(ctx context.Context) *cobra.Command {
 	rootCmd.AddCommand(newGenerateAddCommand(ctx))
 	rootCmd.AddCommand(newDocsCommand(ctx))
 	rootCmd.AddCommand(newVersionCommand())
+	rootCmd.AddCommand(newStatusCommand(ctx))
 	return rootCmd
 }

--- a/cmd/liqoctl/cmd/status.go
+++ b/cmd/liqoctl/cmd/status.go
@@ -1,0 +1,39 @@
+// Copyright 2019-2021 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+
+	"github.com/liqotech/liqo/pkg/liqoctl/status"
+)
+
+func newStatusCommand(ctx context.Context) *cobra.Command {
+	var params = status.Args{}
+
+	cmd := &cobra.Command{
+		Use:           status.UseCommand,
+		Short:         status.ShortHelp,
+		Long:          status.LongHelp,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return params.Handler(ctx)
+		},
+	}
+	cmd.Flags().StringVarP(&params.Namespace, status.Namespace, "n", "liqo", "Namespace Liqo is running in")
+	return cmd
+}

--- a/pkg/liqoctl/status/checker.go
+++ b/pkg/liqoctl/status/checker.go
@@ -1,0 +1,24 @@
+// Copyright 2019-2021 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package status
+
+import "context"
+
+// Checker an interface required to be implemented by all the checkers that
+// collect the status of Liqo.
+type Checker interface {
+	Collect(ctx context.Context) error
+	Format() (string, error)
+}

--- a/pkg/liqoctl/status/consts.go
+++ b/pkg/liqoctl/status/consts.go
@@ -1,0 +1,43 @@
+// Copyright 2019-2021 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package status
+
+const (
+
+	// ShortHelp contains the short help string for liqoctl status command.
+	ShortHelp = "Show overall status of Liqo"
+	// LongHelp contains the Long help string for liqoctl status command.
+	LongHelp = `
+Show overall status of Liqo.
+
+The command shows the status of the Liqo control plane. The command checks that
+every component is up and running.
+
+$ liqoctl status --namespace ns-where-Liqo-is-running
+`
+	// UseCommand contains the name of the command.
+	UseCommand = "status"
+
+	// Namespace contains the name of namespace flag.
+	Namespace = "namespace"
+
+	redCross  = "\u274c"
+	checkMark = "\u2714"
+
+	red    = "\033[31m"
+	yellow = "\033[33m"
+	green  = "\033[32m"
+	reset  = "\033[0m"
+)

--- a/pkg/liqoctl/status/doc.go
+++ b/pkg/liqoctl/status/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2019-2021 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package status contains the logic that handle the status command in liqoctl
+package status

--- a/pkg/liqoctl/status/handler.go
+++ b/pkg/liqoctl/status/handler.go
@@ -1,0 +1,42 @@
+// Copyright 2019-2021 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package status
+
+import (
+	"context"
+
+	k8s "k8s.io/client-go/kubernetes"
+
+	"github.com/liqotech/liqo/pkg/liqoctl/common"
+)
+
+// Args flags of the status command.
+type Args struct {
+	Namespace string
+}
+
+// Handler implements the logic of the status command.
+func (a *Args) Handler(ctx context.Context) error {
+	restConfig := common.GetLiqoctlRestConfOrDie()
+
+	clientSet, err := k8s.NewForConfig(restConfig)
+	if err != nil {
+		return err
+	}
+
+	collector := newK8sStatusCollector(clientSet, *a)
+
+	return collector.collectStatus(ctx)
+}

--- a/pkg/liqoctl/status/k8s.go
+++ b/pkg/liqoctl/status/k8s.go
@@ -34,7 +34,7 @@ func newK8sStatusCollector(client k8s.Interface, params Args) *k8sStatusCollecto
 		client: client,
 		params: params,
 		checkers: []Checker{
-			newPodChecker(params.Namespace, client),
+			newPodChecker(params.Namespace, liqoDeployments, liqoDaemonSets, client),
 		},
 	}
 }

--- a/pkg/liqoctl/status/k8s.go
+++ b/pkg/liqoctl/status/k8s.go
@@ -1,0 +1,55 @@
+// Copyright 2019-2021 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package status
+
+import (
+	"context"
+	"fmt"
+
+	k8s "k8s.io/client-go/kubernetes"
+)
+
+// k8sStatusCollector knows how to interact with k8s cluster.
+type k8sStatusCollector struct {
+	client   k8s.Interface
+	params   Args
+	checkers []Checker
+}
+
+// newK8sStatusCollector returns a new k8sStatusCollector.
+func newK8sStatusCollector(client k8s.Interface, params Args) *k8sStatusCollector {
+	return &k8sStatusCollector{
+		client: client,
+		params: params,
+		checkers: []Checker{
+			newPodChecker(params.Namespace, client),
+		},
+	}
+}
+
+// collectStatus collects the status of each Checker that belongs to the collector.
+func (k *k8sStatusCollector) collectStatus(ctx context.Context) error {
+	for _, checker := range k.checkers {
+		if err := checker.Collect(ctx); err != nil {
+			return err
+		}
+		msg, err := checker.Format()
+		if err != nil {
+			return err
+		}
+		fmt.Print(msg)
+	}
+	return nil
+}

--- a/pkg/liqoctl/status/pods.go
+++ b/pkg/liqoctl/status/pods.go
@@ -1,0 +1,393 @@
+// Copyright 2019-2021 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package status
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+	"text/tabwriter"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	k8s "k8s.io/client-go/kubernetes"
+
+	"github.com/liqotech/liqo/pkg/utils/slice"
+)
+
+const (
+	checkerName = "liqo-control-plane"
+)
+
+var (
+	liqoDeployments = []string{
+		"capsule-controller-manager",
+		"liqo-controller-manager",
+		"liqo-network-manager",
+		"liqo-crd-replicator",
+		"liqo-webhook",
+		"liqo-gateway",
+		"liqo-auth",
+	}
+	liqoDaemonSets = []string{
+		"liqo-route",
+	}
+)
+
+// errorCount is a struct holding a list of errors.
+type errorCount struct {
+	errors []error
+}
+
+// collectionError struct holding the error for a given deployment of Liqo while collecting its status.
+type collectionError struct {
+	appType string
+	appName string
+	err     error
+}
+
+// newCollectionError return a new collectionError with the given arguments set.
+func newCollectionError(appType, appName string, err error) collectionError {
+	return collectionError{
+		appType: appType,
+		appName: appName,
+		err:     err,
+	}
+}
+
+// errorCountMap is a map with:
+// key -> name of the pod;
+// value -> errorCount for the given pod.
+type errorCountMap map[string]*errorCount
+
+// podState counts the number of pods in a particular state for a given deployment.
+type podState struct {
+	// errorFlag set to true if no errors are present.
+	errorFlag bool
+
+	// deploymentType is the type of deployment ("Deployment", "DaemonSet", ...).
+	deploymentType string
+
+	// desired is the number of desired pods to be scheduled.
+	desired int
+
+	// ready is the number of ready pods.
+	ready int
+
+	// available is the number of available pods.
+	available int
+
+	// unavailable is the number of unavailable pods.
+	unavailable int
+
+	// imageVersions is the name of the images used by the pods (containers/init-containers), denoting the version of the images.
+	imageVersions []string
+
+	// errors is the aggregated errors of all pods.
+	errors errorCountMap
+}
+
+// podStateMap is a map with:
+// key -> name of the Liqo component;
+// value -> podState.
+type podStateMap map[string]podState
+
+func newPodState(dType string) podState {
+	return podState{
+		deploymentType: dType,
+	}
+}
+
+// getImages returns the images used by the current deployment/application.
+func (ps *podState) getImages() []string {
+	return ps.imageVersions
+}
+
+// setImages sets the images passed as argument.
+func (ps *podState) setImages(images []string) {
+	ps.imageVersions = images
+}
+
+// addImageVersion adds an image version to the existing ones.
+func (ps *podState) addImageVersion(imageVersion string) {
+	iv := ps.getImages()
+	if !(slice.ContainsString(iv, imageVersion)) {
+		iv = append(iv, imageVersion)
+	}
+	ps.setImages(iv)
+}
+
+// getErrorCount returns the errorCount for given pod belonging to the current deployment/application.
+func (ps *podState) getErrorCount(pod string) *errorCount {
+	var errors errorCountMap
+	// Get the errorCountMap for the current deployment.
+	if ps.errors == nil {
+		ps.errors = errorCountMap{}
+	}
+	errors = ps.errors
+	// If the errorCount for the given pod does not exist then create and set it for the given pod.
+	if errors[pod] == nil {
+		errors[pod] = &errorCount{}
+	}
+	// Return the errorCount for the given pod managed by the given deployment.
+	return errors[pod]
+}
+
+// addErrorPerPod adds an error for a given pod belonging to che current deployment/application.
+// At the same time the errorFlag is set to true. This way the components having an error could be
+// discerned from the error free components.
+func (ps *podState) addErrorPerPod(pod string, err error) {
+	eCount := ps.getErrorCount(pod)
+	eCount.errors = append(eCount.errors, err)
+	// set error flag to true.
+	ps.errorFlag = true
+}
+
+// format returns a string describing the status of the current deployment/application.
+func (ps *podState) format() string {
+	var outputTokens []string
+
+	if ps.desired > 0 {
+		outputTokens = append(outputTokens, fmt.Sprintf("Desired: %d", ps.desired))
+	}
+	if ps.ready > 0 {
+		outputColor := green
+		if ps.ready < ps.desired {
+			outputColor = yellow
+		}
+		outputTokens = append(outputTokens, fmt.Sprintf("Ready: "+outputColor+"%d/%d"+reset, ps.ready, ps.desired))
+	}
+	if ps.available > 0 {
+		outputColor := green
+		if ps.available < ps.desired {
+			outputColor = yellow
+		}
+		outputTokens = append(outputTokens, fmt.Sprintf("available: "+outputColor+"%d/%d"+reset, ps.available, ps.desired))
+	}
+	if ps.unavailable > 0 {
+		outputTokens = append(outputTokens, fmt.Sprintf(" Unavailable: "+red+"%d/%d"+reset, ps.unavailable, ps.desired))
+	}
+	outputTokens = append(outputTokens, fmt.Sprintf("Image version: %s", strings.Join(ps.getImages(), ", ")))
+	return strings.Join(outputTokens, ", ")
+}
+
+// podChecker implements the Check interface.
+// holds the information about the control plane pods of Liqo.
+type podChecker struct {
+	client           k8s.Interface
+	namespace        string
+	name             string
+	podsState        podStateMap
+	errors           bool
+	collectionErrors []collectionError
+}
+
+// newPodChecker return a new pod checker.
+func newPodChecker(namespace string, client k8s.Interface) *podChecker {
+	return &podChecker{
+		client:    client,
+		namespace: namespace,
+		name:      checkerName,
+		podsState: make(podStateMap, 6),
+		errors:    false,
+	}
+}
+
+// Collect implements the collect method of the Checker interface.
+// it collects the status of the components of Liqo. The status is
+// collected at the pod level.
+func (pc *podChecker) Collect(ctx context.Context) error {
+	for _, dName := range liqoDeployments {
+		err := pc.deploymentStatus(ctx, dName)
+		if err != nil {
+			pc.addCollectionError("Deployment", dName, fmt.Errorf("unable to collect status for deployment %s in namespace %s: %w", dName, pc.namespace, err))
+			pc.errors = true
+		}
+	}
+
+	for _, dName := range liqoDaemonSets {
+		err := pc.daemonSetStatus(ctx, dName)
+		if err != nil {
+			pc.addCollectionError("DaemonSet", dName, fmt.Errorf("unable to collect status for daemonSet %s in namespace %s: %w", dName, pc.namespace, err))
+			pc.errors = true
+		}
+	}
+
+	return nil
+}
+
+// Format implements the format method of the Checker interface.
+// it outputs the status of the Liqo components in a string ready to be
+// printed out.
+func (pc *podChecker) Format() (string, error) {
+	var buf bytes.Buffer
+	w := tabwriter.NewWriter(&buf, 0, 0, 4, ' ', 0)
+
+	separator := strings.Repeat("-", len(pc.name))
+	fmt.Fprintf(w, "%s\n", pc.name)
+	fmt.Fprintf(w, "%s\n", separator)
+	if pc.errors {
+		// Add pod state to the buffer for each deployment type.
+		if pc.errors {
+			fmt.Fprintf(w, "%s liqo control plane is not OK\n", redCross)
+			for deployment, podState := range pc.podsState {
+				if podState.errorFlag {
+					fmt.Fprintf(w, "%s\t%s\t%s\n", podState.deploymentType, deployment, podState.format())
+					for pod, errorCol := range podState.errors {
+						for _, err := range errorCol.errors {
+							fmt.Fprintf(w, "%s\t%s\tPod\t%s\t%s\n", podState.deploymentType, deployment, pod, err)
+						}
+					}
+				}
+			}
+			for _, err := range pc.collectionErrors {
+				fmt.Fprintf(w, "%s\t%s\t%s\n", err.appType, err.appName, err.err)
+			}
+		}
+	} else {
+		fmt.Fprintf(w, "%s control plane pods are up and running\n", checkMark)
+	}
+
+	if err := w.Flush(); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}
+
+// deploymentStatus collects the status of a given kubernetes Deployment.
+func (pc *podChecker) deploymentStatus(ctx context.Context, deploymentName string) error {
+	var errors bool
+	d, err := pc.client.AppsV1().Deployments(pc.namespace).Get(ctx, deploymentName, metav1.GetOptions{})
+
+	if err != nil {
+		return err
+	}
+
+	if d == nil {
+		return fmt.Errorf("deployment %s seems to be unavailable", deploymentName)
+	}
+
+	dState := newPodState("Deployment")
+	dState.desired = int(d.Status.Replicas)
+	dState.ready = int(d.Status.ReadyReplicas)
+	dState.unavailable = int(d.Status.UnavailableReplicas)
+	dState.available = int(d.Status.AvailableReplicas)
+
+	// Get all the pods related with the current deployment.
+	pods, err := pc.client.CoreV1().Pods(pc.namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: labels.FormatLabels(d.Spec.Selector.MatchLabels),
+	})
+	if err != nil {
+		return err
+	}
+	if len(pods.Items) == 0 {
+		return fmt.Errorf("no pods found for deployment %s", deploymentName)
+	}
+
+	if errors = checkPodsStatus(pods.Items, &dState); errors {
+		pc.errors = errors
+	}
+	pc.podsState[deploymentName] = dState
+
+	return nil
+}
+
+// daemontSetStatus collects the status of a given kubernetes DaemonSet.
+func (pc *podChecker) daemonSetStatus(ctx context.Context, daemonSetName string) error {
+	d, err := pc.client.AppsV1().DaemonSets(pc.namespace).Get(ctx, daemonSetName, metav1.GetOptions{})
+
+	if err != nil {
+		return err
+	}
+
+	if d == nil {
+		return fmt.Errorf("daemonSet %s seems to be unavailable", daemonSetName)
+	}
+
+	dState := newPodState("DaemonSet")
+	dState.desired = int(d.Status.DesiredNumberScheduled)
+	dState.ready = int(d.Status.NumberReady)
+	dState.unavailable = int(d.Status.NumberUnavailable)
+	dState.available = int(d.Status.NumberAvailable)
+
+	// Get all the pods related with the current daemonset.
+	pods, err := pc.client.CoreV1().Pods(pc.namespace).List(ctx, metav1.ListOptions{
+		TypeMeta:      metav1.TypeMeta{},
+		LabelSelector: labels.FormatLabels(d.Spec.Selector.MatchLabels),
+	})
+	if err != nil {
+		return err
+	}
+	if len(pods.Items) == 0 {
+		return fmt.Errorf("no pods found for deployment %s", daemonSetName)
+	}
+
+	if errors := checkPodsStatus(pods.Items, &dState); errors {
+		pc.errors = errors
+	}
+	pc.podsState[daemonSetName] = dState
+	return nil
+}
+
+// addCollectionError adds a collection error. A collection error is an error that happens while
+// collecting the status of a Liqo component.
+func (pc *podChecker) addCollectionError(deploymentType, deploymenName string, err error) {
+	pc.collectionErrors = append(pc.collectionErrors, newCollectionError(deploymentType, deploymenName, err))
+}
+
+// checkPodsStatus fills the podState data structure for a given pod.
+// It returns a bool value which is set to true if the pod is not up and running, meaning there are errors.
+func checkPodsStatus(podsList []corev1.Pod, dState *podState) bool {
+	var errorBool bool
+	for i := range podsList {
+		pod := podsList[i]
+		podName := pod.Name
+		// Collect images used by the containers of the current pod.
+		for j := range pod.Spec.Containers {
+			c := pod.Spec.Containers[j]
+			dState.addImageVersion(c.Image)
+		}
+		// Collect images used by the init containers of the current pod.
+		for j := range pod.Spec.InitContainers {
+			c := pod.Spec.InitContainers[j]
+			dState.addImageVersion(c.Image)
+		}
+
+		for l := range pod.Status.Conditions {
+			cond := pod.Status.Conditions[l]
+			switch cond.Type {
+			case corev1.PodScheduled:
+				if cond.Status != corev1.ConditionTrue {
+					dState.addErrorPerPod(podName, fmt.Errorf("not scheduled"))
+					errorBool = true
+				}
+			case corev1.PodReady:
+				if cond.Status != corev1.ConditionTrue {
+					dState.addErrorPerPod(podName, fmt.Errorf("not ready"))
+					errorBool = true
+				}
+			case corev1.PodInitialized:
+				if cond.Status != corev1.ConditionTrue {
+					dState.addErrorPerPod(podName, fmt.Errorf("not initialized"))
+					errorBool = true
+				}
+			default:
+			}
+		}
+	}
+	return errorBool
+}

--- a/pkg/liqoctl/status/pods_test.go
+++ b/pkg/liqoctl/status/pods_test.go
@@ -1,0 +1,442 @@
+// Copyright 2019-2021 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package status
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/utils/pointer"
+)
+
+var _ = Describe("Pods", func() {
+	Describe("CollectionError", func() {
+		var (
+			appType = "Deployment"
+			appName = "app"
+			err     = errors.New("ce")
+		)
+
+		Context("creating a new collectionError", func() {
+			It("should hold the passed parameters during the creation", func() {
+				ce := newCollectionError(appType, appName, err)
+				Expect(ce.appType).To(Equal(appType))
+				Expect(ce.appName).To(Equal(appName))
+				Expect(ce.err).To(MatchError(err))
+			})
+		})
+	})
+
+	Describe("ComponentState", func() {
+		var (
+			deploymentType = "Deployment"
+			image          = "liqo:testImage"
+			podS           componentState
+		)
+		JustBeforeEach(func() {
+			podName := "pod1"
+			err := errors.New("pod1")
+			podS = componentState{
+				errorFlag:      false,
+				controllerType: "",
+				desired:        1,
+				ready:          1,
+				available:      1,
+				unavailable:    0,
+				imageVersions:  []string{image},
+				errors:         errorCountMap{podName: &errorCount{[]error{err}}},
+			}
+		})
+
+		Describe("creating a new componentState", func() {
+			It("should hold the passed parameters during the creation", func() {
+				ps := newComponentState(deploymentType)
+				Expect(ps.controllerType).To(Equal(deploymentType))
+			})
+		})
+
+		Describe("handling images field", func() {
+			Context("getting images", func() {
+				It("should return a slice of length 1", func() {
+					im := podS.getImages()
+					Expect(im).To(HaveLen(1))
+					Expect(im[0]).To(Equal(image))
+				})
+			})
+
+			Context("setting images", func() {
+				It("should set the new images", func() {
+					newImages := []string{"image1", "image2"}
+					podS.setImages(newImages)
+					Expect(len(podS.imageVersions)).To(BeNumerically("==", 2))
+					Expect(podS.imageVersions).To(Equal(newImages))
+				})
+			})
+
+			Context("adding an image to the existing ones", func() {
+				When("the image does not exist", func() {
+					It("should append the image to the existing ones", func() {
+						newImage := "newImage"
+						podS.addImageVersion(newImage)
+						Expect(len(podS.imageVersions)).To(BeNumerically("==", 2))
+						Expect(podS.imageVersions[1]).To(Equal(newImage))
+					})
+				})
+
+				When("the image exists", func() {
+					It("should not append the image", func() {
+						podS.addImageVersion(image)
+						Expect(len(podS.imageVersions)).To(BeNumerically("==", 1))
+					})
+				})
+			})
+		})
+
+		Describe("handling errorsPerPod field", func() {
+			var (
+				podName = "pod1"
+				err     = errors.New("new podName error")
+			)
+
+			Context("adding error per podName", func() {
+				When("no errors per podName exists", func() {
+					It("should add the error for the given podName", func() {
+						podS.errors = errorCountMap{}
+						podS.addErrorForPod(podName, err)
+						Expect(podS.errors[podName].errors).To(HaveLen(1))
+						Expect(podS.errors[podName].errors[0]).To(MatchError(err))
+					})
+				})
+
+				When("errors per podName exists", func() {
+					It("should append the new error for the given podName", func() {
+						podS.addErrorForPod(podName, err)
+						Expect(podS.errors[podName].errors).To(HaveLen(2))
+						Expect(podS.errors[podName].errors[1]).To(MatchError(err))
+					})
+				})
+			})
+		})
+
+		Describe("formatting the componentState", func() {
+			When("there are no unavailable pods", func() {
+				It("string should not contain unavailable pods", func() {
+					Expect(podS.format()).NotTo(ContainSubstring("Unavailable"))
+				})
+
+			})
+
+			When("not all pods are ready", func() {
+				It("output should contain unavailable pods", func() {
+					podS.desired = 2
+					podS.unavailable = 1
+					Expect(podS.format()).To(ContainSubstring(fmt.Sprintf(" Unavailable: " + red + "1/2" + reset)))
+				})
+			})
+		})
+	})
+
+	Describe("podChecker", func() {
+		var (
+			pod           *v1.Pod
+			deployment    *appsv1.Deployment
+			daemonSet     *appsv1.DaemonSet
+			podC          podChecker
+			ctx           = context.Background()
+			namespace     = "namespaceTest"
+			deploymentApp = "deploymentTest"
+			deployments   = []string{deploymentApp}
+			daemonSetApp  = "daemonSetTest"
+			daemonSets    = []string{daemonSetApp}
+
+			depLabels = map[string]string{
+				"app": deploymentApp,
+			}
+
+			dsLabels = map[string]string{
+				"app": daemonSetApp,
+			}
+		)
+		BeforeEach(func() {
+			pod = &v1.Pod{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Pod",
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: namespace,
+					Labels:    depLabels,
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name:  "nginx",
+							Image: "nginx",
+						},
+					},
+				},
+			}
+
+			deployment = &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      deploymentApp,
+					Namespace: namespace,
+				},
+				Spec: appsv1.DeploymentSpec{
+					Replicas: pointer.Int32Ptr(1),
+					Selector: &metav1.LabelSelector{
+						MatchLabels: depLabels,
+					},
+				},
+			}
+
+			daemonSet = &appsv1.DaemonSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      daemonSetApp,
+					Namespace: namespace,
+				},
+				Spec: appsv1.DaemonSetSpec{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: dsLabels,
+					},
+				},
+			}
+		})
+		JustBeforeEach(func() {
+			podC = podChecker{
+				deployments:      deployments,
+				daemonSets:       daemonSets,
+				namespace:        namespace,
+				name:             checkerName,
+				podsState:        make(podStateMap, 2),
+				errors:           false,
+				collectionErrors: nil,
+			}
+		})
+
+		Describe("creating a new podChecker", func() {
+			It("should hold the passed parameters during the creation", func() {
+				pc := newPodChecker(namespace, deployments, daemonSets, fake.NewSimpleClientset())
+				Expect(pc.namespace).To(Equal(namespace))
+				Expect(pc.daemonSets).To(Equal(daemonSets))
+				Expect(pc.deployments).To(Equal(deployments))
+				Expect(pc.client).NotTo(BeNil())
+				Expect(pc.errors).To(BeFalse())
+			})
+		})
+
+		Describe("Collect() function", func() {
+			Context("collecting deployment apps", func() {
+				When("fails to get the deployment", func() {
+					It("should add an error to the collectionErrors", func() {
+						podC.client = fake.NewSimpleClientset()
+						Expect(podC.Collect(ctx)).To(BeNil())
+						Expect(podC.errors).To(BeTrue())
+						Expect(podC.collectionErrors).To(HaveLen(2))
+					})
+				})
+
+				When("fails to get the pod related to the deployment", func() {
+					It("should add an error to the collectionErrors", func() {
+						podC.client = fake.NewSimpleClientset(deployment)
+						Expect(podC.Collect(ctx)).To(BeNil())
+						Expect(podC.errors).To(BeTrue())
+						Expect(podC.collectionErrors).To(HaveLen(2))
+					})
+				})
+
+				When("deployment and pod exist", func() {
+					It("should not add errors", func() {
+						pod.SetLabels(depLabels)
+						podC.client = fake.NewSimpleClientset(deployment, pod)
+						Expect(podC.Collect(ctx)).To(BeNil())
+						Expect(podC.errors).To(BeTrue())
+						Expect(podC.collectionErrors).To(HaveLen(1))
+					})
+				})
+			})
+
+			Context("collecting daemonSets apps", func() {
+				When("fails to get the daemonSet", func() {
+					It("should add an error to the collectionErrors", func() {
+						podC.client = fake.NewSimpleClientset()
+						Expect(podC.Collect(ctx)).To(BeNil())
+						Expect(podC.errors).To(BeTrue())
+						Expect(podC.collectionErrors).To(HaveLen(2))
+					})
+				})
+
+				When("fails to get the pod related to the daemonSet", func() {
+					It("should add an error to the collectionErrors", func() {
+						podC.client = fake.NewSimpleClientset(daemonSet)
+						Expect(podC.Collect(ctx)).To(BeNil())
+						Expect(podC.errors).To(BeTrue())
+						Expect(podC.collectionErrors).To(HaveLen(2))
+					})
+				})
+
+				When("daemonSet and pod exist", func() {
+					It("should not add errors", func() {
+						pod.SetLabels(dsLabels)
+						podC.client = fake.NewSimpleClientset(daemonSet, pod)
+						Expect(podC.Collect(ctx)).To(BeNil())
+						Expect(podC.errors).To(BeTrue())
+						Expect(podC.collectionErrors).To(HaveLen(1))
+					})
+				})
+			})
+		})
+
+		Describe("deploymentStatus() function", func() {
+			When("fails to get the deployment", func() {
+				It("should return an error", func() {
+					podC.client = fake.NewSimpleClientset()
+					Expect(podC.deploymentStatus(ctx, deploymentApp)).To(HaveOccurred())
+				})
+			})
+
+			When("fails to get the pod related to the deployment", func() {
+				It("should return an error", func() {
+					podC.client = fake.NewSimpleClientset(deployment)
+					Expect(podC.deploymentStatus(ctx, deploymentApp)).To(HaveOccurred())
+				})
+			})
+
+			When("deployment and pod exist", func() {
+				It("should return nil", func() {
+					pod.SetLabels(depLabels)
+					podC.client = fake.NewSimpleClientset(deployment, pod)
+					Expect(podC.deploymentStatus(ctx, deploymentApp)).NotTo(HaveOccurred())
+				})
+			})
+		})
+
+		Describe("daemonSetStatus() function", func() {
+			When("fails to get the daemonSet", func() {
+				It("should return an error", func() {
+					podC.client = fake.NewSimpleClientset()
+					Expect(podC.daemonSetStatus(ctx, daemonSetApp)).To(HaveOccurred())
+				})
+			})
+
+			When("fails to get the pod related to the daemonSet", func() {
+				It("should return an error", func() {
+					podC.client = fake.NewSimpleClientset(daemonSet)
+					Expect(podC.daemonSetStatus(ctx, daemonSetApp)).To(HaveOccurred())
+				})
+			})
+
+			When("daemonSet and pod exist", func() {
+				It("should return nil", func() {
+					pod.SetLabels(dsLabels)
+					podC.client = fake.NewSimpleClientset(daemonSet, pod)
+					Expect(podC.daemonSetStatus(ctx, daemonSetApp)).NotTo(HaveOccurred())
+				})
+			})
+		})
+
+		Describe("Format() function", func() {
+			When("status is not ok", func() {
+				It("should state that the status is not OK", func() {
+					podC.errors = true
+					msg, err := podC.Format()
+					Expect(err).NotTo(HaveOccurred())
+					Expect(msg).To(ContainSubstring(fmt.Sprintf("%s liqo control plane is not OK\n", redCross)))
+				})
+			})
+
+			When("status is ok", func() {
+				It("should state that the status is OK", func() {
+					msg, err := podC.Format()
+					Expect(err).NotTo(HaveOccurred())
+					Expect(msg).To(ContainSubstring(fmt.Sprintf("%s control plane pods are up and running\n", checkMark)))
+				})
+			})
+		})
+
+		Describe("checkPodsStatus() function", func() {
+
+			var (
+				pod1 = &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "podTest",
+					},
+					Status: v1.PodStatus{
+						Phase: "",
+						Conditions: []v1.PodCondition{
+							{
+								Type:   v1.PodInitialized,
+								Status: v1.ConditionFalse,
+							}},
+					},
+				}
+
+				pod2 = &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "podTest",
+					},
+					Status: v1.PodStatus{
+						Phase: "",
+						Conditions: []v1.PodCondition{
+							{
+								Type:   v1.PodScheduled,
+								Status: v1.ConditionFalse,
+							}},
+					},
+				}
+
+				pod3 = &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "podTest",
+					},
+					Status: v1.PodStatus{
+						Phase: "",
+						Conditions: []v1.PodCondition{
+							{
+								Type:   v1.PodReady,
+								Status: v1.ConditionFalse,
+							}},
+					},
+				}
+			)
+
+			DescribeTable("checking all cases",
+				func(p *v1.Pod, expectedErr error, expectedBool bool) {
+					podsList := []v1.Pod{*p}
+					dState := newComponentState("testing")
+					Expect(checkPodsStatus(podsList, &dState)).To(Equal(expectedBool))
+					if expectedErr != nil {
+						Expect(dState.errors[p.Name].errors[0]).To(MatchError(expectedErr))
+					} else {
+						Expect(dState.errors[p.Name].errors[0]).To(BeNil())
+					}
+				},
+				Entry("pod is not initialized", pod1, fmt.Errorf("not initialized"), true),
+				Entry("pod is not scheduled", pod2, fmt.Errorf("not scheduled"), true),
+				Entry("pod is not ready", pod3, fmt.Errorf("not ready"), true),
+			)
+		})
+	})
+
+})

--- a/pkg/liqoctl/status/status_suite_test.go
+++ b/pkg/liqoctl/status/status_suite_test.go
@@ -12,5 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package status contains the logic that handles the status command in liqoctl
 package status
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestStatus(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Status Suite")
+}


### PR DESCRIPTION
# Description
This PR is the first attempt to implement the `status` command in the `liqoctl` tool. A simple go interface named `Checker` has been defined as follows:
```
type Checker interface {
	Collect(ctx context.Context) error
	Format() (string, error)
}

```
All the checks to be done against Liqo need to implement the `Checker` interface, in order to be run when the `status` command is invoked.

The first check implemented in this PR is the one done for the Liqo control plane. It checks that all the Liqo components are up and running in a given namespace. 

The command description is the following:

```
❯ liqoctl status --help

Show overall status of Liqo.

The command shows the status of the Liqo control plane. The command checks that
every component is up and running.

$ liqoctl status --namespace ns-where-Liqo-is-running

Usage:
  liqoctl status [flags]

Flags:
  -h, --help               help for status
  -n, --namespace string   Namespace Liqo is running in (default "liqo")
```

The following snippet shows the output in case of success:

```
❯ liqoctl status 

liqo-control-plane
------------------
✔ control plane pods are up and running
```
In case of errors in the components of Liqo, the output is similar to this:

```
❯ liqoctl status

liqo-control-plane
------------------
❌ liqo control plane is not OK
Deployment    liqo-gateway    Desired: 3, Ready: 2/3, available: 2/3,  Unavailable: 1/3, Image version: liqo/liqonet-ci:fbe4a7bcb18d6254a5f20d59d084bd7dd1f87972
Deployment    liqo-gateway    Pod    liqo-gateway-5cf4dd9db5-dglkf    not scheduled
```
Fixes #(issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Unit Tests
