### PR TITLE
Connectivity Test Improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -194,6 +194,8 @@ E2E_TARGETS = e2e-infra \
 # export LIQO_VERSION=3e060bc36ffb1a88b988a7e948de2b045ba2e8ce
 # export INFRA=kind
 # export LIQOCTL=${BINDIR}/liqoctl
+# export POD_CIDR_OVERLAPPING=false
+# export TEMPLATE_FILE=cluster-templates.yaml.tmpl
 
 # Run e2e tests
 e2e: $(E2E_TARGETS)
@@ -210,4 +212,4 @@ installer/%:
 	${PWD}/test/e2e/pipeline/$@.sh
 
 e2e/%:
-	go test ${PWD}/test/$@
+	go test ${PWD}/test/$@ -count=1

--- a/test/e2e/pipeline/diagnostic/diagnose.sh
+++ b/test/e2e/pipeline/diagnostic/diagnose.sh
@@ -1,17 +1,19 @@
 #!/bin/bash
 
 # This scripts expects the following variables to be set:
-# CLUSTER_NUMBER -> the number of liqo clusters
-# K8S_VERSION    -> the Kubernetes version
-# CNI            -> the CNI plugin used
-# TMPDIR         -> the directory where the test-related files are stored
-# BINDIR         -> the directory where the test-related binaries are stored
-# TEMPLATE_DIR   -> the directory where to read the cluster templates
-# NAMESPACE      -> the namespace where liqo is running
-# KUBECONFIGDIR  -> the directory where the kubeconfigs are stored
-# LIQO_VERSION   -> the liqo version to test
-# INFRA          -> the Kubernetes provider for the infrastructure
-# LIQOCTL        -> the path where liqoctl is stored
+# CLUSTER_NUMBER        -> the number of liqo clusters
+# K8S_VERSION           -> the Kubernetes version
+# CNI                   -> the CNI plugin used
+# TMPDIR                -> the directory where the test-related files are stored
+# BINDIR                -> the directory where the test-related binaries are stored
+# TEMPLATE_DIR          -> the directory where to read the cluster templates
+# NAMESPACE             -> the namespace where liqo is running
+# KUBECONFIGDIR         -> the directory where the kubeconfigs are stored
+# LIQO_VERSION          -> the liqo version to test
+# INFRA                 -> the Kubernetes provider for the infrastructure
+# LIQOCTL               -> the path where liqoctl is stored
+# POD_CIDR_OVERLAPPING  -> the pod CIDR of the clusters is overlapping
+# CLUSTER_TEMPLATE_FILE -> the file where the cluster template is stored
 
 set -e           # Fail in case of error
 set -o nounset   # Fail if undefined variables are used

--- a/test/e2e/pipeline/infra/kind/clean.sh
+++ b/test/e2e/pipeline/infra/kind/clean.sh
@@ -1,17 +1,19 @@
 #!/bin/bash
 
 # This scripts expects the following variables to be set:
-# CLUSTER_NUMBER -> the number of liqo clusters
-# K8S_VERSION    -> the Kubernetes version
-# CNI            -> the CNI plugin used
-# TMPDIR         -> the directory where the test-related files are stored
-# BINDIR         -> the directory where the test-related binaries are stored
-# TEMPLATE_DIR   -> the directory where to read the cluster templates
-# NAMESPACE      -> the namespace where liqo is running
-# KUBECONFIGDIR  -> the directory where the kubeconfigs are stored
-# LIQO_VERSION   -> the liqo version to test
-# INFRA          -> the Kubernetes provider for the infrastructure
-# LIQOCTL        -> the path where liqoctl is stored
+# CLUSTER_NUMBER        -> the number of liqo clusters
+# K8S_VERSION           -> the Kubernetes version
+# CNI                   -> the CNI plugin used
+# TMPDIR                -> the directory where the test-related files are stored
+# BINDIR                -> the directory where the test-related binaries are stored
+# TEMPLATE_DIR          -> the directory where to read the cluster templates
+# NAMESPACE             -> the namespace where liqo is running
+# KUBECONFIGDIR         -> the directory where the kubeconfigs are stored
+# LIQO_VERSION          -> the liqo version to test
+# INFRA                 -> the Kubernetes provider for the infrastructure
+# LIQOCTL               -> the path where liqoctl is stored
+# POD_CIDR_OVERLAPPING  -> the pod CIDR of the clusters is overlapping
+# CLUSTER_TEMPLATE_FILE -> the file where the cluster template is stored
 
 set -e           # Fail in case of error
 set -o nounset   # Fail if undefined variables are used

