### PR TITLE
Migrate cluster IDs to ClusterIdentity

### DIFF
--- a/apis/discovery/v1alpha1/foreigncluster_types.go
+++ b/apis/discovery/v1alpha1/foreigncluster_types.go
@@ -101,7 +101,7 @@ type ClusterIdentity struct {
 	// Foreign Cluster ID, this is a unique identifier of that cluster.
 	ClusterID string `json:"clusterID"`
 	// Foreign Cluster Name to be shown in GUIs.
-	ClusterName string `json:"clusterName,omitempty"`
+	ClusterName string `json:"clusterName"`
 }
 
 // ForeignClusterStatus defines the observed state of ForeignCluster.

--- a/cmd/auth-service/main.go
+++ b/cmd/auth-service/main.go
@@ -25,6 +25,7 @@ import (
 	authservice "github.com/liqotech/liqo/internal/auth-service"
 	identitymanager "github.com/liqotech/liqo/pkg/identityManager"
 	"github.com/liqotech/liqo/pkg/utils/apiserver"
+	"github.com/liqotech/liqo/pkg/utils/args"
 	"github.com/liqotech/liqo/pkg/utils/restcfg"
 )
 
@@ -41,8 +42,7 @@ func main() {
 	keyPath := flag.String("key-path", "/certs/key.pem", "The path to TLS private key")
 	useTLS := flag.Bool("enable-tls", false, "Enable HTTPS server")
 
-	clusterID := flag.String("cluster-id", "", "The cluster ID of identifying the current cluster")
-	clusterName := flag.String("advertise-cluster-name", "", "The cluster name advertised during the peering process")
+	clusterFlags := args.NewClusterIdentityFlags(true, nil)
 	enableAuth := flag.Bool("enable-authentication", true,
 		"Whether to authenticate remote clusters through tokens before granting an identity (warning: disable only for testing purposes)")
 
@@ -62,8 +62,9 @@ func main() {
 
 	config := restcfg.SetRateLimiter(ctrl.GetConfigOrDie())
 
+	clusterIdentity := clusterFlags.ReadOrDie()
 	authService, err := authservice.NewAuthServiceCtrl(
-		config, *namespace, awsConfig, *resync, apiserver.GetConfig(), *enableAuth, *useTLS, *clusterID, *clusterName)
+		config, *namespace, awsConfig, *resync, apiserver.GetConfig(), *enableAuth, *useTLS, clusterIdentity)
 	if err != nil {
 		klog.Error(err)
 		os.Exit(1)

--- a/cmd/virtual-kubelet/root/flag.go
+++ b/cmd/virtual-kubelet/root/flag.go
@@ -39,9 +39,11 @@ func InstallFlags(flags *pflag.FlagSet, c *Opts) {
 		"how often to perform a full resync of pods between kubernetes and the provider")
 	flags.DurationVar(&c.StartupTimeout, "startup-timeout", c.StartupTimeout, "How long to wait for the virtual-kubelet to start")
 
-	flags.StringVar(&c.ForeignClusterID, "foreign-cluster-id", c.ForeignClusterID, "The Id of the foreign cluster")
+	flags.StringVar(&c.ForeignCluster.ClusterID, "foreign-cluster-id", c.ForeignCluster.ClusterID, "The ID of the foreign cluster")
+	flags.StringVar(&c.ForeignCluster.ClusterName, "foreign-cluster-name", c.ForeignCluster.ClusterName, "The name of the foreign cluster")
 	flags.StringVar(&c.KubeletNamespace, "kubelet-namespace", c.KubeletNamespace, "The namespace of the virtual kubelet")
-	flags.StringVar(&c.HomeClusterID, "home-cluster-id", c.HomeClusterID, "The Id of the home cluster")
+	flags.StringVar(&c.HomeCluster.ClusterID, "home-cluster-id", c.HomeCluster.ClusterID, "The ID of the home cluster")
+	flags.StringVar(&c.HomeCluster.ClusterName, "home-cluster-name", c.HomeCluster.ClusterName, "The name of the home cluster")
 	flags.StringVar(&c.LiqoIpamServer, "ipam-server", c.LiqoIpamServer, "The server the Virtual Kubelet should "+
 		"connect to in order to contact the IPAM module")
 	flags.BoolVar(&c.Profiling, "enable-profiling", c.Profiling, "Enable pprof profiling")

--- a/cmd/virtual-kubelet/root/opts.go
+++ b/cmd/virtual-kubelet/root/opts.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
 	"github.com/liqotech/liqo/pkg/consts"
 	argsutils "github.com/liqotech/liqo/pkg/utils/args"
 )
@@ -73,8 +74,8 @@ type Opts struct {
 	// Startup Timeout is how long to wait for the kubelet to start
 	StartupTimeout time.Duration
 
-	ForeignClusterID string
-	HomeClusterID    string
+	ForeignCluster   discoveryv1alpha1.ClusterIdentity
+	HomeCluster      discoveryv1alpha1.ClusterIdentity
 	KubeletNamespace string
 
 	LiqoIpamServer string

--- a/cmd/virtual-kubelet/root/root.go
+++ b/cmd/virtual-kubelet/root/root.go
@@ -59,8 +59,11 @@ func runRootCommand(ctx context.Context, c *Opts) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	if c.ForeignClusterID == "" {
+	if c.ForeignCluster.ClusterID == "" {
 		return errors.New("cluster id is mandatory")
+	}
+	if c.ForeignCluster.ClusterName == "" {
+		return errors.New("cluster name is mandatory")
 	}
 
 	if c.PodWorkers == 0 || c.ServiceWorkers == 0 || c.EndpointSliceWorkers == 0 || c.ConfigMapWorkers == 0 || c.SecretWorkers == 0 {
@@ -80,9 +83,9 @@ func runRootCommand(ctx context.Context, c *Opts) error {
 
 	// Initialize the pod provider
 	podcfg := podprovider.InitConfig{
-		HomeConfig:      config,
-		HomeClusterID:   c.HomeClusterID,
-		RemoteClusterID: c.ForeignClusterID,
+		HomeConfig:    config,
+		HomeCluster:   c.HomeCluster,
+		RemoteCluster: c.ForeignCluster,
 
 		Namespace: c.KubeletNamespace,
 		NodeName:  c.NodeName,
@@ -112,8 +115,8 @@ func runRootCommand(ctx context.Context, c *Opts) error {
 	// Initialize the node provider
 	nodecfg := nodeprovider.InitConfig{
 		HomeConfig:      config,
-		HomeClusterID:   c.HomeClusterID,
-		RemoteClusterID: c.ForeignClusterID,
+		HomeClusterID:   c.HomeCluster.ClusterID,
+		RemoteClusterID: c.ForeignCluster.ClusterID,
 		Namespace:       c.KubeletNamespace,
 
 		NodeName:         c.NodeName,

--- a/deployments/liqo/crds/discovery.liqo.io_foreignclusters.yaml
+++ b/deployments/liqo/crds/discovery.liqo.io_foreignclusters.yaml
@@ -72,6 +72,7 @@ spec:
                     type: string
                 required:
                 - clusterID
+                - clusterName
                 type: object
               foreignAuthUrl:
                 description: URL where to contact foreign Auth service.

--- a/deployments/liqo/crds/discovery.liqo.io_resourcerequests.yaml
+++ b/deployments/liqo/crds/discovery.liqo.io_resourcerequests.yaml
@@ -58,6 +58,7 @@ spec:
                     type: string
                 required:
                 - clusterID
+                - clusterName
                 type: object
               withdrawalTimestamp:
                 description: WithdrawalTimestamp is set when a graceful deletion is

--- a/deployments/liqo/templates/liqo-auth-deployment.yaml
+++ b/deployments/liqo/templates/liqo-auth-deployment.yaml
@@ -68,6 +68,7 @@ spec:
           command: ["/usr/bin/auth-service"]
           args:
           - --cluster-id=$(CLUSTER_ID)
+          - --cluster-name={{ .Values.discovery.config.clusterName }}
           - --namespace=$(POD_NAMESPACE)
           {{- if not .Values.auth.tls}}
           - --address=:5000
@@ -81,9 +82,6 @@ spec:
           {{- end }}
           {{- if .Values.apiServer.trustedCA }}
           - --advertise-api-server-trusted-ca
-          {{- end }}
-          {{- if .Values.discovery.config.clusterName }}
-          - --advertise-cluster-name={{ .Values.discovery.config.clusterName }}
           {{- end }}
           {{- if .Values.awsConfig.accessKeyId }}
           - --aws-access-key-id=$(ACCESS_KEY_ID)

--- a/deployments/liqo/templates/liqo-clusterid-configmap.yaml
+++ b/deployments/liqo/templates/liqo-clusterid-configmap.yaml
@@ -16,4 +16,6 @@ data:
   {{- end }}
   {{- if .Values.discovery.config.clusterName }}
   CLUSTER_NAME: {{ .Values.discovery.config.clusterName }}
+  {{- else }}
+  {{- fail "The cluster name (.Values.discovery.config.clusterName) must be set" }}
   {{- end }}

--- a/deployments/liqo/templates/liqo-controller-manager.yaml
+++ b/deployments/liqo/templates/liqo-controller-manager.yaml
@@ -36,6 +36,7 @@ spec:
         command: ["/usr/bin/liqo-controller-manager"]
         args:
           - --cluster-id=$(CLUSTER_ID)
+          - --cluster-name={{ .Values.discovery.config.clusterName }}
           - --liqo-namespace=$(POD_NAMESPACE)
           - --enable-incoming-peering={{ .Values.discovery.config.incomingPeeringEnabled }}
           - --resource-sharing-percentage={{ .Values.controllerManager.config.resourceSharingPercentage }}
@@ -47,9 +48,6 @@ spec:
           - --virtual-storage-class-name={{ .Values.storage.virtualStorageClassName }}
           - --real-storage-class-name={{ .Values.storage.realStorageClassName }}
           - --storage-namespace={{ .Values.storage.storageNamespace }}
-          {{- end }}
-          {{- if .Values.discovery.config.clusterName }}
-          - --cluster-name={{ .Values.discovery.config.clusterName }}
           {{- end }}
           {{- if .Values.auth.ingress.enable }}
           - --auth-service-address-override={{ .Values.auth.ingress.host }}

--- a/deployments/liqo/templates/liqo-crd-replicator-deployment.yaml
+++ b/deployments/liqo/templates/liqo-crd-replicator-deployment.yaml
@@ -36,6 +36,7 @@ spec:
           command: ["/usr/bin/crd-replicator"]
           args:
             - --cluster-id=$(CLUSTER_ID)
+            - --cluster-name=$(CLUSTER_NAME)
             {{- if .Values.crdReplicator.pod.extraArgs }}
             {{- toYaml .Values.crdReplicator.pod.extraArgs | nindent 12 }}
             {{- end }}
@@ -45,6 +46,11 @@ spec:
                 configMapKeyRef:
                   name: {{ include "liqo.clusterIdConfig" . }}
                   key: CLUSTER_ID
+            - name: CLUSTER_NAME
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "liqo.clusterIdConfig" . }}
+                  key: CLUSTER_NAME
           resources:
             requests:
               cpu: 30m

--- a/deployments/liqo/templates/liqo-discovery-deployment.yaml
+++ b/deployments/liqo/templates/liqo-discovery-deployment.yaml
@@ -35,6 +35,7 @@ spec:
           command: ["/usr/bin/discovery"]
           args:
           - --cluster-id=$(CLUSTER_ID)
+          - --cluster-name=$(CLUSTER_NAME)
           - --namespace=$(POD_NAMESPACE)
           - --mdns-enable-advertisement={{ .Values.discovery.config.enableAdvertisement }}
           - --mdns-enable-discovery={{ .Values.discovery.config.enableDiscovery }}
@@ -48,6 +49,11 @@ spec:
                 configMapKeyRef:
                   name: {{ include "liqo.clusterIdConfig" . }}
                   key: CLUSTER_ID
+            - name: CLUSTER_NAME
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "liqo.clusterIdConfig" . }}
+                  key: CLUSTER_NAME
             - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/internal/auth-service/idsHttpHandler.go
+++ b/internal/auth-service/idsHttpHandler.go
@@ -52,7 +52,7 @@ func (authService *Controller) ids(w http.ResponseWriter, r *http.Request, ps ht
 
 func (authService *Controller) getIdsResponse() *auth.ClusterInfo {
 	return &auth.ClusterInfo{
-		ClusterID:   authService.localClusterID,
-		ClusterName: authService.localClusterName,
+		ClusterID:   authService.localCluster.ClusterID,
+		ClusterName: authService.localCluster.ClusterName,
 	}
 }

--- a/pkg/discoverymanager/discovery.go
+++ b/pkg/discoverymanager/discovery.go
@@ -21,6 +21,8 @@ import (
 
 	"github.com/grandcat/zeroconf"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
 )
 
 // clusterRole
@@ -49,7 +51,7 @@ type Controller struct {
 	namespacedClient client.Client
 	namespace        string
 
-	LocalClusterID string
+	LocalCluster discoveryv1alpha1.ClusterIdentity
 
 	serverMux      sync.Mutex
 	dialTCPTimeout time.Duration
@@ -60,13 +62,13 @@ type Controller struct {
 
 // NewDiscoveryCtrl returns a new discovery controller.
 func NewDiscoveryCtrl(cl, namespacedClient client.Client, namespace string,
-	localClusterID string, config MDNSConfig, dialTCPTimeout time.Duration) *Controller {
+	localCluster discoveryv1alpha1.ClusterIdentity, config MDNSConfig, dialTCPTimeout time.Duration) *Controller {
 	return &Controller{
 		Client:           cl,
 		namespacedClient: namespacedClient,
 		namespace:        namespace,
 
-		LocalClusterID: localClusterID,
+		LocalCluster: localCluster,
 
 		mdnsConfig:     config,
 		dialTCPTimeout: dialTCPTimeout,

--- a/pkg/discoverymanager/discovery_test.go
+++ b/pkg/discoverymanager/discovery_test.go
@@ -270,13 +270,16 @@ var _ = Describe("Discovery", func() {
 		BeforeEach(func() {
 			ctx = context.Background()
 
-			cID := "local-cluster"
+			clusterIdentity := discoveryv1alpha1.ClusterIdentity{
+				ClusterID:   "local-cluster-id",
+				ClusterName: "local-cluster-name",
+			}
 
 			client := fake.NewClientBuilder().WithScheme(scheme.Scheme).Build()
 			discoveryCtrl = Controller{
 				Client:           client,
 				namespacedClient: client,
-				LocalClusterID:   cID,
+				LocalCluster:     clusterIdentity,
 				namespace:        "default",
 				mdnsConfig: MDNSConfig{
 					Service:             "_liqo_auth._tcp",
@@ -321,7 +324,7 @@ var _ = Describe("Discovery", func() {
 						data: discoveryData{
 							AuthData: NewAuthData("1.2.3.4", 1234, 30),
 							ClusterInfo: &auth.ClusterInfo{
-								ClusterID:   "local-cluster",
+								ClusterID:   "local-cluster-id",
 								ClusterName: "ClusterTest1",
 							},
 						},

--- a/pkg/discoverymanager/foreign.go
+++ b/pkg/discoverymanager/foreign.go
@@ -43,7 +43,7 @@ func (discovery *Controller) updateForeignLAN(data *discoveryData) {
 	ctx := context.TODO()
 
 	discoveryType := discoveryPkg.LanDiscovery
-	if data.ClusterInfo.ClusterID == discovery.LocalClusterID {
+	if data.ClusterInfo.ClusterID == discovery.LocalCluster.ClusterID {
 		// is local cluster
 		return
 	}
@@ -66,7 +66,7 @@ func (discovery *Controller) updateForeignLAN(data *discoveryData) {
 // create it. In both cases update the ForeignCluster TTL
 // This function also sets an owner reference and a label to the ForeignCluster pointing to the SearchDomain CR.
 func UpdateForeignWAN(ctx context.Context,
-	cl client.Client, localClusterID string,
+	cl client.Client, localCluster v1alpha1.ClusterIdentity,
 	data []*AuthData, sd *v1alpha1.SearchDomain) []*v1alpha1.ForeignCluster {
 	createdUpdatedForeign := []*v1alpha1.ForeignCluster{}
 	discoveryType := discoveryPkg.WanDiscovery
@@ -77,7 +77,7 @@ func UpdateForeignWAN(ctx context.Context,
 			continue
 		}
 
-		if clusterInfo.ClusterID == localClusterID {
+		if clusterInfo.ClusterID == localCluster.ClusterID {
 			// is local cluster
 			continue
 		}

--- a/pkg/discoverymanager/register.go
+++ b/pkg/discoverymanager/register.go
@@ -37,7 +37,7 @@ func (discovery *Controller) register(ctx context.Context) {
 
 	discovery.serverMux.Lock()
 	discovery.mdnsServerAuth, err = zeroconf.Register(
-		discovery.LocalClusterID,
+		discovery.LocalCluster.ClusterID,
 		discovery.mdnsConfig.Service,
 		discovery.mdnsConfig.Domain,
 		authPort, nil, discovery.getInterfaces(),

--- a/pkg/discoverymanager/resolve.go
+++ b/pkg/discoverymanager/resolve.go
@@ -75,7 +75,7 @@ func (discovery *Controller) resolve(ctx context.Context, service, domain string
 						klog.Error(err)
 						continue
 					}
-					if dData.ClusterInfo.ClusterID == discovery.LocalClusterID || dData.ClusterInfo.ClusterID == "" {
+					if dData.ClusterInfo.ClusterID == discovery.LocalCluster.ClusterID || dData.ClusterInfo.ClusterID == "" {
 						continue
 					}
 					klog.V(4).Infof("update %s", entry.Instance)

--- a/pkg/identityManager/certificate.go
+++ b/pkg/identityManager/certificate.go
@@ -36,24 +36,25 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/klog/v2"
 
+	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
 	"github.com/liqotech/liqo/pkg/auth"
 	"github.com/liqotech/liqo/pkg/discovery"
 )
 
 // CreateIdentity creates a new key and a new csr to be used as an identity to authenticate with a remote cluster.
-func (certManager *identityManager) CreateIdentity(remoteClusterID string) (*v1.Secret, error) {
-	namespace, err := certManager.namespaceManager.GetNamespace(remoteClusterID)
+func (certManager *identityManager) CreateIdentity(remoteCluster discoveryv1alpha1.ClusterIdentity) (*v1.Secret, error) {
+	namespace, err := certManager.namespaceManager.GetNamespace(remoteCluster)
 	if err != nil {
 		klog.Error(err)
 		return nil, err
 	}
 
-	return certManager.createIdentityInNamespace(remoteClusterID, namespace.Name)
+	return certManager.createIdentityInNamespace(remoteCluster.ClusterID, namespace.Name)
 }
 
 // GetSigningRequest gets the CertificateSigningRequest for a remote cluster.
-func (certManager *identityManager) GetSigningRequest(remoteClusterID string) ([]byte, error) {
-	secret, err := certManager.getSecret(remoteClusterID)
+func (certManager *identityManager) GetSigningRequest(remoteCluster discoveryv1alpha1.ClusterIdentity) ([]byte, error) {
+	secret, err := certManager.getSecret(remoteCluster)
 	if err != nil {
 		klog.Error(err)
 		return nil, err
@@ -61,7 +62,8 @@ func (certManager *identityManager) GetSigningRequest(remoteClusterID string) ([
 
 	csrBytes, ok := secret.Data[csrSecretKey]
 	if !ok {
-		err = fmt.Errorf("csr not found in secret %v/%v for clusterid %v", secret.Namespace, secret.Name, remoteClusterID)
+		err = fmt.Errorf("csr not found in secret %v/%v for clusterid %v",
+			secret.Namespace, secret.Name, remoteCluster.ClusterID)
 		klog.Error(err)
 		return nil, err
 	}
@@ -70,8 +72,9 @@ func (certManager *identityManager) GetSigningRequest(remoteClusterID string) ([
 }
 
 // StoreCertificate stores the certificate issued by a remote authority for the specified remoteClusterID.
-func (certManager *identityManager) StoreCertificate(remoteClusterID string, identityResponse *auth.CertificateIdentityResponse) error {
-	secret, err := certManager.getSecret(remoteClusterID)
+func (certManager *identityManager) StoreCertificate(remoteCluster discoveryv1alpha1.ClusterIdentity,
+	identityResponse *auth.CertificateIdentityResponse) error {
+	secret, err := certManager.getSecret(remoteCluster)
 	if err != nil {
 		klog.Error(err)
 		return err
@@ -120,22 +123,23 @@ func (certManager *identityManager) StoreCertificate(remoteClusterID string, ide
 }
 
 // getSecret retrieves the identity secret given the clusterID.
-func (certManager *identityManager) getSecret(remoteClusterID string) (*v1.Secret, error) {
-	namespace, err := certManager.namespaceManager.GetNamespace(remoteClusterID)
+func (certManager *identityManager) getSecret(remoteCluster discoveryv1alpha1.ClusterIdentity) (*v1.Secret, error) {
+	namespace, err := certManager.namespaceManager.GetNamespace(remoteCluster)
 	if err != nil {
 		klog.Error(err)
 		return nil, err
 	}
 
-	return certManager.getSecretInNamespace(remoteClusterID, namespace.Name)
+	return certManager.getSecretInNamespace(remoteCluster, namespace.Name)
 }
 
 // getSecretInNamespace retrieves the identity secret in the given Namespace.
-func (certManager *identityManager) getSecretInNamespace(remoteClusterID, namespace string) (*v1.Secret, error) {
+func (certManager *identityManager) getSecretInNamespace(remoteCluster discoveryv1alpha1.ClusterIdentity,
+	namespace string) (*v1.Secret, error) {
 	labelSelector := metav1.LabelSelector{
 		MatchLabels: map[string]string{
 			localIdentitySecretLabel: "true",
-			discovery.ClusterIDLabel: remoteClusterID,
+			discovery.ClusterIDLabel: remoteCluster.ClusterID,
 		},
 	}
 	secretList, err := certManager.client.CoreV1().Secrets(namespace).List(context.TODO(), metav1.ListOptions{
@@ -151,7 +155,7 @@ func (certManager *identityManager) getSecretInNamespace(remoteClusterID, namesp
 		err = kerrors.NewNotFound(schema.GroupResource{
 			Group:    "v1",
 			Resource: "secrets",
-		}, fmt.Sprintf("Identity for cluster %v in namespace %v", remoteClusterID, namespace))
+		}, fmt.Sprintf("Identity for cluster %v in namespace %v", remoteCluster.ClusterID, namespace))
 		klog.Error(err)
 		return nil, err
 	}
@@ -176,7 +180,7 @@ func (certManager *identityManager) createCSR() (keyBytes, csrBytes []byte, err 
 	}
 
 	subj := pkix.Name{
-		CommonName:   certManager.localClusterID,
+		CommonName:   certManager.localCluster.ClusterID,
 		Organization: []string{defaultOrganization},
 	}
 	rawSubj := subj.ToRDNSequence()

--- a/pkg/identityManager/certificateIdentityProvider.go
+++ b/pkg/identityManager/certificateIdentityProvider.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 
+	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
 	responsetypes "github.com/liqotech/liqo/pkg/identityManager/responseTypes"
 	tenantnamespace "github.com/liqotech/liqo/pkg/tenantNamespace"
 	certificateSigningRequest "github.com/liqotech/liqo/pkg/vkMachinery/csr"
@@ -49,8 +50,8 @@ type certificateIdentityProvider struct {
 
 // GetRemoteCertificate retrieves a certificate issued in the past,
 // given the clusterid and the signingRequest.
-func (identityProvider *certificateIdentityProvider) GetRemoteCertificate(clusterID, namespace,
-	signingRequest string) (response *responsetypes.SigningRequestResponse, err error) {
+func (identityProvider *certificateIdentityProvider) GetRemoteCertificate(cluster discoveryv1alpha1.ClusterIdentity,
+	namespace, signingRequest string) (response *responsetypes.SigningRequestResponse, err error) {
 	secret, err := identityProvider.client.CoreV1().Secrets(namespace).Get(context.TODO(), remoteCertificateSecret, metav1.GetOptions{})
 	if err != nil {
 		if kerrors.IsNotFound(err) {
@@ -73,7 +74,7 @@ func (identityProvider *certificateIdentityProvider) GetRemoteCertificate(cluste
 
 	// check that this certificate is related to this signing request
 	if csr := base64.StdEncoding.EncodeToString(signingRequestSecret); csr != signingRequest {
-		err = kerrors.NewBadRequest(fmt.Sprintf("the stored and the provided CSR for cluster %s does not match", clusterID))
+		err = kerrors.NewBadRequest(fmt.Sprintf("the stored and the provided CSR for cluster %s does not match", cluster.ClusterName))
 		klog.Error(err)
 		return response, err
 	}
@@ -97,7 +98,7 @@ func (identityProvider *certificateIdentityProvider) GetRemoteCertificate(cluste
 // ApproveSigningRequest approves a remote CertificateSigningRequest.
 // It creates a CertificateSigningRequest CR to be issued by the local cluster, and approves it.
 // This function will wait (with a timeout) for an available certificate before returning.
-func (identityProvider *certificateIdentityProvider) ApproveSigningRequest(clusterID,
+func (identityProvider *certificateIdentityProvider) ApproveSigningRequest(cluster discoveryv1alpha1.ClusterIdentity,
 	signingRequest string) (response *responsetypes.SigningRequestResponse, err error) {
 	signingBytes, err := base64.StdEncoding.DecodeString(signingRequest)
 	if err != nil {
@@ -150,7 +151,7 @@ func (identityProvider *certificateIdentityProvider) ApproveSigningRequest(clust
 	}
 
 	// store the certificate in a Secret, in this way is possbile to retrieve it again in the future
-	if _, err = identityProvider.storeRemoteCertificate(clusterID, signingBytes, response.Certificate); err != nil {
+	if _, err = identityProvider.storeRemoteCertificate(cluster, signingBytes, response.Certificate); err != nil {
 		klog.Error(err)
 		return response, err
 	}
@@ -158,9 +159,9 @@ func (identityProvider *certificateIdentityProvider) ApproveSigningRequest(clust
 }
 
 // storeRemoteCertificate stores the issued certificate in a Secret in the TenantNamespace.
-func (identityProvider *certificateIdentityProvider) storeRemoteCertificate(
-	clusterID string, signingRequest, certificate []byte) (*v1.Secret, error) {
-	namespace, err := identityProvider.namespaceManager.GetNamespace(clusterID)
+func (identityProvider *certificateIdentityProvider) storeRemoteCertificate(cluster discoveryv1alpha1.ClusterIdentity,
+	signingRequest, certificate []byte) (*v1.Secret, error) {
+	namespace, err := identityProvider.namespaceManager.GetNamespace(cluster)
 	if err != nil {
 		klog.Error(err)
 		return nil, err

--- a/pkg/identityManager/fake/reader.go
+++ b/pkg/identityManager/fake/reader.go
@@ -18,6 +18,8 @@ import (
 	"fmt"
 
 	"k8s.io/client-go/rest"
+
+	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
 )
 
 // IdentityReader is a struct implementing an IdentityReader mock for testing purposes.
@@ -42,17 +44,17 @@ func (i *IdentityReader) Add(clusterID, namespace string, restcfg *rest.Config) 
 }
 
 // GetConfig retrieves the rest config associated with a remote cluster.
-func (i *IdentityReader) GetConfig(remoteClusterID, namespace string) (*rest.Config, error) {
-	if restcfg, found := i.configs[remoteClusterID]; found {
+func (i *IdentityReader) GetConfig(remoteCluster discoveryv1alpha1.ClusterIdentity, namespace string) (*rest.Config, error) {
+	if restcfg, found := i.configs[remoteCluster.ClusterID]; found {
 		return restcfg, nil
 	}
-	return nil, fmt.Errorf("remote cluster ID %v not found", remoteClusterID)
+	return nil, fmt.Errorf("remote cluster ID %v not found", remoteCluster.ClusterID)
 }
 
 // GetRemoteTenantNamespace retrieves the tenant namespace associated with a remote cluster.
-func (i *IdentityReader) GetRemoteTenantNamespace(remoteClusterID, namespace string) (string, error) {
-	if namespace, found := i.namespaces[remoteClusterID]; found {
+func (i *IdentityReader) GetRemoteTenantNamespace(remoteCluster discoveryv1alpha1.ClusterIdentity, namespace string) (string, error) {
+	if namespace, found := i.namespaces[remoteCluster.ClusterID]; found {
 		return namespace, nil
 	}
-	return "", fmt.Errorf("remote cluster ID %v not found", remoteClusterID)
+	return "", fmt.Errorf("remote cluster ID %v not found", remoteCluster.ClusterID)
 }

--- a/pkg/identityManager/identityManager_test.go
+++ b/pkg/identityManager/identityManager_test.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 
+	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
 	"github.com/liqotech/liqo/pkg/auth"
 	"github.com/liqotech/liqo/pkg/discovery"
 	responsetypes "github.com/liqotech/liqo/pkg/identityManager/responseTypes"
@@ -55,11 +56,11 @@ var _ = Describe("IdentityManager", func() {
 	var (
 		ctx context.Context
 
-		cluster         testutil.Cluster
-		client          kubernetes.Interface
-		restConfig      *rest.Config
-		localClusterID  string
-		remoteClusterID string
+		cluster       testutil.Cluster
+		client        kubernetes.Interface
+		restConfig    *rest.Config
+		localCluster  discoveryv1alpha1.ClusterIdentity
+		remoteCluster discoveryv1alpha1.ClusterIdentity
 
 		namespace *v1.Namespace
 
@@ -71,8 +72,14 @@ var _ = Describe("IdentityManager", func() {
 	BeforeSuite(func() {
 		ctx = context.Background()
 
-		localClusterID = "local-id"
-		remoteClusterID = "remote-id"
+		localCluster = discoveryv1alpha1.ClusterIdentity{
+			ClusterID:   "local-cluster-id",
+			ClusterName: "local-cluster-name",
+		}
+		remoteCluster = discoveryv1alpha1.ClusterIdentity{
+			ClusterID:   "remote-cluster-id",
+			ClusterName: "remote-cluster-name",
+		}
 
 		var err error
 		cluster, _, err = testutil.NewTestCluster([]string{filepath.Join("..", "..", "deployments", "liqo", "crds")})
@@ -85,16 +92,16 @@ var _ = Describe("IdentityManager", func() {
 		restConfig = cluster.GetCfg()
 
 		namespaceManager = tenantnamespace.NewTenantNamespaceManager(client)
-		identityMan = NewCertificateIdentityManager(cluster.GetClient(), localClusterID, namespaceManager)
-		identityProvider = NewCertificateIdentityProvider(ctx, cluster.GetClient(), localClusterID, namespaceManager)
+		identityMan = NewCertificateIdentityManager(cluster.GetClient(), localCluster, namespaceManager)
+		identityProvider = NewCertificateIdentityProvider(ctx, cluster.GetClient(), localCluster, namespaceManager)
 
-		namespace, err = namespaceManager.CreateNamespace(remoteClusterID)
+		namespace, err = namespaceManager.CreateNamespace(remoteCluster)
 		if err != nil {
 			By(err.Error())
 			os.Exit(1)
 		}
 		// Make sure the namespace has been cached for subsequent retrieval.
-		Eventually(func() (*v1.Namespace, error) { return namespaceManager.GetNamespace(remoteClusterID) }).Should(Equal(namespace))
+		Eventually(func() (*v1.Namespace, error) { return namespaceManager.GetNamespace(remoteCluster) }).Should(Equal(namespace))
 	})
 
 	AfterSuite(func() {
@@ -108,7 +115,7 @@ var _ = Describe("IdentityManager", func() {
 	Context("Local Manager", func() {
 
 		It("Create Identity", func() {
-			secret, err := identityMan.CreateIdentity(remoteClusterID)
+			secret, err := identityMan.CreateIdentity(remoteCluster)
 			Expect(err).To(BeNil())
 			Expect(secret).NotTo(BeNil())
 			Expect(secret.Namespace).To(Equal(namespace.Name))
@@ -118,7 +125,7 @@ var _ = Describe("IdentityManager", func() {
 			Expect(ok).To(BeTrue())
 			v, ok := secret.Labels[discovery.ClusterIDLabel]
 			Expect(ok).To(BeTrue())
-			Expect(v).To(Equal(remoteClusterID))
+			Expect(v).To(Equal(remoteCluster.ClusterID))
 
 			Expect(secret.Annotations).NotTo(BeNil())
 			_, ok = secret.Annotations[certificateExpireTimeAnnotation]
@@ -135,23 +142,23 @@ var _ = Describe("IdentityManager", func() {
 		})
 
 		It("Get Signing Request", func() {
-			csrBytes, err := identityMan.GetSigningRequest(remoteClusterID)
+			csrBytes, err := identityMan.GetSigningRequest(remoteCluster)
 			Expect(err).To(BeNil())
 
 			b, _ := pem.Decode(csrBytes)
 			csr, err := x509.ParseCertificateRequest(b.Bytes)
 			Expect(err).To(BeNil())
-			Expect(csr.Subject.CommonName).To(Equal(localClusterID))
+			Expect(csr.Subject.CommonName).To(Equal(localCluster.ClusterID))
 		})
 
 		It("Get Signing Request with multiple secrets", func() {
 			// we need that at least 1 second passed since the creation of the previous identity
 			time.Sleep(1 * time.Second)
 
-			secret, err := identityMan.CreateIdentity(remoteClusterID)
+			secret, err := identityMan.CreateIdentity(remoteCluster)
 			Expect(err).To(BeNil())
 
-			csrBytes, err := identityMan.GetSigningRequest(remoteClusterID)
+			csrBytes, err := identityMan.GetSigningRequest(remoteCluster)
 			Expect(err).To(BeNil())
 
 			csrBytesSecret, ok := secret.Data[csrSecretKey]
@@ -170,7 +177,7 @@ var _ = Describe("IdentityManager", func() {
 		var stopChan chan struct{}
 
 		BeforeEach(func() {
-			csrBytes, err = identityMan.GetSigningRequest(remoteClusterID)
+			csrBytes, err = identityMan.GetSigningRequest(remoteCluster)
 			Expect(err).To(BeNil())
 
 			stopChan = make(chan struct{})
@@ -182,21 +189,25 @@ var _ = Describe("IdentityManager", func() {
 		})
 
 		It("Approve Signing Request", func() {
-			certificate, err := identityProvider.ApproveSigningRequest(remoteClusterID, base64.StdEncoding.EncodeToString(csrBytes))
+			certificate, err := identityProvider.ApproveSigningRequest(remoteCluster, base64.StdEncoding.EncodeToString(csrBytes))
 			Expect(err).To(BeNil())
 			Expect(certificate).NotTo(BeNil())
 			Expect(certificate.Certificate).To(Equal([]byte(idManTest.FakeCRT)))
 		})
 
 		It("Retrieve Remote Certificate", func() {
-			certificate, err := identityProvider.GetRemoteCertificate(remoteClusterID, namespace.Name, base64.StdEncoding.EncodeToString(csrBytes))
+			certificate, err := identityProvider.GetRemoteCertificate(remoteCluster, namespace.Name, base64.StdEncoding.EncodeToString(csrBytes))
 			Expect(err).To(BeNil())
 			Expect(certificate).NotTo(BeNil())
 			Expect(certificate.Certificate).To(Equal([]byte(idManTest.FakeCRT)))
 		})
 
 		It("Retrieve Remote Certificate wrong clusterid", func() {
-			certificate, err := identityProvider.GetRemoteCertificate("fake", "fake", base64.StdEncoding.EncodeToString(csrBytes))
+			fakeIdentity := discoveryv1alpha1.ClusterIdentity{
+				ClusterID:   "fake-cluster-id",
+				ClusterName: "fake-cluster-name",
+			}
+			certificate, err := identityProvider.GetRemoteCertificate(fakeIdentity, "fake", base64.StdEncoding.EncodeToString(csrBytes))
 			Expect(err).NotTo(BeNil())
 			Expect(kerrors.IsNotFound(err)).To(BeTrue())
 			Expect(kerrors.IsBadRequest(err)).To(BeFalse())
@@ -204,7 +215,7 @@ var _ = Describe("IdentityManager", func() {
 		})
 
 		It("Retrieve Remote Certificate wrong CSR", func() {
-			certificate, err := identityProvider.GetRemoteCertificate(remoteClusterID, namespace.Name, base64.StdEncoding.EncodeToString([]byte("fake")))
+			certificate, err := identityProvider.GetRemoteCertificate(remoteCluster, namespace.Name, base64.StdEncoding.EncodeToString([]byte("fake")))
 			Expect(err).NotTo(BeNil())
 			Expect(kerrors.IsNotFound(err)).To(BeFalse())
 			Expect(kerrors.IsBadRequest(err)).To(BeTrue())
@@ -229,17 +240,17 @@ var _ = Describe("IdentityManager", func() {
 			Expect(err).To(BeNil())
 
 			// store the certificate in the secret
-			err = identityMan.StoreCertificate(remoteClusterID, identityResponse)
+			err = identityMan.StoreCertificate(remoteCluster, identityResponse)
 			Expect(err).To(BeNil())
 
 			// retrieve rest config
-			cnf, err := identityMan.GetConfig(remoteClusterID, "")
+			cnf, err := identityMan.GetConfig(remoteCluster, "")
 			Expect(err).To(BeNil())
 			Expect(cnf).NotTo(BeNil())
 			Expect(cnf.Host).To(Equal("https://127.0.0.1"))
 
 			// retrieve the remote tenant namespace
-			remoteNamespace, err := identityMan.GetRemoteTenantNamespace(remoteClusterID, "")
+			remoteNamespace, err := identityMan.GetRemoteTenantNamespace(remoteCluster, "")
 			Expect(err).To(BeNil())
 			Expect(remoteNamespace).To(Equal("remoteNamespace"))
 		})
@@ -272,7 +283,7 @@ var _ = Describe("IdentityManager", func() {
 			Expect(err).To(BeNil())
 
 			// store the certificate in the secret
-			err = identityMan.StoreCertificate(remoteClusterID, identityResponse)
+			err = identityMan.StoreCertificate(remoteCluster, identityResponse)
 			Expect(err).To(BeNil())
 
 			idMan, ok := identityMan.(*identityManager)
@@ -285,7 +296,7 @@ var _ = Describe("IdentityManager", func() {
 			}
 			idMan.iamTokenManager = &tokenManager
 
-			secret, err := idMan.getSecret(remoteClusterID)
+			secret, err := idMan.getSecret(remoteCluster)
 			Expect(err).To(Succeed())
 
 			Expect(secret.Data[awsAccessKeyIDSecretKey]).To(Equal([]byte(*signingIAMResponse.AwsIdentityResponse.AccessKey.AccessKeyId)))
@@ -295,7 +306,7 @@ var _ = Describe("IdentityManager", func() {
 			Expect(secret.Data[awsIAMUserArnSecretKey]).To(Equal([]byte(identityResponse.AWSIdentityInfo.IAMUserArn)))
 
 			// retrieve rest config
-			cnf, err := identityMan.GetConfig(remoteClusterID, "")
+			cnf, err := identityMan.GetConfig(remoteCluster, "")
 			Expect(err).To(Succeed())
 			Expect(cnf).NotTo(BeNil())
 			Expect(cnf.BearerTokenFile).ToNot(BeEmpty())
@@ -310,13 +321,13 @@ var _ = Describe("IdentityManager", func() {
 			iamTokenManager, ok := idMan.iamTokenManager.(*iamTokenManager)
 			Expect(ok).To(BeTrue())
 
-			namespacedName, ok := iamTokenManager.availableClusterIDSecrets[remoteClusterID]
+			namespacedName, ok := iamTokenManager.availableClusterIDSecrets[remoteCluster.ClusterID]
 			Expect(ok).To(BeTrue())
 
 			// we have to wait for at least a second to have a different token
 			time.Sleep(1 * time.Second)
 
-			err = iamTokenManager.refreshToken(ctx, remoteClusterID, namespacedName)
+			err = iamTokenManager.refreshToken(ctx, remoteCluster, namespacedName)
 			Expect(err).To(Succeed())
 
 			newToken, err := os.ReadFile(cnf.BearerTokenFile)
@@ -330,7 +341,7 @@ var _ = Describe("IdentityManager", func() {
 	Context("Identity Provider", func() {
 
 		It("Certificate Identity Provider", func() {
-			idProvider := NewCertificateIdentityProvider(ctx, cluster.GetClient(), localClusterID, namespaceManager)
+			idProvider := NewCertificateIdentityProvider(ctx, cluster.GetClient(), localCluster, namespaceManager)
 
 			certIDManager, ok := idProvider.(*identityManager)
 			Expect(ok).To(BeTrue())
@@ -340,7 +351,7 @@ var _ = Describe("IdentityManager", func() {
 		})
 
 		It("AWS IAM Identity Provider", func() {
-			idProvider := NewIAMIdentityManager(cluster.GetClient(), localClusterID, &AwsConfig{
+			idProvider := NewIAMIdentityManager(cluster.GetClient(), localCluster, &AwsConfig{
 				AwsAccessKeyID:     "KeyID",
 				AwsSecretAccessKey: "Secret",
 				AwsRegion:          "region",
@@ -359,7 +370,7 @@ var _ = Describe("IdentityManager", func() {
 	Context("Identity Provider", func() {
 
 		It("Certificate Identity Provider", func() {
-			idProvider := NewCertificateIdentityProvider(ctx, cluster.GetClient(), localClusterID, namespaceManager)
+			idProvider := NewCertificateIdentityProvider(ctx, cluster.GetClient(), localCluster, namespaceManager)
 
 			certIDManager, ok := idProvider.(*identityManager)
 			Expect(ok).To(BeTrue())
@@ -369,7 +380,7 @@ var _ = Describe("IdentityManager", func() {
 		})
 
 		It("AWS IAM Identity Provider", func() {
-			idProvider := NewIAMIdentityManager(cluster.GetClient(), localClusterID, &AwsConfig{
+			idProvider := NewIAMIdentityManager(cluster.GetClient(), localCluster, &AwsConfig{
 				AwsAccessKeyID:     "KeyID",
 				AwsSecretAccessKey: "Secret",
 				AwsRegion:          "region",

--- a/pkg/identityManager/interface.go
+++ b/pkg/identityManager/interface.go
@@ -18,27 +18,30 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/rest"
 
+	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
 	"github.com/liqotech/liqo/pkg/auth"
 	responsetypes "github.com/liqotech/liqo/pkg/identityManager/responseTypes"
 )
 
 // IdentityReader provides the interface to retrieve the identities for the remote clusters.
 type IdentityReader interface {
-	GetConfig(remoteClusterID string, namespace string) (*rest.Config, error)
-	GetRemoteTenantNamespace(remoteClusterID string, namespace string) (string, error)
+	GetConfig(remoteCluster discoveryv1alpha1.ClusterIdentity, namespace string) (*rest.Config, error)
+	GetRemoteTenantNamespace(remoteCluster discoveryv1alpha1.ClusterIdentity, namespace string) (string, error)
 }
 
 // IdentityManager interface provides the methods to manage identities for the remote clusters.
 type IdentityManager interface {
 	IdentityReader
 
-	CreateIdentity(remoteClusterID string) (*v1.Secret, error)
-	GetSigningRequest(remoteClusterID string) ([]byte, error)
-	StoreCertificate(remoteClusterID string, identityResponse *auth.CertificateIdentityResponse) error
+	CreateIdentity(remoteCluster discoveryv1alpha1.ClusterIdentity) (*v1.Secret, error)
+	GetSigningRequest(remoteCluster discoveryv1alpha1.ClusterIdentity) ([]byte, error)
+	StoreCertificate(remoteCluster discoveryv1alpha1.ClusterIdentity, identityResponse *auth.CertificateIdentityResponse) error
 }
 
 // IdentityProvider provides the interface to retrieve and approve remote cluster identities.
 type IdentityProvider interface {
-	GetRemoteCertificate(clusterID, namespace, signingRequest string) (response *responsetypes.SigningRequestResponse, err error)
-	ApproveSigningRequest(clusterID, signingRequest string) (response *responsetypes.SigningRequestResponse, err error)
+	GetRemoteCertificate(cluster discoveryv1alpha1.ClusterIdentity,
+		namespace, signingRequest string) (response *responsetypes.SigningRequestResponse, err error)
+	ApproveSigningRequest(cluster discoveryv1alpha1.ClusterIdentity,
+		signingRequest string) (response *responsetypes.SigningRequestResponse, err error)
 }

--- a/pkg/identityManager/tokenManager.go
+++ b/pkg/identityManager/tokenManager.go
@@ -32,11 +32,13 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/aws-iam-authenticator/pkg/token"
+
+	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
 )
 
 type tokenManager interface {
 	start(ctx context.Context)
-	getConfig(secret *v1.Secret, remoteClusterID string) (*rest.Config, error)
+	getConfig(secret *v1.Secret, remoteCluster discoveryv1alpha1.ClusterIdentity) (*rest.Config, error)
 }
 
 type iamTokenManager struct {
@@ -54,7 +56,10 @@ func (tokMan *iamTokenManager) start(ctx context.Context) {
 			case <-time.NewTicker(10 * time.Minute).C:
 				klog.V(4).Info("Refreshing tokens...")
 				for remoteClusterID, namespacedName := range tokMan.availableClusterIDSecrets {
-					if err := tokMan.refreshToken(ctx, remoteClusterID, namespacedName); err != nil {
+					if err := tokMan.refreshToken(ctx, discoveryv1alpha1.ClusterIdentity{
+						ClusterID:   remoteClusterID,
+						ClusterName: remoteClusterID,
+					}, namespacedName); err != nil {
 						klog.Error(err)
 						continue
 					}
@@ -67,52 +72,53 @@ func (tokMan *iamTokenManager) start(ctx context.Context) {
 	}()
 }
 
-func (tokMan *iamTokenManager) refreshToken(ctx context.Context, remoteClusterID string, namespacedName types.NamespacedName) error {
+func (tokMan *iamTokenManager) refreshToken(ctx context.Context, remoteCluster discoveryv1alpha1.ClusterIdentity,
+	namespacedName types.NamespacedName) error {
 	secret, err := tokMan.client.CoreV1().Secrets(namespacedName.Namespace).Get(ctx, namespacedName.Name, metav1.GetOptions{})
 	if err != nil {
-		klog.Errorf("[%v] %v", remoteClusterID, err)
+		klog.Errorf("[%v] %v", remoteCluster.ClusterName, err)
 		return err
 	}
 
-	tok, err := getIAMBearerToken(secret, remoteClusterID)
+	tok, err := getIAMBearerToken(secret, remoteCluster)
 	if err != nil {
-		klog.Errorf("[%v] %v", remoteClusterID, err)
+		klog.Errorf("[%v] %v", remoteCluster.ClusterName, err)
 		return err
 	}
 
-	if _, err = tokMan.storeToken(remoteClusterID, tok); err != nil {
-		klog.Errorf("[%v] %v", remoteClusterID, err)
+	if _, err = tokMan.storeToken(remoteCluster, tok); err != nil {
+		klog.Errorf("[%v] %v", remoteCluster.ClusterName, err)
 		return err
 	}
 	return nil
 }
 
-func (tokMan *iamTokenManager) getConfig(secret *v1.Secret, remoteClusterID string) (*rest.Config, error) {
-	tok, err := getIAMBearerToken(secret, remoteClusterID)
+func (tokMan *iamTokenManager) getConfig(secret *v1.Secret, remoteCluster discoveryv1alpha1.ClusterIdentity) (*rest.Config, error) {
+	tok, err := getIAMBearerToken(secret, remoteCluster)
 	if err != nil {
 		klog.Error(err)
 		return nil, err
 	}
 
-	clusterEndpoint, err := getValue(secret, apiServerURLSecretKey, remoteClusterID)
+	clusterEndpoint, err := getValue(secret, apiServerURLSecretKey, remoteCluster)
 	if err != nil {
 		klog.Error(err)
 		return nil, err
 	}
 
-	ca, err := getValue(secret, apiServerCaSecretKey, remoteClusterID)
+	ca, err := getValue(secret, apiServerCaSecretKey, remoteCluster)
 	if err != nil {
 		klog.Error(err)
 		return nil, err
 	}
 
-	filename, err := tokMan.storeToken(remoteClusterID, tok)
+	filename, err := tokMan.storeToken(remoteCluster, tok)
 	if err != nil {
 		klog.Error(err)
 		return nil, err
 	}
 
-	tokMan.addClusterID(remoteClusterID, types.NamespacedName{
+	tokMan.addClusterID(remoteCluster, types.NamespacedName{
 		Namespace: secret.Namespace,
 		Name:      secret.Name,
 	})
@@ -127,15 +133,15 @@ func (tokMan *iamTokenManager) getConfig(secret *v1.Secret, remoteClusterID stri
 	}, nil
 }
 
-func (tokMan *iamTokenManager) addClusterID(remoteClusterID string, secret types.NamespacedName) {
+func (tokMan *iamTokenManager) addClusterID(remoteCluster discoveryv1alpha1.ClusterIdentity, secret types.NamespacedName) {
 	tokMan.availableTokenMutex.Lock()
 	defer tokMan.availableTokenMutex.Unlock()
-	tokMan.availableClusterIDSecrets[remoteClusterID] = secret
+	tokMan.availableClusterIDSecrets[remoteCluster.ClusterID] = secret
 }
 
-func (tokMan *iamTokenManager) storeToken(remoteClusterID string, tok *token.Token) (string, error) {
+func (tokMan *iamTokenManager) storeToken(remoteCluster discoveryv1alpha1.ClusterIdentity, tok *token.Token) (string, error) {
 	var err error
-	filename, found := tokMan.tokenFiles[remoteClusterID]
+	filename, found := tokMan.tokenFiles[remoteCluster.ClusterID]
 	if found {
 		_, err = os.Stat(filename)
 	}
@@ -153,7 +159,7 @@ func (tokMan *iamTokenManager) storeToken(remoteClusterID string, tok *token.Tok
 		}
 
 		filename = file.Name()
-		tokMan.tokenFiles[remoteClusterID] = filename
+		tokMan.tokenFiles[remoteCluster.ClusterID] = filename
 	}
 
 	err = os.WriteFile(filename, []byte(tok.Token), 0600)
@@ -165,20 +171,20 @@ func (tokMan *iamTokenManager) storeToken(remoteClusterID string, tok *token.Tok
 	return filename, nil
 }
 
-func getIAMBearerToken(secret *v1.Secret, remoteClusterID string) (*token.Token, error) {
-	region, err := getValue(secret, awsRegionSecretKey, remoteClusterID)
+func getIAMBearerToken(secret *v1.Secret, remoteCluster discoveryv1alpha1.ClusterIdentity) (*token.Token, error) {
+	region, err := getValue(secret, awsRegionSecretKey, remoteCluster)
 	if err != nil {
 		klog.Error(err)
 		return nil, err
 	}
 
-	accessKeyID, err := getValue(secret, awsAccessKeyIDSecretKey, remoteClusterID)
+	accessKeyID, err := getValue(secret, awsAccessKeyIDSecretKey, remoteCluster)
 	if err != nil {
 		klog.Error(err)
 		return nil, err
 	}
 
-	secretAccessKey, err := getValue(secret, awsSecretAccessKeySecretKey, remoteClusterID)
+	secretAccessKey, err := getValue(secret, awsSecretAccessKeySecretKey, remoteCluster)
 	if err != nil {
 		klog.Error(err)
 		return nil, err
@@ -197,7 +203,7 @@ func getIAMBearerToken(secret *v1.Secret, remoteClusterID string) (*token.Token,
 		return nil, err
 	}
 
-	eksClusterID, err := getValue(secret, awsEKSClusterIDSecretKey, remoteClusterID)
+	eksClusterID, err := getValue(secret, awsEKSClusterIDSecretKey, remoteCluster)
 	if err != nil {
 		klog.Error(err)
 		return nil, err
@@ -223,14 +229,14 @@ func getIAMBearerToken(secret *v1.Secret, remoteClusterID string) (*token.Token,
 	return &tok, nil
 }
 
-func getValue(secret *v1.Secret, key, remoteClusterID string) ([]byte, error) {
+func getValue(secret *v1.Secret, key string, remoteCluster discoveryv1alpha1.ClusterIdentity) ([]byte, error) {
 	value, ok := secret.Data[key]
 	if !ok {
 		klog.Errorf("key %v not found in secret %v/%v", key, secret.Namespace, secret.Name)
 		err := kerrors.NewNotFound(schema.GroupResource{
 			Group:    "v1",
 			Resource: "secrets",
-		}, remoteClusterID)
+		}, remoteCluster.ClusterID)
 		return nil, err
 	}
 	return value, nil

--- a/pkg/liqo-controller-manager/foreign-cluster-operator/auth.go
+++ b/pkg/liqo-controller-manager/foreign-cluster-operator/auth.go
@@ -50,7 +50,7 @@ const (
 // it creates a new identity and sends it to the remote cluster.
 func (r *ForeignClusterReconciler) ensureRemoteIdentity(ctx context.Context,
 	foreignCluster *discoveryv1alpha1.ForeignCluster) error {
-	_, err := r.IdentityManager.GetConfig(foreignCluster.Spec.ClusterIdentity.ClusterID, foreignCluster.Status.TenantNamespace.Local)
+	_, err := r.IdentityManager.GetConfig(foreignCluster.Spec.ClusterIdentity, foreignCluster.Status.TenantNamespace.Local)
 	if err != nil && !kerrors.IsNotFound(err) {
 		klog.Error(err)
 		return err
@@ -77,7 +77,7 @@ func (r *ForeignClusterReconciler) ensureRemoteIdentity(ctx context.Context,
 func (r *ForeignClusterReconciler) fetchRemoteTenantNamespace(ctx context.Context,
 	foreignCluster *discoveryv1alpha1.ForeignCluster) error {
 	remoteNamespace, err := r.IdentityManager.GetRemoteTenantNamespace(
-		foreignCluster.Spec.ClusterIdentity.ClusterID, foreignCluster.Status.TenantNamespace.Local)
+		foreignCluster.Spec.ClusterIdentity, foreignCluster.Status.TenantNamespace.Local)
 	if err != nil {
 		klog.Error(err)
 		return err
@@ -89,19 +89,19 @@ func (r *ForeignClusterReconciler) fetchRemoteTenantNamespace(ctx context.Contex
 
 // validateIdentity sends an HTTP request to validate the identity for the remote cluster (Certificate).
 func (r *ForeignClusterReconciler) validateIdentity(ctx context.Context, fc *discoveryv1alpha1.ForeignCluster) error {
-	remoteClusterID := fc.Spec.ClusterIdentity.ClusterID
-	token, err := authenticationtoken.GetAuthToken(ctx, fc.Spec.ClusterIdentity.ClusterID, r.Client)
+	remoteCluster := fc.Spec.ClusterIdentity
+	token, err := authenticationtoken.GetAuthToken(ctx, remoteCluster.ClusterID, r.Client)
 	if err != nil {
 		return err
 	}
 
-	_, err = r.IdentityManager.CreateIdentity(remoteClusterID)
+	_, err = r.IdentityManager.CreateIdentity(remoteCluster)
 	if err != nil {
 		klog.Error(err)
 		return err
 	}
 
-	csr, err := r.IdentityManager.GetSigningRequest(remoteClusterID)
+	csr, err := r.IdentityManager.GetSigningRequest(remoteCluster)
 	if err != nil {
 		klog.Error(err)
 		return err
@@ -113,7 +113,7 @@ func (r *ForeignClusterReconciler) validateIdentity(ctx context.Context, fc *dis
 		return err
 	}
 
-	request := auth.NewCertificateIdentityRequest(r.ClusterID, localToken, token, csr)
+	request := auth.NewCertificateIdentityRequest(r.HomeCluster.ClusterID, localToken, token, csr)
 	responseBytes, err := sendIdentityRequest(request, fc)
 	if err != nil {
 		klog.Error(err)
@@ -126,7 +126,7 @@ func (r *ForeignClusterReconciler) validateIdentity(ctx context.Context, fc *dis
 		return err
 	}
 
-	if err = r.IdentityManager.StoreCertificate(remoteClusterID, &response); err != nil {
+	if err = r.IdentityManager.StoreCertificate(remoteCluster, &response); err != nil {
 		klog.Error(err)
 		return err
 	}

--- a/pkg/liqo-controller-manager/foreign-cluster-operator/foreign-cluster-controller.go
+++ b/pkg/liqo-controller-manager/foreign-cluster-operator/foreign-cluster-controller.go
@@ -90,8 +90,7 @@ type ForeignClusterReconciler struct {
 	LiqoNamespace string
 
 	ResyncPeriod                         time.Duration
-	ClusterID                            string
-	ClusterName                          string
+	HomeCluster                          discoveryv1alpha1.ClusterIdentity
 	AuthServiceAddressOverride           string
 	AuthServicePortOverride              string
 	AutoJoin                             bool
@@ -333,7 +332,7 @@ func (r *ForeignClusterReconciler) unpeerNamespaced(ctx context.Context,
 	var resourceRequest discoveryv1alpha1.ResourceRequest
 	err := r.Client.Get(ctx, types.NamespacedName{
 		Namespace: foreignCluster.Status.TenantNamespace.Local,
-		Name:      r.ClusterID,
+		Name:      r.HomeCluster.ClusterID,
 	}, &resourceRequest)
 	if errors.IsNotFound(err) {
 		peeringconditionsutils.EnsureStatus(foreignCluster,

--- a/pkg/liqo-controller-manager/foreign-cluster-operator/permission.go
+++ b/pkg/liqo-controller-manager/foreign-cluster-operator/permission.go
@@ -27,79 +27,79 @@ import (
 )
 
 func (r *ForeignClusterReconciler) ensurePermission(ctx context.Context, foreignCluster *discoveryv1alpha1.ForeignCluster) (err error) {
-	remoteClusterID := foreignCluster.Spec.ClusterIdentity.ClusterID
+	remoteCluster := foreignCluster.Spec.ClusterIdentity
 	peeringPhase := foreignclusterutils.GetPeeringPhase(foreignCluster)
 
-	if _, err = r.NamespaceManager.BindClusterRoles(remoteClusterID, r.PeeringPermission.Basic...); err != nil {
+	if _, err = r.NamespaceManager.BindClusterRoles(remoteCluster, r.PeeringPermission.Basic...); err != nil {
 		klog.Error(err)
 		return err
 	}
 
 	switch peeringPhase {
 	case consts.PeeringPhaseNone, consts.PeeringPhaseAuthenticated:
-		if err = r.NamespaceManager.UnbindClusterRoles(remoteClusterID,
+		if err = r.NamespaceManager.UnbindClusterRoles(remoteCluster,
 			clusterRolesToNames(r.PeeringPermission.Outgoing)...); err != nil {
 			klog.Error(err)
 			return err
 		}
-		if err = r.NamespaceManager.UnbindClusterRoles(remoteClusterID,
+		if err = r.NamespaceManager.UnbindClusterRoles(remoteCluster,
 			clusterRolesToNames(r.PeeringPermission.Incoming)...); err != nil {
 			klog.Error(err)
 			return err
 		}
 		if r.OwnerReferencesPermissionEnforcement {
-			if err = r.NamespaceManager.UnbindIncomingClusterWideRole(ctx, remoteClusterID); err != nil {
+			if err = r.NamespaceManager.UnbindIncomingClusterWideRole(ctx, remoteCluster); err != nil {
 				klog.Error(err)
 				return err
 			}
 		}
 	case consts.PeeringPhaseOutgoing:
-		if _, err = r.NamespaceManager.BindClusterRoles(remoteClusterID,
+		if _, err = r.NamespaceManager.BindClusterRoles(remoteCluster,
 			r.PeeringPermission.Outgoing...); err != nil {
 			klog.Error(err)
 			return err
 		}
-		if err = r.NamespaceManager.UnbindClusterRoles(remoteClusterID,
+		if err = r.NamespaceManager.UnbindClusterRoles(remoteCluster,
 			clusterRolesToNames(r.PeeringPermission.Incoming)...); err != nil {
 			klog.Error(err)
 			return err
 		}
 		if r.OwnerReferencesPermissionEnforcement {
-			if err = r.NamespaceManager.UnbindIncomingClusterWideRole(ctx, remoteClusterID); err != nil {
+			if err = r.NamespaceManager.UnbindIncomingClusterWideRole(ctx, remoteCluster); err != nil {
 				klog.Error(err)
 				return err
 			}
 		}
 	case consts.PeeringPhaseIncoming:
-		if err = r.NamespaceManager.UnbindClusterRoles(remoteClusterID,
+		if err = r.NamespaceManager.UnbindClusterRoles(remoteCluster,
 			clusterRolesToNames(r.PeeringPermission.Outgoing)...); err != nil {
 			klog.Error(err)
 			return err
 		}
-		if _, err = r.NamespaceManager.BindClusterRoles(remoteClusterID,
+		if _, err = r.NamespaceManager.BindClusterRoles(remoteCluster,
 			r.PeeringPermission.Incoming...); err != nil {
 			klog.Error(err)
 			return err
 		}
 		if r.OwnerReferencesPermissionEnforcement {
-			if _, err = r.NamespaceManager.BindIncomingClusterWideRole(ctx, remoteClusterID); err != nil {
+			if _, err = r.NamespaceManager.BindIncomingClusterWideRole(ctx, remoteCluster); err != nil {
 				klog.Error(err)
 				return err
 			}
 		}
 	case consts.PeeringPhaseBidirectional:
-		if _, err = r.NamespaceManager.BindClusterRoles(remoteClusterID,
+		if _, err = r.NamespaceManager.BindClusterRoles(remoteCluster,
 			r.PeeringPermission.Outgoing...); err != nil {
 			klog.Error(err)
 			return err
 		}
-		if _, err = r.NamespaceManager.BindClusterRoles(remoteClusterID,
+		if _, err = r.NamespaceManager.BindClusterRoles(remoteCluster,
 			r.PeeringPermission.Incoming...); err != nil {
 			klog.Error(err)
 			return err
 		}
 		if r.OwnerReferencesPermissionEnforcement {
-			if _, err = r.NamespaceManager.BindIncomingClusterWideRole(ctx, remoteClusterID); err != nil {
+			if _, err = r.NamespaceManager.BindIncomingClusterWideRole(ctx, remoteCluster); err != nil {
 				klog.Error(err)
 				return err
 			}

--- a/pkg/liqo-controller-manager/foreign-cluster-operator/resourceRequest.go
+++ b/pkg/liqo-controller-manager/foreign-cluster-operator/resourceRequest.go
@@ -33,7 +33,7 @@ func (r *ForeignClusterReconciler) ensureResourceRequest(ctx context.Context,
 	foreignCluster *discoveryv1alpha1.ForeignCluster) (*discoveryv1alpha1.ResourceRequest, error) {
 	klog.Infof("[%v] ensuring ResourceRequest existence", foreignCluster.Spec.ClusterIdentity.ClusterID)
 
-	localClusterID := r.ClusterID
+	localClusterID := r.HomeCluster.ClusterID
 	remoteClusterID := foreignCluster.Spec.ClusterIdentity.ClusterID
 	localNamespace := foreignCluster.Status.TenantNamespace.Local
 
@@ -63,11 +63,8 @@ func (r *ForeignClusterReconciler) ensureResourceRequest(ctx context.Context,
 		resourceRequest.SetLabels(labels)
 
 		resourceRequest.Spec = discoveryv1alpha1.ResourceRequestSpec{
-			ClusterIdentity: discoveryv1alpha1.ClusterIdentity{
-				ClusterID:   localClusterID,
-				ClusterName: r.ClusterName,
-			},
-			AuthURL: authURL,
+			ClusterIdentity: r.HomeCluster,
+			AuthURL:         authURL,
 		}
 
 		return controllerutil.SetControllerReference(foreignCluster, resourceRequest, r.Scheme)

--- a/pkg/liqo-controller-manager/foreign-cluster-operator/tenantNamespace.go
+++ b/pkg/liqo-controller-manager/foreign-cluster-operator/tenantNamespace.go
@@ -25,7 +25,7 @@ import (
 // ensureLocalTenantNamespace creates the LocalTenantNamespace for the given ForeignCluster, if it is not yet present.
 func (r *ForeignClusterReconciler) ensureLocalTenantNamespace(
 	ctx context.Context, foreignCluster *v1alpha1.ForeignCluster) error {
-	namespace, err := r.NamespaceManager.CreateNamespace(foreignCluster.Spec.ClusterIdentity.ClusterID)
+	namespace, err := r.NamespaceManager.CreateNamespace(foreignCluster.Spec.ClusterIdentity)
 	if err != nil {
 		klog.Error(err)
 		return err

--- a/pkg/liqo-controller-manager/foreign-cluster-operator/validator.go
+++ b/pkg/liqo-controller-manager/foreign-cluster-operator/validator.go
@@ -81,7 +81,7 @@ func (r *ForeignClusterReconciler) isClusterProcessable(ctx context.Context,
 	foreignCluster *discoveryv1alpha1.ForeignCluster) (bool, error) {
 	foreignClusterID := foreignCluster.Spec.ClusterIdentity.ClusterID
 
-	if foreignClusterID == r.ClusterID {
+	if foreignClusterID == r.HomeCluster.ClusterID {
 		// this is the local cluster, it is not processable
 		peeringconditionsutils.EnsureStatus(foreignCluster,
 			discoveryv1alpha1.ProcessForeignClusterStatusCondition,

--- a/pkg/liqo-controller-manager/namespaceMap-controller/create_remote_clients.go
+++ b/pkg/liqo-controller-manager/namespaceMap-controller/create_remote_clients.go
@@ -18,28 +18,29 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 
+	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
 	identitymanager "github.com/liqotech/liqo/pkg/identityManager"
 	tenantnamespace "github.com/liqotech/liqo/pkg/tenantNamespace"
 )
 
 // checkRemoteClientPresence creates a new controller-runtime Client for a remote cluster, if it isn't already present
 // in RemoteClients Struct of NamespaceMap Controller.
-func (r *NamespaceMapReconciler) checkRemoteClientPresence(remoteClusterID string) error {
+func (r *NamespaceMapReconciler) checkRemoteClientPresence(remoteCluster discoveryv1alpha1.ClusterIdentity) error {
 	if r.RemoteClients == nil {
 		r.RemoteClients = map[string]kubernetes.Interface{}
 	}
 
-	if _, ok := r.RemoteClients[remoteClusterID]; !ok {
+	if _, ok := r.RemoteClients[remoteCluster.ClusterID]; !ok {
 		tenantNamespaceManager := tenantnamespace.NewTenantNamespaceManager(r.IdentityManagerClient)
-		identityManager := identitymanager.NewCertificateIdentityReader(r.IdentityManagerClient, r.LocalClusterID, tenantNamespaceManager)
-		restConfig, err := identityManager.GetConfig(remoteClusterID, "")
+		identityManager := identitymanager.NewCertificateIdentityReader(r.IdentityManagerClient, r.LocalCluster, tenantNamespaceManager)
+		restConfig, err := identityManager.GetConfig(remoteCluster, "")
 		if err != nil {
 			klog.Error(err)
 			return err
 		}
 
-		if r.RemoteClients[remoteClusterID], err = kubernetes.NewForConfig(restConfig); err != nil {
-			klog.Errorf("%s -> unable to create client for cluster '%s'", err, remoteClusterID)
+		if r.RemoteClients[remoteCluster.ClusterID], err = kubernetes.NewForConfig(restConfig); err != nil {
+			klog.Errorf("%s -> unable to create client for cluster '%s'", err, remoteCluster.ClusterName)
 			return err
 		}
 	}

--- a/pkg/liqo-controller-manager/namespaceMap-controller/namespacemap_controller.go
+++ b/pkg/liqo-controller-manager/namespaceMap-controller/namespacemap_controller.go
@@ -24,6 +24,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
 	mapsv1alpha1 "github.com/liqotech/liqo/apis/virtualkubelet/v1alpha1"
 )
 
@@ -32,7 +33,7 @@ type NamespaceMapReconciler struct {
 	client.Client
 	RemoteClients         map[string]kubernetes.Interface
 	IdentityManagerClient kubernetes.Interface
-	LocalClusterID        string
+	LocalCluster          discoveryv1alpha1.ClusterIdentity
 	RequeueTime           time.Duration
 }
 
@@ -81,6 +82,7 @@ func (r *NamespaceMapReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 	// Create/Delete remote Namespaces if it is necessary, according to NamespaceMap status.
 	if err := r.ensureRemoteNamespaces(ctx, namespaceMap); err != nil {
+		klog.Errorf("Updating remote namespaces: %s", err)
 		return ctrl.Result{}, err
 	}
 

--- a/pkg/liqo-controller-manager/namespaceMap-controller/suite_test.go
+++ b/pkg/liqo-controller-manager/namespaceMap-controller/suite_test.go
@@ -27,24 +27,34 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	"k8s.io/utils/pointer"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
 
+	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
 	offv1alpha1 "github.com/liqotech/liqo/apis/offloading/v1alpha1"
 	mapsv1alpha1 "github.com/liqotech/liqo/apis/virtualkubelet/v1alpha1"
 	liqoconst "github.com/liqotech/liqo/pkg/consts"
+	"github.com/liqotech/liqo/pkg/discovery"
 )
 
 const (
 	// Namespace where the NamespaceMaps are created.
 	mapNamespaceName = "default"
-	remoteClusterID1 = "899890-dsd-323s"
-	localClusterID   = "478374-dsa-432dd"
 )
 
 var (
+	remoteCluster1 = discoveryv1alpha1.ClusterIdentity{
+		ClusterID:   "899890-dsd-323s",
+		ClusterName: "remote-cluster-1",
+	}
+	localCluster = discoveryv1alpha1.ClusterIdentity{
+		ClusterID:   "478374-dsa-432dd",
+		ClusterName: "home-cluster",
+	}
+
 	homeCfg    *rest.Config
 	remote1Cfg *rest.Config
 	remote2Cfg *rest.Config
@@ -100,14 +110,10 @@ var _ = BeforeSuite(func(done Done) {
 	Expect(err).ToNot(HaveOccurred())
 	Expect(remote2Cfg).ToNot(BeNil())
 
-	err = corev1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	err = mapsv1alpha1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	err = offv1alpha1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
+	Expect(corev1.AddToScheme(scheme.Scheme)).To(Succeed())
+	Expect(discoveryv1alpha1.AddToScheme(scheme.Scheme)).To(Succeed())
+	Expect(mapsv1alpha1.AddToScheme(scheme.Scheme)).To(Succeed())
+	Expect(offv1alpha1.AddToScheme(scheme.Scheme)).To(Succeed())
 
 	// +kubebuilder:scaffold:scheme
 
@@ -128,27 +134,47 @@ var _ = BeforeSuite(func(done Done) {
 	Expect(homeClient).ToNot(BeNil())
 
 	controllerClients := map[string]kubernetes.Interface{
-		remoteClusterID1: remoteClient1,
+		remoteCluster1.ClusterID: remoteClient1,
 	}
 
 	// Necessary resources in HomeCluster
+	fc1 := discoveryv1alpha1.ForeignCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: remoteCluster1.ClusterName,
+			Labels: map[string]string{
+				discovery.ClusterIDLabel: remoteCluster1.ClusterID,
+			},
+		},
+		Spec: discoveryv1alpha1.ForeignClusterSpec{
+			ClusterIdentity: discoveryv1alpha1.ClusterIdentity{
+				ClusterID:   remoteCluster1.ClusterID,
+				ClusterName: remoteCluster1.ClusterName,
+			},
+			OutgoingPeeringEnabled: discoveryv1alpha1.PeeringEnabledAuto,
+			IncomingPeeringEnabled: discoveryv1alpha1.PeeringEnabledAuto,
+			ForeignAuthURL:         "https://example.com",
+			InsecureSkipTLSVerify:  pointer.BoolPtr(true),
+		},
+	}
+	Expect(homeClient.Create(context.Background(), &fc1)).To(Succeed())
+
 	nms = &mapsv1alpha1.NamespaceMapList{}
 
 	nm1 = &mapsv1alpha1.NamespaceMap{
 		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: fmt.Sprintf("%s-", remoteClusterID1),
+			GenerateName: fmt.Sprintf("%s-", remoteCluster1.ClusterID),
 			Namespace:    mapNamespaceName,
 			Labels: map[string]string{
-				liqoconst.RemoteClusterID: remoteClusterID1,
+				liqoconst.RemoteClusterID: remoteCluster1.ClusterID,
 			},
 		},
 	}
 	Expect(homeClient.Create(context.TODO(), nm1)).Should(Succeed())
 
 	err = (&NamespaceMapReconciler{
-		Client:         homeClient,
-		RemoteClients:  controllerClients,
-		LocalClusterID: localClusterID,
+		Client:        homeClient,
+		RemoteClients: controllerClients,
+		LocalCluster:  localCluster,
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 

--- a/pkg/liqo-controller-manager/namespaceOffloading-controller/namespaceoffloading_controller.go
+++ b/pkg/liqo-controller-manager/namespaceOffloading-controller/namespaceoffloading_controller.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
+	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
 	offv1alpha1 "github.com/liqotech/liqo/apis/offloading/v1alpha1"
 	liqoconst "github.com/liqotech/liqo/pkg/consts"
 )
@@ -35,8 +36,8 @@ import (
 // ClusterSelector field.
 type NamespaceOffloadingReconciler struct {
 	client.Client
-	Scheme         *runtime.Scheme
-	LocalClusterID string
+	Scheme       *runtime.Scheme
+	LocalCluster discoveryv1alpha1.ClusterIdentity
 }
 
 const (

--- a/pkg/liqo-controller-manager/namespaceOffloading-controller/namespaceoffloading_controller_test.go
+++ b/pkg/liqo-controller-manager/namespaceOffloading-controller/namespaceoffloading_controller_test.go
@@ -116,14 +116,14 @@ var _ = Describe("Namespace controller", func() {
 
 			By(" 2 - Check NamespaceMap of virtual nodes 1 ")
 			Eventually(func() bool {
-				Expect(homeClient.List(context.TODO(), nms, client.MatchingLabels{liqoconst.RemoteClusterID: remoteClusterId1})).To(Succeed())
+				Expect(homeClient.List(context.TODO(), nms, client.MatchingLabels{liqoconst.RemoteClusterID: remoteCluster1.ClusterID})).To(Succeed())
 				Expect(len(nms.Items) == 1).To(BeTrue())
 				return nms.Items[0].Spec.DesiredMapping[namespace1Name] == namespace1Name
 			}, timeout, interval).Should(BeTrue())
 
 			By(" 2 - Check NamespaceMap of virtual nodes 2 ")
 			Eventually(func() bool {
-				Expect(homeClient.List(context.TODO(), nms, client.MatchingLabels{liqoconst.RemoteClusterID: remoteClusterId2})).To(Succeed())
+				Expect(homeClient.List(context.TODO(), nms, client.MatchingLabels{liqoconst.RemoteClusterID: remoteCluster2.ClusterID})).To(Succeed())
 				Expect(len(nms.Items) == 1).To(BeTrue())
 				_, ok := nms.Items[0].Spec.DesiredMapping[namespace1Name]
 				return !ok
@@ -131,7 +131,7 @@ var _ = Describe("Namespace controller", func() {
 
 			By(" 3 - Check NamespaceMap of virtual node 3 ")
 			Eventually(func() bool {
-				Expect(homeClient.List(context.TODO(), nms, client.MatchingLabels{liqoconst.RemoteClusterID: remoteClusterId3})).To(Succeed())
+				Expect(homeClient.List(context.TODO(), nms, client.MatchingLabels{liqoconst.RemoteClusterID: remoteCluster3.ClusterID})).To(Succeed())
 				Expect(len(nms.Items) == 1).To(BeTrue())
 				return nms.Items[0].Spec.DesiredMapping[namespace1Name] == namespace1Name
 			}, timeout, interval).Should(BeTrue())
@@ -269,8 +269,8 @@ var _ = Describe("Namespace controller", func() {
 					return false
 				}
 				namespaceOffloading2.Status.RemoteNamespacesConditions = map[string]offv1alpha1.RemoteNamespaceConditions{}
-				namespaceOffloading2.Status.RemoteNamespacesConditions[remoteClusterId1] =
-					append(namespaceOffloading2.Status.RemoteNamespacesConditions[remoteClusterId1], offv1alpha1.RemoteNamespaceCondition{
+				namespaceOffloading2.Status.RemoteNamespacesConditions[remoteCluster1.ClusterID] =
+					append(namespaceOffloading2.Status.RemoteNamespacesConditions[remoteCluster1.ClusterID], offv1alpha1.RemoteNamespaceCondition{
 						Type:               offv1alpha1.NamespaceReady,
 						Status:             corev1.ConditionFalse,
 						LastTransitionTime: metav1.Now(),
@@ -310,7 +310,7 @@ var _ = Describe("Namespace controller", func() {
 					return false
 				}
 				patch := namespaceOffloading2.DeepCopy()
-				delete(namespaceOffloading2.Status.RemoteNamespacesConditions, remoteClusterId1)
+				delete(namespaceOffloading2.Status.RemoteNamespacesConditions, remoteCluster1.ClusterID)
 				err := homeClient.Patch(context.TODO(), namespaceOffloading2, client.MergeFrom(patch))
 				return err == nil
 			}, timeout, interval).Should(BeTrue())
@@ -328,7 +328,7 @@ var _ = Describe("Namespace controller", func() {
 		It(" TEST 3: Create a NamespaceOffloading resource with an empty clusterSelector", func() {
 
 			namespace3Name := "namespace3"
-			remoteNamespace3Name := fmt.Sprintf("%s-%s", namespace3Name, localClusterId)
+			remoteNamespace3Name := fmt.Sprintf("%s-%s", namespace3Name, localCluster.ClusterID)
 			namespace3 := &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: namespace3Name,
@@ -601,7 +601,7 @@ var _ = Describe("Namespace controller", func() {
 
 			By(" 2 - Check NamespaceMap of virtual nodes 1 ")
 			Eventually(func() bool {
-				Expect(homeClient.List(context.TODO(), nms, client.MatchingLabels{liqoconst.RemoteClusterID: remoteClusterId1})).To(Succeed())
+				Expect(homeClient.List(context.TODO(), nms, client.MatchingLabels{liqoconst.RemoteClusterID: remoteCluster1.ClusterID})).To(Succeed())
 				Expect(len(nms.Items) == 1).To(BeTrue())
 				if value, ok := nms.Items[0].Spec.DesiredMapping[namespace5Name]; !ok || value != namespace5Name {
 					return false
@@ -617,7 +617,7 @@ var _ = Describe("Namespace controller", func() {
 
 			By(" 3 - Check NamespaceMap of virtual nodes 2 ")
 			Eventually(func() bool {
-				Expect(homeClient.List(context.TODO(), nms, client.MatchingLabels{liqoconst.RemoteClusterID: remoteClusterId2})).To(Succeed())
+				Expect(homeClient.List(context.TODO(), nms, client.MatchingLabels{liqoconst.RemoteClusterID: remoteCluster2.ClusterID})).To(Succeed())
 				Expect(len(nms.Items) == 1).To(BeTrue())
 				if _, ok := nms.Items[0].Spec.DesiredMapping[namespace5Name]; ok {
 					return false
@@ -633,7 +633,7 @@ var _ = Describe("Namespace controller", func() {
 
 			By(" 4 - Check NamespaceMap of virtual node 3 ")
 			Eventually(func() bool {
-				Expect(homeClient.List(context.TODO(), nms, client.MatchingLabels{liqoconst.RemoteClusterID: remoteClusterId3})).To(Succeed())
+				Expect(homeClient.List(context.TODO(), nms, client.MatchingLabels{liqoconst.RemoteClusterID: remoteCluster3.ClusterID})).To(Succeed())
 				Expect(len(nms.Items) == 1).To(BeTrue())
 				if value, ok := nms.Items[0].Spec.DesiredMapping[namespace5Name]; !ok || value != namespace5Name {
 					return false

--- a/pkg/liqo-controller-manager/namespaceOffloading-controller/namespaceoffloading_lifecycle.go
+++ b/pkg/liqo-controller-manager/namespaceOffloading-controller/namespaceoffloading_lifecycle.go
@@ -81,7 +81,7 @@ func (r *NamespaceOffloadingReconciler) initialConfiguration(ctx context.Context
 	if noff.Spec.NamespaceMappingStrategy == offv1alpha1.EnforceSameNameMappingStrategyType {
 		noff.Status.RemoteNamespaceName = noff.Namespace
 	} else {
-		noff.Status.RemoteNamespaceName = fmt.Sprintf("%s-%s", noff.Namespace, r.LocalClusterID)
+		noff.Status.RemoteNamespaceName = fmt.Sprintf("%s-%s", noff.Namespace, r.LocalCluster.ClusterID)
 	}
 	// 4 - Patch the NamespaceOffloading resource.
 	if err := r.Patch(ctx, noff, client.MergeFrom(patch)); err != nil {

--- a/pkg/liqo-controller-manager/namespaceOffloading-controller/suite_test.go
+++ b/pkg/liqo-controller-manager/namespaceOffloading-controller/suite_test.go
@@ -33,6 +33,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
 
+	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
 	offv1alpha1 "github.com/liqotech/liqo/apis/offloading/v1alpha1"
 	mapsv1alpha1 "github.com/liqotech/liqo/apis/virtualkubelet/v1alpha1"
 	liqoconst "github.com/liqotech/liqo/pkg/consts"
@@ -48,11 +49,6 @@ const (
 	virtualNode2Name = "liqo-899890-dsd-323s"
 	virtualNode3Name = "liqo-refc453-ds43d-43rs"
 
-	localClusterId   = "0-789o-uhibi-oioi"
-	remoteClusterId1 = "1-6a0e9f-b52-4ed0"
-	remoteClusterId2 = "2-899890-dsd-323s"
-	remoteClusterId3 = "3-refc453-ds43d-43rs"
-
 	providerLabel = "provider/liqo.io"
 	regionLabel   = "region/liqo.io"
 	regionA       = "A"
@@ -62,6 +58,23 @@ const (
 )
 
 var (
+	localCluster = discoveryv1alpha1.ClusterIdentity{
+		ClusterID:   "0-789o-uhibi-oioi",
+		ClusterName: "local-cluster-name",
+	}
+	remoteCluster1 = discoveryv1alpha1.ClusterIdentity{
+		ClusterID:   "1-6a0e9f-b52-4ed0",
+		ClusterName: "remote-cluster-1",
+	}
+	remoteCluster2 = discoveryv1alpha1.ClusterIdentity{
+		ClusterID:   "2-899890-dsd-323s",
+		ClusterName: "remote-cluster-2",
+	}
+	remoteCluster3 = discoveryv1alpha1.ClusterIdentity{
+		ClusterID:   "3-refc453-ds43d-43rs",
+		ClusterName: "remote-cluster-3",
+	}
+
 	homeCfg        *rest.Config
 	homeClient     client.Client
 	homeClusterEnv *envtest.Environment
@@ -126,9 +139,9 @@ var _ = BeforeSuite(func(done Done) {
 	Expect(homeClient).ToNot(BeNil())
 
 	err = (&NamespaceOffloadingReconciler{
-		Client:         homeClient,
-		Scheme:         k8sManager.GetScheme(),
-		LocalClusterID: localClusterId,
+		Client:       homeClient,
+		Scheme:       k8sManager.GetScheme(),
+		LocalCluster: localCluster,
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
@@ -143,7 +156,7 @@ var _ = BeforeSuite(func(done Done) {
 			Name: virtualNode1Name,
 			Labels: map[string]string{
 				liqoconst.TypeLabel:       liqoconst.TypeNode,
-				liqoconst.RemoteClusterID: remoteClusterId1,
+				liqoconst.RemoteClusterID: remoteCluster1.ClusterID,
 				regionLabel:               regionA,
 				providerLabel:             providerAWS,
 			},
@@ -155,7 +168,7 @@ var _ = BeforeSuite(func(done Done) {
 			Name: virtualNode2Name,
 			Labels: map[string]string{
 				liqoconst.TypeLabel:       liqoconst.TypeNode,
-				liqoconst.RemoteClusterID: remoteClusterId2,
+				liqoconst.RemoteClusterID: remoteCluster2.ClusterID,
 				regionLabel:               regionB,
 				providerLabel:             providerGKE,
 			},
@@ -167,7 +180,7 @@ var _ = BeforeSuite(func(done Done) {
 			Name: virtualNode3Name,
 			Labels: map[string]string{
 				liqoconst.TypeLabel:       liqoconst.TypeNode,
-				liqoconst.RemoteClusterID: remoteClusterId3,
+				liqoconst.RemoteClusterID: remoteCluster3.ClusterID,
 				regionLabel:               regionA,
 				providerLabel:             providerGKE,
 			},
@@ -178,30 +191,30 @@ var _ = BeforeSuite(func(done Done) {
 
 	nm1 = &mapsv1alpha1.NamespaceMap{
 		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: fmt.Sprintf("%s-", remoteClusterId1),
+			GenerateName: fmt.Sprintf("%s-", remoteCluster1.ClusterID),
 			Namespace:    mapNamespaceName,
 			Labels: map[string]string{
-				liqoconst.RemoteClusterID: remoteClusterId1,
+				liqoconst.RemoteClusterID: remoteCluster1.ClusterID,
 			},
 		},
 	}
 
 	nm2 = &mapsv1alpha1.NamespaceMap{
 		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: fmt.Sprintf("%s-", remoteClusterId2),
+			GenerateName: fmt.Sprintf("%s-", remoteCluster2.ClusterID),
 			Namespace:    mapNamespaceName,
 			Labels: map[string]string{
-				liqoconst.RemoteClusterID: remoteClusterId2,
+				liqoconst.RemoteClusterID: remoteCluster2.ClusterID,
 			},
 		},
 	}
 
 	nm3 = &mapsv1alpha1.NamespaceMap{
 		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: fmt.Sprintf("%s-", remoteClusterId3),
+			GenerateName: fmt.Sprintf("%s-", remoteCluster3.ClusterID),
 			Namespace:    mapNamespaceName,
 			Labels: map[string]string{
-				liqoconst.RemoteClusterID: remoteClusterId3,
+				liqoconst.RemoteClusterID: remoteCluster3.ClusterID,
 			},
 		},
 	}

--- a/pkg/liqo-controller-manager/resource-request-controller/broadcaster.go
+++ b/pkg/liqo-controller-manager/resource-request-controller/broadcaster.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/klog/v2"
 	resourcehelper "k8s.io/kubectl/pkg/util/resource"
 
+	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
 	"github.com/liqotech/liqo/pkg/consts"
 	"github.com/liqotech/liqo/pkg/liqo-controller-manager/resource-request-controller/interfaces"
 	"github.com/liqotech/liqo/pkg/utils"
@@ -309,7 +310,11 @@ func (b *Broadcaster) enqueueForCreationOrUpdate(clusterID string) {
 		b.resourcePodMap[clusterID] = corev1.ResourceList{}
 	}
 	b.podMutex.Unlock()
-	b.updater.Push(clusterID)
+	// todo: use foreigncluster.GetForeignClusterByID once the Broadcaster refactor is merged
+	b.updater.Push(discoveryv1alpha1.ClusterIdentity{
+		ClusterID:   clusterID,
+		ClusterName: clusterID,
+	})
 }
 
 // RemoveClusterID removes a clusterID from all broadcaster internal structures

--- a/pkg/liqo-controller-manager/resource-request-controller/interfaces/updaterInterface.go
+++ b/pkg/liqo-controller-manager/resource-request-controller/interfaces/updaterInterface.go
@@ -17,6 +17,8 @@ package interfaces
 import (
 	"context"
 	"sync"
+
+	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
 )
 
 // UpdaterInterface represents a generic subset of Updater exported methods to be used instead of a direct access to
@@ -25,5 +27,5 @@ type UpdaterInterface interface {
 	// Start runs an instance of an updater which will be stopped when ctx.Done() is closed.
 	Start(ctx context.Context, group *sync.WaitGroup)
 	// Push adds the clusterID to the internal queue to be processed as soon as possible.
-	Push(clusterID string)
+	Push(cluster discoveryv1alpha1.ClusterIdentity)
 }

--- a/pkg/liqo-controller-manager/resource-request-controller/resourceRequest_controller.go
+++ b/pkg/liqo-controller-manager/resource-request-controller/resourceRequest_controller.go
@@ -34,7 +34,7 @@ import (
 type ResourceRequestReconciler struct {
 	client.Client
 	Scheme                *runtime.Scheme
-	ClusterID             string
+	HomeCluster           discoveryv1alpha1.ClusterIdentity
 	Broadcaster           *Broadcaster
 	EnableIncomingPeering bool
 }

--- a/pkg/liqo-controller-manager/resource-request-controller/resourceRequest_controller_methods.go
+++ b/pkg/liqo-controller-manager/resource-request-controller/resourceRequest_controller_methods.go
@@ -17,7 +17,6 @@ package resourcerequestoperator
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	capsulev1beta1 "github.com/clastix/capsule/api/v1beta1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -110,7 +109,7 @@ func (r *ResourceRequestReconciler) ensureTenantDeletion(ctx context.Context,
 
 func (r *ResourceRequestReconciler) checkOfferState(ctx context.Context,
 	resourceRequest *discoveryv1alpha1.ResourceRequest) error {
-	name := strings.Join([]string{offerPrefix, r.ClusterID}, "")
+	name := offerPrefix + r.HomeCluster.ClusterID
 
 	var resourceOffer sharingv1alpha1.ResourceOffer
 	err := r.Client.Get(ctx, types.NamespacedName{

--- a/pkg/liqo-controller-manager/resource-request-controller/resourceRequest_operator_test.go
+++ b/pkg/liqo-controller-manager/resource-request-controller/resourceRequest_operator_test.go
@@ -182,7 +182,7 @@ var _ = Describe("ResourceRequest Operator", func() {
 			By("Checking Offer creation")
 			createdResourceOffer := &sharingv1alpha1.ResourceOffer{}
 			offerName := types.NamespacedName{
-				Name:      offerPrefix + homeClusterID,
+				Name:      offerPrefix + homeCluster.ClusterID,
 				Namespace: ResourcesNamespace,
 			}
 			klog.Info(offerName)
@@ -191,7 +191,7 @@ var _ = Describe("ResourceRequest Operator", func() {
 			}, timeout, interval).ShouldNot(HaveOccurred())
 			By("Checking all ResourceOffer parameters")
 
-			Expect(createdResourceOffer.Name).Should(ContainSubstring(homeClusterID))
+			Expect(createdResourceOffer.Name).Should(ContainSubstring(homeCluster.ClusterID))
 			Expect(createdResourceOffer.Labels[discovery.ClusterIDLabel]).Should(Equal(createdResourceRequest.Spec.ClusterIdentity.ClusterID))
 			Expect(createdResourceOffer.Labels[consts.ReplicationRequestedLabel]).Should(Equal("true"))
 			Expect(createdResourceOffer.Labels[consts.ReplicationDestinationLabel]).Should(Equal(createdResourceRequest.Spec.ClusterIdentity.ClusterID))
@@ -220,7 +220,7 @@ var _ = Describe("ResourceRequest Operator", func() {
 				podList := []corev1.ResourceList{
 					0: podReq,
 				}
-				return testutils.CheckResourceOfferUpdate(ctx, offerPrefix, homeClusterID, ResourcesNamespace, nodeList, podList, k8sClient)
+				return testutils.CheckResourceOfferUpdate(ctx, offerPrefix, homeCluster.ClusterID, ResourcesNamespace, nodeList, podList, k8sClient)
 			}, timeout, interval).Should(BeTrue())
 
 			By("Checking ResourceOffer invalidation on request set deleting phase")
@@ -338,7 +338,7 @@ var _ = Describe("ResourceRequest Operator", func() {
 				podList := []corev1.ResourceList{
 					0: podReq,
 				}
-				return testutils.CheckResourceOfferUpdate(ctx, offerPrefix, homeClusterID, ResourcesNamespace, nodeList, podList, k8sClient)
+				return testutils.CheckResourceOfferUpdate(ctx, offerPrefix, homeCluster.ClusterID, ResourcesNamespace, nodeList, podList, k8sClient)
 			}, timeout, interval).Should(BeTrue())
 			node1, err = testutils.SetNodeReadyStatus(ctx, node1, true, clientset)
 			Expect(err).ToNot(HaveOccurred())
@@ -352,7 +352,7 @@ var _ = Describe("ResourceRequest Operator", func() {
 				podList := []corev1.ResourceList{
 					0: podReq,
 				}
-				return testutils.CheckResourceOfferUpdate(ctx, offerPrefix, homeClusterID, ResourcesNamespace, nodeList, podList, k8sClient)
+				return testutils.CheckResourceOfferUpdate(ctx, offerPrefix, homeCluster.ClusterID, ResourcesNamespace, nodeList, podList, k8sClient)
 			}, timeout, interval).Should(BeTrue())
 			Eventually(func() bool {
 				resourcesRead := broadcaster.ReadResources(ClusterID1)
@@ -398,7 +398,7 @@ var _ = Describe("ResourceRequest Operator", func() {
 				podList := []corev1.ResourceList{
 					0: podReq,
 				}
-				return testutils.CheckResourceOfferUpdate(ctx, offerPrefix, homeClusterID, ResourcesNamespace, nodeList, podList, k8sClient)
+				return testutils.CheckResourceOfferUpdate(ctx, offerPrefix, homeCluster.ClusterID, ResourcesNamespace, nodeList, podList, k8sClient)
 			}, timeout, interval).Should(BeTrue())
 			By("Checking Node Delete")
 			err = clientset.CoreV1().Nodes().Delete(ctx, node1.Name, metav1.DeleteOptions{})
@@ -423,7 +423,7 @@ var _ = Describe("ResourceRequest Operator", func() {
 				podList := []corev1.ResourceList{
 					0: podReq,
 				}
-				return testutils.CheckResourceOfferUpdate(ctx, offerPrefix, homeClusterID, ResourcesNamespace, nodeList, podList, k8sClient)
+				return testutils.CheckResourceOfferUpdate(ctx, offerPrefix, homeCluster.ClusterID, ResourcesNamespace, nodeList, podList, k8sClient)
 			}, timeout, interval).Should(BeTrue())
 			By("Checking correct update of resource after pod changing Status")
 			podWithoutLabel, err = testutils.SetPodReadyStatus(ctx, podWithoutLabel, false, clientset)
@@ -433,7 +433,7 @@ var _ = Describe("ResourceRequest Operator", func() {
 					0: node2.Status.Allocatable,
 				}
 				var podList []corev1.ResourceList
-				return testutils.CheckResourceOfferUpdate(ctx, offerPrefix, homeClusterID, ResourcesNamespace, nodeList, podList, k8sClient)
+				return testutils.CheckResourceOfferUpdate(ctx, offerPrefix, homeCluster.ClusterID, ResourcesNamespace, nodeList, podList, k8sClient)
 			}, timeout, interval).Should(BeTrue())
 			// set the pod ready again
 			podWithoutLabel, err = testutils.SetPodReadyStatus(ctx, podWithoutLabel, true, clientset)
@@ -445,7 +445,7 @@ var _ = Describe("ResourceRequest Operator", func() {
 				podList := []corev1.ResourceList{
 					0: podReq,
 				}
-				return testutils.CheckResourceOfferUpdate(ctx, offerPrefix, homeClusterID, ResourcesNamespace, nodeList, podList, k8sClient)
+				return testutils.CheckResourceOfferUpdate(ctx, offerPrefix, homeCluster.ClusterID, ResourcesNamespace, nodeList, podList, k8sClient)
 			}, timeout, interval).Should(BeTrue())
 			By("Adding pod offloaded by cluster which refers the ResourceOffer. Expected no change in resources")
 			_, err = testutils.CreateNewPod(ctx, "pod-offloaded-"+ClusterID1, ClusterID1, false, clientset)
@@ -457,7 +457,7 @@ var _ = Describe("ResourceRequest Operator", func() {
 				podList := []corev1.ResourceList{
 					0: podReq,
 				}
-				return testutils.CheckResourceOfferUpdate(ctx, offerPrefix, homeClusterID, ResourcesNamespace, nodeList, podList, k8sClient)
+				return testutils.CheckResourceOfferUpdate(ctx, offerPrefix, homeCluster.ClusterID, ResourcesNamespace, nodeList, podList, k8sClient)
 			}, timeout, interval).Should(BeTrue())
 			By("Adding pods offloaded by a different clusters. Expected change in resources.")
 			podOffloaded, err := testutils.CreateNewPod(ctx, "pod-offloaded-"+ClusterID2, ClusterID2, false, clientset)
@@ -475,7 +475,7 @@ var _ = Describe("ResourceRequest Operator", func() {
 					1: podReq2,
 					2: podReq3,
 				}
-				return testutils.CheckResourceOfferUpdate(ctx, offerPrefix, homeClusterID, ResourcesNamespace, nodeList, podList, k8sClient)
+				return testutils.CheckResourceOfferUpdate(ctx, offerPrefix, homeCluster.ClusterID, ResourcesNamespace, nodeList, podList, k8sClient)
 			}, timeout, interval).Should(BeTrue())
 			By("Checking change ready status for offloaded pod. Expected no change in offer.")
 			_, err = testutils.SetPodReadyStatus(ctx, podOffloaded, false, clientset)
@@ -489,7 +489,7 @@ var _ = Describe("ResourceRequest Operator", func() {
 					1: podReq2,
 					2: podReq3,
 				}
-				return testutils.CheckResourceOfferUpdate(ctx, offerPrefix, homeClusterID, ResourcesNamespace, nodeList, podList, k8sClient)
+				return testutils.CheckResourceOfferUpdate(ctx, offerPrefix, homeCluster.ClusterID, ResourcesNamespace, nodeList, podList, k8sClient)
 			}, timeout, interval).Should(BeTrue())
 
 			By("Update threshold with huge amount to test isAboveThreshold function")
@@ -531,7 +531,7 @@ var _ = Describe("ResourceRequest Operator", func() {
 				podList := []corev1.ResourceList{
 					0: podReq,
 				}
-				return testutils.CheckResourceOfferUpdate(ctx, offerPrefix, homeClusterID, ResourcesNamespace, nodeList, podList, k8sClient)
+				return testutils.CheckResourceOfferUpdate(ctx, offerPrefix, homeCluster.ClusterID, ResourcesNamespace, nodeList, podList, k8sClient)
 			}, timeout, interval).Should(BeTrue())
 		})
 		It("Testing shadow pod creation", func() {
@@ -559,7 +559,7 @@ var _ = Describe("ResourceRequest Operator", func() {
 				podList := []corev1.ResourceList{
 					0: podReq1,
 				}
-				return testutils.CheckResourceOfferUpdate(ctx, offerPrefix, homeClusterID, ResourcesNamespace, nodeList, podList, k8sClient)
+				return testutils.CheckResourceOfferUpdate(ctx, offerPrefix, homeCluster.ClusterID, ResourcesNamespace, nodeList, podList, k8sClient)
 			}, timeout, interval).Should(BeTrue())
 		})
 	})
@@ -579,7 +579,7 @@ var _ = Describe("ResourceRequest Operator", func() {
 			Eventually(func() bool {
 				offer := &sharingv1alpha1.ResourceOffer{}
 				err = k8sClient.Get(ctx, types.NamespacedName{
-					Name:      offerPrefix + homeClusterID,
+					Name:      offerPrefix + homeCluster.ClusterID,
 					Namespace: ResourcesNamespace,
 				}, offer)
 				Expect(err).ToNot(HaveOccurred())

--- a/pkg/liqo-controller-manager/resource-request-controller/suite_test.go
+++ b/pkg/liqo-controller-manager/resource-request-controller/suite_test.go
@@ -38,15 +38,15 @@ import (
 )
 
 var (
-	cfg           *rest.Config
-	k8sClient     client.Client
-	homeClusterID string
-	clientset     kubernetes.Interface
-	testEnv       *envtest.Environment
-	broadcaster   Broadcaster
-	ctx           context.Context
-	cancel        context.CancelFunc
-	group         sync.WaitGroup
+	cfg         *rest.Config
+	k8sClient   client.Client
+	homeCluster discoveryv1alpha1.ClusterIdentity
+	clientset   kubernetes.Interface
+	testEnv     *envtest.Environment
+	broadcaster Broadcaster
+	ctx         context.Context
+	cancel      context.CancelFunc
+	group       sync.WaitGroup
 )
 
 func TestAPIs(t *testing.T) {
@@ -87,13 +87,17 @@ func createCluster() {
 	// Disabling panic on failure.
 	liqoerrors.SetPanicOnErrorMode(false)
 	clientset = kubernetes.NewForConfigOrDie(k8sManager.GetConfig())
-	homeClusterID = "test-cluster"
+
+	homeCluster = discoveryv1alpha1.ClusterIdentity{
+		ClusterID:   "home-cluster-id",
+		ClusterName: "home-cluster-name",
+	}
 
 	// Initializing a new updater and adding it to the manager.
 	localStorageClassName := ""
 	enableStorage := true
 	updater := OfferUpdater{}
-	updater.Setup(homeClusterID, k8sManager.GetScheme(), &broadcaster, k8sManager.GetClient(), nil, localStorageClassName, enableStorage)
+	updater.Setup(homeCluster, k8sManager.GetScheme(), &broadcaster, k8sManager.GetClient(), nil, localStorageClassName, enableStorage)
 
 	// Initializing a new broadcaster, starting it and adding it its configuration.
 	err = broadcaster.SetupBroadcaster(clientset, &updater, 5*time.Second, testutils.DefaultScalePercentage, 5)
@@ -104,7 +108,7 @@ func createCluster() {
 	err = (&ResourceRequestReconciler{
 		Client:                k8sManager.GetClient(),
 		Scheme:                k8sManager.GetScheme(),
-		ClusterID:             homeClusterID,
+		HomeCluster:           homeCluster,
 		Broadcaster:           &broadcaster,
 		EnableIncomingPeering: true,
 	}).SetupWithManager(k8sManager)

--- a/pkg/liqo-controller-manager/resource-request-controller/utils.go
+++ b/pkg/liqo-controller-manager/resource-request-controller/utils.go
@@ -101,7 +101,7 @@ func (r *ResourceRequestReconciler) invalidateResourceOffer(ctx context.Context,
 	var offer sharingv1alpha1.ResourceOffer
 	err := r.Client.Get(ctx, types.NamespacedName{
 		Namespace: request.GetNamespace(),
-		Name:      offerPrefix + r.ClusterID,
+		Name:      offerPrefix + r.HomeCluster.ClusterID,
 	}, &offer)
 	if apierrors.IsNotFound(err) {
 		// ignore not found errors
@@ -123,7 +123,7 @@ func (r *ResourceRequestReconciler) invalidateResourceOffer(ctx context.Context,
 			klog.Error(err)
 			return err
 		}
-		klog.Infof("%s -> Offer: %s/%s", r.ClusterID, offer.Namespace, offer.Name)
+		klog.Infof("%s -> Offer: %s/%s", r.HomeCluster.ClusterName, offer.Namespace, offer.Name)
 		return nil
 	case sharingv1alpha1.VirtualKubeletStatusNone:
 		err = client.IgnoreNotFound(r.Client.Delete(ctx, &offer))
@@ -135,7 +135,7 @@ func (r *ResourceRequestReconciler) invalidateResourceOffer(ctx context.Context,
 			now := metav1.Now()
 			request.Status.OfferWithdrawalTimestamp = &now
 		}
-		klog.Infof("%s -> Deleted Offer: %s/%s", r.ClusterID, offer.Namespace, offer.Name)
+		klog.Infof("%s -> Deleted Offer: %s/%s", r.HomeCluster.ClusterName, offer.Namespace, offer.Name)
 		return nil
 	default:
 		err := fmt.Errorf("unknown VirtualKubeletStatus %v", offer.Status.VirtualKubeletStatus)

--- a/pkg/liqo-controller-manager/resourceoffer-controller/controller_config.go
+++ b/pkg/liqo-controller-manager/resourceoffer-controller/controller_config.go
@@ -19,12 +19,13 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
+	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
 	"github.com/liqotech/liqo/pkg/vkMachinery/forge"
 )
 
 // NewResourceOfferController creates and returns a new reconciler for the ResourceOffers.
 func NewResourceOfferController(
-	mgr manager.Manager, clusterID string,
+	mgr manager.Manager, cluster discoveryv1alpha1.ClusterIdentity,
 	resyncPeriod time.Duration, liqoNamespace string,
 	virtualKubeletOpts *forge.VirtualKubeletOpts,
 	disableAutoAccept bool) *ResourceOfferReconciler {
@@ -33,7 +34,7 @@ func NewResourceOfferController(
 		Scheme: mgr.GetScheme(),
 
 		eventsRecorder: mgr.GetEventRecorderFor("ResourceOffer"),
-		clusterID:      clusterID,
+		cluster:        cluster,
 
 		liqoNamespace: liqoNamespace,
 

--- a/pkg/liqo-controller-manager/resourceoffer-controller/resourceoffer_controller.go
+++ b/pkg/liqo-controller-manager/resourceoffer-controller/resourceoffer_controller.go
@@ -39,6 +39,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
+	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
 	sharingv1alpha1 "github.com/liqotech/liqo/apis/sharing/v1alpha1"
 	"github.com/liqotech/liqo/internal/crdReplicator/reflection"
 	"github.com/liqotech/liqo/pkg/vkMachinery"
@@ -53,7 +54,7 @@ type ResourceOfferReconciler struct {
 	Scheme *runtime.Scheme
 
 	eventsRecorder record.EventRecorder
-	clusterID      string
+	cluster        discoveryv1alpha1.ClusterIdentity
 
 	liqoNamespace string
 

--- a/pkg/liqo-controller-manager/search-domain-operator/search-domain-controller.go
+++ b/pkg/liqo-controller-manager/search-domain-operator/search-domain-controller.go
@@ -35,8 +35,8 @@ type SearchDomainReconciler struct {
 
 	ResyncPeriod time.Duration
 
-	LocalClusterID string
-	DNSAddress     string
+	LocalCluster discoveryv1alpha1.ClusterIdentity
+	DNSAddress   string
 }
 
 // Reconcile reconciles SearchDomain resources.
@@ -64,7 +64,7 @@ func (r *SearchDomainReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			RequeueAfter: r.ResyncPeriod,
 		}, err
 	}
-	discovery.UpdateForeignWAN(ctx, r.Client, r.LocalClusterID, authData, &sd)
+	discovery.UpdateForeignWAN(ctx, r.Client, r.LocalCluster, authData, &sd)
 
 	klog.Info("SearchDomain " + req.Name + " successfully reconciled")
 	return ctrl.Result{

--- a/pkg/liqoctl/install/aks/aks_test.go
+++ b/pkg/liqoctl/install/aks/aks_test.go
@@ -53,7 +53,7 @@ var _ = Describe("Extract elements from AKS", func() {
 		cmd := &cobra.Command{}
 
 		GenerateFlags(cmd)
-		cmd.Flags().String("cluster-name", "test-cluster", "")
+		cmd.Flags().String("cluster-name", "", "")
 		cmd.Flags().Bool("generate-name", true, "")
 		cmd.Flags().String("reserved-subnets", "", "")
 

--- a/pkg/liqoctl/install/aks/aks_test.go
+++ b/pkg/liqoctl/install/aks/aks_test.go
@@ -53,7 +53,7 @@ var _ = Describe("Extract elements from AKS", func() {
 		cmd := &cobra.Command{}
 
 		GenerateFlags(cmd)
-		cmd.Flags().String("cluster-name", "", "")
+		cmd.Flags().String("cluster-name", "test-cluster", "")
 		cmd.Flags().Bool("generate-name", true, "")
 		cmd.Flags().String("reserved-subnets", "", "")
 

--- a/pkg/liqoctl/install/eks/eks_test.go
+++ b/pkg/liqoctl/install/eks/eks_test.go
@@ -54,7 +54,7 @@ var _ = Describe("Extract elements from EKS", func() {
 		cmd := &cobra.Command{}
 
 		GenerateFlags(cmd)
-		cmd.Flags().String("cluster-name", "", "")
+		cmd.Flags().String("cluster-name", "test-cluster", "")
 		cmd.Flags().Bool("generate-name", true, "")
 		cmd.Flags().String("reserved-subnets", "", "")
 

--- a/pkg/liqoctl/install/eks/eks_test.go
+++ b/pkg/liqoctl/install/eks/eks_test.go
@@ -54,7 +54,7 @@ var _ = Describe("Extract elements from EKS", func() {
 		cmd := &cobra.Command{}
 
 		GenerateFlags(cmd)
-		cmd.Flags().String("cluster-name", "test-cluster", "")
+		cmd.Flags().String("cluster-name", "", "")
 		cmd.Flags().Bool("generate-name", true, "")
 		cmd.Flags().String("reserved-subnets", "", "")
 

--- a/pkg/liqoctl/install/gke/gke_test.go
+++ b/pkg/liqoctl/install/gke/gke_test.go
@@ -50,7 +50,7 @@ var _ = Describe("Extract elements from GKE", func() {
 		cmd := &cobra.Command{}
 
 		GenerateFlags(cmd)
-		cmd.Flags().String("cluster-name", "test-cluster", "")
+		cmd.Flags().String("cluster-name", "", "")
 		cmd.Flags().Bool("generate-name", true, "")
 		cmd.Flags().String("reserved-subnets", "", "")
 

--- a/pkg/liqoctl/install/gke/gke_test.go
+++ b/pkg/liqoctl/install/gke/gke_test.go
@@ -50,7 +50,7 @@ var _ = Describe("Extract elements from GKE", func() {
 		cmd := &cobra.Command{}
 
 		GenerateFlags(cmd)
-		cmd.Flags().String("cluster-name", "", "")
+		cmd.Flags().String("cluster-name", "test-cluster", "")
 		cmd.Flags().Bool("generate-name", true, "")
 		cmd.Flags().String("reserved-subnets", "", "")
 

--- a/pkg/liqoctl/install/k3s/k3s_test.go
+++ b/pkg/liqoctl/install/k3s/k3s_test.go
@@ -51,7 +51,7 @@ var _ = Describe("Extract elements from K3S", func() {
 		cmd := &cobra.Command{}
 
 		GenerateFlags(cmd)
-		cmd.Flags().String("cluster-name", "test-cluster", "")
+		cmd.Flags().String("cluster-name", "", "")
 		cmd.Flags().Bool("generate-name", true, "")
 		cmd.Flags().String("reserved-subnets", "", "")
 

--- a/pkg/liqoctl/install/k3s/k3s_test.go
+++ b/pkg/liqoctl/install/k3s/k3s_test.go
@@ -51,7 +51,7 @@ var _ = Describe("Extract elements from K3S", func() {
 		cmd := &cobra.Command{}
 
 		GenerateFlags(cmd)
-		cmd.Flags().String("cluster-name", "", "")
+		cmd.Flags().String("cluster-name", "test-cluster", "")
 		cmd.Flags().Bool("generate-name", true, "")
 		cmd.Flags().String("reserved-subnets", "", "")
 

--- a/pkg/liqoctl/install/openshift/openshift_test.go
+++ b/pkg/liqoctl/install/openshift/openshift_test.go
@@ -44,7 +44,7 @@ var _ = Describe("Extract elements from OpenShift", func() {
 		cmd := &cobra.Command{}
 
 		GenerateFlags(cmd)
-		cmd.Flags().String("cluster-name", "", "")
+		cmd.Flags().String("cluster-name", "test-cluster", "")
 		cmd.Flags().Bool("generate-name", true, "")
 		cmd.Flags().String("reserved-subnets", "", "")
 

--- a/pkg/liqoctl/install/openshift/openshift_test.go
+++ b/pkg/liqoctl/install/openshift/openshift_test.go
@@ -44,7 +44,7 @@ var _ = Describe("Extract elements from OpenShift", func() {
 		cmd := &cobra.Command{}
 
 		GenerateFlags(cmd)
-		cmd.Flags().String("cluster-name", "test-cluster", "")
+		cmd.Flags().String("cluster-name", "", "")
 		cmd.Flags().Bool("generate-name", true, "")
 		cmd.Flags().String("reserved-subnets", "", "")
 

--- a/pkg/liqoctl/install/provider/generic.go
+++ b/pkg/liqoctl/install/provider/generic.go
@@ -51,6 +51,7 @@ func (p *GenericProvider) ValidateGenericCommandArguments(flags *flag.FlagSet) (
 		return fmt.Errorf("you must provide a cluster name or use --generate-name")
 	}
 	if clusterName != "" && generate {
+		fmt.Printf("%#v %#v\n", clusterName, generate)
 		return fmt.Errorf("cannot set a cluster name and use --generate-name at the same time")
 	}
 	if generate {

--- a/pkg/tenantNamespace/interface.go
+++ b/pkg/tenantNamespace/interface.go
@@ -19,15 +19,17 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+
+	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
 )
 
 // Manager provides the methods to handle the creation and
 // the management of tenant namespaces.
 type Manager interface {
-	CreateNamespace(clusterID string) (*v1.Namespace, error)
-	GetNamespace(clusterID string) (*v1.Namespace, error)
-	BindClusterRoles(clusterID string, clusterRoles ...*rbacv1.ClusterRole) ([]*rbacv1.RoleBinding, error)
-	UnbindClusterRoles(clusterID string, clusterRoles ...string) error
-	BindIncomingClusterWideRole(ctx context.Context, clusterID string) (*rbacv1.ClusterRoleBinding, error)
-	UnbindIncomingClusterWideRole(ctx context.Context, clusterID string) error
+	CreateNamespace(cluster discoveryv1alpha1.ClusterIdentity) (*v1.Namespace, error)
+	GetNamespace(cluster discoveryv1alpha1.ClusterIdentity) (*v1.Namespace, error)
+	BindClusterRoles(cluster discoveryv1alpha1.ClusterIdentity, clusterRoles ...*rbacv1.ClusterRole) ([]*rbacv1.RoleBinding, error)
+	UnbindClusterRoles(cluster discoveryv1alpha1.ClusterIdentity, clusterRoles ...string) error
+	BindIncomingClusterWideRole(ctx context.Context, cluster discoveryv1alpha1.ClusterIdentity) (*rbacv1.ClusterRoleBinding, error)
+	UnbindIncomingClusterWideRole(ctx context.Context, cluster discoveryv1alpha1.ClusterIdentity) error
 }

--- a/pkg/utils/args/args_test.go
+++ b/pkg/utils/args/args_test.go
@@ -15,6 +15,7 @@
 package args
 
 import (
+	"flag"
 	"net"
 	"testing"
 
@@ -204,6 +205,43 @@ var _ = Describe("ParseArguments", func() {
 
 			Entry("incorrect cidr", parseCidrTestCase{
 				cidr:          "10.0.0..0/16",
+				expectedError: HaveOccurred(),
+			}),
+		)
+
+	})
+
+	Context("ClusterIdentity", func() {
+
+		type parseClusterIdentityTestCase struct {
+			args          []string
+			expectedError OmegaMatcher
+		}
+
+		DescribeTable("ClusterIdentity table",
+			func(c parseClusterIdentityTestCase) {
+				flagset := flag.NewFlagSet("test", flag.ContinueOnError)
+				flags := NewClusterIdentityFlags(true, flagset)
+				Expect(flagset.Parse(c.args)).To(Succeed())
+				_, err := flags.Read()
+				Expect(err).To(c.expectedError)
+			},
+
+			Entry("no cluster ID", parseClusterIdentityTestCase{
+				args:          []string{"--cluster-name=foo"},
+				expectedError: HaveOccurred(),
+			}),
+			Entry("no cluster name", parseClusterIdentityTestCase{
+				args:          []string{"--cluster-id=foo"},
+				expectedError: HaveOccurred(),
+			}),
+
+			Entry("invalid cluster ID", parseClusterIdentityTestCase{
+				args:          []string{"--cluster-id=Foo!", "--cluster-name=foo"},
+				expectedError: HaveOccurred(),
+			}),
+			Entry("invalid cluster name", parseClusterIdentityTestCase{
+				args:          []string{"--cluster-id=foo", "--cluster-name=Foo!"},
 				expectedError: HaveOccurred(),
 			}),
 		)

--- a/pkg/utils/args/cluster-identity.go
+++ b/pkg/utils/args/cluster-identity.go
@@ -1,0 +1,103 @@
+// Copyright 2019-2021 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package args
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/klog/v2"
+
+	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
+)
+
+// ClusterIdentityFlags stores the values of flags representing a ClusterIdentity.
+type ClusterIdentityFlags struct {
+	local       bool
+	ClusterID   *string
+	ClusterName *string
+}
+
+// NewClusterIdentityFlags returns a set of command line flags to read a cluster identity.
+// If local=true the identity refers to the local cluster, otherwise it refers to a foreign cluster.
+// Set flags=nil to use command-line flags (os.Argv).
+//
+// Example usage:
+//
+//   fcFlags := NewClusterIdentityFlags(false, nil)
+//   flag.Parse()
+//   foreignClusterIdentity := fcFlags.Read()
+func NewClusterIdentityFlags(local bool, flags *flag.FlagSet) ClusterIdentityFlags {
+	var prefix, description string
+	if local {
+		prefix = "cluster" // nolint:goconst // No need to make the word "cluster" a const...
+		description = "The %s of the current cluster"
+	} else {
+		prefix = "foreign-cluster"
+		description = "The %s of the foreign cluster"
+	}
+	if flags == nil {
+		flags = flag.CommandLine
+	}
+	return ClusterIdentityFlags{
+		local:       local,
+		ClusterID:   flags.String(fmt.Sprintf("%s-id", prefix), "", fmt.Sprintf(description, "ID")),
+		ClusterName: flags.String(fmt.Sprintf("%s-name", prefix), "", fmt.Sprintf(description, "name")),
+	}
+}
+
+// Read performs validation on the values passed and returns a ClusterIdentity if successful.
+func (f ClusterIdentityFlags) Read() (discoveryv1alpha1.ClusterIdentity, error) {
+	var clusterWord string
+	if f.local {
+		clusterWord = "cluster"
+	} else {
+		clusterWord = "foreign cluster"
+	}
+
+	if *f.ClusterID == "" {
+		return discoveryv1alpha1.ClusterIdentity{}, fmt.Errorf("the %s ID may not be empty", clusterWord)
+	}
+	if *f.ClusterName == "" {
+		return discoveryv1alpha1.ClusterIdentity{}, fmt.Errorf("the %s name may not be empty", clusterWord)
+	}
+	errs := validation.IsDNS1123Label(*f.ClusterID)
+	if len(errs) != 0 {
+		return discoveryv1alpha1.ClusterIdentity{},
+			fmt.Errorf("the %s ID may only contain lowercase letters, numbers and hyphens, and must not be no longer than 63 characters", clusterWord)
+	}
+	errs = validation.IsDNS1123Label(*f.ClusterName)
+	if len(errs) != 0 {
+		return discoveryv1alpha1.ClusterIdentity{},
+			fmt.Errorf("the %s name may only contain lowercase letters, numbers and hyphens, and must not be no longer than 63 characters", clusterWord)
+	}
+
+	return discoveryv1alpha1.ClusterIdentity{
+		ClusterID:   *f.ClusterID,
+		ClusterName: *f.ClusterName,
+	}, nil
+}
+
+// ReadOrDie returns a ClusterIdentity. It prints an error message and exits if the values are not valid.
+func (f ClusterIdentityFlags) ReadOrDie() discoveryv1alpha1.ClusterIdentity {
+	identity, err := f.Read()
+	if err != nil {
+		klog.Error(err)
+		os.Exit(1)
+	}
+	return identity
+}

--- a/pkg/vkMachinery/forge/creation.go
+++ b/pkg/vkMachinery/forge/creation.go
@@ -20,15 +20,16 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
 	sharingv1alpha1 "github.com/liqotech/liqo/apis/sharing/v1alpha1"
 	"github.com/liqotech/liqo/pkg/discovery"
 	"github.com/liqotech/liqo/pkg/vkMachinery"
 )
 
 // VirtualKubeletDeployment forges the deployment for a virtual-kubelet.
-func VirtualKubeletDeployment(remoteClusterID, vkName, vkNamespace, liqoNamespace,
-	nodeName, homeClusterID string, opts *VirtualKubeletOpts, resourceOffer *sharingv1alpha1.ResourceOffer) (*appsv1.Deployment, error) {
-	vkLabels := VirtualKubeletLabels(remoteClusterID, opts)
+func VirtualKubeletDeployment(homeCluster, remoteCluster discoveryv1alpha1.ClusterIdentity, vkName, vkNamespace, liqoNamespace,
+	nodeName string, opts *VirtualKubeletOpts, resourceOffer *sharingv1alpha1.ResourceOffer) (*appsv1.Deployment, error) {
+	vkLabels := VirtualKubeletLabels(remoteCluster.ClusterID, opts)
 	annotations := opts.ExtraAnnotations
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -46,7 +47,7 @@ func VirtualKubeletDeployment(remoteClusterID, vkName, vkNamespace, liqoNamespac
 					Labels:      vkLabels,
 					Annotations: annotations,
 				},
-				Spec: forgeVKPodSpec(vkName, vkNamespace, liqoNamespace, homeClusterID, remoteClusterID, nodeName, opts, resourceOffer),
+				Spec: forgeVKPodSpec(vkName, vkNamespace, liqoNamespace, homeCluster, remoteCluster, nodeName, opts, resourceOffer),
 			},
 		},
 	}, nil


### PR DESCRIPTION
# Description

This PR refactors all components to identify clusters by their ClusterIdentity (which internally contains their ID and name) rather than the cluster ID.

This opens the possibility of using user-friendly names in both Kubernetes object names and log messages.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Unit tests
- [x] E2E tests
