### PR TITLE
Make virtual kubelet resources configurable

### DIFF
--- a/cmd/liqo-controller-manager/main.go
+++ b/cmd/liqo-controller-manager/main.go
@@ -85,6 +85,8 @@ func main() {
 	var kubeletExtraAnnotations, kubeletExtraLabels argsutils.StringMap
 	var kubeletExtraArgs argsutils.StringList
 	var nodeExtraAnnotations, nodeExtraLabels argsutils.StringMap
+	var kubeletCPURequests, kubeletCPULimits = argsutils.NewQuantity("250m"), argsutils.NewQuantity("1000m")
+	var kubeletRAMRequests, kubeletRAMLimits = argsutils.NewQuantity("100M"), argsutils.NewQuantity("250M")
 
 	metricsAddr := flag.String("metrics-address", ":8080", "The address the metric endpoint binds to")
 	probeAddr := flag.String("health-probe-address", ":8081", "The address the health probe endpoint binds to")
@@ -135,6 +137,10 @@ func main() {
 	flag.Var(&kubeletExtraAnnotations, "kubelet-extra-annotations", "Extra annotations to add to the Virtual Kubelet Deployments and Pods")
 	flag.Var(&kubeletExtraLabels, "kubelet-extra-labels", "Extra labels to add to the Virtual Kubelet Deployments and Pods")
 	flag.Var(&kubeletExtraArgs, "kubelet-extra-args", "Extra arguments to add to the Virtual Kubelet Deployments and Pods")
+	flag.Var(&kubeletCPURequests, "kubelet-cpu-requests", "CPU requests assigned to the Virtual Kubelet Pod")
+	flag.Var(&kubeletCPULimits, "kubelet-cpu-limits", "CPU limits assigned to the Virtual Kubelet Pod")
+	flag.Var(&kubeletRAMRequests, "kubelet-ram-requests", "RAM requests assigned to the Virtual Kubelet Pod")
+	flag.Var(&kubeletRAMLimits, "kubelet-ram-limits", "RAM limits assigned to the Virtual Kubelet Pod")
 	flag.Var(&nodeExtraAnnotations, "node-extra-annotations", "Extra annotations to add to the Virtual Node")
 	flag.Var(&nodeExtraLabels, "node-extra-labels", "Extra labels to add to the Virtual Node")
 
@@ -243,6 +249,10 @@ func main() {
 		ExtraArgs:             kubeletExtraArgs.StringList,
 		NodeExtraAnnotations:  nodeExtraAnnotations,
 		NodeExtraLabels:       nodeExtraLabels,
+		RequestsCPU:           kubeletCPURequests.Quantity,
+		RequestsRAM:           kubeletRAMRequests.Quantity,
+		LimitsCPU:             kubeletCPULimits.Quantity,
+		LimitsRAM:             kubeletRAMLimits.Quantity,
 	}
 
 	resourceOfferReconciler := resourceoffercontroller.NewResourceOfferController(

--- a/pkg/utils/args/args_test.go
+++ b/pkg/utils/args/args_test.go
@@ -22,6 +22,7 @@ import (
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 func TestParseArguments(t *testing.T) {
@@ -251,6 +252,40 @@ var _ = Describe("ParseArguments", func() {
 			}),
 		)
 
+	})
+
+	Context("Quantity", func() {
+		type parseQuantityTestcase struct {
+			str            string
+			expectedError  OmegaMatcher
+			expectedValue  resource.Quantity
+			expectedString string
+		}
+
+		DescribeTable("Quantity table",
+			func(c parseQuantityTestcase) {
+				q := Quantity{}
+				err := q.Set(c.str)
+				Expect(err).To(c.expectedError)
+
+				if err == nil {
+					Expect(q.Quantity.Equal(c.expectedValue)).To(BeTrue())
+					Expect(q.String()).To(Equal(c.expectedString))
+				}
+			},
+
+			Entry("invalid string", parseQuantityTestcase{
+				str:           "11z",
+				expectedError: HaveOccurred(),
+			}),
+
+			Entry("valid string", parseQuantityTestcase{
+				str:            "55m",
+				expectedError:  Not(HaveOccurred()),
+				expectedValue:  *resource.NewScaledQuantity(55, resource.Milli),
+				expectedString: "55m",
+			}),
+		)
 	})
 
 })

