### PR TITLE
Add PVC Reflector in the VirtualKubelet

### DIFF
--- a/cmd/virtual-kubelet/root/flag.go
+++ b/cmd/virtual-kubelet/root/flag.go
@@ -32,6 +32,8 @@ func InstallFlags(flags *pflag.FlagSet, c *Opts) {
 		"the number of endpointslice reflection workers")
 	flags.UintVar(&c.ConfigMapWorkers, "configmap-reflection-workers", c.ConfigMapWorkers, "the number of configmap reflection workers")
 	flags.UintVar(&c.SecretWorkers, "secret-reflection-workers", c.SecretWorkers, "the number of secret reflection workers")
+	flags.UintVar(&c.PersistenVolumeClaimWorkers, "persistentvolumeclaim-reflection-workers", c.PersistenVolumeClaimWorkers,
+		"the number of persistentvolumeclaim reflection workers")
 
 	flags.DurationVar(&c.InformerResyncPeriod, "full-resync-period", c.InformerResyncPeriod,
 		"how often to perform a full resync of pods between kubernetes and the provider")
@@ -48,6 +50,10 @@ func InstallFlags(flags *pflag.FlagSet, c *Opts) {
 
 	flags.Var(&c.NodeExtraAnnotations, "node-extra-annotations", "Extra annotations to add to the Virtual Node")
 	flags.Var(&c.NodeExtraLabels, "node-extra-labels", "Extra labels to add to the Virtual Node")
+
+	flags.BoolVar(&c.EnableStorage, "enable-storage", false, "Enable the Liqo storage reflection")
+	flags.StringVar(&c.VirtualStorageClassName, "virtual-storage-class-name", "liqo", "Name of the virtual storage class")
+	flags.StringVar(&c.RemoteRealStorageClassName, "remote-real-storage-class-name", "", "Name of the real storage class to use for the actual volumes")
 
 	flagset := flag.NewFlagSet("klog", flag.PanicOnError)
 	klog.InitFlags(flagset)

--- a/cmd/virtual-kubelet/root/opts.go
+++ b/cmd/virtual-kubelet/root/opts.go
@@ -34,11 +34,12 @@ const (
 	DefaultMetricsAddr                            = ":10255"
 	DefaultListenPort                             = 10250
 
-	DefaultPodWorkers           = 10
-	DefaultServiceWorkers       = 3
-	DefaultEndpointSliceWorkers = 10
-	DefaultConfigMapWorkers     = 3
-	DefaultSecretWorkers        = 3
+	DefaultPodWorkers                  = 10
+	DefaultServiceWorkers              = 3
+	DefaultEndpointSliceWorkers        = 10
+	DefaultConfigMapWorkers            = 3
+	DefaultSecretWorkers               = 3
+	DefaultPersistenVolumeClaimWorkers = 3
 
 	DefaultKubeletNamespace = "default"
 	DefaultLiqoIpamServer   = consts.NetworkManagerServiceName
@@ -60,12 +61,13 @@ type Opts struct {
 
 	MetricsAddr string
 
-	// Number of workers to use to handle pod and resource reflection
-	PodWorkers           uint
-	ServiceWorkers       uint
-	EndpointSliceWorkers uint
-	ConfigMapWorkers     uint
-	SecretWorkers        uint
+	// Number of workers to use to handle pod notifications and resource reflection
+	PodWorkers                  uint
+	ServiceWorkers              uint
+	EndpointSliceWorkers        uint
+	ConfigMapWorkers            uint
+	SecretWorkers               uint
+	PersistenVolumeClaimWorkers uint
 
 	InformerResyncPeriod     time.Duration
 	LiqoInformerResyncPeriod time.Duration
@@ -83,6 +85,10 @@ type Opts struct {
 
 	NodeExtraAnnotations argsutils.StringMap
 	NodeExtraLabels      argsutils.StringMap
+
+	EnableStorage              bool
+	VirtualStorageClassName    string
+	RemoteRealStorageClassName string
 }
 
 // SetDefaultOpts sets default options for unset values on the passed in option struct.
@@ -118,6 +124,10 @@ func SetDefaultOpts(c *Opts) error {
 
 	if c.SecretWorkers == 0 {
 		c.SecretWorkers = DefaultSecretWorkers
+	}
+
+	if c.PersistenVolumeClaimWorkers == 0 {
+		c.PersistenVolumeClaimWorkers = DefaultPersistenVolumeClaimWorkers
 	}
 
 	if c.ListenPort == 0 {

--- a/cmd/virtual-kubelet/root/root.go
+++ b/cmd/virtual-kubelet/root/root.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
 
 	"github.com/liqotech/liqo/internal/utils/errdefs"
@@ -90,14 +91,20 @@ func runRootCommand(ctx context.Context, c *Opts) error {
 		LiqoIpamServer:       c.LiqoIpamServer,
 		InformerResyncPeriod: c.InformerResyncPeriod,
 
-		PodWorkers:           c.PodWorkers,
-		ServiceWorkers:       c.ServiceWorkers,
-		EndpointSliceWorkers: c.EndpointSliceWorkers,
-		ConfigMapWorkers:     c.ConfigMapWorkers,
-		SecretWorkers:        c.SecretWorkers,
+		PodWorkers:                  c.PodWorkers,
+		ServiceWorkers:              c.ServiceWorkers,
+		EndpointSliceWorkers:        c.EndpointSliceWorkers,
+		ConfigMapWorkers:            c.ConfigMapWorkers,
+		SecretWorkers:               c.SecretWorkers,
+		PersistenVolumeClaimWorkers: c.PersistenVolumeClaimWorkers,
+
+		EnableStorage:              c.EnableStorage,
+		VirtualStorageClassName:    c.VirtualStorageClassName,
+		RemoteRealStorageClassName: c.RemoteRealStorageClassName,
 	}
 
-	podProvider, err := podprovider.NewLiqoProvider(ctx, &podcfg)
+	eb := record.NewBroadcaster()
+	podProvider, err := podprovider.NewLiqoProvider(ctx, &podcfg, eb)
 	if err != nil {
 		return err
 	}

--- a/deployments/liqo/files/liqo-virtual-kubelet-local-ClusterRole.yaml
+++ b/deployments/liqo/files/liqo-virtual-kubelet-local-ClusterRole.yaml
@@ -97,6 +97,25 @@ rules:
   - get
   - update
 - apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  - persistentvolumes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
   - discovery.k8s.io
   resources:
   - endpointslices
@@ -123,6 +142,14 @@ rules:
   - list
   - patch
   - update
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - get
+  - list
   - watch
 - apiGroups:
   - virtualkubelet.liqo.io

--- a/pkg/liqo-controller-manager/storageprovisioner/remoteprovisioner.go
+++ b/pkg/liqo-controller-manager/storageprovisioner/remoteprovisioner.go
@@ -13,3 +13,104 @@
 // limitations under the License.
 
 package storageprovisioner
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1apply "k8s.io/client-go/applyconfigurations/core/v1"
+	corev1clients "k8s.io/client-go/kubernetes/typed/core/v1"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+	"sigs.k8s.io/sig-storage-lib-external-provisioner/v7/controller"
+
+	"github.com/liqotech/liqo/pkg/virtualKubelet/forge"
+)
+
+// ProvisionRemotePVC ensures the existence of a remote PVC and returns a virtual PV for that remote storage device.
+func ProvisionRemotePVC(ctx context.Context,
+	options controller.ProvisionOptions,
+	remoteNamespace, remoteRealStorageClass string,
+	remotePvcLister corev1listers.PersistentVolumeClaimNamespaceLister,
+	remotePvcClient corev1clients.PersistentVolumeClaimInterface) (*corev1.PersistentVolume, controller.ProvisioningState, error) {
+	virtualPvc := options.PVC
+
+	mutation := remotePersistentVolumeClaim(virtualPvc, remoteRealStorageClass, remoteNamespace)
+	_, err := remotePvcClient.Apply(ctx, mutation, forge.ApplyOptions())
+	if err != nil {
+		return nil, controller.ProvisioningInBackground, err
+	}
+
+	pv := &corev1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: options.PVName,
+		},
+		Spec: corev1.PersistentVolumeSpec{
+			StorageClassName: options.StorageClass.Name,
+			AccessModes:      options.PVC.Spec.AccessModes,
+			Capacity: corev1.ResourceList{
+				corev1.ResourceStorage: options.PVC.Spec.Resources.Requests[corev1.ResourceStorage],
+			},
+			PersistentVolumeSource: corev1.PersistentVolumeSource{
+				HostPath: &corev1.HostPathVolumeSource{
+					Path: "/tmp/liqo-placeholder",
+				},
+			},
+			NodeAffinity: &corev1.VolumeNodeAffinity{
+				Required: &corev1.NodeSelector{
+					NodeSelectorTerms: []corev1.NodeSelectorTerm{
+						{
+							MatchExpressions: []corev1.NodeSelectorRequirement{
+								{
+									Key:      corev1.LabelHostname,
+									Operator: corev1.NodeSelectorOpIn,
+									Values:   []string{options.SelectedNode.Name},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if options.StorageClass.ReclaimPolicy != nil {
+		pv.Spec.PersistentVolumeReclaimPolicy = *options.StorageClass.ReclaimPolicy
+	}
+
+	return pv, controller.ProvisioningFinished, nil
+}
+
+// remotePersistentVolumeClaim forges the apply patch for the reflected PersistentVolumeClaim, given the local one.
+func remotePersistentVolumeClaim(virtualPvc *corev1.PersistentVolumeClaim,
+	storageClass, namespace string) *v1apply.PersistentVolumeClaimApplyConfiguration {
+	return v1apply.PersistentVolumeClaim(virtualPvc.Name, namespace).
+		WithLabels(virtualPvc.GetLabels()).
+		WithLabels(forge.ReflectionLabels()).
+		WithSpec(remotePersistentVolumeClaimSpec(virtualPvc, storageClass))
+}
+
+func remotePersistentVolumeClaimSpec(virtualPvc *corev1.PersistentVolumeClaim,
+	storageClass string) *v1apply.PersistentVolumeClaimSpecApplyConfiguration {
+	res := v1apply.PersistentVolumeClaimSpec().
+		WithAccessModes(virtualPvc.Spec.AccessModes...).
+		WithVolumeMode(func() corev1.PersistentVolumeMode {
+			if virtualPvc.Spec.VolumeMode != nil {
+				return *virtualPvc.Spec.VolumeMode
+			}
+			return corev1.PersistentVolumeFilesystem
+		}()).
+		WithResources(persistenVolumeClaimResources(virtualPvc.Spec.Resources))
+
+	if storageClass != "" {
+		res.WithStorageClassName(storageClass)
+	}
+
+	return res
+}
+
+func persistenVolumeClaimResources(resources corev1.ResourceRequirements) *v1apply.ResourceRequirementsApplyConfiguration {
+	return v1apply.ResourceRequirements().
+		WithLimits(resources.Limits).
+		WithRequests(resources.Requests)
+}

--- a/pkg/liqo-controller-manager/storageprovisioner/suite_test.go
+++ b/pkg/liqo-controller-manager/storageprovisioner/suite_test.go
@@ -19,10 +19,29 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+)
+
+var (
+	testEnv       envtest.Environment
+	testEnvClient kubernetes.Interface
 )
 
 func TestStorageProvisioner(t *testing.T) {
-	defer GinkgoRecover()
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Test Storage Provisioner")
 }
+
+var _ = BeforeSuite(func() {
+	testEnv = envtest.Environment{}
+	cfg, err := testEnv.Start()
+	Expect(err).ToNot(HaveOccurred())
+
+	// Need to use a real client, as server side apply seems not to be currently supported by the fake one.
+	testEnvClient = kubernetes.NewForConfigOrDie(cfg)
+})
+
+var _ = AfterSuite(func() {
+	Expect(testEnv.Stop()).To(Succeed())
+})

--- a/pkg/utils/nodeUtils.go
+++ b/pkg/utils/nodeUtils.go
@@ -56,3 +56,13 @@ func MergeNodeSelector(ns1, ns2 *corev1.NodeSelector) corev1.NodeSelector {
 	}
 	return mergedNodeSelector
 }
+
+// GetNodeClusterID returns the clusterID given a virtual node.
+func GetNodeClusterID(selectedNode *corev1.Node) (string, bool) {
+	remoteClusterID, ok := selectedNode.Labels[liqoconst.RemoteClusterID]
+	if !ok || remoteClusterID == "" {
+		return "", false
+	}
+
+	return remoteClusterID, true
+}

--- a/pkg/virtualKubelet/forge/pods.go
+++ b/pkg/virtualKubelet/forge/pods.go
@@ -155,7 +155,7 @@ func translateContainer(container corev1.Container, volumes []corev1.VolumeMount
 func forgeVolumes(volumesIn []corev1.Volume) []corev1.Volume {
 	volumesOut := make([]corev1.Volume, 0)
 	for _, v := range volumesIn {
-		if v.ConfigMap != nil || v.EmptyDir != nil || v.DownwardAPI != nil || v.Projected != nil {
+		if v.ConfigMap != nil || v.EmptyDir != nil || v.DownwardAPI != nil || v.Projected != nil || v.PersistentVolumeClaim != nil {
 			volumesOut = append(volumesOut, v)
 		}
 		// copy all volumes of type Secret except for the default token

--- a/pkg/virtualKubelet/reflection/options/options.go
+++ b/pkg/virtualKubelet/reflection/options/options.go
@@ -21,6 +21,7 @@ import (
 	corev1informers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/record"
 
 	liqoclient "github.com/liqotech/liqo/pkg/client/clientset/versioned"
 	liqoinformers "github.com/liqotech/liqo/pkg/client/informers/externalversions"
@@ -62,6 +63,8 @@ type NamespacedOpts struct {
 	RemoteFactory     informers.SharedInformerFactory
 	LocalLiqoFactory  liqoinformers.SharedInformerFactory
 	RemoteLiqoFactory liqoinformers.SharedInformerFactory
+
+	EventBroadcaster record.EventBroadcaster
 
 	Ready          func() bool
 	HandlerFactory func(Keyer) cache.ResourceEventHandler
@@ -111,5 +114,11 @@ func (ro *NamespacedOpts) WithHandlerFactory(handler func(Keyer) cache.ResourceE
 // WithReadinessFunc configures the readiness function of the NamespacedOpts.
 func (ro *NamespacedOpts) WithReadinessFunc(ready func() bool) *NamespacedOpts {
 	ro.Ready = ready
+	return ro
+}
+
+// WithEventBroadcaster configures the event broadcaster of the NamespacedOpts.
+func (ro *NamespacedOpts) WithEventBroadcaster(broadcaster record.EventBroadcaster) *NamespacedOpts {
+	ro.EventBroadcaster = broadcaster
 	return ro
 }

--- a/pkg/virtualKubelet/reflection/options/options_test.go
+++ b/pkg/virtualKubelet/reflection/options/options_test.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/record"
 
 	liqoclient "github.com/liqotech/liqo/pkg/client/clientset/versioned"
 	liqoclientfake "github.com/liqotech/liqo/pkg/client/clientset/versioned/fake"
@@ -80,6 +81,7 @@ var _ = Describe("Options", func() {
 			Expect(opts.RemoteLiqoClient).To(BeNil())
 			Expect(opts.RemoteFactory).To(BeNil())
 			Expect(opts.RemoteLiqoFactory).To(BeNil())
+			Expect(opts.EventBroadcaster).To(BeNil())
 			Expect(opts.HandlerFactory).To(BeNil())
 			Expect(opts.Ready).To(BeNil())
 		})
@@ -95,6 +97,7 @@ var _ = Describe("Options", func() {
 			liqoClient  liqoclient.Interface
 			factory     informers.SharedInformerFactory
 			liqoFactory liqoinformers.SharedInformerFactory
+			broadcaster record.EventBroadcaster
 		)
 
 		BeforeEach(func() {
@@ -102,6 +105,7 @@ var _ = Describe("Options", func() {
 			liqoClient = liqoclientfake.NewSimpleClientset()
 			factory = informers.NewSharedInformerFactory(client, 10*time.Hour)
 			liqoFactory = liqoinformers.NewSharedInformerFactory(liqoClient, 10*time.Hour)
+			broadcaster = record.NewBroadcaster()
 		})
 
 		JustBeforeEach(func() { original = options.NewNamespaced() })
@@ -122,6 +126,7 @@ var _ = Describe("Options", func() {
 				Expect(opts.RemoteLiqoClient).To(BeNil())
 				Expect(opts.RemoteFactory).To(BeNil())
 				Expect(opts.RemoteLiqoFactory).To(BeNil())
+				Expect(opts.EventBroadcaster).To(BeNil())
 				Expect(opts.HandlerFactory).To(BeNil())
 				Expect(opts.Ready).To(BeNil())
 			})
@@ -143,6 +148,7 @@ var _ = Describe("Options", func() {
 				Expect(opts.RemoteLiqoClient).To(BeNil())
 				Expect(opts.RemoteFactory).To(BeNil())
 				Expect(opts.RemoteLiqoFactory).To(BeNil())
+				Expect(opts.EventBroadcaster).To(BeNil())
 				Expect(opts.HandlerFactory).To(BeNil())
 				Expect(opts.Ready).To(BeNil())
 			})
@@ -164,6 +170,7 @@ var _ = Describe("Options", func() {
 				Expect(opts.LocalLiqoFactory).To(BeNil())
 				Expect(opts.RemoteLiqoClient).To(BeNil())
 				Expect(opts.RemoteLiqoFactory).To(BeNil())
+				Expect(opts.EventBroadcaster).To(BeNil())
 				Expect(opts.HandlerFactory).To(BeNil())
 				Expect(opts.Ready).To(BeNil())
 			})
@@ -185,6 +192,7 @@ var _ = Describe("Options", func() {
 				Expect(opts.LocalLiqoFactory).To(BeNil())
 				Expect(opts.RemoteClient).To(BeNil())
 				Expect(opts.RemoteFactory).To(BeNil())
+				Expect(opts.EventBroadcaster).To(BeNil())
 				Expect(opts.HandlerFactory).To(BeNil())
 				Expect(opts.Ready).To(BeNil())
 			})
@@ -210,6 +218,7 @@ var _ = Describe("Options", func() {
 				Expect(opts.RemoteLiqoClient).To(BeNil())
 				Expect(opts.RemoteFactory).To(BeNil())
 				Expect(opts.RemoteLiqoFactory).To(BeNil())
+				Expect(opts.EventBroadcaster).To(BeNil())
 				Expect(opts.Ready).To(BeNil())
 			})
 		})
@@ -233,7 +242,30 @@ var _ = Describe("Options", func() {
 				Expect(opts.RemoteLiqoClient).To(BeNil())
 				Expect(opts.RemoteFactory).To(BeNil())
 				Expect(opts.RemoteLiqoFactory).To(BeNil())
+				Expect(opts.EventBroadcaster).To(BeNil())
 				Expect(opts.HandlerFactory).To(BeNil())
+			})
+		})
+
+		Describe("The WithEventBroadcaster function", func() {
+			JustBeforeEach(func() { opts = original.WithEventBroadcaster(broadcaster) })
+
+			It("should return a non-nil pointer", func() { Expect(opts).ToNot(BeNil()) })
+			It("should return the same pointer of the receiver", func() { Expect(opts).To(BeIdenticalTo(original)) })
+			It("should correctly set the event broadcaster value", func() { Expect(opts.EventBroadcaster).To(BeIdenticalTo(broadcaster)) })
+			It("should leave the other fields unset", func() {
+				Expect(opts.LocalNamespace).To(BeEmpty())
+				Expect(opts.RemoteNamespace).To(BeEmpty())
+				Expect(opts.LocalClient).To(BeNil())
+				Expect(opts.LocalFactory).To(BeNil())
+				Expect(opts.LocalLiqoClient).To(BeNil())
+				Expect(opts.LocalFactory).To(BeNil())
+				Expect(opts.RemoteClient).To(BeNil())
+				Expect(opts.RemoteLiqoClient).To(BeNil())
+				Expect(opts.RemoteFactory).To(BeNil())
+				Expect(opts.RemoteLiqoFactory).To(BeNil())
+				Expect(opts.HandlerFactory).To(BeNil())
+				Expect(opts.Ready).To(BeNil())
 			})
 		})
 	})

--- a/pkg/virtualKubelet/reflection/storage/controller.go
+++ b/pkg/virtualKubelet/reflection/storage/controller.go
@@ -1,0 +1,196 @@
+// Copyright 2019-2021 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ref "k8s.io/client-go/tools/reference"
+	"k8s.io/klog/v2"
+	"k8s.io/kubectl/pkg/scheme"
+	"sigs.k8s.io/sig-storage-lib-external-provisioner/v7/controller"
+	"sigs.k8s.io/sig-storage-lib-external-provisioner/v7/util"
+)
+
+const (
+	annStorageProvisioner     = "volume.beta.kubernetes.io/storage-provisioner"
+	annSelectedNode           = "volume.kubernetes.io/selected-node"
+	annAlphaSelectedNode      = "volume.alpha.kubernetes.io/selected-node"
+	annDynamicallyProvisioned = "pv.kubernetes.io/provisioned-by"
+)
+
+//
+// the methods in this file are largely taken (and simplified in the parts not required for our use-case) from
+// https://github.com/kubernetes-sigs/sig-storage-lib-external-provisioner/blob/v7.0.1/controller/controller.go
+//
+
+// shouldProvision checks if the PVC reflector has to reflect this volume claim or not.
+// It checks if:
+// - the volume name is not set
+// - the provisioner name (in the annotation) is the same of the current provisioner
+// - the storage class exists and it is the same which we are provisioning
+// - the volume binding mode is WaitForFirstConsumer
+// - the selected node is the one the reflector is managing.
+func (npvcr *NamespacedPersistentVolumeClaimReflector) shouldProvision(claim *corev1.PersistentVolumeClaim) (bool, error) {
+	if claim.Spec.VolumeName != "" {
+		return false, nil
+	}
+
+	if provisioner, found := claim.Annotations[annStorageProvisioner]; found {
+		if npvcr.knownProvisioner(provisioner) {
+			claimClass := util.GetPersistentVolumeClaimClass(claim)
+			if claimClass != npvcr.virtualStorageClassName {
+				return false, nil
+			}
+
+			class, err := npvcr.classes.Get(claimClass)
+			if err != nil {
+				return false, err
+			}
+
+			if class.VolumeBindingMode != nil && *class.VolumeBindingMode == storagev1.VolumeBindingWaitForFirstConsumer {
+				// When claim is in delay binding mode, annSelectedNode is
+				// required to provision volume.
+				// Though PV controller set annStorageProvisioner only when
+				// annSelectedNode is set, but provisioner may remove
+				// annSelectedNode to notify scheduler to reschedule again.
+				if selectedNode, ok := claim.Annotations[annSelectedNode]; ok && selectedNode != "" {
+					return true, nil
+				}
+				return false, nil
+			}
+			// do not provision if the binding mode is not WaitForFirstConsumer
+			return false, nil
+		}
+	}
+
+	return false, nil
+}
+
+func (npvcr *NamespacedPersistentVolumeClaimReflector) knownProvisioner(provisioner string) bool {
+	return provisioner == npvcr.provisionerName
+}
+
+type provisionFunc func(context.Context, controller.ProvisionOptions) (*corev1.PersistentVolume, controller.ProvisioningState, error)
+
+// provisionClaimOperation attempts to provision a volume for the given claim.
+// Returns nil error only when the volume was provisioned (in which case it also returns ProvisioningFinished),
+// a normal error when the volume was not provisioned and provisioning should be retried (requeue the claim),
+// or the special errStopProvision when provisioning was impossible and no further attempts to provision should be tried.
+func (npvcr *NamespacedPersistentVolumeClaimReflector) provisionClaimOperation(ctx context.Context,
+	claim *corev1.PersistentVolumeClaim, provision provisionFunc) (controller.ProvisioningState, error) {
+	// Most code here is identical to that found in controller.go of kube's PV controller...
+	claimClass := util.GetPersistentVolumeClaimClass(claim)
+
+	//  A previous doProvisionClaim may just have finished while we were waiting for
+	//  the locks. Check that PV (with deterministic name) hasn't been provisioned
+	//  yet.
+	pvName := strings.Join([]string{"pvc", string(claim.UID)}, "-")
+	_, err := npvcr.volumes.Get(pvName)
+	if err == nil {
+		// Volume has been already provisioned, nothing to do.
+		klog.V(4).Infof("Persistentvolume %q already exists, skipping", pvName)
+		return controller.ProvisioningFinished, nil
+	}
+
+	// Prepare a claimRef to the claim early (to fail before a volume is
+	// provisioned)
+	claimRef, err := ref.GetReference(scheme.Scheme, claim)
+	if err != nil {
+		klog.Error("Unexpected error getting claim reference (local claim %q): %v", npvcr.LocalRef(claim.GetName()), err)
+		return controller.ProvisioningNoChange, err
+	}
+
+	// For any issues getting fields from StorageClass (including reclaimPolicy & mountOptions),
+	// retry the claim because the storageClass can be fixed/(re)created independently of the claim
+	class, err := npvcr.classes.Get(claimClass)
+	if err != nil {
+		klog.Error("Error getting StorageClass field of claim %q: %v", npvcr.LocalRef(claim.GetName()), err)
+		return controller.ProvisioningFinished, err
+	}
+	if !npvcr.knownProvisioner(class.Provisioner) {
+		// class.Provisioner has either changed since shouldProvision() or
+		// annDynamicallyProvisioned contains different provisioner than
+		// class.Provisioner.
+		klog.Error("Unknown provisioner %q requested in StorageClass of claim %q", class.Provisioner, npvcr.LocalRef(claim.GetName()))
+		return controller.ProvisioningFinished, nil
+	}
+
+	var selectedNode *corev1.Node
+	// Get SelectedNode
+	if nodeName, ok := getString(claim.Annotations, annSelectedNode, annAlphaSelectedNode); ok {
+		selectedNode, err = npvcr.nodes.Get(nodeName)
+		if err != nil {
+			err = fmt.Errorf("failed to get target node: %w", err)
+			npvcr.eventRecorder.Event(claim, corev1.EventTypeWarning, "ProvisioningFailed", err.Error())
+			return controller.ProvisioningNoChange, err
+		}
+	}
+
+	options := controller.ProvisionOptions{
+		StorageClass: class,
+		PVName:       pvName,
+		PVC:          claim,
+		SelectedNode: selectedNode,
+	}
+
+	npvcr.eventRecorder.Event(claim, corev1.EventTypeNormal, "Provisioning",
+		fmt.Sprintf("External provisioner is provisioning volume for claim %q", npvcr.LocalRef(claim.GetName())))
+
+	volume, result, err := provision(ctx, options)
+	if err != nil {
+		var ierr *controller.IgnoredError
+		if ok := errors.As(err, &ierr); ok {
+			// Provision ignored, do nothing and hope another provisioner will provision it.
+			klog.V(4).Infof("Volume provision ignored: %w", ierr)
+			return controller.ProvisioningFinished, nil
+		}
+		err = fmt.Errorf("failed to provision volume with StorageClass %q: %w", claimClass, err)
+		npvcr.eventRecorder.Event(claim, corev1.EventTypeWarning, "ProvisioningFailed", err.Error())
+		return result, err
+	}
+
+	klog.Infof("Volume %q provisioned (local claim %q)", volume.Name, npvcr.LocalRef(claim.GetName()))
+
+	// Set ClaimRef and the PV controller will bind and set annBoundByController for us
+	volume.Spec.ClaimRef = claimRef
+
+	metav1.SetMetaDataAnnotation(&volume.ObjectMeta, annDynamicallyProvisioned, class.Provisioner)
+	volume.Spec.StorageClassName = claimClass
+
+	_, err = npvcr.localPersistentVolumesClient.Create(ctx, volume, metav1.CreateOptions{})
+	return controller.ProvisioningFinished, err
+}
+
+// getString reads a string from a map, using the key value or the alternatives if the
+// first one is not set.
+func getString(m map[string]string, key string, alts ...string) (string, bool) {
+	if m == nil {
+		return "", false
+	}
+	keys := append([]string{key}, alts...)
+	for _, k := range keys {
+		if v, ok := m[k]; ok {
+			return v, true
+		}
+	}
+	return "", false
+}

--- a/pkg/virtualKubelet/reflection/storage/controller_test.go
+++ b/pkg/virtualKubelet/reflection/storage/controller_test.go
@@ -1,0 +1,97 @@
+// Copyright 2019-2021 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+
+	"github.com/liqotech/liqo/pkg/consts"
+)
+
+var _ = Describe("controller methods", func() {
+
+	Context("shouldProvision method", func() {
+
+		type shouldProvisionTestcase struct {
+			claim          *corev1.PersistentVolumeClaim
+			expectedShould OmegaMatcher
+		}
+
+		DescribeTable("shouldProvision table",
+			func(c shouldProvisionTestcase) {
+				should, err := reflector.shouldProvision(c.claim)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(should).To(c.expectedShould)
+			},
+
+			Entry("volume already defined", shouldProvisionTestcase{
+				claim: &corev1.PersistentVolumeClaim{
+					Spec: corev1.PersistentVolumeClaimSpec{
+						VolumeName: "test",
+					},
+				},
+				expectedShould: BeFalse(),
+			}),
+
+			Entry("PVC with wrong provisioner", shouldProvisionTestcase{
+				claim: &corev1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							annStorageProvisioner: "other-provisioner",
+						},
+					},
+					Spec: corev1.PersistentVolumeClaimSpec{},
+				},
+				expectedShould: BeFalse(),
+			}),
+
+			Entry("PVC with wrong storage class", shouldProvisionTestcase{
+				claim: &corev1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							annStorageProvisioner: consts.StorageProvisionerName,
+						},
+					},
+					Spec: corev1.PersistentVolumeClaimSpec{
+						StorageClassName: pointer.String("other-class"),
+					},
+				},
+				expectedShould: BeFalse(),
+			}),
+
+			Entry("correct PVC", shouldProvisionTestcase{
+				claim: &corev1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							annStorageProvisioner: consts.StorageProvisionerName,
+							annSelectedNode:       "node-1",
+						},
+					},
+					Spec: corev1.PersistentVolumeClaimSpec{
+						StorageClassName: pointer.String(VirtualStorageClassName),
+					},
+				},
+				expectedShould: BeTrue(),
+			}),
+		)
+
+	})
+
+})

--- a/pkg/virtualKubelet/reflection/storage/doc.go
+++ b/pkg/virtualKubelet/reflection/storage/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2019-2021 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package storage implements the reflection logic for persistentvolumeclaims.
+package storage

--- a/pkg/virtualKubelet/reflection/storage/persistentvolumeclaim.go
+++ b/pkg/virtualKubelet/reflection/storage/persistentvolumeclaim.go
@@ -1,0 +1,197 @@
+// Copyright 2019-2021 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"context"
+	"fmt"
+	"path"
+
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	corev1clients "k8s.io/client-go/kubernetes/typed/core/v1"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+	storagev1listers "k8s.io/client-go/listers/storage/v1"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/klog/v2"
+	"k8s.io/utils/trace"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/sig-storage-lib-external-provisioner/v7/controller"
+
+	"github.com/liqotech/liqo/pkg/consts"
+	liqostorageprovisioner "github.com/liqotech/liqo/pkg/liqo-controller-manager/storageprovisioner"
+	"github.com/liqotech/liqo/pkg/utils"
+	"github.com/liqotech/liqo/pkg/virtualKubelet/forge"
+	"github.com/liqotech/liqo/pkg/virtualKubelet/reflection/generic"
+	"github.com/liqotech/liqo/pkg/virtualKubelet/reflection/manager"
+	"github.com/liqotech/liqo/pkg/virtualKubelet/reflection/options"
+)
+
+const (
+	// PersistentVolumeClaimReflectorName -> The name associated with the PersistentVolumeClaim reflector.
+	PersistentVolumeClaimReflectorName = "PersistentVolumeClaim"
+)
+
+var _ manager.NamespacedReflector = (*NamespacedPersistentVolumeClaimReflector)(nil)
+
+// NamespacedPersistentVolumeClaimReflector manages the PersistentVolumeClaim reflection for a given pair of local and remote namespaces.
+type NamespacedPersistentVolumeClaimReflector struct {
+	generic.NamespacedReflector
+
+	classes                             storagev1listers.StorageClassLister
+	volumes                             corev1listers.PersistentVolumeLister
+	nodes                               corev1listers.NodeLister
+	localPersistentVolumeClaims         corev1listers.PersistentVolumeClaimNamespaceLister
+	remotePersistentVolumeClaims        corev1listers.PersistentVolumeClaimNamespaceLister
+	remotePersistentVolumesClaimsClient corev1clients.PersistentVolumeClaimInterface
+	localPersistentVolumesClient        corev1clients.PersistentVolumeInterface
+	localPersistentVolumeClaimsClient   corev1clients.PersistentVolumeClaimInterface
+
+	provisionerName string
+
+	virtualStorageClassName    string
+	remoteRealStorageClassName string
+
+	eventRecorder record.EventRecorder
+}
+
+// NewPersistentVolumeClaimReflector returns a new PersistentVolumeClaimReflector instance.
+func NewPersistentVolumeClaimReflector(workers uint,
+	virtualStorageClassName, remoteRealStorageClassName string) manager.Reflector {
+	return generic.NewReflector(PersistentVolumeClaimReflectorName,
+		NewNamespacedPersistentVolumeClaimReflector(virtualStorageClassName, remoteRealStorageClassName),
+		generic.WithoutFallback(), workers)
+}
+
+// NewNamespacedPersistentVolumeClaimReflector returns a function generating NamespacedPersistentVolumeClaimReflector instances.
+func NewNamespacedPersistentVolumeClaimReflector(virtualStorageClassName,
+	remoteRealStorageClassName string) func(*options.NamespacedOpts) manager.NamespacedReflector {
+	return func(opts *options.NamespacedOpts) manager.NamespacedReflector {
+		local := opts.LocalFactory.Core().V1().PersistentVolumeClaims()
+		remote := opts.RemoteFactory.Core().V1().PersistentVolumeClaims()
+		localStorage := opts.LocalFactory.Storage().V1().StorageClasses()
+		localVolumes := opts.LocalFactory.Core().V1().PersistentVolumes()
+		localNodes := opts.LocalFactory.Core().V1().Nodes()
+
+		local.Informer().AddEventHandler(opts.HandlerFactory(generic.NamespacedKeyer(opts.LocalNamespace)))
+		remote.Informer().AddEventHandler(opts.HandlerFactory(generic.NamespacedKeyer(opts.LocalNamespace)))
+
+		return &NamespacedPersistentVolumeClaimReflector{
+			NamespacedReflector: generic.NewNamespacedReflector(opts),
+
+			classes:                             localStorage.Lister(),
+			volumes:                             localVolumes.Lister(),
+			nodes:                               localNodes.Lister(),
+			localPersistentVolumeClaims:         local.Lister().PersistentVolumeClaims(opts.LocalNamespace),
+			remotePersistentVolumeClaims:        remote.Lister().PersistentVolumeClaims(opts.RemoteNamespace),
+			remotePersistentVolumesClaimsClient: opts.RemoteClient.CoreV1().PersistentVolumeClaims(opts.RemoteNamespace),
+			localPersistentVolumesClient:        opts.LocalClient.CoreV1().PersistentVolumes(),
+			localPersistentVolumeClaimsClient:   opts.LocalClient.CoreV1().PersistentVolumeClaims(opts.LocalNamespace),
+
+			provisionerName: consts.StorageProvisionerName,
+
+			virtualStorageClassName:    virtualStorageClassName,
+			remoteRealStorageClassName: remoteRealStorageClassName,
+
+			eventRecorder: opts.EventBroadcaster.NewRecorder(scheme.Scheme,
+				corev1.EventSource{Component: path.Join("remote-storage-provisioner", forge.RemoteClusterID)}),
+		}
+	}
+}
+
+// Handle reconciles PersistentVolumeClaim objects.
+func (npvcr *NamespacedPersistentVolumeClaimReflector) Handle(ctx context.Context, name string) error {
+	tracer := trace.FromContext(ctx)
+
+	// Retrieve the local and remote objects (only not found errors can occur).
+	klog.V(4).Infof("Handling reflection of local PersistentVolumeClaim %q (remote: %q)", npvcr.LocalRef(name), npvcr.RemoteRef(name))
+	local, lerr := npvcr.localPersistentVolumeClaims.Get(name)
+	utilruntime.Must(client.IgnoreNotFound(lerr))
+	remote, rerr := npvcr.remotePersistentVolumeClaims.Get(name)
+	utilruntime.Must(client.IgnoreNotFound(rerr))
+	tracer.Step("Retrieved the local and remote objects")
+
+	// Abort the reflection if the remote object is not managed by us, as we do not want to mutate others' objects.
+	if rerr == nil && !forge.IsReflected(remote) {
+		klog.Infof("Skipping reflection of local PersistentVolumeClaim %q as remote already exists and is not managed by us", npvcr.LocalRef(name))
+		return nil
+	}
+	tracer.Step("Performed the sanity checks")
+
+	// The local PersistentVolumeClaim does no longer exist. Ensure it is also absent from the remote cluster.
+	if kerrors.IsNotFound(lerr) {
+		defer tracer.Step("Ensured the absence of the remote object")
+		if !kerrors.IsNotFound(rerr) {
+			klog.V(4).Infof("Deleting remote PersistentVolumeClaim %q, since local %q does no longer exist", npvcr.RemoteRef(name), npvcr.LocalRef(name))
+			return npvcr.DeleteRemote(ctx, npvcr.remotePersistentVolumesClaimsClient, PersistentVolumeClaimReflectorName, name, remote.GetUID())
+		}
+
+		klog.V(4).Infof("Local PersistentVolumeClaim %q and remote PersistentVolumeClaim %q both vanished", npvcr.LocalRef(name), npvcr.RemoteRef(name))
+		return nil
+	}
+
+	// DeepCopy the local object to allow modifications.
+	local = local.DeepCopy()
+
+	// Check if we should provision storage for that PVC. We have to check if no volume is already provisioned and the storage class is the expected one.
+	if should, err := npvcr.shouldProvision(local); err != nil {
+		klog.V(4).Infof("Error checking if should provision a local PersistentVolumeClaim %q: %v", npvcr.LocalRef(name), err.Error())
+		return err
+	} else if !should {
+		klog.V(4).Infof("Skipping PersistentVolumeClaim %q since we should not provision it", npvcr.LocalRef(name))
+		return nil
+	}
+	tracer.Step("Ensured to have to provision the volume")
+
+	// Run the actual remote PVC reconciliation.
+	// Similarly to what a storage class controller does, we provide a local PV for a local PVC.
+	// https://github.com/kubernetes-sigs/sig-storage-lib-external-provisioner/blob/v7.0.1/controller/controller.go#L1275
+	// In addition, we use the provisionFunc to ensure the provisioning of the remote PVC.
+	state, err := npvcr.provisionClaimOperation(ctx, local,
+		func(c context.Context, options controller.ProvisionOptions) (*corev1.PersistentVolume, controller.ProvisioningState, error) {
+			if clusterID, found := utils.GetNodeClusterID(options.SelectedNode); !found || clusterID != forge.RemoteClusterID {
+				return nil, controller.ProvisioningFinished, &controller.IgnoredError{Reason: "this provisioner is not provisioning storage on that node"}
+			}
+
+			pv, state, err := liqostorageprovisioner.ProvisionRemotePVC(ctx,
+				options, npvcr.RemoteNamespace(), npvcr.remoteRealStorageClassName,
+				npvcr.remotePersistentVolumeClaims, npvcr.remotePersistentVolumesClaimsClient)
+			if err == nil && state == controller.ProvisioningFinished {
+				local.Spec.VolumeName = options.PVName
+			}
+			return pv, state, err
+		})
+	if err != nil {
+		klog.Error("Error provisioning the remote PersistentVolumeClaim %q: %v", npvcr.RemoteRef(name), err.Error())
+		return err
+	}
+	tracer.Step("Remote mutation created")
+
+	klog.V(4).Infof("Handle of local PersistentVolumeClaim %q (remote: %q) finished with state %q", npvcr.LocalRef(name), npvcr.RemoteRef(name), state)
+	switch state {
+	case controller.ProvisioningFinished, controller.ProvisioningNoChange, controller.ProvisioningReschedule:
+		if _, err = npvcr.localPersistentVolumeClaimsClient.Update(ctx, local, metav1.UpdateOptions{}); err != nil {
+			return err
+		}
+		return nil
+	case controller.ProvisioningInBackground:
+		return fmt.Errorf("provisioning of local PersistentVolumeClaim %q is still in progress", npvcr.LocalRef(name))
+	default:
+		return fmt.Errorf("unknown state %v", state)
+	}
+}

