### PR TITLE
Namespace checker for liqoctl status command

### DIFF
--- a/pkg/liqoctl/status/common.go
+++ b/pkg/liqoctl/status/common.go
@@ -14,12 +14,19 @@
 
 package status
 
-import "context"
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"text/tabwriter"
+)
 
-// Checker an interface required to be implemented by all the checkers that
-// collect the status of Liqo.
-type Checker interface {
-	Collect(ctx context.Context) error
-	Format() (string, error)
-	HasSucceeded() bool
+func newTabWriter(checkerName string) (*tabwriter.Writer, *bytes.Buffer) {
+	var buf bytes.Buffer
+	w := tabwriter.NewWriter(&buf, 0, 0, 4, ' ', 0)
+
+	separator := strings.Repeat("-", len(checkerName))
+	fmt.Fprintf(w, "%s\n", checkerName)
+	fmt.Fprintf(w, "%s\n", separator)
+	return w, &buf
 }

--- a/pkg/liqoctl/status/k8s.go
+++ b/pkg/liqoctl/status/k8s.go
@@ -34,6 +34,7 @@ func newK8sStatusCollector(client k8s.Interface, params Args) *k8sStatusCollecto
 		client: client,
 		params: params,
 		checkers: []Checker{
+			newNamespaceChecker(params.Namespace, client),
 			newPodChecker(params.Namespace, liqoDeployments, liqoDaemonSets, client),
 		},
 	}
@@ -50,6 +51,9 @@ func (k *k8sStatusCollector) collectStatus(ctx context.Context) error {
 			return err
 		}
 		fmt.Print(msg)
+		if !checker.HasSucceeded() {
+			break
+		}
 	}
 	return nil
 }

--- a/pkg/liqoctl/status/namespace.go
+++ b/pkg/liqoctl/status/namespace.go
@@ -1,0 +1,80 @@
+// Copyright 2019-2021 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package status
+
+import (
+	"context"
+	"fmt"
+
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8s "k8s.io/client-go/kubernetes"
+)
+
+const nsCheckerName = "namespace-existence"
+
+// namespaceChecker implements the Check interface.
+// checks if the namespace passed as an argument to liqoctl status command
+// exists. If it does not exist the liqoctl status returns.
+type namespaceChecker struct {
+	client        k8s.Interface
+	namespace     string
+	name          string
+	succeeded     bool
+	failureReason error
+}
+
+func newNamespaceChecker(namespace string, client k8s.Interface) *namespaceChecker {
+	return &namespaceChecker{
+		client:    client,
+		namespace: namespace,
+		name:      nsCheckerName,
+	}
+}
+
+func (nc *namespaceChecker) Collect(ctx context.Context) error {
+	// Check if the namespace exists.
+	if _, err := nc.client.CoreV1().Namespaces().Get(ctx, nc.namespace, v1.GetOptions{}); err != nil {
+		nc.succeeded = false
+		nc.failureReason = err
+		return nil
+	}
+
+	nc.succeeded = true
+
+	return nil
+}
+
+func (nc *namespaceChecker) Format() (string, error) {
+	w, buf := newTabWriter(nc.name)
+
+	if nc.succeeded {
+		fmt.Fprintf(w, "%s liqo control plane namespace %s[%s]%s exists\n", checkMark, green, nc.namespace, reset)
+	} else {
+		fmt.Fprintf(w, "%s liqo control plane namespace %s[%s]%s is not OK\n", redCross, red, nc.namespace, reset)
+		fmt.Fprintf(w, "Reason: %s\n", nc.failureReason)
+	}
+
+	// Add a new line ad the end of the message.
+	fmt.Fprintf(w, "\n")
+	if err := w.Flush(); err != nil {
+		return "", err
+	}
+
+	return buf.String(), nil
+}
+
+func (nc *namespaceChecker) HasSucceeded() bool {
+	return nc.succeeded
+}

