### PR TITLE
Fix Slash commands in Liqo pipelines

### DIFF
--- a/.github/workflows/slash-commands.yml
+++ b/.github/workflows/slash-commands.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Dispatch Slash Commands
-        uses: peter-evans/slash-command-dispatch@v2
+        uses: peter-evans/slash-command-dispatch@permissions
         with:
           token: ${{ secrets.CI_TOKEN }}
           reaction-token: ${{ secrets.CI_TOKEN }}


### PR DESCRIPTION
# Description

This PR fixes a problem in the slash-command action, which represents the trigger for the pipelines.

# How Has This Been Tested?

Manually.