--- a/pkg/virtualKubelet/reflection/storage/persistentvolumeclaim_test.go
+++ b/pkg/virtualKubelet/reflection/storage/persistentvolumeclaim_test.go
@@ -1,0 +1,58 @@
+// Copyright 2019-2021 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	. "github.com/liqotech/liqo/pkg/utils/testutil"
+)
+
+var _ = Describe("reflector methods", func() {
+
+	Context("Handle method", func() {
+
+		It("the remote PVC does not exist", func() {
+			Expect(reflector.Handle(ctx, remotePvcName)).To(Succeed())
+
+			offloadedPvc, err := k8sClient.CoreV1().PersistentVolumeClaims(RemoteNamespace).Get(ctx, remotePvcName, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(offloadedPvc).ToNot(BeNil())
+
+			Expect(offloadedPvc.Spec.StorageClassName).To(PointTo(Equal(RealRemoteStorageClassName)))
+
+			localPvc, err := k8sClient.CoreV1().PersistentVolumeClaims(LocalNamespace).Get(ctx, remotePvcName, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(localPvc.Spec.VolumeName).ToNot(BeEmpty())
+
+			localPv, err := k8sClient.CoreV1().PersistentVolumes().Get(ctx, localPvc.Spec.VolumeName, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(localPv).ToNot(BeNil())
+		})
+
+		It("the PVC is not on the virtual node", func() {
+			// the function has to succeed, we have not reenqueue this item
+			Expect(reflector.Handle(ctx, localPvcName)).To(Succeed())
+
+			_, err := k8sClient.CoreV1().PersistentVolumeClaims(RemoteNamespace).Get(ctx, localPvcName, metav1.GetOptions{})
+			Expect(err).To(BeNotFound())
+		})
+
+	})
+
+})

--- a/pkg/virtualKubelet/reflection/storage/storage_suite_test.go
+++ b/pkg/virtualKubelet/reflection/storage/storage_suite_test.go
@@ -1,0 +1,239 @@
+// Copyright 2019-2021 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"context"
+	"flag"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/klog/v2"
+	"k8s.io/utils/pointer"
+	"k8s.io/utils/trace"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+
+	"github.com/liqotech/liqo/pkg/consts"
+	"github.com/liqotech/liqo/pkg/virtualKubelet/forge"
+	"github.com/liqotech/liqo/pkg/virtualKubelet/reflection/manager"
+	"github.com/liqotech/liqo/pkg/virtualKubelet/reflection/options"
+)
+
+const (
+	LocalNamespace  = "local-namespace"
+	RemoteNamespace = "remote-namespace"
+
+	LocalClusterID  = "local-cluster"
+	RemoteClusterID = "remote-cluster"
+
+	VirtualStorageClassName    = "liqo"
+	RealRemoteStorageClassName = "other-class"
+
+	VirtualNodeName = "liqo-node"
+	RealNodeName    = "real-node"
+	localPvcName    = "pvc-local"
+	remotePvcName   = "pvc-remote"
+)
+
+var (
+	testEnv   envtest.Environment
+	k8sClient kubernetes.Interface
+
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	reflectorBuilder func(*options.NamespacedOpts) manager.NamespacedReflector
+	factory          informers.SharedInformerFactory
+	reflector        *NamespacedPersistentVolumeClaimReflector
+
+	checkErrIgnoreAlreadyExists = func(_ runtime.Object, err error) {
+		if !apierrors.IsAlreadyExists(err) {
+			checkErr(nil, err)
+		}
+	}
+
+	checkErr = func(_ runtime.Object, err error) {
+		Expect(err).ToNot(HaveOccurred())
+	}
+)
+
+func TestStorage(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Storage Reflection Suite")
+}
+
+var _ = BeforeSuite(func() {
+	klog.SetOutput(GinkgoWriter)
+	flagset := flag.NewFlagSet("klog", flag.PanicOnError)
+	klog.InitFlags(flagset)
+	Expect(flagset.Set("v", "4")).To(Succeed())
+	klog.LogToStderr(false)
+
+	testEnv = envtest.Environment{}
+	cfg, err := testEnv.Start()
+	Expect(err).ToNot(HaveOccurred())
+
+	// Need to use a real client, as server side apply seems not to be currently supported by the fake one.
+	k8sClient = kubernetes.NewForConfigOrDie(cfg)
+
+	_, err = k8sClient.CoreV1().Namespaces().Create(context.TODO(), &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: LocalNamespace,
+		},
+	}, metav1.CreateOptions{})
+	Expect(err).ToNot(HaveOccurred())
+
+	_, err = k8sClient.CoreV1().Namespaces().Create(context.TODO(), &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: RemoteNamespace,
+		},
+	}, metav1.CreateOptions{})
+	Expect(err).ToNot(HaveOccurred())
+})
+
+var _ = BeforeEach(func() {
+	ctx, cancel = context.WithCancel(context.Background())
+	ctx = trace.ContextWithTrace(ctx, trace.New("PersistentVolumeClaim"))
+
+	bindingMode := storagev1.VolumeBindingWaitForFirstConsumer
+	sc1 := &storagev1.StorageClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "liqo",
+		},
+		Provisioner:       consts.StorageProvisionerName,
+		VolumeBindingMode: &bindingMode,
+	}
+
+	sc2 := &storagev1.StorageClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "other-class",
+		},
+		Provisioner:       consts.StorageProvisionerName,
+		VolumeBindingMode: &bindingMode,
+	}
+
+	realNode := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: RealNodeName,
+		},
+	}
+
+	virtualNode := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: VirtualNodeName,
+			Labels: map[string]string{
+				consts.RemoteClusterID: RemoteClusterID,
+			},
+		},
+	}
+
+	localPvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      localPvcName,
+			Namespace: LocalNamespace,
+			Annotations: map[string]string{
+				annStorageProvisioner: consts.StorageProvisionerName,
+				annSelectedNode:       RealNodeName,
+			},
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			StorageClassName: pointer.String(VirtualStorageClassName),
+			AccessModes: []corev1.PersistentVolumeAccessMode{
+				corev1.ReadWriteOnce,
+			},
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: resource.MustParse("1Gi"),
+				},
+			},
+		},
+	}
+
+	remotePvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      remotePvcName,
+			Namespace: LocalNamespace,
+			Annotations: map[string]string{
+				annStorageProvisioner: consts.StorageProvisionerName,
+				annSelectedNode:       VirtualNodeName,
+			},
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			StorageClassName: pointer.String(VirtualStorageClassName),
+			AccessModes: []corev1.PersistentVolumeAccessMode{
+				corev1.ReadWriteOnce,
+			},
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: resource.MustParse("1Gi"),
+				},
+			},
+		},
+	}
+
+	checkErrIgnoreAlreadyExists(k8sClient.CoreV1().Nodes().Create(ctx, realNode, metav1.CreateOptions{}))
+	checkErrIgnoreAlreadyExists(k8sClient.CoreV1().Nodes().Create(ctx, virtualNode, metav1.CreateOptions{}))
+	checkErrIgnoreAlreadyExists(k8sClient.StorageV1().StorageClasses().Create(ctx, sc1, metav1.CreateOptions{}))
+	checkErrIgnoreAlreadyExists(k8sClient.StorageV1().StorageClasses().Create(ctx, sc2, metav1.CreateOptions{}))
+	checkErrIgnoreAlreadyExists(k8sClient.CoreV1().PersistentVolumeClaims(LocalNamespace).Create(ctx, localPvc, metav1.CreateOptions{}))
+	checkErrIgnoreAlreadyExists(k8sClient.CoreV1().PersistentVolumeClaims(LocalNamespace).Create(ctx, remotePvc, metav1.CreateOptions{}))
+
+	forge.Init(LocalClusterID, RemoteClusterID, virtualNode.Name, "127.0.0.1")
+
+	reflectorBuilder = NewNamespacedPersistentVolumeClaimReflector(VirtualStorageClassName,
+		RealRemoteStorageClassName)
+	factory = informers.NewSharedInformerFactory(k8sClient, 10*time.Hour)
+})
+
+var _ = JustBeforeEach(func() {
+	options := options.NewNamespaced().
+		WithLocal(LocalNamespace, k8sClient, factory).
+		WithRemote(RemoteNamespace, k8sClient, factory).
+		WithHandlerFactory(FakeEventHandler).WithEventBroadcaster(record.NewBroadcaster())
+
+	reflector = reflectorBuilder(options).(*NamespacedPersistentVolumeClaimReflector)
+	Expect(reflector).ToNot(BeNil())
+
+	factory.Start(ctx.Done())
+	factory.WaitForCacheSync(ctx.Done())
+})
+
+var _ = AfterEach(func() {
+	cancel()
+})
+
+var _ = AfterSuite(func() {
+	Expect(testEnv.Stop()).To(Succeed())
+})
+
+var FakeEventHandler = func(options.Keyer) cache.ResourceEventHandler {
+	return cache.ResourceEventHandlerFuncs{
+		AddFunc:    func(_ interface{}) {},
+		UpdateFunc: func(_, obj interface{}) {},
+		DeleteFunc: func(_ interface{}) {},
+	}
+}