--- a/pkg/liqoctl/status/namespace_test.go
+++ b/pkg/liqoctl/status/namespace_test.go
@@ -1,0 +1,123 @@
+// Copyright 2019-2021 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package status
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	k8serror "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+var (
+	nsChecker     namespaceChecker
+	ctx           context.Context
+	namespaceName string
+	namespace     *corev1.Namespace
+)
+
+var _ = Describe("Namespace", func() {
+	Describe("namespaceChecker", func() {
+		BeforeEach(func() {
+			ctx = context.Background()
+			namespaceName = "foo"
+			namespace = &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: namespaceName,
+				},
+			}
+		})
+
+		JustBeforeEach(func() {
+			nsChecker = namespaceChecker{
+				namespace: namespaceName,
+				name:      nsCheckerName,
+			}
+		})
+
+		Describe("creating a new namespaceChecker", func() {
+			It("should hold the parameters passed during the creation", func() {
+				nc := newNamespaceChecker(namespaceName, fake.NewSimpleClientset())
+				Expect(nc.namespace).To(Equal(namespaceName))
+				Expect(nc.failureReason).To(BeNil())
+				Expect(nc.succeeded).To(BeFalse())
+				Expect(nc.client).NotTo(BeNil())
+			})
+		})
+
+		Describe("Collect() function", func() {
+			When("fails to get the namespace", func() {
+				It("should set succeeded field to false, and the reason of failure", func() {
+					nsChecker.client = fake.NewSimpleClientset()
+					Expect(nsChecker.Collect(ctx)).To(BeNil())
+					Expect(nsChecker.succeeded).To(BeFalse())
+					Expect(k8serror.IsNotFound(nsChecker.failureReason)).To(BeTrue())
+				})
+			})
+
+			When("succeeds to get the namespace", func() {
+				It("should set the succeeded field to true", func() {
+					nsChecker.client = fake.NewSimpleClientset(namespace)
+					Expect(nsChecker.Collect(ctx)).To(BeNil())
+					Expect(nsChecker.succeeded).To(BeTrue())
+					Expect(nsChecker.failureReason).To(BeNil())
+				})
+			})
+		})
+
+		Describe("Format() function", func() {
+			When("the collection has failed", func() {
+				It("should state that the check has failed", func() {
+					nsChecker.succeeded = false
+					nsChecker.failureReason = fmt.Errorf("unable to find namespace foo")
+					msg, err := nsChecker.Format()
+					Expect(err).NotTo(HaveOccurred())
+					Expect(msg).To(ContainSubstring(fmt.Sprintf("%s liqo control plane namespace %s[%s]%s is not OK\n", redCross, red, nsChecker.namespace, reset)))
+					Expect(msg).To(ContainSubstring(fmt.Sprintf("Reason: %s\n", nsChecker.failureReason)))
+				})
+			})
+
+			When("succeeds to get the namespace", func() {
+				It("should set the succeeded field to true", func() {
+					nsChecker.succeeded = true
+					msg, err := nsChecker.Format()
+					Expect(err).NotTo(HaveOccurred())
+					Expect(msg).To(ContainSubstring(fmt.Sprintf("%s liqo control plane namespace %s[%s]%s exists\n", checkMark, green, nsChecker.namespace, reset)))
+				})
+			})
+		})
+
+		Describe("HasSucceeded() function", func() {
+			When("check succeeds", func() {
+				It("should return true", func() {
+					nsChecker.succeeded = true
+					Expect(nsChecker.HasSucceeded()).To(BeTrue())
+				})
+			})
+
+			When("check fails", func() {
+				It("should return false", func() {
+					nsChecker.succeeded = false
+					Expect(nsChecker.HasSucceeded()).To(BeFalse())
+				})
+			})
+		})
+	})
+})

--- a/pkg/liqoctl/status/pods_test.go
+++ b/pkg/liqoctl/status/pods_test.go
@@ -375,6 +375,22 @@ var _ = Describe("Pods", func() {
 			})
 		})
 
+		Describe("HasSucceeded() function", func() {
+			When("check succeeds", func() {
+				It("should return true", func() {
+					podC.errors = false
+					Expect(podC.HasSucceeded()).To(BeTrue())
+				})
+			})
+
+			When("check fails", func() {
+				It("should return false", func() {
+					podC.errors = true
+					Expect(podC.HasSucceeded()).To(BeFalse())
+				})
+			})
+		})
+
 		Describe("checkPodsStatus() function", func() {
 
 			var (


### PR DESCRIPTION
# Description

`liqoctl status -n namespace` now checks the namespace's existence before running additional checks. 

The output of  `liqoctl status -n liqo` when successful is:
```
namespace-existence
-------------------
✔ liqo control plane namespace [liqo] exists

liqo-control-plane
------------------
✔ control plane pods are up and running

```
If it is not possible to determine the existence of the namespace then something similar to the following snippet is printed out:

```
namespace-existence
-------------------
❌ liqo control plane namespace [liqo] is not OK
Reason: namespaces "liqo" not found

```

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Unit Tests
