### PR TITLE
Increase the idempotence of the tunnel endpoint creator 

### DIFF
--- a/cmd/liqonet/network-manager.go
+++ b/cmd/liqonet/network-manager.go
@@ -124,7 +124,6 @@ func runNetworkManager(commonFlags *liqonetCommonFlags, managerFlags *networkMan
 	tec := &tunnelendpointcreator.TunnelEndpointCreator{
 		Client:    mgr.GetClient(),
 		Scheme:    mgr.GetScheme(),
-		DynClient: dynClient,
 		IPManager: ipam,
 	}
 

--- a/deployments/liqo/files/liqo-network-manager-ClusterRole.yaml
+++ b/deployments/liqo/files/liqo-network-manager-ClusterRole.yaml
@@ -83,12 +83,4 @@ rules:
   - patch
   - update
   - watch
-- apiGroups:
-  - net.liqo.io
-  resources:
-  - tunnelendpoints/status
-  verbs:
-  - get
-  - patch
-  - update
 


### PR DESCRIPTION
# Description

This PR refactors the tunnel endpoint creator, to reduce the overall network setup time thanks to the increase of its idempotence and the removal of the reliance on resyncs. 

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Existing
