### PR TITLE
controller-manager: fix peering status reporting logic

### DIFF
--- a/apis/discovery/v1alpha1/foreigncluster_types.go
+++ b/apis/discovery/v1alpha1/foreigncluster_types.go
@@ -28,7 +28,7 @@ const (
 	// PeeringConditionStatusNone indicates that there is no peering.
 	PeeringConditionStatusNone PeeringConditionStatusType = "None"
 	// PeeringConditionStatusPending indicates that the peering is pending,
-	// and we are waiting for the remote cluster feedback.
+	// and we are either waiting for the remote cluster feedback or for us to accept the ResourceOffer.
 	PeeringConditionStatusPending PeeringConditionStatusType = "Pending"
 	// PeeringConditionStatusEstablished indicates that the peering has been established.
 	PeeringConditionStatusEstablished PeeringConditionStatusType = "Established"


### PR DESCRIPTION
# Description

Wait for ResourceOffer being accepted before setting OutgoingPeeringStatus=Established (we currently set it to Established once we _receive_ the ResourceOffer).

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Manual tests
- [x] Automated tests
