### PR TITLE
epslice reflection: fix warning

### DIFF
--- a/pkg/virtualKubelet/reflection/exposition/endpointslice.go
+++ b/pkg/virtualKubelet/reflection/exposition/endpointslice.go
@@ -98,7 +98,11 @@ func (ner *NamespacedEndpointSliceReflector) Handle(ctx context.Context, name st
 
 	// Abort the reflection if the remote object is not managed by us, as we do not want to mutate others' objects.
 	if rerr == nil && (!forge.IsReflected(remote) || !forge.IsEndpointSliceManagedByReflection(remote)) {
-		klog.Infof("Skipping reflection of local EndpointSlice %q as remote already exists and is not managed by us", ner.LocalRef(name))
+		// Prevent misleading warnings triggered by remote non-reflected endpointslices, since they inherit
+		// the labels from the service. Hence, vanilla remote endpointslices do also trigger the Handle function.
+		if lerr == nil {
+			klog.Infof("Skipping reflection of local EndpointSlice %q as remote already exists and is not managed by us", ner.LocalRef(name))
+		}
 		return nil
 	}
 	tracer.Step("Performed the sanity checks")


### PR DESCRIPTION
# Description

This PR fixes a misleading warning message in the endpointslice reflection, which was always triggered since endpointslices automatically inherit the service labels. Now, it is emitted only if a corresponding local object does also exist.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Existing
