### PR TITLE
fix groupname for custom resource code generation

### DIFF
--- a/apis/virtualkubelet/v1alpha1/doc.go
+++ b/apis/virtualkubelet/v1alpha1/doc.go
@@ -1,0 +1,18 @@
+// Copyright 2019-2021 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package v1alpha1 contains API Schema definitions for the virtualkubelet v1alpha1 API group.
+// +kubebuilder:object:generate=true
+// +groupName=virtualkubelet.liqo.io
+package v1alpha1

--- a/apis/virtualkubelet/v1alpha1/groupversion_info.go
+++ b/apis/virtualkubelet/v1alpha1/groupversion_info.go
@@ -12,9 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package v1alpha1 contains API Schema definitions for the virtualkubelet v1alpha1 API group
-// +kubebuilder:object:generate=true
-// +groupName=virtualkubelet.liqo.io
 package v1alpha1
 
 import (

--- a/pkg/client/clientset/versioned/typed/virtualkubelet/v1alpha1/fake/fake_namespacemap.go
+++ b/pkg/client/clientset/versioned/typed/virtualkubelet/v1alpha1/fake/fake_namespacemap.go
@@ -35,9 +35,9 @@ type FakeNamespaceMaps struct {
 	ns   string
 }
 
-var namespacemapsResource = schema.GroupVersionResource{Group: "virtualkubelet", Version: "v1alpha1", Resource: "namespacemaps"}
+var namespacemapsResource = schema.GroupVersionResource{Group: "virtualkubelet.liqo.io", Version: "v1alpha1", Resource: "namespacemaps"}
 
-var namespacemapsKind = schema.GroupVersionKind{Group: "virtualkubelet", Version: "v1alpha1", Kind: "NamespaceMap"}
+var namespacemapsKind = schema.GroupVersionKind{Group: "virtualkubelet.liqo.io", Version: "v1alpha1", Kind: "NamespaceMap"}
 
 // Get takes name of the namespaceMap, and returns the corresponding namespaceMap object, and an error if there is any.
 func (c *FakeNamespaceMaps) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha1.NamespaceMap, err error) {

--- a/pkg/client/clientset/versioned/typed/virtualkubelet/v1alpha1/fake/fake_shadowpod.go
+++ b/pkg/client/clientset/versioned/typed/virtualkubelet/v1alpha1/fake/fake_shadowpod.go
@@ -35,9 +35,9 @@ type FakeShadowPods struct {
 	ns   string
 }
 
-var shadowpodsResource = schema.GroupVersionResource{Group: "virtualkubelet", Version: "v1alpha1", Resource: "shadowpods"}
+var shadowpodsResource = schema.GroupVersionResource{Group: "virtualkubelet.liqo.io", Version: "v1alpha1", Resource: "shadowpods"}
 
-var shadowpodsKind = schema.GroupVersionKind{Group: "virtualkubelet", Version: "v1alpha1", Kind: "ShadowPod"}
+var shadowpodsKind = schema.GroupVersionKind{Group: "virtualkubelet.liqo.io", Version: "v1alpha1", Kind: "ShadowPod"}
 
 // Get takes name of the shadowPod, and returns the corresponding shadowPod object, and an error if there is any.
 func (c *FakeShadowPods) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha1.ShadowPod, err error) {

--- a/pkg/client/clientset/versioned/typed/virtualkubelet/v1alpha1/virtualkubelet_client.go
+++ b/pkg/client/clientset/versioned/typed/virtualkubelet/v1alpha1/virtualkubelet_client.go
@@ -29,7 +29,7 @@ type VirtualkubeletV1alpha1Interface interface {
 	ShadowPodsGetter
 }
 
-// VirtualkubeletV1alpha1Client is used to interact with features provided by the virtualkubelet group.
+// VirtualkubeletV1alpha1Client is used to interact with features provided by the virtualkubelet.liqo.io group.
 type VirtualkubeletV1alpha1Client struct {
 	restClient rest.Interface
 }

--- a/pkg/client/informers/externalversions/generic.go
+++ b/pkg/client/informers/externalversions/generic.go
@@ -51,7 +51,7 @@ func (f *genericInformer) Lister() cache.GenericLister {
 // TODO extend this to unknown resources with a client pool
 func (f *sharedInformerFactory) ForResource(resource schema.GroupVersionResource) (GenericInformer, error) {
 	switch resource {
-	// Group=virtualkubelet, Version=v1alpha1
+	// Group=virtualkubelet.liqo.io, Version=v1alpha1
 	case v1alpha1.SchemeGroupVersion.WithResource("namespacemaps"):
 		return &genericInformer{resource: resource.GroupResource(), informer: f.Virtualkubelet().V1alpha1().NamespaceMaps().Informer()}, nil
 	case v1alpha1.SchemeGroupVersion.WithResource("shadowpods"):


### PR DESCRIPTION
# Description

In order to have a groupname different from the one specified in the "input" parameter for the code generator, we have to set the "+groupName=<groupname>" marker in the doc.go file in the resource package. Put the marker in any other package and the generator won't pick that up.