--- a/test/e2e/pipeline/infra/kind/pre-requirements.sh
+++ b/test/e2e/pipeline/infra/kind/pre-requirements.sh
@@ -1,17 +1,19 @@
 #!/bin/bash
 
 # This scripts expects the following variables to be set:
-# CLUSTER_NUMBER -> the number of liqo clusters
-# K8S_VERSION    -> the Kubernetes version
-# CNI            -> the CNI plugin used
-# TMPDIR         -> the directory where the test-related files are stored
-# BINDIR         -> the directory where the test-related binaries are stored
-# TEMPLATE_DIR   -> the directory where to read the cluster templates
-# NAMESPACE      -> the namespace where liqo is running
-# KUBECONFIGDIR  -> the directory where the kubeconfigs are stored
-# LIQO_VERSION   -> the liqo version to test
-# INFRA          -> the Kubernetes provider for the infrastructure
-# LIQOCTL        -> the path where liqoctl is stored
+# CLUSTER_NUMBER        -> the number of liqo clusters
+# K8S_VERSION           -> the Kubernetes version
+# CNI                   -> the CNI plugin used
+# TMPDIR                -> the directory where the test-related files are stored
+# BINDIR                -> the directory where the test-related binaries are stored
+# TEMPLATE_DIR          -> the directory where to read the cluster templates
+# NAMESPACE             -> the namespace where liqo is running
+# KUBECONFIGDIR         -> the directory where the kubeconfigs are stored
+# LIQO_VERSION          -> the liqo version to test
+# INFRA                 -> the Kubernetes provider for the infrastructure
+# LIQOCTL               -> the path where liqoctl is stored
+# POD_CIDR_OVERLAPPING  -> the pod CIDR of the clusters is overlapping
+# CLUSTER_TEMPLATE_FILE -> the file where the cluster template is stored
 
 set -e           # Fail in case of error
 set -o nounset   # Fail if undefined variables are used

--- a/test/e2e/pipeline/infra/kind/setup.sh
+++ b/test/e2e/pipeline/infra/kind/setup.sh
@@ -1,17 +1,19 @@
 #!/bin/bash
 
 # This scripts expects the following variables to be set:
-# CLUSTER_NUMBER -> the number of liqo clusters
-# K8S_VERSION    -> the Kubernetes version
-# CNI            -> the CNI plugin used
-# TMPDIR         -> the directory where the test-related files are stored
-# BINDIR         -> the directory where the test-related binaries are stored
-# TEMPLATE_DIR   -> the directory where to read the cluster templates
-# NAMESPACE      -> the namespace where liqo is running
-# KUBECONFIGDIR  -> the directory where the kubeconfigs are stored
-# LIQO_VERSION   -> the liqo version to test
-# INFRA          -> the Kubernetes provider for the infrastructure
-# LIQOCTL        -> the path where liqoctl is stored
+# CLUSTER_NUMBER        -> the number of liqo clusters
+# K8S_VERSION           -> the Kubernetes version
+# CNI                   -> the CNI plugin used
+# TMPDIR                -> the directory where the test-related files are stored
+# BINDIR                -> the directory where the test-related binaries are stored
+# TEMPLATE_DIR          -> the directory where to read the cluster templates
+# NAMESPACE             -> the namespace where liqo is running
+# KUBECONFIGDIR         -> the directory where the kubeconfigs are stored
+# LIQO_VERSION          -> the liqo version to test
+# INFRA                 -> the Kubernetes provider for the infrastructure
+# LIQOCTL               -> the path where liqoctl is stored
+# POD_CIDR_OVERLAPPING  -> the pod CIDR of the clusters is overlapping
+# CLUSTER_TEMPLATE_FILE -> the file where the cluster template is stored
 
 set -e           # Fail in case of error
 set -o nounset   # Fail if undefined variables are used
@@ -28,14 +30,17 @@ fi
 
 export SERVICE_CIDR=10.100.0.0/16
 export POD_CIDR=10.200.0.0/16
