### PR TITLE
liqoctl: use most recent release if no --version is given (fixes #935)

### DIFF
--- a/pkg/liqoctl/install/utils.go
+++ b/pkg/liqoctl/install/utils.go
@@ -72,7 +72,7 @@ func initHelmClient(config *rest.Config, arguments *provider.CommonArguments) (*
 
 func installOrUpdate(ctx context.Context, helmClient *helm.HelmClient, k provider.InstallProviderInterface, cArgs *provider.CommonArguments) error {
 	if cArgs.Version == "" {
-		version, err := FindNewestRelease()
+		version, err := FindNewestRelease(ctx)
 		if err != nil {
 			return err
 		}
@@ -149,10 +149,14 @@ type tagsAPIResponse struct {
 }
 
 // FindNewestRelease queries the Docker Hub and gets the first release tag (i.e. not a release candidate, alpha, etc).
-func FindNewestRelease() (string, error) {
+func FindNewestRelease(ctx context.Context) (string, error) {
 	page := "https://registry.hub.docker.com/v2/repositories/liqo/liqo-controller-manager/tags/"
 	for {
-		resp, err := http.Get(page)
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, page, nil)
+		if err != nil {
+			return "", err
+		}
+		resp, err := http.DefaultClient.Do(req)
 		if err != nil {
 			return "", err
 		}

--- a/pkg/liqoctl/install/utils_test.go
+++ b/pkg/liqoctl/install/utils_test.go
@@ -1,6 +1,21 @@
+// Copyright 2019-2021 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package install
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -17,7 +32,7 @@ var _ = Describe("liqoctl", func() {
 	Context("install", func() {
 		When("the user does not specify a tag", func() {
 			It("returns a suitable tag", func() {
-				tag, err := FindNewestRelease()
+				tag, err := FindNewestRelease(context.Background())
 				Expect(err).To(BeNil())
 				tag = strings.ToLower(tag)
 				// Do not pick "latest", because it's not guaranteed to be a release


### PR DESCRIPTION
# Description

Makes liqoctl not ignore the --version passed from the command line, and also use the most recent release (not rc or alpha) if no --version is given.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Manual tests
- [x] Automated tests