### PR TITLE
Store Bearer Token in a tmp file

### DIFF
--- a/pkg/identityManager/identityManager.go
+++ b/pkg/identityManager/identityManager.go
@@ -110,6 +110,7 @@ func newIdentityManager(client kubernetes.Interface,
 	iamTokenManager := &iamTokenManager{
 		client:                    client,
 		availableClusterIDSecrets: map[string]types.NamespacedName{},
+		tokenFiles:                map[string]string{},
 	}
 	iamTokenManager.start(context.TODO())
 

--- a/pkg/identityManager/identityManager_test.go
+++ b/pkg/identityManager/identityManager_test.go
@@ -45,11 +45,6 @@ import (
 	"github.com/liqotech/liqo/pkg/utils/testutil"
 )
 
-type mockApiServerConfigProvider struct {
-	address   string
-	trustedCA bool
-}
-
 func TestIdentityManager(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "IdentityManager Suite")
@@ -286,6 +281,7 @@ var _ = Describe("IdentityManager", func() {
 			tokenManager := iamTokenManager{
 				client:                    idMan.client,
 				availableClusterIDSecrets: map[string]types.NamespacedName{},
+				tokenFiles:                map[string]string{},
 			}
 			idMan.iamTokenManager = &tokenManager
 


### PR DESCRIPTION
# Description

This pr fixes a permission problem in writing token files. The pod user is no more root and it has no permission on writing in the pod filesystem.

# How Has This Been Tested?

- [x] locally on KinD
