### PR TITLE
Implement basic caching in IPAM storage

### DIFF
--- a/pkg/liqonet/ipam/ipam_test.go
+++ b/pkg/liqonet/ipam/ipam_test.go
@@ -1520,6 +1520,11 @@ var _ = Describe("Ipam", func() {
 				err = updateIpamStorageResource(ipamStorage)
 				Expect(err).To(BeNil())
 
+				// Recreate the cached representation of the IPAM storage.
+				storage, err := NewIPAMStorage(dynClient)
+				Expect(err).ToNot(HaveOccurred())
+				ipam.ipamStorage = storage
+
 				// Add mapping to resource NatMapping
 				natMappingResource, err := getNatMappingResourcePerCluster(clusterID1)
 				Expect(err).To(BeNil())


### PR DESCRIPTION
# Description

This PR introduces a basic cache in the IPAM storage component, to reduce the number of "get" requests to the API server and improve the overall performance. The cache enforces no guarantees (as the current implemented version), with concurrent reads allowed while performing a patch operation, which only at the end updates the cached version. 

Fixes #(issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Existing
