### PR TITLE
Liqoctl Set NodePort Services in k3s

### DIFF
--- a/pkg/liqoctl/install/k3s/provider.go
+++ b/pkg/liqoctl/install/k3s/provider.go
@@ -139,11 +139,21 @@ func (k *k3sProvider) UpdateChartValues(values map[string]interface{}) {
 	values["apiServer"] = map[string]interface{}{
 		"address": k.apiServer,
 	}
+	values["auth"] = map[string]interface{}{
+		"service": map[string]interface{}{
+			"type": "NodePort",
+		},
+	}
 	values["networkManager"] = map[string]interface{}{
 		"config": map[string]interface{}{
 			"serviceCIDR":     k.serviceCIDR,
 			"podCIDR":         k.podCIDR,
 			"reservedSubnets": installutils.GetInterfaceSlice(k.ReservedSubnets),
+		},
+	}
+	values["gateway"] = map[string]interface{}{
+		"service": map[string]interface{}{
+			"type": "NodePort",
 		},
 	}
 	values["discovery"] = map[string]interface{}{


### PR DESCRIPTION
# Description

This pr changes the default service type from `LoadBalancer` to `NodePort` on k3s provider

# How Has This Been Tested?

- [x] locally

