### PR TITLE
change vk dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.0
-	github.com/virtual-kubelet/virtual-kubelet v1.5.1
+	github.com/virtual-kubelet/virtual-kubelet v1.6.0
 	github.com/vishvananda/netlink v1.1.1-0.20201029203352-d40f9887b852
 	github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae
 	golang.org/x/sys v0.0.0-20210817190340-bfb29a6856f2
@@ -212,8 +212,6 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.1.2 // indirect
 	sigs.k8s.io/yaml v1.2.0 // indirect
 )
-
-replace github.com/virtual-kubelet/virtual-kubelet => github.com/liqotech/virtual-kubelet v1.5.1-0.20211028083903-28902eb9305f
 
 replace github.com/grandcat/zeroconf => github.com/liqotech/zeroconf v1.0.1-0.20201020081245-6384f3f21ffb
 

--- a/go.sum
+++ b/go.sum
@@ -836,8 +836,6 @@ github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de h1:9TO3cAIGXtEhn
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de/go.mod h1:zAbeS9B/r2mtpb6U+EI2rYA5OAXxsYw6wTamcNW+zcE=
 github.com/liqotech/go-helm-client v0.8.3-0.20211106110643-962712c10b2d h1:JQfdDRGLiFL9+EzX8kj/BvSlntIWsSgDYznN5dfmmns=
 github.com/liqotech/go-helm-client v0.8.3-0.20211106110643-962712c10b2d/go.mod h1:DVtyXr7KDPIT44X320DkxF39nfbZn8KdjvibnN7iHnQ=
-github.com/liqotech/virtual-kubelet v1.5.1-0.20211028083903-28902eb9305f h1:zJ8ine7sLBQTXhpRZtad1d9/n5GC1UpMF9Z3lAoB5Nk=
-github.com/liqotech/virtual-kubelet v1.5.1-0.20211028083903-28902eb9305f/go.mod h1:Uf0+/KqEDz5Tz6TNQSok5B4A+guFZV6cs4JohQTHdEQ=
 github.com/liqotech/zeroconf v1.0.1-0.20201020081245-6384f3f21ffb h1:FokBo/2VZRYP72Y030Z5bQXiIr7gs/nt/ISqnuCsiq0=
 github.com/liqotech/zeroconf v1.0.1-0.20201020081245-6384f3f21ffb/go.mod h1:lTKmG1zh86XyCoUeIHSA4FJMBwCJiQmGfcP2PdzytEs=
 github.com/lithammer/dedent v1.1.0/go.mod h1:jrXYCQtgg0nJiN+StA2KgR7w6CiQNv9Fd/Z9BP0jIOc=
@@ -1199,6 +1197,8 @@ github.com/urfave/cli v1.22.2 h1:gsqYFH8bb9ekPA12kRo0hfjngWQjkJPlN9R0N78BoUo=
 github.com/urfave/cli v1.22.2/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/vdemeester/k8s-pkg-credentialprovider v0.0.0-20200107171650-7c61ffa44238/go.mod h1:JwQJCMWpUDqjZrB5jpw0f5VbN7U95zxFy1ZDpoEarGo=
 github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv3vaXspKw=
+github.com/virtual-kubelet/virtual-kubelet v1.6.0 h1:BJAsHB3ItrXVhzQszWiIqmwVkuxrtu4f0Xz5hjMPR7c=
+github.com/virtual-kubelet/virtual-kubelet v1.6.0/go.mod h1:Uf0+/KqEDz5Tz6TNQSok5B4A+guFZV6cs4JohQTHdEQ=
 github.com/vishvananda/netlink v0.0.0-20181108222139-023a6dafdcdf/go.mod h1:+SR5DhBJrl6ZM7CoCKvpw5BKroDKQ+PJqOg65H/2ktk=
 github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYppBueQtXaqoE=
 github.com/vishvananda/netlink v1.1.1-0.20201029203352-d40f9887b852 h1:cPXZWzzG0NllBLdjWoD1nDfaqu98YMv+OneaKc8sPOA=


### PR DESCRIPTION
# Description

Use official virtual-kubelet dependency rather than liqotech fork since it is not necessary with the new working queue-based reflection.  

Fixes #(issue)

# How Has This Been Tested?

Existing tests.
