### PR TITLE
refactor: move from io/ioutil to io and os packages

### DIFF
--- a/internal/auth-service/auth_test.go
+++ b/internal/auth-service/auth_test.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -294,7 +294,7 @@ var _ = Describe("Auth", func() {
 
 				recorder.Flush()
 
-				body, err := ioutil.ReadAll(recorder.Body)
+				body, err := io.ReadAll(recorder.Body)
 				Expect(err).To(Succeed())
 				Expect(string(body)).To(ContainSubstring(string(c.body)))
 				Expect(recorder.Code).To(Equal(c.code))

--- a/internal/auth-service/identity.go
+++ b/internal/auth-service/identity.go
@@ -17,7 +17,7 @@ package authservice
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/julienschmidt/httprouter"
@@ -38,7 +38,7 @@ func (authService *Controller) identity(w http.ResponseWriter, r *http.Request, 
 	ctx := trace.ContextWithTrace(r.Context(), tracer)
 	defer tracer.LogIfLong(traceutils.LongThreshold())
 
-	bytes, err := ioutil.ReadAll(r.Body)
+	bytes, err := io.ReadAll(r.Body)
 	if err != nil {
 		klog.Error(err)
 		authService.handleError(w, err)

--- a/pkg/discoverymanager/utils/utils.go
+++ b/pkg/discoverymanager/utils/utils.go
@@ -21,7 +21,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -51,7 +51,7 @@ func GetClusterInfo(skipTLSVerify bool, url string) (*auth.ClusterInfo, error) {
 	}
 	defer resp.Body.Close()
 
-	respBytes, err := ioutil.ReadAll(resp.Body)
+	respBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		klog.Error(err)
 		return nil, err

--- a/pkg/identityManager/identityManager_test.go
+++ b/pkg/identityManager/identityManager_test.go
@@ -20,7 +20,6 @@ import (
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/pem"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -305,7 +304,7 @@ var _ = Describe("IdentityManager", func() {
 			Expect(cnf).NotTo(BeNil())
 			Expect(cnf.BearerTokenFile).ToNot(BeEmpty())
 
-			token, err := ioutil.ReadFile(cnf.BearerTokenFile)
+			token, err := os.ReadFile(cnf.BearerTokenFile)
 			Expect(err).To(Succeed())
 			Expect(token).ToNot(BeEmpty())
 
@@ -324,7 +323,7 @@ var _ = Describe("IdentityManager", func() {
 			err = iamTokenManager.refreshToken(ctx, remoteClusterID, namespacedName)
 			Expect(err).To(Succeed())
 
-			newToken, err := ioutil.ReadFile(cnf.BearerTokenFile)
+			newToken, err := os.ReadFile(cnf.BearerTokenFile)
 			Expect(err).To(Succeed())
 			Expect(newToken).ToNot(BeEmpty())
 			Expect(newToken).ToNot(Equal(token))

--- a/pkg/identityManager/tokenManager.go
+++ b/pkg/identityManager/tokenManager.go
@@ -16,7 +16,6 @@ package identitymanager
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sync"
@@ -145,7 +144,7 @@ func (tokMan *iamTokenManager) storeToken(remoteClusterID string, tok *token.Tok
 	}
 
 	filename := filepath.Join(tokenDir, remoteClusterID)
-	err = ioutil.WriteFile(filename, []byte(tok.Token), 0600)
+	err = os.WriteFile(filename, []byte(tok.Token), 0600)
 	if err != nil {
 		klog.Error(err)
 		return "", err

--- a/pkg/liqo-controller-manager/foreign-cluster-operator/auth.go
+++ b/pkg/liqo-controller-manager/foreign-cluster-operator/auth.go
@@ -21,7 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -153,7 +153,7 @@ func sendIdentityRequest(request auth.IdentityRequest, fc *discoveryv1alpha1.For
 		return nil, err
 	}
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		klog.Error(err)
 		return nil, err

--- a/pkg/liqoctl/common/utils_test.go
+++ b/pkg/liqoctl/common/utils_test.go
@@ -15,7 +15,6 @@
 package common
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -39,7 +38,7 @@ var _ = BeforeSuite(func() {
 var _ = Describe("Get REST config", func() {
 	When("A configuration is set", func() {
 		BeforeEach(func() {
-			tmpFile, err := ioutil.TempFile(os.TempDir(), "liqoctl-test-")
+			tmpFile, err := os.CreateTemp(os.TempDir(), "liqoctl-test-")
 			Expect(err).To(BeNil())
 			Expect(os.Getenv("KUBECONFIG")).To(BeEmpty())
 			Expect(os.Setenv("KUBECONFIG", tmpFile.Name())).To(Succeed())

--- a/pkg/liqoctl/install/eks/iamkeycache.go
+++ b/pkg/liqoctl/install/eks/iamkeycache.go
@@ -15,7 +15,6 @@
 package eks
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -65,11 +64,8 @@ func storeIamAccessKey(iamUserName, accessKeyID, secretAccessKey string) error {
 	}
 
 	fileName := filepath.Join(liqoDirPath, liqoIamCredentialsFile)
-	if err = ioutil.WriteFile(fileName, data, 0600); err != nil {
-		return err
-	}
 
-	return nil
+	return os.WriteFile(fileName, data, 0600)
 }
 
 func retrieveIamAccessKey(iamUserName string) (accessKeyID, secretAccessKey string, err error) {
@@ -98,7 +94,7 @@ func readCache() (iamUserCredentialCache, error) {
 		return iamUserCredentialCache{}, nil
 	}
 
-	data, err := ioutil.ReadFile(filepath.Clean(fileName))
+	data, err := os.ReadFile(filepath.Clean(fileName))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/liqonet/overlay/vxlan.go
+++ b/pkg/liqonet/overlay/vxlan.go
@@ -17,8 +17,8 @@ package overlay
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net"
+	"os"
 	"reflect"
 	"strings"
 	"syscall"
@@ -214,7 +214,7 @@ func (vxlan *VxlanDevice) enableRPFilter() error {
 	klog.V(4).Infof("setting reverse path filtering for interface {%s} to loose mode", ifaceName)
 	rpFilterFilePath := strings.Join([]string{"/proc/sys/net/ipv4/conf/", ifaceName, "/rp_filter"}, "")
 	// Enable loose mode reverse path filtering on the overlay interface.
-	err := ioutil.WriteFile(rpFilterFilePath, []byte("2"), 0600)
+	err := os.WriteFile(rpFilterFilePath, []byte("2"), 0600)
 	if err != nil {
 		klog.Errorf("an error occurred while writing to file %s: %v", rpFilterFilePath, err)
 		return err

--- a/pkg/liqonet/routing/common.go
+++ b/pkg/liqonet/routing/common.go
@@ -16,8 +16,8 @@ package routing
 
 import (
 	"errors"
-	"io/ioutil"
 	"net"
+	"os"
 	"reflect"
 	"strings"
 	"time"
@@ -307,7 +307,7 @@ func parseIP(ip string) (net.IP, error) {
 
 // EnableIPForwarding enables ipv4 forwarding in the current network namespace.
 func EnableIPForwarding() error {
-	return ioutil.WriteFile("/proc/sys/net/ipv4/ip_forward", []byte("1"), 0600)
+	return os.WriteFile("/proc/sys/net/ipv4/ip_forward", []byte("1"), 0600)
 }
 
 // EnableProxyArp enables proxy arp for the given network interface.
@@ -319,7 +319,7 @@ func EnableProxyArp(iFaceName string) error {
 		return errors.Is(err, unix.ENOENT)
 	}
 	writeToFile := func() error {
-		if err := ioutil.WriteFile(proxyArpFilePath, []byte("1"), 0600); err != nil {
+		if err := os.WriteFile(proxyArpFilePath, []byte("1"), 0600); err != nil {
 			klog.Errorf("an error occurred while enabling proxy arp for interface %s: %v", iFaceName, err)
 			return err
 		}

--- a/pkg/liqonet/routing/common_test.go
+++ b/pkg/liqonet/routing/common_test.go
@@ -15,8 +15,8 @@
 package routing
 
 import (
-	"io/ioutil"
 	"net"
+	"os"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -521,7 +521,7 @@ var _ = Describe("Common", func() {
 				var enabled byte = '1'
 				err := EnableIPForwarding()
 				Expect(err).ShouldNot(HaveOccurred())
-				txt, err := ioutil.ReadFile("/proc/sys/net/ipv4/ip_forward")
+				txt, err := os.ReadFile("/proc/sys/net/ipv4/ip_forward")
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(txt[0]).Should(Equal(enabled))
 			})
@@ -534,7 +534,7 @@ var _ = Describe("Common", func() {
 				var enabled byte = '1'
 				err := EnableProxyArp(dummylink1.Attrs().Name)
 				Expect(err).ShouldNot(HaveOccurred())
-				txt, err := ioutil.ReadFile("/proc/sys/net/ipv4/conf/" + dummylink1.Attrs().Name + "/proxy_arp")
+				txt, err := os.ReadFile("/proc/sys/net/ipv4/conf/" + dummylink1.Attrs().Name + "/proxy_arp")
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(txt[0]).Should(Equal(enabled))
 			})

--- a/pkg/mutate/server.go
+++ b/pkg/mutate/server.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -75,7 +75,7 @@ func NewMutationServer(ctx context.Context, c *MutationConfig) (*MutationServer,
 
 func (s *MutationServer) handleMutate(w http.ResponseWriter, r *http.Request) {
 	// read the body / request
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		klog.Error(err)
 		standardErrMessage := fmt.Errorf("unable to correctly read the body of the request")

--- a/pkg/utils/apiserver/config.go
+++ b/pkg/utils/apiserver/config.go
@@ -17,7 +17,7 @@ package apiserver
 import (
 	"encoding/base64"
 	"flag"
-	"io/ioutil"
+	"os"
 
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -78,7 +78,7 @@ func retrieveAPIServerCA(restcfg *rest.Config) (string, error) {
 	}
 	if restcfg.CAFile != "" {
 		// CAData is not available, read it from the CAFile.
-		data, err := ioutil.ReadFile(restcfg.CAFile)
+		data, err := os.ReadFile(restcfg.CAFile)
 		if err != nil {
 			return "", err
 		}


### PR DESCRIPTION
# Description

The `io/ioutil` package has been deprecated in Go 1.16 (See https://golang.org/doc/go1.16#ioutil). Since Liqo has been upgraded to Go 1.17 (#983), this PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Unit test (`make unit`)
- [x] E2E test (`make e2e`)