### PR TITLE
Virtual kubelet: add liqo client and informers to reflection manager

### DIFF
--- a/pkg/virtualKubelet/reflection/manager/manager.go
+++ b/pkg/virtualKubelet/reflection/manager/manager.go
@@ -27,6 +27,8 @@ import (
 	"k8s.io/klog/v2"
 	"k8s.io/utils/trace"
 
+	liqoclient "github.com/liqotech/liqo/pkg/client/clientset/versioned"
+	liqoinformers "github.com/liqotech/liqo/pkg/client/informers/externalversions"
 	traceutils "github.com/liqotech/liqo/pkg/utils/trace"
 	"github.com/liqotech/liqo/pkg/virtualKubelet/forge"
 	"github.com/liqotech/liqo/pkg/virtualKubelet/reflection/options"
@@ -38,9 +40,11 @@ var _ Manager = (*manager)(nil)
 type manager struct {
 	sync.Mutex
 
-	local  kubernetes.Interface
-	remote kubernetes.Interface
-	resync time.Duration
+	local      kubernetes.Interface
+	remote     kubernetes.Interface
+	localLiqo  liqoclient.Interface
+	remoteLiqo liqoclient.Interface
+	resync     time.Duration
 
 	reflectors              []Reflector
 	localPodInformerFactory informers.SharedInformerFactory
@@ -50,16 +54,18 @@ type manager struct {
 }
 
 // New returns a new manager to start the reflection towards a remote cluster.
-func New(local, remote kubernetes.Interface, resync time.Duration) Manager {
+func New(local, remote kubernetes.Interface, localLiqo, remoteLiqo liqoclient.Interface, resync time.Duration) Manager {
 	// Configure the field selector to retrieve only the pods scheduled on the current virtual node.
 	localPodTweakListOptions := func(opts *metav1.ListOptions) {
 		opts.FieldSelector = fields.OneTermEqualSelector("spec.nodeName", forge.LiqoNodeName()).String()
 	}
 
 	return &manager{
-		local:  local,
-		remote: remote,
-		resync: resync,
+		local:      local,
+		remote:     remote,
+		localLiqo:  localLiqo,
+		remoteLiqo: remoteLiqo,
+		resync:     resync,
 
 		reflectors: make([]Reflector, 0),
 		localPodInformerFactory: informers.NewSharedInformerFactoryWithOptions(local, resync,
@@ -123,19 +129,22 @@ func (m *manager) StartNamespace(local, remote string) {
 	ctx, cancel := context.WithCancel(context.Background())
 	m.stop[local] = cancel
 
-	// The local informer factory, which selects all resources in the given namespace.
+	// The local informer factories, which select all resources in the given namespace.
 	localFactory := informers.NewSharedInformerFactoryWithOptions(m.local, m.resync, informers.WithNamespace(local))
+	localLiqoFactory := liqoinformers.NewSharedInformerFactoryWithOptions(m.localLiqo, m.resync, liqoinformers.WithNamespace(local))
 
-	// The remote informer factory, which selects all resources in the given namespace and with the reflection labels.
+	// The remote informer factories, which select all resources in the given namespace and with the reflection labels.
 	remoteTweakListOptions := func(opts *metav1.ListOptions) { opts.LabelSelector = forge.ReflectedLabelSelector().String() }
 	remoteFactory := informers.NewSharedInformerFactoryWithOptions(m.remote, m.resync,
 		informers.WithNamespace(remote), informers.WithTweakListOptions(remoteTweakListOptions))
+	remoteLiqoFactory := liqoinformers.NewSharedInformerFactoryWithOptions(m.remoteLiqo, m.resync,
+		liqoinformers.WithNamespace(remote), liqoinformers.WithTweakListOptions(remoteTweakListOptions))
 
 	ready := false
 	for _, reflector := range m.reflectors {
 		opts := options.NewNamespaced().
-			WithLocal(local, m.local, localFactory).
-			WithRemote(remote, m.remote, remoteFactory).
+			WithLocal(local, m.local, localFactory).WithLiqoLocal(m.localLiqo, localLiqoFactory).
+			WithRemote(remote, m.remote, remoteFactory).WithLiqoRemote(m.remoteLiqo, remoteLiqoFactory).
 			WithReadinessFunc(func() bool { return ready })
 		reflector.StartNamespace(opts)
 	}
@@ -147,10 +156,14 @@ func (m *manager) StartNamespace(local, remote string) {
 
 		// Start the factories, and wait for their caches to sync
 		localFactory.Start(ctx.Done())
+		localLiqoFactory.Start(ctx.Done())
 		remoteFactory.Start(ctx.Done())
+		remoteLiqoFactory.Start(ctx.Done())
 
 		localFactory.WaitForCacheSync(ctx.Done())
+		localLiqoFactory.WaitForCacheSync(ctx.Done())
 		remoteFactory.WaitForCacheSync(ctx.Done())
+		remoteLiqoFactory.WaitForCacheSync(ctx.Done())
 
 		// If the context was closed before the cache was ready, let abort the setup
 		select {

--- a/pkg/virtualKubelet/reflection/options/options.go
+++ b/pkg/virtualKubelet/reflection/options/options.go
@@ -21,6 +21,9 @@ import (
 	corev1informers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
+
+	liqoclient "github.com/liqotech/liqo/pkg/client/clientset/versioned"
+	liqoinformers "github.com/liqotech/liqo/pkg/client/informers/externalversions"
 )
 
 // Keyer retrieves a NamespacedName referring to the reconciliation target from the object metadata.
@@ -50,11 +53,15 @@ type NamespacedOpts struct {
 	LocalNamespace  string
 	RemoteNamespace string
 
-	LocalClient  kubernetes.Interface
-	RemoteClient kubernetes.Interface
+	LocalClient      kubernetes.Interface
+	RemoteClient     kubernetes.Interface
+	LocalLiqoClient  liqoclient.Interface
+	RemoteLiqoClient liqoclient.Interface
 
-	LocalFactory  informers.SharedInformerFactory
-	RemoteFactory informers.SharedInformerFactory
+	LocalFactory      informers.SharedInformerFactory
+	RemoteFactory     informers.SharedInformerFactory
+	LocalLiqoFactory  liqoinformers.SharedInformerFactory
+	RemoteLiqoFactory liqoinformers.SharedInformerFactory
 
 	Ready          func() bool
 	HandlerFactory func(Keyer) cache.ResourceEventHandler
@@ -73,11 +80,25 @@ func (ro *NamespacedOpts) WithLocal(namespace string, client kubernetes.Interfac
 	return ro
 }
 
+// WithLiqoLocal configures the local liqo client and informer factory parameters of the NamespacedOpts.
+func (ro *NamespacedOpts) WithLiqoLocal(client liqoclient.Interface, factory liqoinformers.SharedInformerFactory) *NamespacedOpts {
+	ro.LocalLiqoClient = client
+	ro.LocalLiqoFactory = factory
+	return ro
+}
+
 // WithRemote configures the remote parameters of the NamespacedOpts.
 func (ro *NamespacedOpts) WithRemote(namespace string, client kubernetes.Interface, factory informers.SharedInformerFactory) *NamespacedOpts {
 	ro.RemoteNamespace = namespace
 	ro.RemoteClient = client
 	ro.RemoteFactory = factory
+	return ro
+}
+
+// WithLiqoRemote configures the remote liqo client and informer factory parameters of the NamespacedOpts.
+func (ro *NamespacedOpts) WithLiqoRemote(client liqoclient.Interface, factory liqoinformers.SharedInformerFactory) *NamespacedOpts {
+	ro.RemoteLiqoClient = client
+	ro.RemoteLiqoFactory = factory
 	return ro
 }
 


### PR DESCRIPTION
# Description

This PR extends the virtual kubelet reflection manager to introduce the support for the client and the informers specific for liqo resources.

Fixes #(issue)

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Unit tests (new + existing)
- [x] E2E tests (existing)