-export POD_CIDR_OVERLAPPING=${POD_CIDR_OVERLAPPING:-"true"}
+export POD_CIDR_OVERLAPPING=${POD_CIDR_OVERLAPPING:-"false"}
+
+CLUSTER_TEMPLATE_FILE=${CLUSTER_TEMPLATE_FILE:-cluster-templates.yaml.tmpl}
 
 for i in $(seq 1 "${CLUSTER_NUMBER}");
 do
 	if [[ ${POD_CIDR_OVERLAPPING} != "true" ]]; then
-		export POD_CIDR=10.${i}.0.0/16
+		# this should avoid the ipam to reserve a pod CIDR of another cluster as local external CIDR causing remapping
+		export POD_CIDR="10.$((i * 10)).0.0/16"
 	fi
-	envsubst < "${TEMPLATE_DIR}/templates/cluster-templates.yaml.tmpl" > "${TMPDIR}/liqo-cluster-${CLUSTER_NAME}${i}.yaml"
+	envsubst < "${TEMPLATE_DIR}/templates/$CLUSTER_TEMPLATE_FILE" > "${TMPDIR}/liqo-cluster-${CLUSTER_NAME}${i}.yaml"
 	echo "Creating cluster ${CLUSTER_NAME}${i}..."
 	${KIND} create cluster --name "${CLUSTER_NAME}${i}" --kubeconfig "${TMPDIR}/kubeconfigs/liqo_kubeconf_${i}" --config "${TMPDIR}/liqo-cluster-${CLUSTER_NAME}${i}.yaml" --wait 2m
 done

--- a/test/e2e/pipeline/infra/kind/templates/cluster-templates-admission-control.yaml.tmpl
+++ b/test/e2e/pipeline/infra/kind/templates/cluster-templates-admission-control.yaml.tmpl
@@ -1,0 +1,17 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+networking:
+  disableDefaultCNI: ${DISABLE_KINDNET}
+  serviceSubnet: "${SERVICE_CIDR}"
+  podSubnet: "${POD_CIDR}"
+nodes:
+  - role: control-plane
+    image: kindest/node:${K8S_VERSION}
+    kubeadmConfigPatches:
+    - |
+      kind: ClusterConfiguration
+      apiServer:
+        extraArgs:
+          enable-admission-plugins: NodeRestriction,OwnerReferencesPermissionEnforcement,LimitRanger,ServiceAccount,PodNodeSelector,Priority,PodTolerationRestriction,PersistentVolumeClaimResize,RuntimeClass,CertificateApproval,CertificateSigning,CertificateSubjectRestriction,ValidatingAdmissionWebhook,ResourceQuota,NamespaceLifecycle,LimitRanger,ServiceAccount,TaintNodesByCondition,PodNodeSelector,Priority,DefaultTolerationSeconds,PodTolerationRestriction,PersistentVolumeLabel,DefaultStorageClass,StorageObjectInUseProtection,RuntimeClass,DefaultIngressClass,MutatingAdmissionWebhook
+  - role: worker
+    image: kindest/node:${K8S_VERSION}

--- a/test/e2e/pipeline/installer/liqoctl/helm-utils.sh
+++ b/test/e2e/pipeline/installer/liqoctl/helm-utils.sh
@@ -1,17 +1,19 @@
 #!/bin/bash
 
 # This scripts expects the following variables to be set:
-# CLUSTER_NUMBER -> the number of liqo clusters
-# K8S_VERSION    -> the Kubernetes version
-# CNI            -> the CNI plugin used
-# TMPDIR         -> the directory where the test-related files are stored
-# BINDIR         -> the directory where the test-related binaries are stored
-# TEMPLATE_DIR   -> the directory where to read the cluster templates
-# NAMESPACE      -> the namespace where liqo is running
-# KUBECONFIGDIR  -> the directory where the kubeconfigs are stored
-# LIQO_VERSION   -> the liqo version to test
-# INFRA          -> the Kubernetes provider for the infrastructure
-# LIQOCTL        -> the path where liqoctl is stored
+# CLUSTER_NUMBER        -> the number of liqo clusters
+# K8S_VERSION           -> the Kubernetes version
+# CNI                   -> the CNI plugin used
+# TMPDIR                -> the directory where the test-related files are stored
+# BINDIR                -> the directory where the test-related binaries are stored
+# TEMPLATE_DIR          -> the directory where to read the cluster templates
+# NAMESPACE             -> the namespace where liqo is running
+# KUBECONFIGDIR         -> the directory where the kubeconfigs are stored
+# LIQO_VERSION          -> the liqo version to test
+# INFRA                 -> the Kubernetes provider for the infrastructure
+# LIQOCTL               -> the path where liqoctl is stored
+# POD_CIDR_OVERLAPPING  -> the pod CIDR of the clusters is overlapping
+# CLUSTER_TEMPLATE_FILE -> the file where the cluster template is stored
 
 set -e           # Fail in case of error
 set -o nounset   # Fail if undefined variables are used

