### PR TITLE
Make foreign cluster workers configurable

### DIFF
--- a/cmd/liqo-controller-manager/main.go
+++ b/cmd/liqo-controller-manager/main.go
@@ -94,6 +94,7 @@ func main() {
 	clusterID := flag.String("cluster-id", "", "The cluster ID identifying the current cluster")
 	liqoNamespace := flag.String("liqo-namespace", defaultNamespace,
 		"Name of the namespace where the liqo components are running")
+	foreignClusterWorkers := flag.Uint("foreign-cluster-workers", 1, "The number of workers used to reconcile ForeignCluster resources.")
 
 	// Discovery parameters
 	clusterName := flag.String(consts.ClusterNameParameter, "", "A mnemonic name associated with the current cluster")
@@ -208,7 +209,7 @@ func main() {
 		IdentityManager:   idManager,
 		PeeringPermission: *permissions,
 	}
-	if err = foreignClusterReconciler.SetupWithManager(mgr); err != nil {
+	if err = foreignClusterReconciler.SetupWithManager(mgr, *foreignClusterWorkers); err != nil {
 		klog.Fatal(err)
 	}
 


### PR DESCRIPTION
# Description

This PR adds a flag to the liqo-controller-manager to allow the configuration of the number of workers used to reconcile ForeignClusters.

Fixes #(issue)

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Existing
- [X] Manual testing with 50 clusters
