### PR TITLE
Enable Default K3s Ingress in Liqoctl

### DIFF
--- a/cmd/liqoctl/cmd/install.go
+++ b/cmd/liqoctl/cmd/install.go
@@ -53,6 +53,8 @@ func newInstallCommand(ctx context.Context) *cobra.Command {
 	installCmd.PersistentFlags().String("resource-sharing-percentage", "90", "It defines the percentage of available cluster resources that "+
 		"you are willing to share with foreign clusters. It accepts [0 - 100] values.")
 	installCmd.PersistentFlags().Bool("enable-ha", false, "Enable the gateway component support active/passive high availability.")
+	installCmd.PersistentFlags().String("auth-service-hostname", "", "If set, Liqo exposes the authentication service with an ingress "+
+		"with that hostname (optional)")
 
 	for _, providerName := range providers {
 		cmd, err := getCommand(ctx, providerName)

--- a/deployments/liqo/templates/liqo-auth-service.yaml
+++ b/deployments/liqo/templates/liqo-auth-service.yaml
@@ -18,7 +18,11 @@ spec:
     {{- include "liqo.selectorLabels" $authConfig | nindent 4 }}
     {{- include "liqo.authServiceLabels" . | nindent 4 }}
   ports:
+    {{- if not .Values.auth.tls }}
+    - name: http
+    {{- else }}
     - name: https
+    {{- end }}
       protocol: TCP
       {{- if not .Values.auth.tls }}
       port: 5000

--- a/pkg/liqoctl/install/aks/aks_test.go
+++ b/pkg/liqoctl/install/aks/aks_test.go
@@ -55,6 +55,7 @@ var _ = Describe("Extract elements from AKS", func() {
 		GenerateFlags(cmd)
 		cmd.Flags().String("cluster-name", "", "Name to assign to the Liqo Cluster")
 		cmd.Flags().String("reserved-subnets", "", "")
+		cmd.Flags().String("auth-service-hostname", "", "")
 
 		flags := cmd.Flags()
 		Expect(flags.Set("subscription-id", subscriptionID)).To(Succeed())

--- a/pkg/liqoctl/install/eks/eks_test.go
+++ b/pkg/liqoctl/install/eks/eks_test.go
@@ -56,6 +56,7 @@ var _ = Describe("Extract elements from EKS", func() {
 		GenerateFlags(cmd)
 		cmd.Flags().String("cluster-name", "", "Name to assign to the Liqo Cluster")
 		cmd.Flags().String("reserved-subnets", "", "")
+		cmd.Flags().String("auth-service-hostname", "", "")
 
 		flags := cmd.Flags()
 		Expect(flags.Set("region", region)).To(Succeed())

--- a/pkg/liqoctl/install/gke/gke_test.go
+++ b/pkg/liqoctl/install/gke/gke_test.go
@@ -52,6 +52,7 @@ var _ = Describe("Extract elements from GKE", func() {
 		GenerateFlags(cmd)
 		cmd.Flags().String("cluster-name", "", "Name to assign to the Liqo Cluster")
 		cmd.Flags().String("reserved-subnets", "", "")
+		cmd.Flags().String("auth-service-hostname", "", "")
 
 		flags := cmd.Flags()
 		Expect(flags.Set("credentials-path", credentialsPath)).To(Succeed())

--- a/pkg/liqoctl/install/k3s/k3s_test.go
+++ b/pkg/liqoctl/install/k3s/k3s_test.go
@@ -53,6 +53,7 @@ var _ = Describe("Extract elements from K3S", func() {
 		GenerateFlags(cmd)
 		cmd.Flags().String("cluster-name", "", "Name to assign to the Liqo Cluster")
 		cmd.Flags().String("reserved-subnets", "", "")
+		cmd.Flags().String("auth-service-hostname", "", "")
 
 		flags := cmd.Flags()
 		Expect(flags.Set("pod-cidr", podCIDR)).To(Succeed())

--- a/pkg/liqoctl/install/kubeadm/provider.go
+++ b/pkg/liqoctl/install/kubeadm/provider.go
@@ -81,6 +81,8 @@ func (k *Kubeadm) UpdateChartValues(values map[string]interface{}) {
 			"clusterLabels": installutils.GetInterfaceMap(k.ClusterLabels),
 		},
 	}
+
+	k.SetupIngress(values, false)
 }
 
 // GenerateFlags generates the set of specific subpath and flags are accepted for a specific provider.


### PR DESCRIPTION
# Description

This pr add the possibility to create an ingress resource with the `liqoctl` install command on providers:

* `kubeadm`
* `k3s` (enabled by default)

# How Has This Been Tested?

- [x] locally
- [x] on k3s installation
