### PR TITLE
pod reflection: prevent race condition in fallback management

### DIFF
--- a/pkg/virtualKubelet/reflection/workload/podns.go
+++ b/pkg/virtualKubelet/reflection/workload/podns.go
@@ -164,7 +164,7 @@ func (npr *NamespacedPodReflector) Handle(ctx context.Context, name string) erro
 	}
 
 	// Do not offload the pod if it was previously rejected, as new copies should have already been re-created.
-	if local.Status.Phase == corev1.PodFailed && local.Status.Reason == forge.PodRejectedReason {
+	if local.Status.Phase == corev1.PodFailed && local.Status.Reason == forge.PodOffloadingAbortedReason {
 		// Ensure the corresponding remote shadowpod is not still present due to transients.
 		if shadowExists && shadow.DeletionTimestamp.IsZero() {
 			defer tracer.Step("Ensured the absence of the remote object")

--- a/pkg/virtualKubelet/reflection/workload/podns_test.go
+++ b/pkg/virtualKubelet/reflection/workload/podns_test.go
@@ -283,10 +283,10 @@ var _ = Describe("Namespaced Pod Reflection Tests", func() {
 				})
 			})
 
-			When("the local object does exist and has been rejected", func() {
+			When("the local object does exist and has been rejected (OffloadingAborted)", func() {
 				BeforeEach(func() {
 					local.Status.Phase = corev1.PodFailed
-					local.Status.Reason = forge.PodRejectedReason
+					local.Status.Reason = forge.PodOffloadingAbortedReason
 					CreatePod(client, &local)
 
 					shadow.SetLabels(forge.ReflectionLabels())


### PR DESCRIPTION
# Description

This PR updates the fallback management of pod reflection, to prevent issues when a pod is scheduled to a virtual node before the corresponding reflection has been started. Specifically, a pod is now marked as Pending (`OffloadingBackOff`) if that namespace reflection is not started, while Failed (`OffloadingAborted`) in case the pod has been previously offloaded and reflection is then stopped. It also updates the forging logic to avoid overwriting the existing status.


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Unit testing (new + existing)
- [x] E2E testing
