### PR TITLE
Add Support For OwnerReferencesPermissionEnforcement Admission Controller

### DIFF
--- a/apis/sharing/v1alpha1/groupversion_info.go
+++ b/apis/sharing/v1alpha1/groupversion_info.go
@@ -26,8 +26,6 @@ var (
 	// GroupVersion is group version used to register these objects.
 	GroupVersion = schema.GroupVersion{Group: "sharing.liqo.io", Version: "v1alpha1"}
 
-	GroupResource = schema.GroupResource{Group: GroupVersion.Group, Resource: "advertisements"}
-
 	// ResourceOfferGroupResource is group resource used by resourceOffer objects.
 	ResourceOfferGroupResource = schema.GroupResource{Group: GroupVersion.Group, Resource: "resourceoffers"}
 

--- a/cmd/discovery/main.go
+++ b/cmd/discovery/main.go
@@ -63,6 +63,9 @@ func main() {
 	authServicePortOverride := flag.String(consts.AuthServicePortOverrideParameter, "",
 		"The port the authentication service is reachable from foreign clusters (automatically retrieved if not set")
 	autoJoin := flag.Bool("auto-join-discovered-clusters", true, "Whether to automatically peer with discovered clusters")
+	ownerReferencesPermissionEnforcement := flag.Bool("owner-references-permission-enforcement", false,
+		"Enable support for the OwnerReferencesPermissionEnforcement admission controller "+
+			"https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement")
 
 	var mdnsConfig discovery.MDNSConfig
 	flag.BoolVar(&mdnsConfig.EnableAdvertisement, "mdns-enable-advertisement", false, "Enable the mDNS advertisement on LANs")
@@ -144,7 +147,7 @@ func main() {
 	klog.Info("Starting ForeignCluster operator")
 	foreignclusteroperator.StartOperator(mgr, namespacedClient, clientset, *namespace,
 		*requeueAfter, localClusterID, *clusterName, *authServiceAddressOverride,
-		*authServicePortOverride, *autoJoin)
+		*authServicePortOverride, *autoJoin, *ownerReferencesPermissionEnforcement)
 
 	if err := mgr.Add(auxmgr); err != nil {
 		klog.Errorf("Unable to add the auxiliary manager to the main one: %w", err)

--- a/deployments/liqo/files/liqo-controller-manager-ClusterRole.yaml
+++ b/deployments/liqo/files/liqo-controller-manager-ClusterRole.yaml
@@ -36,6 +36,19 @@ rules:
   verbs:
   - create
   - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes/finalizers
+  verbs:
+  - get
+  - patch
+  - update
 - apiGroups:
   - ""
   resources:
@@ -210,8 +223,6 @@ rules:
   verbs:
   - get
   - list
-  - patch
-  - update
   - watch
 - apiGroups:
   - ""
@@ -245,6 +256,7 @@ rules:
 - apiGroups:
   - discovery.liqo.io
   resources:
+  - foreignclusters/finalizers
   - foreignclusters/status
   verbs:
   - get
@@ -265,6 +277,15 @@ rules:
 - apiGroups:
   - discovery.liqo.io
   resources:
+  - resourcerequests/finalizers
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - discovery.liqo.io
+  resources:
+  - resourcerequests/finalizers
   - resourcerequests/status
   verbs:
   - get
@@ -331,6 +352,8 @@ rules:
   resources:
   - resourceoffers/finalizers
   verbs:
+  - get
+  - patch
   - update
 - apiGroups:
   - sharing.liqo.io
@@ -352,4 +375,12 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - virtualkubelet.liqo.io
+  resources:
+  - namespacemaps/finalizers
+  verbs:
+  - get
+  - patch
+  - update
 

--- a/deployments/liqo/files/liqo-discovery-ClusterRole.yaml
+++ b/deployments/liqo/files/liqo-discovery-ClusterRole.yaml
@@ -1,5 +1,13 @@
 rules:
 - apiGroups:
+  - capsule.clastix.io
+  resources:
+  - tenants/finalizers
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
   - ""
   resources:
   - namespaces
@@ -41,6 +49,14 @@ rules:
 - apiGroups:
   - discovery.liqo.io
   resources:
+  - foreignclusters/finalizers
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - discovery.liqo.io
+  resources:
   - foreignclusters/status
   verbs:
   - create
@@ -49,14 +65,6 @@ rules:
   - list
   - patch
   - update
-  - watch
-- apiGroups:
-  - discovery.liqo.io
-  resources:
-  - peeringrequests
-  verbs:
-  - get
-  - list
   - watch
 - apiGroups:
   - discovery.liqo.io
@@ -83,6 +91,14 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - discovery.liqo.io
+  resources:
+  - searchdomains/finalizers
+  verbs:
+  - get
+  - patch
+  - update
 - apiGroups:
   - net.liqo.io
   resources:
@@ -117,12 +133,15 @@ rules:
   - clusterrolebindings
   verbs:
   - create
+  - delete
   - get
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - clusterroles
   verbs:
+  - create
+  - delete
   - get
   - list
   - watch
@@ -135,26 +154,4 @@ rules:
   - delete
   - deletecollection
   - get
-- apiGroups:
-  - sharing.liqo.io
-  resources:
-  - advertisements
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - update
-  - watch
-- apiGroups:
-  - sharing.liqo.io
-  resources:
-  - advertisements/status
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - update
-  - watch
 

--- a/deployments/liqo/files/liqo-network-manager-ClusterRole.yaml
+++ b/deployments/liqo/files/liqo-network-manager-ClusterRole.yaml
@@ -34,6 +34,7 @@ rules:
 - apiGroups:
   - discovery.liqo.io
   resources:
+  - foreignclusters/finalizers
   - foreignclusters/status
   verbs:
   - get

--- a/deployments/liqo/files/liqo-virtual-kubelet-local-ClusterRole.yaml
+++ b/deployments/liqo/files/liqo-virtual-kubelet-local-ClusterRole.yaml
@@ -116,7 +116,6 @@ rules:
 - apiGroups:
   - sharing.liqo.io
   resources:
-  - advertisements
   - resourceoffers
   verbs:
   - delete

--- a/internal/discovery/foreign-cluster-operator/permission.go
+++ b/internal/discovery/foreign-cluster-operator/permission.go
@@ -47,6 +47,12 @@ func (r *ForeignClusterReconciler) ensurePermission(ctx context.Context, foreign
 			klog.Error(err)
 			return err
 		}
+		if r.ownerReferencesPermissionEnforcement {
+			if err = r.namespaceManager.UnbindOutgoingClusterWideRole(ctx, remoteClusterID); err != nil {
+				klog.Error(err)
+				return err
+			}
+		}
 	case consts.PeeringPhaseOutgoing:
 		if _, err = r.namespaceManager.BindClusterRoles(remoteClusterID,
 			r.peeringPermission.Outgoing...); err != nil {
@@ -57,6 +63,12 @@ func (r *ForeignClusterReconciler) ensurePermission(ctx context.Context, foreign
 			clusterRolesToNames(r.peeringPermission.Incoming)...); err != nil {
 			klog.Error(err)
 			return err
+		}
+		if r.ownerReferencesPermissionEnforcement {
+			if _, err = r.namespaceManager.BindOutgoingClusterWideRole(ctx, remoteClusterID); err != nil {
+				klog.Error(err)
+				return err
+			}
 		}
 	case consts.PeeringPhaseIncoming:
 		if err = r.namespaceManager.UnbindClusterRoles(remoteClusterID,
@@ -69,6 +81,12 @@ func (r *ForeignClusterReconciler) ensurePermission(ctx context.Context, foreign
 			klog.Error(err)
 			return err
 		}
+		if r.ownerReferencesPermissionEnforcement {
+			if err = r.namespaceManager.UnbindOutgoingClusterWideRole(ctx, remoteClusterID); err != nil {
+				klog.Error(err)
+				return err
+			}
+		}
 	case consts.PeeringPhaseBidirectional:
 		if _, err = r.namespaceManager.BindClusterRoles(remoteClusterID,
 			r.peeringPermission.Outgoing...); err != nil {
@@ -79,6 +97,12 @@ func (r *ForeignClusterReconciler) ensurePermission(ctx context.Context, foreign
 			r.peeringPermission.Incoming...); err != nil {
 			klog.Error(err)
 			return err
+		}
+		if r.ownerReferencesPermissionEnforcement {
+			if _, err = r.namespaceManager.BindOutgoingClusterWideRole(ctx, remoteClusterID); err != nil {
+				klog.Error(err)
+				return err
+			}
 		}
 	default:
 		err = fmt.Errorf("invalid PeeringPhase %v", peeringPhase)

--- a/internal/discovery/foreign-cluster-operator/setup.go
+++ b/internal/discovery/foreign-cluster-operator/setup.go
@@ -47,7 +47,7 @@ func init() {
 func StartOperator(
 	mgr manager.Manager, namespacedClient client.Client, clientset kubernetes.Interface, namespace string,
 	requeueAfter time.Duration, localClusterID clusterid.ClusterID, clusterName string,
-	authServiceAddressOverride, authServicePortOverride string, autoJoin bool) {
+	authServiceAddressOverride, authServicePortOverride string, autoJoin, ownerReferencesPermissionEnforcement bool) {
 	namespaceManager := tenantnamespace.NewTenantNamespaceManager(clientset)
 	idManager := identitymanager.NewCertificateIdentityManager(clientset, localClusterID, namespaceManager)
 
@@ -64,12 +64,13 @@ func StartOperator(
 		Scheme:               mgr.GetScheme(),
 		liqoNamespace:        namespace,
 
-		requeueAfter:               requeueAfter,
-		clusterID:                  localClusterID,
-		clusterName:                clusterName,
-		authServiceAddressOverride: authServiceAddressOverride,
-		authServicePortOverride:    authServicePortOverride,
-		autoJoin:                   autoJoin,
+		requeueAfter:                         requeueAfter,
+		clusterID:                            localClusterID,
+		clusterName:                          clusterName,
+		authServiceAddressOverride:           authServiceAddressOverride,
+		authServicePortOverride:              authServicePortOverride,
+		autoJoin:                             autoJoin,
+		ownerReferencesPermissionEnforcement: ownerReferencesPermissionEnforcement,
 
 		namespaceManager:  namespaceManager,
 		identityManager:   idManager,

--- a/internal/liqonet/tunnelEndpointCreator/tunnelEndpointCreator-operator.go
+++ b/internal/liqonet/tunnelEndpointCreator/tunnelEndpointCreator-operator.go
@@ -118,7 +118,7 @@ type TunnelEndpointCreator struct {
 // +kubebuilder:rbac:groups=net.liqo.io,resources=ipamstorages,verbs=get;list;create;update;patch
 // +kubebuilder:rbac:groups=net.liqo.io,resources=natmappings,verbs=get;list;create;update;patch;delete;watch
 // +kubebuilder:rbac:groups=discovery.liqo.io,resources=foreignclusters,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=discovery.liqo.io,resources=foreignclusters/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=discovery.liqo.io,resources=foreignclusters/status;foreignclusters/finalizers,verbs=get;update;patch
 // +kubebuilder:rbac:groups=core,resources=nodes,verbs=get;list;watch
 // +kubebuilder:rbac:groups=core,resources=events,verbs=get;list;watch;create;update;patch;delete
 // role

--- a/pkg/liqo-controller-manager/namespaceMap-controller/namespacemap_controller.go
+++ b/pkg/liqo-controller-manager/namespaceMap-controller/namespacemap_controller.go
@@ -40,6 +40,7 @@ type NamespaceMapReconciler struct {
 // +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch;
 // +kubebuilder:rbac:groups=discovery.liqo.io,resources=foreignclusters,verbs=get;list;watch
 // +kubebuilder:rbac:groups=virtualkubelet.liqo.io,resources=namespacemaps,verbs=get;watch;list;update;patch;create;delete
+// +kubebuilder:rbac:groups=virtualkubelet.liqo.io,resources=namespacemaps/finalizers,verbs=get;update;patch
 // +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create;update;patch;delete

--- a/pkg/liqo-controller-manager/resource-request-controller/resourceRequest_controller.go
+++ b/pkg/liqo-controller-manager/resource-request-controller/resourceRequest_controller.go
@@ -46,9 +46,9 @@ const (
 // +kubebuilder:rbac:groups=sharing.liqo.io,resources=resourceoffers,verbs=get;list;watch;create;update;patch;
 // +kubebuilder:rbac:groups=sharing.liqo.io,resources=resourceoffers/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=discovery.liqo.io,resources=resourcerequests,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=discovery.liqo.io,resources=resourcerequests/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=discovery.liqo.io,resources=resourcerequests/status;resourcerequests/finalizers,verbs=get;update;patch
 // +kubebuilder:rbac:groups=discovery.liqo.io,resources=foreignclusters,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=discovery.liqo.io,resources=foreignclusters/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=discovery.liqo.io,resources=foreignclusters/status;foreignclusters/finalizers,verbs=get;update;patch
 
 // +kubebuilder:rbac:groups=capsule.clastix.io,resources=tenants,verbs=get;list;watch;create;update;patch;delete;
 

--- a/pkg/liqo-controller-manager/resourceoffer-controller/resourceoffer_controller.go
+++ b/pkg/liqo-controller-manager/resourceoffer-controller/resourceoffer_controller.go
@@ -65,7 +65,8 @@ type ResourceOfferReconciler struct {
 
 //+kubebuilder:rbac:groups=sharing.liqo.io,resources=resourceoffers,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=sharing.liqo.io,resources=resourceoffers/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=sharing.liqo.io,resources=resourceoffers/finalizers,verbs=update
+//+kubebuilder:rbac:groups=sharing.liqo.io,resources=resourceoffers/finalizers,verbs=get;update;patch
+//+kubebuilder:rbac:groups=discovery.liqo.io,resources=resourcerequests/finalizers,verbs=get;update;patch
 //+kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=capsule.clastix.io,resources=tenants,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings,verbs=get;list;watch;create;update;patch;delete;deletecollection

--- a/pkg/liqo-controller-manager/virtualNode-controller/virtualnode_controller.go
+++ b/pkg/liqo-controller-manager/virtualNode-controller/virtualnode_controller.go
@@ -44,7 +44,8 @@ type VirtualNodeReconciler struct {
 }
 
 // cluster-role
-// +kubebuilder:rbac:groups=core,resources=nodes,verbs=get;list;watch;patch;update
+// +kubebuilder:rbac:groups="",resources=nodes,verbs=get;list;watch;patch;update
+// +kubebuilder:rbac:groups="",resources=nodes/finalizers,verbs=get;update;patch
 // +kubebuilder:rbac:groups=virtualkubelet.liqo.io,resources=namespacemaps,verbs=get;list;watch;delete;create
 // +kubebuilder:rbac:groups=discovery.liqo.io,resources=foreignclusters,verbs=get;list;watch
 

--- a/pkg/tenantNamespace/clusterwide.go
+++ b/pkg/tenantNamespace/clusterwide.go
@@ -1,0 +1,119 @@
+// Copyright 2019-2021 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tenantnamespace
+
+import (
+	"context"
+	"fmt"
+
+	capsulev1beta1 "github.com/clastix/capsule/api/v1beta1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+
+	"github.com/liqotech/liqo/pkg/discovery"
+)
+
+const (
+	clusterRolePrefix = "liqo-remote-cluster-role"
+	tenantPrefix      = "tenant"
+)
+
+// BindOutgoingClusterWideRole creates and binds a ClusterRole for the cluster-wide permission required
+// to establish the peering by the remote cluster.
+func (nm *tenantNamespaceManager) BindOutgoingClusterWideRole(ctx context.Context,
+	clusterID string) (*rbacv1.ClusterRoleBinding, error) {
+	clusterRoleName := getClusterRoleName(clusterID)
+	clusterRole := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: clusterRoleName,
+			Labels: map[string]string{
+				discovery.ClusterIDLabel: clusterID,
+			},
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups:     []string{capsulev1beta1.GroupVersion.Group},
+				Resources:     []string{"tenants/finalizers"},
+				Verbs:         []string{"get", "patch", "update"},
+				ResourceNames: []string{getTenantName(clusterID)},
+			},
+		},
+	}
+
+	_, err := nm.client.RbacV1().ClusterRoles().Create(ctx, clusterRole, metav1.CreateOptions{})
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		klog.Error(err)
+		return nil, err
+	}
+
+	clusterRoleBinding := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: clusterRoleName,
+			Labels: map[string]string{
+				discovery.ClusterIDLabel: clusterID,
+			},
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:     rbacv1.UserKind,
+				APIGroup: rbacv1.GroupName,
+				Name:     clusterID,
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: rbacv1.GroupName,
+			Kind:     "ClusterRole",
+			Name:     clusterRoleName,
+		},
+	}
+
+	clusterRoleBinding, err = nm.client.RbacV1().ClusterRoleBindings().Create(ctx, clusterRoleBinding, metav1.CreateOptions{})
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		klog.Error(err)
+		return nil, err
+	}
+
+	return clusterRoleBinding, nil
+}
+
+// UnbindOutgoingClusterWideRole unbinds and deletes a ClusterRole for the cluster-wide permission required
+// to establish the peering by the remote cluster.
+func (nm *tenantNamespaceManager) UnbindOutgoingClusterWideRole(ctx context.Context, clusterID string) error {
+	clusterRoleName := getClusterRoleName(clusterID)
+
+	err := nm.client.RbacV1().ClusterRoleBindings().Delete(ctx, clusterRoleName, metav1.DeleteOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		klog.Error(err)
+		return err
+	}
+
+	err = nm.client.RbacV1().ClusterRoles().Delete(ctx, clusterRoleName, metav1.DeleteOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		klog.Error(err)
+		return err
+	}
+
+	return nil
+}
+
+func getClusterRoleName(clusterID string) string {
+	return fmt.Sprintf("%v-%v", clusterRolePrefix, clusterID)
+}
+
+func getTenantName(clusterID string) string {
+	return fmt.Sprintf("%v-%v", tenantPrefix, clusterID)
+}

--- a/pkg/tenantNamespace/interface.go
+++ b/pkg/tenantNamespace/interface.go
@@ -15,6 +15,8 @@
 package tenantnamespace
 
 import (
+	"context"
+
 	v1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 )
@@ -26,4 +28,6 @@ type Manager interface {
 	GetNamespace(clusterID string) (*v1.Namespace, error)
 	BindClusterRoles(clusterID string, clusterRoles ...*rbacv1.ClusterRole) ([]*rbacv1.RoleBinding, error)
 	UnbindClusterRoles(clusterID string, clusterRoles ...string) error
+	BindOutgoingClusterWideRole(ctx context.Context, clusterID string) (*rbacv1.ClusterRoleBinding, error)
+	UnbindOutgoingClusterWideRole(ctx context.Context, clusterID string) error
 }

--- a/pkg/tenantNamespace/tenantNamespaceManager_test.go
+++ b/pkg/tenantNamespace/tenantNamespaceManager_test.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"testing"
 
+	capsulev1beta1 "github.com/clastix/capsule/api/v1beta1"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
@@ -158,6 +159,7 @@ var _ = Describe("TenantNamespace", func() {
 		Context("Single ClusterRole", func() {
 
 			var rb []*rbacv1.RoleBinding
+			var crb *rbacv1.ClusterRoleBinding
 
 			It("Bind ClusterRole", func() {
 				var err error
@@ -225,6 +227,66 @@ var _ = Describe("TenantNamespace", func() {
 				_, err = client.RbacV1().RoleBindings(namespace.Name).Get(context.TODO(), rb[0].Name, metav1.GetOptions{})
 				Expect(err).NotTo(BeNil())
 				Expect(kerrors.IsNotFound(err)).To(BeTrue())
+			})
+
+			It("cluster wide outgoing permission management", func() {
+				var err error
+				ctx := context.Background()
+
+				var checkLabels = func(labels map[string]string) {
+					cID, ok := labels[discovery.ClusterIDLabel]
+					Expect(ok).To(BeTrue())
+					Expect(cID).To(Equal(clusterID))
+				}
+
+				clusterRoleName := fmt.Sprintf("%v-%v", clusterRolePrefix, clusterID)
+
+				By("Creating the binding")
+
+				crb, err = namespaceManager.BindOutgoingClusterWideRole(ctx, clusterID)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(crb).NotTo(BeNil())
+
+				checkLabels(crb.GetLabels())
+
+				Expect(len(crb.Subjects)).To(Equal(1))
+				Expect(crb.Subjects[0].Kind).To(Equal(rbacv1.UserKind))
+				Expect(crb.Subjects[0].Name).To(Equal(clusterID))
+				Expect(crb.RoleRef.Kind).To(Equal("ClusterRole"))
+				Expect(crb.RoleRef.Name).To(Equal(clusterRoleName))
+
+				cr, err := client.RbacV1().ClusterRoles().Get(ctx, clusterRoleName, metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cr).NotTo(BeNil())
+
+				checkLabels(cr.GetLabels())
+
+				Expect(len(cr.Rules)).To(BeNumerically("==", 1))
+				Expect(cr.Rules[0].APIGroups).To(ContainElement(capsulev1beta1.GroupVersion.Group))
+				Expect(cr.Rules[0].ResourceNames).To(ContainElement(fmt.Sprintf("%v-%v", tenantPrefix, clusterID)))
+				Expect(cr.Rules[0].Resources).To(ContainElement("tenants/finalizers"))
+				Expect(cr.Rules[0].Verbs).To(ContainElements("get", "patch", "update"))
+
+				By("Creating the binding twice")
+
+				crb, err = namespaceManager.BindOutgoingClusterWideRole(ctx, clusterID)
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Deleting the binding")
+
+				Expect(namespaceManager.UnbindOutgoingClusterWideRole(ctx, clusterID)).To(Succeed())
+
+				_, err = client.RbacV1().ClusterRoles().Get(ctx, clusterRoleName, metav1.GetOptions{})
+				Expect(err).To(HaveOccurred())
+				Expect(kerrors.IsNotFound(err)).To(BeTrue())
+
+				_, err = client.RbacV1().ClusterRoleBindings().Get(ctx, clusterRoleName, metav1.GetOptions{})
+				Expect(err).To(HaveOccurred())
+				Expect(kerrors.IsNotFound(err)).To(BeTrue())
+
+				By("Deleting the binding twice")
+
+				Expect(namespaceManager.UnbindOutgoingClusterWideRole(ctx, clusterID)).To(Succeed())
 			})
 
 		})

--- a/pkg/virtualKubelet/roles/local/role.go
+++ b/pkg/virtualKubelet/roles/local/role.go
@@ -30,6 +30,6 @@ package local
 
 // +kubebuilder:rbac:groups=virtualkubelet.liqo.io,resources=namespacemaps,verbs=get;list;watch;
 // +kubebuilder:rbac:groups=net.liqo.io,resources=tunnelendpoints,verbs=get;list;watch
-// +kubebuilder:rbac:groups=sharing.liqo.io,resources=advertisements;resourceoffers,verbs=get;list;watch;update;patch;delete
+// +kubebuilder:rbac:groups=sharing.liqo.io,resources=resourceoffers,verbs=get;list;watch;update;patch;delete
 
 // +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;create;update;delete


### PR DESCRIPTION
# Description

This pr add the support for the [OwnerReferencesPermissionEnforcement](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement) admission controller.

# How Has This Been Tested?

- [x] locally on KinD
- [x] add unit test