--- a/test/e2e/pipeline/installer/liqoctl/peer.sh
+++ b/test/e2e/pipeline/installer/liqoctl/peer.sh
@@ -1,17 +1,19 @@
 #!/bin/bash
 
 # This scripts expects the following variables to be set:
-# CLUSTER_NUMBER -> the number of liqo clusters
-# K8S_VERSION    -> the Kubernetes version
-# CNI            -> the CNI plugin used
-# TMPDIR         -> the directory where the test-related files are stored
-# BINDIR         -> the directory where the test-related binaries are stored
-# TEMPLATE_DIR   -> the directory where to read the cluster templates
-# NAMESPACE      -> the namespace where liqo is running
-# KUBECONFIGDIR  -> the directory where the kubeconfigs are stored
-# LIQO_VERSION   -> the liqo version to test
-# INFRA          -> the Kubernetes provider for the infrastructure
-# LIQOCTL        -> the path where liqoctl is stored
+# CLUSTER_NUMBER        -> the number of liqo clusters
+# K8S_VERSION           -> the Kubernetes version
+# CNI                   -> the CNI plugin used
+# TMPDIR                -> the directory where the test-related files are stored
+# BINDIR                -> the directory where the test-related binaries are stored
+# TEMPLATE_DIR          -> the directory where to read the cluster templates
+# NAMESPACE             -> the namespace where liqo is running
+# KUBECONFIGDIR         -> the directory where the kubeconfigs are stored
+# LIQO_VERSION          -> the liqo version to test
+# INFRA                 -> the Kubernetes provider for the infrastructure
+# LIQOCTL               -> the path where liqoctl is stored
+# POD_CIDR_OVERLAPPING  -> the pod CIDR of the clusters is overlapping
+# CLUSTER_TEMPLATE_FILE -> the file where the cluster template is stored
 
 set -e           # Fail in case of error
 set -o nounset   # Fail if undefined variables are used

--- a/test/e2e/pipeline/installer/liqoctl/setup.sh
+++ b/test/e2e/pipeline/installer/liqoctl/setup.sh
@@ -1,17 +1,19 @@
 #!/bin/bash
 
 # This scripts expects the following variables to be set:
-# CLUSTER_NUMBER -> the number of liqo clusters
-# K8S_VERSION    -> the Kubernetes version
-# CNI            -> the CNI plugin used
-# TMPDIR         -> the directory where the test-related files are stored
-# BINDIR         -> the directory where the test-related binaries are stored
-# TEMPLATE_DIR   -> the directory where to read the cluster templates
-# NAMESPACE      -> the namespace where liqo is running
-# KUBECONFIGDIR  -> the directory where the kubeconfigs are stored
-# LIQO_VERSION   -> the liqo version to test
-# INFRA          -> the Kubernetes provider for the infrastructure
-# LIQOCTL        -> the path where liqoctl is stored
+# CLUSTER_NUMBER        -> the number of liqo clusters
+# K8S_VERSION           -> the Kubernetes version
+# CNI                   -> the CNI plugin used
+# TMPDIR                -> the directory where the test-related files are stored
+# BINDIR                -> the directory where the test-related binaries are stored
+# TEMPLATE_DIR          -> the directory where to read the cluster templates
+# NAMESPACE             -> the namespace where liqo is running
+# KUBECONFIGDIR         -> the directory where the kubeconfigs are stored
+# LIQO_VERSION          -> the liqo version to test
+# INFRA                 -> the Kubernetes provider for the infrastructure
+# LIQOCTL               -> the path where liqoctl is stored
+# POD_CIDR_OVERLAPPING  -> the pod CIDR of the clusters is overlapping
+# CLUSTER_TEMPLATE_FILE -> the file where the cluster template is stored
 
 set -e           # Fail in case of error
 set -o nounset   # Fail if undefined variables are used

