### PR TITLE
Disable Discovery Deployment

### DIFF
--- a/cmd/liqoctl/cmd/install.go
+++ b/cmd/liqoctl/cmd/install.go
@@ -37,7 +37,7 @@ func newInstallCommand(ctx context.Context) *cobra.Command {
 	installCmd.PersistentFlags().BoolP("only-output-values", "", false, "Generate a values file for further customization")
 	installCmd.PersistentFlags().StringP("dump-values-path", "", "./values.yaml", "Path for the output value file")
 	installCmd.PersistentFlags().BoolP("dry-run", "", false, "Simulate an install")
-	installCmd.PersistentFlags().BoolP("enable-lan-discovery", "", true, "Enable LAN discovery")
+	installCmd.PersistentFlags().BoolP("enable-lan-discovery", "", false, "Enable LAN discovery")
 	installCmd.PersistentFlags().StringP("cluster-labels", "", "",
 		"Cluster Labels to append to Liqo Cluster, supports '='.(e.g. --cluster-labels key1=value1,key2=value2)")
 	installCmd.PersistentFlags().BoolP("disable-endpoint-check", "", false,

--- a/cmd/liqoctl/cmd/remove.go
+++ b/cmd/liqoctl/cmd/remove.go
@@ -40,9 +40,9 @@ func newRemoveClusterCommand(ctx context.Context) *cobra.Command {
 		Short: remove.LiqoctlRemoveShortHelp,
 		Long:  remove.LiqoctlRemoveLongHelp,
 		Args:  cobra.MinimumNArgs(1),
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			removeArgs.ClusterName = args[0]
-			remove.HandleRemoveCommand(ctx, removeArgs)
+			return remove.HandleRemoveCommand(ctx, removeArgs)
 		},
 	}
 

--- a/deployments/liqo/README.md
+++ b/deployments/liqo/README.md
@@ -38,8 +38,8 @@
 | discovery.config.autojoin | bool | `true` | Automatically join discovered clusters |
 | discovery.config.clusterLabels | object | `{}` | A set of labels which characterizes the local cluster when exposed remotely as a virtual node. It is suggested to specify the distinguishing characteristics that may be used to decide whether to offload pods on this cluster. |
 | discovery.config.clusterName | string | `""` | Set a mnemonic name for your cluster |
-| discovery.config.enableAdvertisement | bool | `true` | Enable the mDNS advertisement on LANs, set to false to not be discoverable from other clusters in the same LAN |
-| discovery.config.enableDiscovery | bool | `true` | Enable the mDNS discovery on LANs, set to false to not look for other clusters available in the same LAN |
+| discovery.config.enableAdvertisement | bool | `false` | Enable the mDNS advertisement on LANs, set to false to not be discoverable from other clusters in the same LAN |
+| discovery.config.enableDiscovery | bool | `false` | Enable the mDNS discovery on LANs, set to false to not look for other clusters available in the same LAN |
 | discovery.config.incomingPeeringEnabled | bool | `true` | Allow (by default) the remote clusters to establish a peering with our cluster |
 | discovery.config.ttl | int | `90` | Time-to-live before an automatically discovered clusters is deleted from the list of available ones if no longer announced (in seconds) |
 | discovery.imageName | string | `"liqo/discovery"` | discovery image repository |

--- a/deployments/liqo/templates/liqo-discovery-deployment.yaml
+++ b/deployments/liqo/templates/liqo-discovery-deployment.yaml
@@ -1,3 +1,5 @@
+{{- if or .Values.discovery.config.enableAdvertisement .Values.discovery.config.enableDiscovery }}
+
 ---
 {{- $discoveryConfig := (merge (dict "name" "discovery" "module" "discovery") .) -}}
 
@@ -11,10 +13,8 @@ spec:
   selector:
     matchLabels:
       {{- include "liqo.selectorLabels" $discoveryConfig | nindent 6 }}
-  {{- if or ( eq .Values.discovery.config.enableAdvertisement true ) ( eq .Values.discovery.config.enableDiscovery true ) }}
   strategy:
     type: Recreate
-  {{- end }}
   template:
     metadata:
       labels:
@@ -56,6 +56,6 @@ spec:
             requests:
               cpu: 50m
               memory: 50M
-      {{- if or ( eq .Values.discovery.config.enableAdvertisement true ) ( eq .Values.discovery.config.enableDiscovery true ) }}
       hostNetwork: true
-      {{- end }}
+
+{{- end }}

--- a/deployments/liqo/templates/liqo-discovery-rbac.yaml
+++ b/deployments/liqo/templates/liqo-discovery-rbac.yaml
@@ -1,3 +1,5 @@
+{{- if or .Values.discovery.config.enableAdvertisement .Values.discovery.config.enableDiscovery }}
+
 ---
 {{- $discoveryConfig := (merge (dict "name" "discovery" "module" "discovery") .) -}}
 
@@ -54,3 +56,5 @@ metadata:
   labels:
   {{- include "liqo.labels" $discoveryConfig| nindent 4 }}
 {{ .Files.Get (include "liqo.role-filename" (dict "prefix" ( include "liqo.prefixedName" $discoveryConfig))) }}
+
+{{- end }}

--- a/deployments/liqo/values.yaml
+++ b/deployments/liqo/values.yaml
@@ -118,9 +118,9 @@ discovery:
     # -- Allow (by default) the remote clusters to establish a peering with our cluster
     incomingPeeringEnabled: true
     # -- Enable the mDNS advertisement on LANs, set to false to not be discoverable from other clusters in the same LAN
-    enableAdvertisement: true
+    enableAdvertisement: false
     # -- Enable the mDNS discovery on LANs, set to false to not look for other clusters available in the same LAN
-    enableDiscovery: true
+    enableDiscovery: false
     # -- Time-to-live before an automatically discovered clusters is deleted from the list of available ones if no longer announced (in seconds)
     ttl: 90
 

--- a/docs/pages/installation/chart_values.md
+++ b/docs/pages/installation/chart_values.md
@@ -43,8 +43,8 @@ weight: 5
 | discovery.config.autojoin | bool | `true` | Automatically join discovered clusters |
 | discovery.config.clusterLabels | object | `{}` | A set of labels which characterizes the local cluster when exposed remotely as a virtual node. It is suggested to specify the distinguishing characteristics that may be used to decide whether to offload pods on this cluster. |
 | discovery.config.clusterName | string | `""` | Set a mnemonic name for your cluster |
-| discovery.config.enableAdvertisement | bool | `true` | Enable the mDNS advertisement on LANs, set to false to not be discoverable from other clusters in the same LAN |
-| discovery.config.enableDiscovery | bool | `true` | Enable the mDNS discovery on LANs, set to false to not look for other clusters available in the same LAN |
+| discovery.config.enableAdvertisement | bool | `false` | Enable the mDNS advertisement on LANs, set to false to not be discoverable from other clusters in the same LAN |
+| discovery.config.enableDiscovery | bool | `false` | Enable the mDNS discovery on LANs, set to false to not look for other clusters available in the same LAN |
 | discovery.config.incomingPeeringEnabled | bool | `true` | Allow (by default) the remote clusters to establish a peering with our cluster |
 | discovery.config.ttl | int | `90` | Time-to-live before an automatically discovered clusters is deleted from the list of available ones if no longer announced (in seconds) |
 | discovery.imageName | string | `"liqo/discovery"` | discovery image repository |

--- a/install.sh
+++ b/install.sh
@@ -425,6 +425,8 @@ function install_liqo() {
 		--set auth.config.enableAuthentication=false \
 		--set auth.service.type="NodePort" \
 		--set gateway.service.type="NodePort" \
+		--set discovery.config.enableAdvertisement=true \
+		--set discovery.config.enableDiscovery=true \
         > /dev/null || fatal "[INSTALL]" "Something went wrong while installing Liqo"
 
 	info "[INSTALL]" "Hooray! Liqo is now installed on your cluster"

--- a/pkg/liqoctl/install/kind/provider.go
+++ b/pkg/liqoctl/install/kind/provider.go
@@ -49,8 +49,10 @@ func (k *Kind) UpdateChartValues(values map[string]interface{}) {
 	}
 	values["discovery"] = map[string]interface{}{
 		"config": map[string]interface{}{
-			"clusterLabels": installutils.GetInterfaceMap(k.ClusterLabels),
-			"clusterName":   k.ClusterName,
+			"clusterLabels":       installutils.GetInterfaceMap(k.ClusterLabels),
+			"clusterName":         k.ClusterName,
+			"enableAdvertisement": true,
+			"enableDiscovery":     true,
 		},
 	}
 }

--- a/pkg/liqoctl/remove/handler.go
+++ b/pkg/liqoctl/remove/handler.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
@@ -34,22 +33,25 @@ type ClusterArgs struct {
 }
 
 // HandleRemoveCommand handles the remove command, configuring all the resources required to disable an outgoing peering.
-func HandleRemoveCommand(ctx context.Context, t *ClusterArgs) {
+func HandleRemoveCommand(ctx context.Context, t *ClusterArgs) error {
 	restConfig := common.GetLiqoctlRestConfOrDie()
 
 	k8sClient, err := client.New(restConfig, client.Options{})
 	if err != nil {
-		klog.Fatalf(err.Error())
+		return err
 	}
 
-	if err := processRemoveCluster(ctx, t, k8sClient); err != nil {
-		klog.Fatalf(err.Error())
+	err = processRemoveCluster(ctx, t, k8sClient)
+	if err != nil {
+		return err
 	}
 
 	err = printSuccessfulOutputMessage(ctx, t, k8sClient)
 	if err != nil {
-		klog.Fatalf(err.Error())
+		return err
 	}
+
+	return nil
 }
 
 func printSuccessfulOutputMessage(ctx context.Context, t *ClusterArgs, k8sClient client.Client) error {


### PR DESCRIPTION
# Description

This pr disables the discovery component by default. It will be enabled if one of the following is true:

* the mDNS discovery is enabled
* the mDNS advertisement is enabled
* we are installing on a KinD cluster

# How Has This Been Tested?

- [x] locally
