### PR TITLE
Fix Headless Services Reflection

### DIFF
--- a/pkg/virtualKubelet/forge/pods.go
+++ b/pkg/virtualKubelet/forge/pods.go
@@ -146,6 +146,8 @@ func (f *apiForger) forgePodSpec(inputPodSpec corev1.PodSpec) corev1.PodSpec {
 	outputPodSpec.Containers = forgeContainers(inputPodSpec.Containers, outputPodSpec.Volumes)
 	outputPodSpec.Tolerations = Tolerations(inputPodSpec.Tolerations)
 	outputPodSpec.EnableServiceLinks = inputPodSpec.EnableServiceLinks
+	outputPodSpec.Hostname = inputPodSpec.Hostname
+	outputPodSpec.Subdomain = inputPodSpec.Subdomain
 
 	return outputPodSpec
 }

--- a/pkg/virtualKubelet/forge/services.go
+++ b/pkg/virtualKubelet/forge/services.go
@@ -17,6 +17,7 @@ package forge
 import (
 	corev1 "k8s.io/api/core/v1"
 	corev1apply "k8s.io/client-go/applyconfigurations/core/v1"
+	"k8s.io/utils/pointer"
 )
 
 // nodePortUnset -> the value representing an unset NodePort.
@@ -48,6 +49,10 @@ func RemoteServiceSpec(local *corev1.ServiceSpec) *corev1apply.ServiceSpecApplyC
 	remote.LoadBalancerSourceRanges = local.LoadBalancerSourceRanges
 	remote.PublishNotReadyAddresses = &local.PublishNotReadyAddresses
 	remote.SessionAffinity = &local.SessionAffinity
+
+	if local.ClusterIP == corev1.ClusterIPNone {
+		remote.ClusterIP = pointer.String(corev1.ClusterIPNone)
+	}
 
 	return remote
 }


### PR DESCRIPTION
# Description

This pr adds the reflection of some fields required (in services and pods) to handle the headless services

# How Has This Been Tested?

- [x] locally on kind