--- a/test/e2e/pipeline/installer/liqoctl/uninstall.sh
+++ b/test/e2e/pipeline/installer/liqoctl/uninstall.sh
@@ -1,17 +1,19 @@
 #!/bin/bash
 
 # This scripts expects the following variables to be set:
-# CLUSTER_NUMBER -> the number of liqo clusters
-# K8S_VERSION    -> the Kubernetes version
-# CNI            -> the CNI plugin used
-# TMPDIR         -> the directory where the test-related files are stored
-# BINDIR         -> the directory where the test-related binaries are stored
-# TEMPLATE_DIR   -> the directory where to read the cluster templates
-# NAMESPACE      -> the namespace where liqo is running
-# KUBECONFIGDIR  -> the directory where the kubeconfigs are stored
-# LIQO_VERSION   -> the liqo version to test
-# INFRA          -> the Kubernetes provider for the infrastructure
-# LIQOCTL        -> the path where liqoctl is stored
+# CLUSTER_NUMBER        -> the number of liqo clusters
+# K8S_VERSION           -> the Kubernetes version
+# CNI                   -> the CNI plugin used
+# TMPDIR                -> the directory where the test-related files are stored
+# BINDIR                -> the directory where the test-related binaries are stored
+# TEMPLATE_DIR          -> the directory where to read the cluster templates
+# NAMESPACE             -> the namespace where liqo is running
+# KUBECONFIGDIR         -> the directory where the kubeconfigs are stored
+# LIQO_VERSION          -> the liqo version to test
+# INFRA                 -> the Kubernetes provider for the infrastructure
+# LIQOCTL               -> the path where liqoctl is stored
+# POD_CIDR_OVERLAPPING  -> the pod CIDR of the clusters is overlapping
+# CLUSTER_TEMPLATE_FILE -> the file where the cluster template is stored
 
 set -e           # Fail in case of error
 set -o nounset   # Fail if undefined variables are used

--- a/test/e2e/pipeline/installer/liqoctl/unpeer.sh
+++ b/test/e2e/pipeline/installer/liqoctl/unpeer.sh
@@ -1,17 +1,19 @@
 #!/bin/bash
 
 # This scripts expects the following variables to be set:
-# CLUSTER_NUMBER -> the number of liqo clusters
-# K8S_VERSION    -> the Kubernetes version
-# CNI            -> the CNI plugin used
-# TMPDIR         -> the directory where the test-related files are stored
-# BINDIR         -> the directory where the test-related binaries are stored
-# TEMPLATE_DIR   -> the directory where to read the cluster templates
-# NAMESPACE      -> the namespace where liqo is running
-# KUBECONFIGDIR  -> the directory where the kubeconfigs are stored
-# LIQO_VERSION   -> the liqo version to test
-# INFRA          -> the Kubernetes provider for the infrastructure
-# LIQOCTL        -> the path where liqoctl is stored
+# CLUSTER_NUMBER        -> the number of liqo clusters
+# K8S_VERSION           -> the Kubernetes version
+# CNI                   -> the CNI plugin used
+# TMPDIR                -> the directory where the test-related files are stored
+# BINDIR                -> the directory where the test-related binaries are stored
+# TEMPLATE_DIR          -> the directory where to read the cluster templates
+# NAMESPACE             -> the namespace where liqo is running
+# KUBECONFIGDIR         -> the directory where the kubeconfigs are stored
+# LIQO_VERSION          -> the liqo version to test
+# INFRA                 -> the Kubernetes provider for the infrastructure
+# LIQOCTL               -> the path where liqoctl is stored
+# POD_CIDR_OVERLAPPING  -> the pod CIDR of the clusters is overlapping
+# CLUSTER_TEMPLATE_FILE -> the file where the cluster template is stored
 
 set -e           # Fail in case of error
 set -o nounset   # Fail if undefined variables are used


### PR DESCRIPTION
# Description

This pr adds some connectivity e2e tests:

- pod to pod test in a full-mesh peering with multiple clusters (if the pod CIDRs are not overlapping)
- pod to service in a full-mesh peering with multiple clusters (both for overlapping and not overlapping pod CIDRs)