--- a/pkg/utils/args/resource.go
+++ b/pkg/utils/args/resource.go
@@ -1,0 +1,47 @@
+// Copyright 2019-2021 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package args
+
+import "k8s.io/apimachinery/pkg/api/resource"
+
+// Quantity implements the flag.Value interface and allows to parse strings expressing resource quantities.
+type Quantity struct {
+	Quantity resource.Quantity
+}
+
+// NewQuantity returns a new Quantity object initialized with the given resource quantity.
+func NewQuantity(quantity string) Quantity {
+	return Quantity{Quantity: resource.MustParse(quantity)}
+}
+
+// String returns the stringified quantity.
+func (q *Quantity) String() string {
+	return q.Quantity.String()
+}
+
+// Set parses the provided string as a resource quantity.
+func (q *Quantity) Set(str string) error {
+	quantity, err := resource.ParseQuantity(str)
+	if err != nil {
+		return err
+	}
+	q.Quantity = quantity
+	return nil
+}
+
+// Type returns the quantity type.
+func (q *Quantity) Type() string {
+	return "quantity"
+}

--- a/pkg/vkMachinery/forge/forge.go
+++ b/pkg/vkMachinery/forge/forge.go
@@ -18,16 +18,10 @@ import (
 	"fmt"
 
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 
 	liqoconst "github.com/liqotech/liqo/pkg/consts"
 	vk "github.com/liqotech/liqo/pkg/vkMachinery"
 )
-
-const vkCPUResourceReq = "300m"
-const vkMemoryResourceReq = "100M"
-const vkCPUResourceLim = "1000m"
-const vkMemoryResourceLim = "250M"
 
 func forgeVKAffinity() *v1.Affinity {
 	return &v1.Affinity{
@@ -68,7 +62,7 @@ func forgeVKInitContainers(nodeName string, opts *VirtualKubeletOpts) []v1.Conta
 
 	return []v1.Container{
 		{
-			Resources: forgeVKResources(),
+			Resources: forgeVKResources(opts),
 			Name:      "crt-generator",
 			Image:     opts.InitContainerImage,
 			Command: []string{
@@ -136,7 +130,7 @@ func forgeVKContainers(
 	return []v1.Container{
 		{
 			Name:         "virtual-kubelet",
-			Resources:    forgeVKResources(),
+			Resources:    forgeVKResources(opts),
 			Image:        vkImage,
 			Command:      command,
 			Args:         args,
@@ -172,15 +166,15 @@ func forgeVKPodSpec(
 	}
 }
 
-func forgeVKResources() v1.ResourceRequirements {
+func forgeVKResources(opts *VirtualKubeletOpts) v1.ResourceRequirements {
 	return v1.ResourceRequirements{
 		Limits: v1.ResourceList{
-			"cpu":    resource.MustParse(vkCPUResourceLim),
-			"memory": resource.MustParse(vkMemoryResourceLim),
+			v1.ResourceCPU:    opts.LimitsCPU,
+			v1.ResourceMemory: opts.LimitsRAM,
 		},
 		Requests: v1.ResourceList{
-			"cpu":    resource.MustParse(vkCPUResourceReq),
-			"memory": resource.MustParse(vkMemoryResourceReq),
+			v1.ResourceCPU:    opts.RequestsCPU,
+			v1.ResourceMemory: opts.RequestsRAM,
 		},
 	}
 }

--- a/pkg/vkMachinery/forge/type.go
+++ b/pkg/vkMachinery/forge/type.go
@@ -15,6 +15,8 @@
 package forge
 
 import (
+	"k8s.io/apimachinery/pkg/api/resource"
+
 	argsutils "github.com/liqotech/liqo/pkg/utils/args"
 )
 
@@ -32,4 +34,8 @@ type VirtualKubeletOpts struct {
 	ExtraArgs             []string
 	NodeExtraAnnotations  argsutils.StringMap
 	NodeExtraLabels       argsutils.StringMap
+	RequestsCPU           resource.Quantity
+	LimitsCPU             resource.Quantity
+	RequestsRAM           resource.Quantity
+	LimitsRAM             resource.Quantity
 }


### PR DESCRIPTION
# Description

This PR makes the resource requests and limits assigned to the virtual kubelet pod configurable through command line arguments.

Fixes #(issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Existing
- [x] Manual testing
