### PR TITLE
Move TunnelEndpoint fields to the spec stanza

### DIFF
--- a/apis/net/v1alpha1/tunnel_endpoint_types.go
+++ b/apis/net/v1alpha1/tunnel_endpoint_types.go
@@ -23,14 +23,35 @@ import (
 
 // TunnelEndpointSpec defines the desired state of TunnelEndpoint.
 type TunnelEndpointSpec struct {
-	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
-	// Important: Run "make" to regenerate code after modifying this file
-	// The ID of the remote cluster that will receive this CRD.
+	// The ID of the remote cluster.
 	ClusterID string `json:"clusterID"`
+
+	// PodCIDR of local cluster.
+	LocalPodCIDR string `json:"localPodCIDR"`
+	// Network used in the remote cluster to map the local PodCIDR, in case of conflicts (in the remote cluster).
+	// +kubebuilder:default="None"
+	// +kubebuilder:validation:Optional
+	LocalNATPodCIDR string `json:"localNATPodCIDR"`
+	// ExternalCIDR of local cluster.
+	LocalExternalCIDR string `json:"localExternalCIDR"`
+	// Network used in the remote cluster to map the local ExternalCIDR, in case of conflicts (in the remote cluster).
+	// +kubebuilder:default="None"
+	// +kubebuilder:validation:Optional
+	LocalNATExternalCIDR string `json:"localNATExternalCIDR"`
+
 	// PodCIDR of remote cluster.
-	PodCIDR string `json:"podCIDR"`
+	RemotePodCIDR string `json:"remotePodCIDR"`
+	// Network used in the local cluster to map the remote cluster PodCIDR, in case of conflicts with RemotePodCIDR.
+	// +kubebuilder:default="None"
+	// +kubebuilder:validation:Optional
+	RemoteNATPodCIDR string `json:"remoteNATPodCIDR"`
 	// ExternalCIDR of remote cluster.
-	ExternalCIDR string `json:"externalCIDR"`
+	RemoteExternalCIDR string `json:"remoteExternalCIDR"`
+	// Network used in the local cluster to map the remote cluster ExternalCIDR, in case of conflicts with RemoteExternalCIDR.
+	// +kubebuilder:default="None"
+	// +kubebuilder:validation:Optional
+	RemoteNATExternalCIDR string `json:"remoteNATExternalCIDR"`
+
 	// Public IP of the node where the VPN tunnel is created.
 	EndpointIP string `json:"endpointIP"`
 	// Vpn technology used to interconnect two clusters.
@@ -41,35 +62,12 @@ type TunnelEndpointSpec struct {
 
 // TunnelEndpointStatus defines the observed state of TunnelEndpoint.
 type TunnelEndpointStatus struct {
-	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
-	// Important: Run "make" to regenerate code after modifying this file\
-
-	Phase string `json:"phase,omitempty"`
-	// PodCIDR of local cluster.
-	LocalPodCIDR string `json:"localPodCIDR,omitempty"`
-	// Network used in the remote cluster to map the local PodCIDR, in case of conflicts(in the remote cluster).
-	// Default is "None".
-	LocalNATPodCIDR string `json:"localNATPodCIDR,omitempty"`
-	// Network used in the local cluster to map the remote cluster PodCIDR, in case of conflicts with Spec.PodCIDR.
-	// Default is "None".
-	RemoteNATPodCIDR string `json:"remoteNATPodCIDR,omitempty"`
-	// ExternalCIDR of local cluster.
-	LocalExternalCIDR string `json:"localExternalCIDR,omitempty"`
-	// Network used in the remote cluster to map the local ExternalCIDR, in case of conflicts(in the remote cluster).
-	// Default is "None".
-	LocalNATExternalCIDR string `json:"localNATExternalCIDR,omitempty"`
-	// Network used in the local cluster to map the remote cluster ExternalCIDR, in case of conflicts with
-	// Spec.ExternalCIDR.
-	// Default is "None".
-	RemoteNATExternalCIDR string     `json:"remoteNATExternalCIDR,omitempty"`
-	RemoteEndpointIP      string     `json:"remoteTunnelPublicIP,omitempty"`
-	LocalEndpointIP       string     `json:"localTunnelPublicIP,omitempty"`
-	TunnelIFaceIndex      int        `json:"tunnelIFaceIndex,omitempty"`
-	TunnelIFaceName       string     `json:"tunnelIFaceName,omitempty"`
-	VethIFaceIndex        int        `json:"vethIFaceIndex,omitempty"`
-	VethIFaceName         string     `json:"vethIFaceName,omitempty"`
-	GatewayIP             string     `json:"gatewayIP,omitempty"`
-	Connection            Connection `json:"connection,omitempty"`
+	TunnelIFaceIndex int        `json:"tunnelIFaceIndex,omitempty"`
+	TunnelIFaceName  string     `json:"tunnelIFaceName,omitempty"`
+	VethIFaceIndex   int        `json:"vethIFaceIndex,omitempty"`
+	VethIFaceName    string     `json:"vethIFaceName,omitempty"`
+	GatewayIP        string     `json:"gatewayIP,omitempty"`
+	Connection       Connection `json:"connection,omitempty"`
 }
 
 // Connection holds the configuration and status of a vpn tunnel connecting to remote cluster.

--- a/deployments/liqo/crds/net.liqo.io_tunnelendpoints.yaml
+++ b/deployments/liqo/crds/net.liqo.io_tunnelendpoints.yaml
@@ -62,17 +62,41 @@ spec:
                 description: Vpn technology used to interconnect two clusters.
                 type: string
               clusterID:
-                description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
-                  Important: Run "make" to regenerate code after modifying this file
-                  The ID of the remote cluster that will receive this CRD.'
+                description: The ID of the remote cluster.
                 type: string
               endpointIP:
                 description: Public IP of the node where the VPN tunnel is created.
                 type: string
-              externalCIDR:
+              localExternalCIDR:
+                description: ExternalCIDR of local cluster.
+                type: string
+              localNATExternalCIDR:
+                default: None
+                description: Network used in the remote cluster to map the local ExternalCIDR,
+                  in case of conflicts (in the remote cluster).
+                type: string
+              localNATPodCIDR:
+                default: None
+                description: Network used in the remote cluster to map the local PodCIDR,
+                  in case of conflicts (in the remote cluster).
+                type: string
+              localPodCIDR:
+                description: PodCIDR of local cluster.
+                type: string
+              remoteExternalCIDR:
                 description: ExternalCIDR of remote cluster.
                 type: string
-              podCIDR:
+              remoteNATExternalCIDR:
+                default: None
+                description: Network used in the local cluster to map the remote cluster
+                  ExternalCIDR, in case of conflicts with RemoteExternalCIDR.
+                type: string
+              remoteNATPodCIDR:
+                default: None
+                description: Network used in the local cluster to map the remote cluster
+                  PodCIDR, in case of conflicts with RemotePodCIDR.
+                type: string
+              remotePodCIDR:
                 description: PodCIDR of remote cluster.
                 type: string
             required:
@@ -80,8 +104,10 @@ spec:
             - backend_config
             - clusterID
             - endpointIP
-            - externalCIDR
-            - podCIDR
+            - localExternalCIDR
+            - localPodCIDR
+            - remoteExternalCIDR
+            - remotePodCIDR
             type: object
           status:
             description: TunnelEndpointStatus defines the observed state of TunnelEndpoint.
@@ -102,35 +128,6 @@ spec:
                     type: string
                 type: object
               gatewayIP:
-                type: string
-              localExternalCIDR:
-                description: ExternalCIDR of local cluster.
-                type: string
-              localNATExternalCIDR:
-                description: Network used in the remote cluster to map the local ExternalCIDR,
-                  in case of conflicts(in the remote cluster). Default is "None".
-                type: string
-              localNATPodCIDR:
-                description: Network used in the remote cluster to map the local PodCIDR,
-                  in case of conflicts(in the remote cluster). Default is "None".
-                type: string
-              localPodCIDR:
-                description: PodCIDR of local cluster.
-                type: string
-              localTunnelPublicIP:
-                type: string
-              phase:
-                type: string
-              remoteNATExternalCIDR:
-                description: Network used in the local cluster to map the remote cluster
-                  ExternalCIDR, in case of conflicts with Spec.ExternalCIDR. Default
-                  is "None".
-                type: string
-              remoteNATPodCIDR:
-                description: Network used in the local cluster to map the remote cluster
-                  PodCIDR, in case of conflicts with Spec.PodCIDR. Default is "None".
-                type: string
-              remoteTunnelPublicIP:
                 type: string
               tunnelIFaceIndex:
                 type: integer

--- a/internal/liqonet/route-operator/routeOperator.go
+++ b/internal/liqonet/route-operator/routeOperator.go
@@ -88,7 +88,7 @@ func (rc *RouteController) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		return result, nil
 	}
 	// Here we check that the tunnelEndpoint resource has been fully processed. If not we do nothing.
-	if tep.Status.RemoteNATPodCIDR == "" || tep.Status.GatewayIP == "" {
+	if tep.Status.GatewayIP == "" {
 		return result, nil
 	}
 	clusterID := tep.Spec.ClusterID

--- a/internal/liqonet/tunnel-operator/tunnel-operator.go
+++ b/internal/liqonet/tunnel-operator/tunnel-operator.go
@@ -254,12 +254,7 @@ func (tc *TunnelController) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return result, nil
 	}
 	clusterID = tep.Spec.ClusterID
-	// We wait for the resource to be ready. The resource is created in two steps, first the spec and metadata fields
-	// then the status field. So we wait for the status to be ready.
-	if tep.Status.Phase != liqoconst.TepReady {
-		klog.Infof("%s -> resource %s is not ready", tep.Spec.ClusterID, tep.Name)
-		return result, nil
-	}
+
 	_, remotePodCIDR = utils.GetPodCIDRS(tep)
 	_, remoteExternalCIDR = utils.GetExternalCIDRS(tep)
 	// Examine DeletionTimestamp to determine if object is under deletion.

--- a/internal/liqonet/tunnel-operator/tunnel_operator_suite_test.go
+++ b/internal/liqonet/tunnel-operator/tunnel_operator_suite_test.go
@@ -56,31 +56,27 @@ var (
 	iptNetns     ns.NetNS
 	tep1         = &netv1alpha1.TunnelEndpoint{
 		Spec: netv1alpha1.TunnelEndpointSpec{
-			ClusterID:    clusterID1,
-			PodCIDR:      "10.0.0.0/24",
-			ExternalCIDR: "10.0.1.0/24",
-		},
-		Status: netv1alpha1.TunnelEndpointStatus{
+			ClusterID:             clusterID1,
 			LocalPodCIDR:          "192.168.0.0/24",
 			LocalNATPodCIDR:       "192.168.1.0/24",
-			RemoteNATPodCIDR:      "10.0.70.0/24",
 			LocalExternalCIDR:     "192.168.3.0/24",
 			LocalNATExternalCIDR:  "192.168.4.0/24",
+			RemotePodCIDR:         "10.0.0.0/24",
+			RemoteNATPodCIDR:      "10.0.70.0/24",
+			RemoteExternalCIDR:    "10.0.1.0/24",
 			RemoteNATExternalCIDR: "192.168.5.0/24",
 		},
 	}
 	tep2 = &netv1alpha1.TunnelEndpoint{
 		Spec: netv1alpha1.TunnelEndpointSpec{
-			ClusterID:    clusterID2,
-			PodCIDR:      "10.0.0.0/24",
-			ExternalCIDR: "10.0.1.0/24",
-		},
-		Status: netv1alpha1.TunnelEndpointStatus{
+			ClusterID:             clusterID2,
 			LocalPodCIDR:          "192.168.0.0/24",
 			LocalNATPodCIDR:       "192.168.1.0/24",
-			RemoteNATPodCIDR:      "10.0.70.0/24",
 			LocalExternalCIDR:     "192.168.3.0/24",
 			LocalNATExternalCIDR:  "192.168.4.0/24",
+			RemotePodCIDR:         "10.0.0.0/24",
+			RemoteNATPodCIDR:      "10.0.70.0/24",
+			RemoteExternalCIDR:    "10.0.1.0/24",
 			RemoteNATExternalCIDR: "192.168.5.0/24",
 		},
 	}

--- a/pkg/consts/liqonet.go
+++ b/pkg/consts/liqonet.go
@@ -21,8 +21,6 @@ const (
 	NetworkManagerServiceName = "liqo-network-manager"
 	// DefaultCIDRValue is the default value for a string that contains a CIDR.
 	DefaultCIDRValue = "None"
-	// TepReady is the ready state of TunnelEndpoint resource.
-	TepReady = "Ready"
 	// NatMappingKind is the constant representing
 	// the value of the Kind field of all NatMapping resources.
 	NatMappingKind = "NatMapping"

--- a/pkg/liqonet/iptables/iptables.go
+++ b/pkg/liqonet/iptables/iptables.go
@@ -490,7 +490,7 @@ func getPreRoutingRulesPerTunnelEndpoint(tep *netv1alpha1.TunnelEndpoint) ([]IPT
 	if err := utils.CheckTep(tep); err != nil {
 		return nil, fmt.Errorf("invalid TunnelEndpoint resource: %w", err)
 	}
-	localPodCIDR := tep.Status.LocalPodCIDR
+	localPodCIDR := tep.Spec.LocalPodCIDR
 	localRemappedPodCIDR, remotePodCIDR := utils.GetPodCIDRS(tep)
 
 	rules := make([]IPTableRule, 0)
@@ -681,7 +681,7 @@ func getPostroutingRules(tep *netv1alpha1.TunnelEndpoint) ([]IPTableRule, error)
 		return nil, fmt.Errorf("invalid TunnelEndpoint resource: %w", err)
 	}
 	clusterID := tep.Spec.ClusterID
-	localPodCIDR := tep.Status.LocalPodCIDR
+	localPodCIDR := tep.Spec.LocalPodCIDR
 	localRemappedPodCIDR, remotePodCIDR := utils.GetPodCIDRS(tep)
 	_, remoteExternalCIDR := utils.GetExternalCIDRS(tep)
 	if localRemappedPodCIDR != consts.DefaultCIDRValue {
@@ -704,7 +704,7 @@ func getPostroutingRules(tep *netv1alpha1.TunnelEndpoint) ([]IPTableRule, error)
 	natIP, err := utils.GetFirstIP(localPodCIDR)
 	if err != nil {
 		klog.Errorf("Unable to get the IP from localPodCidr %s for cluster %s used to NAT the traffic from localhosts to remote hosts",
-			tep.Spec.PodCIDR, clusterID)
+			tep.Spec.RemotePodCIDR, clusterID)
 		return nil, err
 	}
 	return []IPTableRule{

--- a/pkg/liqonet/routing/common_test.go
+++ b/pkg/liqonet/routing/common_test.go
@@ -486,8 +486,8 @@ var _ = Describe("Common", func() {
 			It("should return no error", func() {
 				dstPodCIDRNet, dstExternalCIDRNet, gwIP, iFaceIndex, err := getRouteConfig(&tep, ipAddress2NoSubnet)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(dstPodCIDRNet).Should(Equal(tep.Status.RemoteNATPodCIDR))
-				Expect(dstExternalCIDRNet).Should(Equal(tep.Status.RemoteNATExternalCIDR))
+				Expect(dstPodCIDRNet).Should(Equal(tep.Spec.RemoteNATPodCIDR))
+				Expect(dstExternalCIDRNet).Should(Equal(tep.Spec.RemoteNATExternalCIDR))
 				Expect(gwIP).Should(Equal(""))
 				Expect(iFaceIndex).Should(BeNumerically("==", tep.Status.VethIFaceIndex))
 			})
@@ -497,8 +497,8 @@ var _ = Describe("Common", func() {
 			It("should return nil and a link index of the interface through which the Gateway is reachable", func() {
 				dstPodCIDRNet, dstExternalCIDRNet, gwIP, iFaceIndex, err := getRouteConfig(&tep, notReachableIP)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(dstPodCIDRNet).Should(Equal(tep.Status.RemoteNATPodCIDR))
-				Expect(dstExternalCIDRNet).Should(Equal(tep.Status.RemoteNATExternalCIDR))
+				Expect(dstPodCIDRNet).Should(Equal(tep.Spec.RemoteNATPodCIDR))
+				Expect(dstExternalCIDRNet).Should(Equal(tep.Spec.RemoteNATExternalCIDR))
 				Expect(gwIP).Should(Equal(ipAddress2NoSubnet))
 				Expect(iFaceIndex).Should(BeNumerically("==", dummylink1.Attrs().Index))
 			})

--- a/pkg/liqonet/routing/directRouting_test.go
+++ b/pkg/liqonet/routing/directRouting_test.go
@@ -95,7 +95,7 @@ var _ = Describe("DirectRouting", func() {
 
 			It("route configuration fails while adding policy routing rule for PodCIDR", func() {
 				tepCopy := tep
-				tepCopy.Status.RemoteNATPodCIDR = ""
+				tepCopy.Spec.RemoteNATPodCIDR = ""
 				added, err := drm.EnsureRoutesPerCluster(&tepCopy)
 				Expect(err).Should(Equal(&errors.WrongParameter{
 					Parameter: "fromSubnet and toSubnet",
@@ -107,7 +107,7 @@ var _ = Describe("DirectRouting", func() {
 
 			It("route configuration fails while adding policy routing rule for ExternalCIDR", func() {
 				tepCopy := tep
-				tepCopy.Status.RemoteNATExternalCIDR = ""
+				tepCopy.Spec.RemoteNATExternalCIDR = ""
 				added, err := drm.EnsureRoutesPerCluster(&tepCopy)
 				Expect(err).Should(Equal(&errors.WrongParameter{
 					Parameter: "fromSubnet and toSubnet",
@@ -141,26 +141,26 @@ var _ = Describe("DirectRouting", func() {
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(added).Should(BeTrue())
 				// Get the inserted route
-				_, dstPodCIDRNet, err := net.ParseCIDR(tep.Status.RemoteNATPodCIDR)
+				_, dstPodCIDRNet, err := net.ParseCIDR(tep.Spec.RemoteNATPodCIDR)
 				Expect(err).ShouldNot(HaveOccurred())
-				_, dstExternalCIDRNet, err := net.ParseCIDR(tep.Status.RemoteNATExternalCIDR)
+				_, dstExternalCIDRNet, err := net.ParseCIDR(tep.Spec.RemoteNATExternalCIDR)
 				Expect(err).ShouldNot(HaveOccurred())
 				routes, err := netlink.RouteListFiltered(netlink.FAMILY_V4, &netlink.Route{Dst: dstPodCIDRNet,
 					Table: routingTableIDDRM}, netlink.RT_FILTER_DST|netlink.RT_FILTER_TABLE)
 				Expect(err).ShouldNot(HaveOccurred())
-				Expect(routes[0].Dst.String()).Should(Equal(tep.Status.RemoteNATPodCIDR))
+				Expect(routes[0].Dst.String()).Should(Equal(tep.Spec.RemoteNATPodCIDR))
 				Expect(routes[0].Gw.String()).Should(Equal(tep.Status.GatewayIP))
 				routes, err = netlink.RouteListFiltered(netlink.FAMILY_V4, &netlink.Route{Dst: dstExternalCIDRNet,
 					Table: routingTableIDDRM}, netlink.RT_FILTER_DST|netlink.RT_FILTER_TABLE)
 				Expect(err).ShouldNot(HaveOccurred())
-				Expect(routes[0].Dst.String()).Should(Equal(tep.Status.RemoteNATExternalCIDR))
+				Expect(routes[0].Dst.String()).Should(Equal(tep.Spec.RemoteNATExternalCIDR))
 				Expect(routes[0].Gw.String()).Should(Equal(tep.Status.GatewayIP))
 			})
 
 			It("routes already exist, should return false and nil", func() {
 				tepCopy := tep
-				tepCopy.Status.RemoteNATPodCIDR = existingRoutesDRM[0].Dst.String()
-				tepCopy.Status.RemoteNATExternalCIDR = existingRoutesDRM[1].Dst.String()
+				tepCopy.Spec.RemoteNATPodCIDR = existingRoutesDRM[0].Dst.String()
+				tepCopy.Spec.RemoteNATExternalCIDR = existingRoutesDRM[1].Dst.String()
 				tepCopy.Status.GatewayIP = existingRoutesDRM[0].Gw.String()
 				existingRoutesDRM[1].Gw = existingRoutesDRM[0].Gw
 				added, err := drm.EnsureRoutesPerCluster(&tepCopy)
@@ -170,7 +170,7 @@ var _ = Describe("DirectRouting", func() {
 
 			It("route is outdated, should return true and nil", func() {
 				tepCopy := tep
-				tepCopy.Status.RemoteNATPodCIDR = existingRoutesDRM[1].Dst.String()
+				tepCopy.Spec.RemoteNATPodCIDR = existingRoutesDRM[1].Dst.String()
 				tepCopy.Status.GatewayIP = gwIPCorrect
 				added, err := drm.EnsureRoutesPerCluster(&tepCopy)
 				Expect(err).ShouldNot(HaveOccurred())
@@ -179,7 +179,7 @@ var _ = Describe("DirectRouting", func() {
 				routes, err := netlink.RouteListFiltered(netlink.FAMILY_V4, existingRoutesDRM[1],
 					netlink.RT_FILTER_DST|netlink.RT_FILTER_TABLE)
 				Expect(err).ShouldNot(HaveOccurred())
-				Expect(routes[0].Dst.String()).Should(Equal(tepCopy.Status.RemoteNATPodCIDR))
+				Expect(routes[0].Dst.String()).Should(Equal(tepCopy.Spec.RemoteNATPodCIDR))
 				Expect(routes[0].Gw.String()).Should(Equal(tepCopy.Status.GatewayIP))
 			})
 		})
@@ -198,7 +198,7 @@ var _ = Describe("DirectRouting", func() {
 
 			It("fails to remove route configuration while removing policy routing rule for PodCIDR", func() {
 				tepCopy := tep
-				tepCopy.Status.RemoteNATPodCIDR = ""
+				tepCopy.Spec.RemoteNATPodCIDR = ""
 				added, err := drm.RemoveRoutesPerCluster(&tepCopy)
 				Expect(err).Should(Equal(&errors.WrongParameter{
 					Parameter: "fromSubnet and toSubnet",
@@ -210,7 +210,7 @@ var _ = Describe("DirectRouting", func() {
 
 			It("fails to remove route configuration while removing policy routing rule for ExternalCIDR", func() {
 				tepCopy := tep
-				tepCopy.Status.RemoteNATExternalCIDR = ""
+				tepCopy.Spec.RemoteNATExternalCIDR = ""
 				added, err := drm.RemoveRoutesPerCluster(&tepCopy)
 				Expect(err).Should(Equal(&errors.WrongParameter{
 					Parameter: "fromSubnet and toSubnet",
@@ -232,8 +232,8 @@ var _ = Describe("DirectRouting", func() {
 
 			It("route configuration should be correctly removed", func() {
 				tepCopy := tep
-				tepCopy.Status.RemoteNATPodCIDR = existingRoutesDRM[0].Dst.String()
-				tepCopy.Status.RemoteNATExternalCIDR = existingRoutesDRM[1].Dst.String()
+				tepCopy.Spec.RemoteNATPodCIDR = existingRoutesDRM[0].Dst.String()
+				tepCopy.Spec.RemoteNATExternalCIDR = existingRoutesDRM[1].Dst.String()
 				tepCopy.Status.GatewayIP = existingRoutesDRM[0].Gw.String()
 				added, err := drm.RemoveRoutesPerCluster(&tepCopy)
 				Expect(err).ShouldNot(HaveOccurred())

--- a/pkg/liqonet/routing/routing_suite_test.go
+++ b/pkg/liqonet/routing/routing_suite_test.go
@@ -65,14 +65,14 @@ var _ = BeforeSuite(func() {
 	Expect(drm).NotTo(BeNil())
 	tep = netv1alpha1.TunnelEndpoint{
 		Spec: netv1alpha1.TunnelEndpointSpec{
-			ExternalCIDR: "10.151.0.0/16",
-		},
-		Status: netv1alpha1.TunnelEndpointStatus{
 			LocalNATPodCIDR:       "10.150.0.0/16",
 			RemoteNATPodCIDR:      "10.250.0.0/16",
+			RemoteExternalCIDR:    "10.151.0.0/16",
 			RemoteNATExternalCIDR: "10.251.0.0/16",
-			VethIFaceIndex:        12345,
-			GatewayIP:             ipAddress2NoSubnet,
+		},
+		Status: netv1alpha1.TunnelEndpointStatus{
+			VethIFaceIndex: 12345,
+			GatewayIP:      ipAddress2NoSubnet,
 		}}
 
 	// Create vxlan device for Vxlan Routing manager tests.

--- a/pkg/liqonet/utils/utils.go
+++ b/pkg/liqonet/utils/utils.go
@@ -164,27 +164,27 @@ func Next(network string) (string, error) {
 // GetPodCIDRS for a given tep the function retrieves the values for localPodCIDR and remotePodCIDR.
 // Their values depend if the NAT is required or not.
 func GetPodCIDRS(tep *netv1alpha1.TunnelEndpoint) (localRemappedPodCIDR, remotePodCIDR string) {
-	if tep.Status.RemoteNATPodCIDR != consts.DefaultCIDRValue {
-		remotePodCIDR = tep.Status.RemoteNATPodCIDR
+	if tep.Spec.RemoteNATPodCIDR != consts.DefaultCIDRValue {
+		remotePodCIDR = tep.Spec.RemoteNATPodCIDR
 	} else {
-		remotePodCIDR = tep.Spec.PodCIDR
+		remotePodCIDR = tep.Spec.RemotePodCIDR
 	}
-	localRemappedPodCIDR = tep.Status.LocalNATPodCIDR
+	localRemappedPodCIDR = tep.Spec.LocalNATPodCIDR
 	return localRemappedPodCIDR, remotePodCIDR
 }
 
 // GetExternalCIDRS for a given tep the function retrieves the values for localExternalCIDR and remoteExternalCIDR.
 // Their values depend if the NAT is required or not.
 func GetExternalCIDRS(tep *netv1alpha1.TunnelEndpoint) (localExternalCIDR, remoteExternalCIDR string) {
-	if tep.Status.LocalNATExternalCIDR != consts.DefaultCIDRValue {
-		localExternalCIDR = tep.Status.LocalNATExternalCIDR
+	if tep.Spec.LocalNATExternalCIDR != consts.DefaultCIDRValue {
+		localExternalCIDR = tep.Spec.LocalNATExternalCIDR
 	} else {
-		localExternalCIDR = tep.Status.LocalExternalCIDR
+		localExternalCIDR = tep.Spec.LocalExternalCIDR
 	}
-	if tep.Status.RemoteNATExternalCIDR != consts.DefaultCIDRValue {
-		remoteExternalCIDR = tep.Status.RemoteNATExternalCIDR
+	if tep.Spec.RemoteNATExternalCIDR != consts.DefaultCIDRValue {
+		remoteExternalCIDR = tep.Spec.RemoteNATExternalCIDR
 	} else {
-		remoteExternalCIDR = tep.Spec.ExternalCIDR
+		remoteExternalCIDR = tep.Spec.RemoteExternalCIDR
 	}
 	return
 }
@@ -212,52 +212,52 @@ func CheckTep(tep *netv1alpha1.TunnelEndpoint) error {
 			Reason:    liqoneterrors.StringNotEmpty,
 		}
 	}
-	if err := IsValidCIDR(tep.Spec.PodCIDR); err != nil {
+	if err := IsValidCIDR(tep.Spec.RemotePodCIDR); err != nil {
 		return &liqoneterrors.WrongParameter{
 			Parameter: consts.PodCIDR,
 			Reason:    liqoneterrors.ValidCIDR,
 		}
 	}
-	if err := IsValidCIDR(tep.Spec.ExternalCIDR); err != nil {
+	if err := IsValidCIDR(tep.Spec.RemoteExternalCIDR); err != nil {
 		return &liqoneterrors.WrongParameter{
 			Parameter: consts.ExternalCIDR,
 			Reason:    liqoneterrors.ValidCIDR,
 		}
 	}
-	if err := IsValidCIDR(tep.Status.LocalPodCIDR); err != nil {
+	if err := IsValidCIDR(tep.Spec.LocalPodCIDR); err != nil {
 		return &liqoneterrors.WrongParameter{
 			Parameter: consts.LocalPodCIDR,
 			Reason:    liqoneterrors.ValidCIDR,
 		}
 	}
-	if err := IsValidCIDR(tep.Status.LocalExternalCIDR); err != nil {
+	if err := IsValidCIDR(tep.Spec.LocalExternalCIDR); err != nil {
 		return &liqoneterrors.WrongParameter{
 			Parameter: consts.LocalExternalCIDR,
 			Reason:    liqoneterrors.ValidCIDR,
 		}
 	}
-	if err := IsValidCIDR(tep.Status.LocalNATPodCIDR); tep.Status.LocalNATPodCIDR != consts.DefaultCIDRValue &&
+	if err := IsValidCIDR(tep.Spec.LocalNATPodCIDR); tep.Spec.LocalNATPodCIDR != consts.DefaultCIDRValue &&
 		err != nil {
 		return &liqoneterrors.WrongParameter{
 			Parameter: consts.LocalNATPodCIDR,
 			Reason:    liqoneterrors.ValidCIDR,
 		}
 	}
-	if err := IsValidCIDR(tep.Status.LocalNATExternalCIDR); tep.Status.LocalNATExternalCIDR != consts.DefaultCIDRValue &&
+	if err := IsValidCIDR(tep.Spec.LocalNATExternalCIDR); tep.Spec.LocalNATExternalCIDR != consts.DefaultCIDRValue &&
 		err != nil {
 		return &liqoneterrors.WrongParameter{
 			Parameter: consts.LocalNATExternalCIDR,
 			Reason:    liqoneterrors.ValidCIDR,
 		}
 	}
-	if err := IsValidCIDR(tep.Status.RemoteNATPodCIDR); tep.Status.RemoteNATPodCIDR != consts.DefaultCIDRValue &&
+	if err := IsValidCIDR(tep.Spec.RemoteNATPodCIDR); tep.Spec.RemoteNATPodCIDR != consts.DefaultCIDRValue &&
 		err != nil {
 		return &liqoneterrors.WrongParameter{
 			Parameter: consts.RemoteNATPodCIDR,
 			Reason:    liqoneterrors.ValidCIDR,
 		}
 	}
-	if err := IsValidCIDR(tep.Status.RemoteNATExternalCIDR); tep.Status.RemoteNATExternalCIDR != consts.DefaultCIDRValue &&
+	if err := IsValidCIDR(tep.Spec.RemoteNATExternalCIDR); tep.Spec.RemoteNATExternalCIDR != consts.DefaultCIDRValue &&
 		err != nil {
 		return &liqoneterrors.WrongParameter{
 			Parameter: consts.RemoteNATExternalCIDR,

--- a/test/integration/integration_suite_test.go
+++ b/test/integration/integration_suite_test.go
@@ -71,31 +71,27 @@ var (
 	iptNetns ns.NetNS
 	tep1     = &netv1alpha1.TunnelEndpoint{
 		Spec: netv1alpha1.TunnelEndpointSpec{
-			ClusterID:    clusterID1,
-			PodCIDR:      "10.0.0.0/24",
-			ExternalCIDR: "10.0.1.0/24",
-		},
-		Status: netv1alpha1.TunnelEndpointStatus{
+			ClusterID:             clusterID1,
 			LocalPodCIDR:          "192.168.0.0/24",
 			LocalNATPodCIDR:       "192.168.1.0/24",
-			RemoteNATPodCIDR:      "10.0.70.0/24",
 			LocalExternalCIDR:     "192.168.3.0/24",
 			LocalNATExternalCIDR:  "192.168.4.0/24",
+			RemotePodCIDR:         "10.0.0.0/24",
+			RemoteNATPodCIDR:      "10.0.70.0/24",
+			RemoteExternalCIDR:    "10.0.1.0/24",
 			RemoteNATExternalCIDR: "192.168.5.0/24",
 		},
 	}
 	tep2 = &netv1alpha1.TunnelEndpoint{
 		Spec: netv1alpha1.TunnelEndpointSpec{
-			ClusterID:    clusterID2,
-			PodCIDR:      "10.0.0.0/24",
-			ExternalCIDR: "10.0.1.0/24",
-		},
-		Status: netv1alpha1.TunnelEndpointStatus{
+			ClusterID:             clusterID2,
 			LocalPodCIDR:          "192.168.0.0/24",
 			LocalNATPodCIDR:       "192.168.1.0/24",
-			RemoteNATPodCIDR:      "10.0.70.0/24",
 			LocalExternalCIDR:     "192.168.3.0/24",
 			LocalNATExternalCIDR:  "192.168.4.0/24",
+			RemotePodCIDR:         "10.0.0.0/24",
+			RemoteNATPodCIDR:      "10.0.70.0/24",
+			RemoteExternalCIDR:    "10.0.1.0/24",
 			RemoteNATExternalCIDR: "192.168.5.0/24",
 		},
 	}


### PR DESCRIPTION
# Description

This PR moves the fields of the TunnelEndpoint configured at creation time to the spec stanza, and updates the related references. Overall, this improves the performance, since the creation is no longer a two step process, which required a requeue period to expire before configuring the status stanza. Additionally, it improves the separation of concerns between different operators.

Fixes #(issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Unit testing (existing)
- [x] E2E testing (existing)
