### PR TITLE
Make MTU and listening port of the vpn tunnel configurable

### DIFF
--- a/cmd/liqoctl/cmd/install.go
+++ b/cmd/liqoctl/cmd/install.go
@@ -20,6 +20,8 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/klog/v2"
 
+	liqoconst "github.com/liqotech/liqo/pkg/consts"
+	"github.com/liqotech/liqo/pkg/liqoctl/install/provider"
 	installutils "github.com/liqotech/liqo/pkg/liqoctl/install/utils"
 )
 
@@ -53,8 +55,10 @@ func newInstallCommand(ctx context.Context) *cobra.Command {
 	installCmd.PersistentFlags().String("resource-sharing-percentage", "90", "It defines the percentage of available cluster resources that "+
 		"you are willing to share with foreign clusters. It accepts [0 - 100] values.")
 	installCmd.PersistentFlags().Bool("enable-ha", false, "Enable the gateway component support active/passive high availability.")
+	installCmd.PersistentFlags().Int("mtu", 0, "mtu is the maximum transmission unit for interfaces managed by Liqo")
+	installCmd.PersistentFlags().Int("vpn-listening-port", liqoconst.GatewayListeningPort, "vpn-listening-port is the port used by the vpn tunnel")
 
-	for _, providerName := range providers {
+	for _, providerName := range provider.Providers {
 		cmd, err := getCommand(ctx, providerName)
 		if err != nil {
 			klog.Fatal(err)

--- a/cmd/liqoctl/cmd/providers.go
+++ b/cmd/liqoctl/cmd/providers.go
@@ -35,8 +35,6 @@ const (
 	installLongHelp  = "Install Liqo on a selected %s cluster"
 )
 
-var providers = []string{"kubeadm", "kind", "k3s", "eks", "gke", "aks", "openshift"}
-
 var providerInitFunc = map[string]func(*cobra.Command){
 	"kubeadm":   kubeadm.GenerateFlags,
 	"kind":      kubeadm.GenerateFlags,

--- a/cmd/liqonet/route-operator.go
+++ b/cmd/liqonet/route-operator.go
@@ -45,7 +45,7 @@ type routeOperatorFlags struct {
 
 func addRouteOperatorFlags(liqonet *routeOperatorFlags) {
 	flag.IntVar(&liqonet.vni, "route.vxlan-vni", 18952, "VXLAN Virtual Network Identifier (VNI) for the Liqonet intra-cluster overlay network")
-	flag.IntVar(&liqonet.mtu, "route.vxlan-mtu", 1420, "VXLAN Max Transmit Unit (MTU) for the Liqonet intra-cluster overlay network")
+	flag.IntVar(&liqonet.mtu, "route.vxlan-mtu", liqoconst.DefaultMTU, "VXLAN Max Transmit Unit (MTU) for the Liqonet intra-cluster overlay network")
 	flag.IntVar(&liqonet.vtepPort, "route.vxlan-vtep-port", 4879,
 		"VXLAN Virtual Tunnel Endpoints (VTEP) port for the Liqonet intra-cluster overlay network")
 }

--- a/deployments/liqo/README.md
+++ b/deployments/liqo/README.md
@@ -47,6 +47,7 @@
 | discovery.pod.extraArgs | list | `[]` | discovery pod extra arguments |
 | discovery.pod.labels | object | `{}` | discovery pod labels |
 | fullnameOverride | string | `""` | full liqo name override |
+| gateway.config.listeningPort | int | `5871` | port used by the vpn tunnel. |
 | gateway.imageName | string | `"liqo/liqonet"` | gateway image repository |
 | gateway.pod.annotations | object | `{}` | gateway pod annotations |
 | gateway.pod.extraArgs | list | `[]` | gateway pod extra arguments |
@@ -55,6 +56,7 @@
 | gateway.service.annotations | object | `{}` |  |
 | gateway.service.type | string | `"LoadBalancer"` | If you plan to use liqo over the Internet consider to change this field to "LoadBalancer". More generally, if your cluster nodes are directly reachable by the cluster to whom you are peering, you may change it to "NodePort". |
 | nameOverride | string | `""` | liqo name override |
+| networkConfig.mtu | int | `1440` | set the mtu for the interfaces managed by liqo: vxlan, tunnel and veth interfaces The value is used by the gateway and route operators. |
 | networkManager.config.additionalPools | list | `[]` | Set of additional network pools. Network pools are used to map a cluster network into another one in order to prevent conflicts. Default set of network pools is: [10.0.0.0/8, 192.168.0.0/16, 172.16.0.0/12] |
 | networkManager.config.podCIDR | string | `""` | The subnet used by the cluster for the pods, in CIDR notation |
 | networkManager.config.reservedSubnets | list | `[]` | Usually the IPs used for the pods in k8s clusters belong to private subnets In order to prevent IP conflicting between locally used private subnets in your infrastructure and private subnets belonging to remote clusters you need tell liqo the subnets used in your cluster. E.g if your cluster nodes belong to the 192.168.2.0/24 subnet then you should add that subnet to the reservedSubnets. PodCIDR and serviceCIDR used in the local cluster are automatically added to the reserved list. |

--- a/deployments/liqo/templates/liqo-gateway-deployment.yaml
+++ b/deployments/liqo/templates/liqo-gateway-deployment.yaml
@@ -32,11 +32,13 @@ spec:
           imagePullPolicy: {{ .Values.pullPolicy }}
           name: {{ $gatewayConfig.name }}
           ports:
-          - containerPort: 5871
+          - containerPort: {{ .Values.gateway.config.listeningPort }}
           command: ["/usr/bin/liqonet"]
           args:
           - --run-as=liqo-gateway
           - --gateway.leader-elect=true
+          - --gateway.mtu={{ .Values.networkConfig.mtu }}
+          - --gateway.listening-port={{ .Values.gateway.config.listeningPort }}
           {{- if .Values.gateway.pod.extraArgs }}
           {{- toYaml .Values.gateway.pod.extraArgs | nindent 10 }}
           {{- end }}

--- a/deployments/liqo/templates/liqo-gateway-service.yaml
+++ b/deployments/liqo/templates/liqo-gateway-service.yaml
@@ -16,8 +16,8 @@ spec:
   type: {{ .Values.gateway.service.type }}
   ports:
     - name: wireguard
-      port: 5871
-      targetPort: 5871
+      port: {{ .Values.gateway.config.listeningPort }}
+      targetPort: {{ .Values.gateway.config.listeningPort }}
       protocol: UDP
   selector:
     {{- include "liqo.gatewaySelector" $gatewayConfig | nindent 4 }}

--- a/deployments/liqo/templates/liqo-route-daemonset.yaml
+++ b/deployments/liqo/templates/liqo-route-daemonset.yaml
@@ -44,6 +44,7 @@ spec:
           command: ["/usr/bin/liqonet"]
           args:
           - --run-as=liqo-route
+          - --route.vxlan-mtu={{ .Values.networkConfig.mtu }}
           {{- if .Values.route.pod.extraArgs }}
           {{- toYaml .Values.route.pod.extraArgs | nindent 10 }}
           {{- end }}

--- a/deployments/liqo/values.yaml
+++ b/deployments/liqo/values.yaml
@@ -57,6 +57,9 @@ gateway:
     # More generally, if your cluster nodes are directly reachable by the cluster to whom you are peering, you may change it to "NodePort".
     type: "LoadBalancer"
     annotations: {}
+  config:
+    # -- port used by the vpn tunnel.
+    listeningPort: 5871
 
 networkManager:
   pod:
@@ -227,6 +230,12 @@ awsConfig:
 openshiftConfig:
   # -- enable the OpenShift support
   enable: false
+
+# configuration for liqo networking
+networkConfig:
+  # -- set the mtu for the interfaces managed by liqo: vxlan, tunnel and veth interfaces
+  # The value is used by the gateway and route operators.
+  mtu: 1440
 
 # capsule subchart configuration
 capsule:

--- a/docs/pages/configuration/networking.md
+++ b/docs/pages/configuration/networking.md
@@ -1,0 +1,56 @@
+---
+title: Networking
+weight: 2
+---
+
+### MTU Configuration
+
+The maximum transmission unit (MTU) is a measurement representing the largest data packet that can be transmitted through a network.
+The correct MTU setting is vital for a given network.
+In general a larger MTU brings greater efficiency allowing to reach the maximum performance of the network.
+Beware that higher MTU could cause fragmentation or dropped packets on the path between two devices.
+Special cases are the tunnel devices interconnecting different networks and need to be carefully configured in order for the packets flowing between the tunnel devices to not be dropped or fragmented.
+
+#### Liqo's Network Interfaces
+
+Liqo's network operators handle different network interfaces.
+On each node of a given cluster a VxLAN network interface named `liqo.vxlan` is configured bringing up an overlay network between all the nodes. 
+In the node where the active gateway is running there will be a [custom network namespace](../../../concepts/networking/components/gateway/#tunnel-operator) named `liqo-netns`.
+In the custom namespace a tunnel device named `liqo.wg`, used to interconnect the cluster to remote ones, is created.
+In the host network namespace a veth device named `liqo.host` is created, and the other end named `liqo.gateway` is created in the custom network namespace.
+
+#### Liqo and MTU size
+
+The following table lists common MTU sizes for Liqo environments.
+{{% notice note %}}
+Beware that the MTU is a global property of the network path between endpoints, you should set the MTU to the minimum MTU of any path that the packets may take. 
+For example if you are interconnecting two clusters one running in AKS and the other one in GCE the MTU should be set to 1340 for both clusters.
+{{% /notice %}}
+
+|Network MTU	| Li Liqo Wireguard MTU(IPV4)|   	
+|---	        |---                        |
+|   1500        |   1440                    |
+|   9000	    |   8940                    |
+|   1500 (AKS)  |   1340                    |
+|   1460 (GCE)  |   1400                    |
+|   1500 (EKS)  |   1440                    |
+
+VxLAN uses a 50-byte header and WireGuard uses a [60-byte header](https://lists.zx2c4.com/pipermail/wireguard/2017-December/002201.html).
+In the AKS environment the network interfaces will have an MTU of 1500 but the underlying network has an [MTU of 1400](https://docs.microsoft.com/en-us/azure/virtual-network/virtual-network-tcpip-performance-tuning#azure-and-vm-mtu).
+Since WireGuard sets the `Don't Fragment(DF)` bit on its packets, the MTU for the Liqo network interfaces has to be set to 1340.
+
+#### Configure MTU
+
+Configuring the MTU is as simple as specifying the mtu value in [liqoctl](../../../installation/#quick-installation) install command by using the appropriate flag:
+
+```
+liqoctl install ${YOUR_PROVIDER} --cluster-name ${YOUR_CLUSTER_NAME} --mtu 1400
+```
+{{% notice note %}}
+The `liqoctl install` command is idempotent and can be executed multiple times to enforce the desired configuration.
+{{% /notice %}}
+
+If you are installing Liqo using the provided helm chart than the MTU size can be configured by setting the `networkConfig.mtu` variable in the [values.yaml file](../../../installation/chart_values/#values).
+
+
+

--- a/docs/pages/installation/chart_values.md
+++ b/docs/pages/installation/chart_values.md
@@ -52,6 +52,7 @@ weight: 5
 | discovery.pod.extraArgs | list | `[]` | discovery pod extra arguments |
 | discovery.pod.labels | object | `{}` | discovery pod labels |
 | fullnameOverride | string | `""` | full liqo name override |
+| gateway.config.listeningPort | int | `5871` | port used by the vpn tunnel. |
 | gateway.imageName | string | `"liqo/liqonet"` | gateway image repository |
 | gateway.pod.annotations | object | `{}` | gateway pod annotations |
 | gateway.pod.extraArgs | list | `[]` | gateway pod extra arguments |
@@ -60,6 +61,7 @@ weight: 5
 | gateway.service.annotations | object | `{}` |  |
 | gateway.service.type | string | `"LoadBalancer"` | If you plan to use liqo over the Internet consider to change this field to "LoadBalancer". More generally, if your cluster nodes are directly reachable by the cluster to whom you are peering, you may change it to "NodePort". |
 | nameOverride | string | `""` | liqo name override |
+| networkConfig.mtu | int | `1440` | set the mtu for the interfaces managed by liqo: vxlan, tunnel and veth interfaces The value is used by the gateway and route operators. |
 | networkManager.config.additionalPools | list | `[]` | Set of additional network pools. Network pools are used to map a cluster network into another one in order to prevent conflicts. Default set of network pools is: [10.0.0.0/8, 192.168.0.0/16, 172.16.0.0/12] |
 | networkManager.config.podCIDR | string | `""` | The subnet used by the cluster for the pods, in CIDR notation |
 | networkManager.config.reservedSubnets | list | `[]` | Usually the IPs used for the pods in k8s clusters belong to private subnets In order to prevent IP conflicting between locally used private subnets in your infrastructure and private subnets belonging to remote clusters you need tell liqo the subnets used in your cluster. E.g if your cluster nodes belong to the 192.168.2.0/24 subnet then you should add that subnet to the reservedSubnets. PodCIDR and serviceCIDR used in the local cluster are automatically added to the reserved list. |

--- a/pkg/consts/liqonet.go
+++ b/pkg/consts/liqonet.go
@@ -90,4 +90,15 @@ const (
 	RemoteNATExternalCIDR = "RemoteNATExternalCIDR"
 	// FinalizersSuffix suffix used by the network operators to create the finalizers added to k8s resources.
 	FinalizersSuffix = "net.liqo.io"
+	// UDPMinPort min value for a udp port.
+	UDPMinPort = 1
+	// UDPMaxPort max value for a udp port.
+	UDPMaxPort = 65535
+	// DefaultMTU default value for the mtu used in the network interfaces managed by the network operators.
+	// Used by:
+	//  - the route operator for the vxlan interfaces;
+	//  - the gateway operator for vpn tunnel and veth pair between host network namespace and custom network namespace.
+	DefaultMTU = 1440
+	// GatewayListeningPort port used by the vpn tunnel.
+	GatewayListeningPort = 5871
 )

--- a/pkg/liqoctl/install/handler.go
+++ b/pkg/liqoctl/install/handler.go
@@ -43,7 +43,7 @@ func HandleInstallCommand(ctx context.Context, cmd *cobra.Command, baseCommand, 
 	}
 
 	fmt.Printf("* Initializing installer... 🔌 \n")
-	commonArgs, err := installprovider.ValidateCommonArguments(cmd.Flags())
+	commonArgs, err := installprovider.ValidateCommonArguments(providerName, cmd.Flags())
 	if err != nil {
 		return err
 	}

--- a/pkg/liqoctl/install/provider/args_test.go
+++ b/pkg/liqoctl/install/provider/args_test.go
@@ -1,0 +1,76 @@
+// Copyright 2019-2021 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Args", func() {
+	Describe("getDefaultMTU() function", func() {
+		When("provider does not exist", func() {
+			It("should return an error", func() {
+				mtu, err := getDefaultMTU("notExistingProvider")
+				Expect(mtu).To(BeZero())
+				Expect(err).To(MatchError(fmt.Errorf("mtu for provider notExistingProvider not found")))
+			})
+		})
+
+		When("provider exists", func() {
+			It("should succeed", func() {
+				mtu, err := getDefaultMTU("aks")
+				Expect(mtu).To(Equal(providersDefaultMTU["aks"]))
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+	})
+
+	Describe("parseCommonValues() function", func() {
+		Context("setting mtu for network interfaces", func() {
+			When("mtu is set to zero, falling back to default value for each provider", func() {
+				It("should return the right mtu in the configuration map", func() {
+					for _, provider := range Providers {
+						config, err := parseCommonValues(provider, "", "", "", "", false, false, 0, 0)
+						Expect(err).NotTo(HaveOccurred())
+						netConfig := config["networkConfig"].(map[string]interface{})
+						Expect(netConfig["mtu"]).To(BeNumerically("==", providersDefaultMTU[provider]))
+					}
+				})
+			})
+
+			When("the provider does not exist", func() {
+				It("should return an error", func() {
+					_, err := parseCommonValues("notExisting", "", "", "", "", false, false, 0, 0)
+					Expect(err).To(HaveOccurred())
+					Expect(err).To(MatchError(fmt.Errorf("mtu for provider notExisting not found")))
+				})
+			})
+
+			When("the mtu is set by the user", func() {
+				It("should set the mtu", func() {
+					var mtu float64 = 1340
+					config, err := parseCommonValues("eks", "", "", "", "", false, false, mtu, 0)
+					Expect(err).NotTo(HaveOccurred())
+					netConfig := config["networkConfig"].(map[string]interface{})
+					Expect(netConfig["mtu"]).To(BeNumerically("==", mtu))
+				})
+			})
+
+		})
+	})
+})

--- a/pkg/liqoctl/install/provider/generic.go
+++ b/pkg/liqoctl/install/provider/generic.go
@@ -20,6 +20,9 @@ import (
 	argsutils "github.com/liqotech/liqo/pkg/utils/args"
 )
 
+// Providers list of providers supported by liqoctl.
+var Providers = []string{"kubeadm", "kind", "k3s", "eks", "gke", "aks", "openshift"}
+
 // GenericProvider includes the fields and the logic required by every install provider.
 type GenericProvider struct {
 	ReservedSubnets []string

--- a/pkg/liqoctl/install/provider/provider_suite_test.go
+++ b/pkg/liqoctl/install/provider/provider_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright 2019-2021 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestProvider(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Provider Suite")
+}

--- a/pkg/liqonet/tunnel/driver.go
+++ b/pkg/liqonet/tunnel/driver.go
@@ -23,7 +23,7 @@ import (
 )
 
 // DriverCreateFunc function prototype to create a new driver.
-type DriverCreateFunc func(k8sClientset k8s.Interface, namespace string) (Driver, error)
+type DriverCreateFunc func(k8sClientset k8s.Interface, namespace string, config Config) (Driver, error)
 
 // Drivers static map of supported drivers.
 var Drivers = map[string]DriverCreateFunc{}
@@ -35,6 +35,12 @@ func AddDriver(name string, driverCreate DriverCreateFunc) {
 	}
 	klog.Infof("driver for %s VPN successfully registered", name)
 	Drivers[name] = driverCreate
+}
+
+// Config configuration for tunnel drivers passed during the creation.
+type Config struct {
+	MTU           int
+	ListeningPort int
 }
 
 // Driver the interface needed to be implemented by new vpn drivers.

--- a/pkg/liqonet/tunnel/wireguard/driver_test.go
+++ b/pkg/liqonet/tunnel/wireguard/driver_test.go
@@ -23,6 +23,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	netv1alpha1 "github.com/liqotech/liqo/apis/net/v1alpha1"
+	liqoconst "github.com/liqotech/liqo/pkg/consts"
 )
 
 const (
@@ -51,14 +52,16 @@ var _ = Describe("Driver", func() {
 				tep.Spec.BackendConfig[ListeningPort] = outOfRangeMin
 				port, err := getTunnelPortFromTep(tep)
 				Expect(port).To(BeNumerically("==", 0))
-				Expect(err).To(MatchError(fmt.Sprintf("port {%s} should be greater than {%d} and minor than {%d}", outOfRangeMin, udpMinPort, udpMaxPort)))
+				Expect(err).To(MatchError(fmt.Sprintf("port {%s} should be greater than {%d} and minor than {%d}",
+					outOfRangeMin, liqoconst.UDPMinPort, liqoconst.UDPMaxPort)))
 			})
 
 			It("port > than max acceptable value", func() {
 				tep.Spec.BackendConfig[ListeningPort] = outOfRangeMax
 				port, err := getTunnelPortFromTep(tep)
 				Expect(port).To(BeNumerically("==", 0))
-				Expect(err).To(MatchError(fmt.Sprintf("port {%s} should be greater than {%d} and minor than {%d}", outOfRangeMax, udpMinPort, udpMaxPort)))
+				Expect(err).To(MatchError(fmt.Sprintf("port {%s} should be greater than {%d} and minor than {%d}",
+					outOfRangeMax, liqoconst.UDPMinPort, liqoconst.UDPMaxPort)))
 			})
 
 			It("port is not a valid number", func() {


### PR DESCRIPTION
# Description

Liqo's network operators handle different network interfaces:
  - liqo-gateway: tunnel interface and veth interfaces (interconnecting custom netns with the host netns);
  - liqo-route: vxlan interface.
  
This PR enables the user to specify the `MTU` for those interfaces by setting it directly in the `values.yaml` file if installing Liqo using the helm chart or specifying the new desired `MTU` in the liqoctl install command:
`liqoctl install kind --mtu 1420`

Same way the user can set the listening port for the vpn tunnel.

Fixes #(issue)
#919

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Unit Tests