--- a/pkg/virtualKubelet/roles/local/role.go
+++ b/pkg/virtualKubelet/roles/local/role.go
@@ -22,6 +22,9 @@ package local
 // +kubebuilder:rbac:groups="",resources=pods,verbs=get;patch;list;watch;delete;create
 // +kubebuilder:rbac:groups="",resources=pods/status;services/status;nodes/status,verbs=get;update;patch;list;watch;delete;create
 // +kubebuilder:rbac:groups="",resources=pods/eviction,verbs=create
+// +kubebuilder:rbac:groups=core,resources=persistentvolumeclaims;persistentvolumes,verbs=get;list;watch;create;delete;update
+// +kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
+// +kubebuilder:rbac:groups=storage.k8s.io,resources=storageclasses,verbs=get;list;watch
 
 // +kubebuilder:rbac:groups=apps,resources=replicasets,verbs=get;list;watch
 // +kubebuilder:rbac:groups=discovery.k8s.io,resources=endpointslices,verbs=create;get;list;watch


### PR DESCRIPTION
# Description

This pr includes the logic for the PVC namespaced reflector. This component offloads the PVC when they are been bound by a pod offloaded in the remote cluster the vk is targeting

Ref #944 

# How Has This Been Tested?

- [x] locally on KinD
- [x] add unit test
