### PR TITLE
liqoctl: generate random cluster name if none is provided

### DIFF
--- a/cmd/liqoctl/cmd/install.go
+++ b/cmd/liqoctl/cmd/install.go
@@ -25,7 +25,7 @@ import (
 	installutils "github.com/liqotech/liqo/pkg/liqoctl/install/utils"
 )
 
-// installCmd represents the generateInstall command.
+// newInstallCommand generates a new Command representing `liqoctl install`.
 func newInstallCommand(ctx context.Context) *cobra.Command {
 	var installCmd = &cobra.Command{
 		Use:   installutils.LiqoctlInstallCommand,
@@ -47,7 +47,8 @@ func newInstallCommand(ctx context.Context) *cobra.Command {
 		"Disable the check that the current kubeconfig context contains the same endpoint retrieved from the cloud provider (AKS, EKS, GKE)")
 	installCmd.PersistentFlags().String("chart-path", installutils.LiqoChartFullName,
 		"Specify a path to get the Liqo chart, instead of installing the chart from the official repository")
-	installCmd.PersistentFlags().String("cluster-name", "", "Name to assign to the Liqo Cluster")
+	installCmd.PersistentFlags().StringP("cluster-name", "n", "", "Name to assign to the Liqo cluster")
+	installCmd.PersistentFlags().Bool("generate-name", false, "Generate a random Docker-like name for the cluster")
 	installCmd.PersistentFlags().String("reserved-subnets", "", "In order to prevent IP conflicting between locally used private subnets in your "+
 		"infrastructure and private subnets belonging to remote clusters "+
 		"you need tell liqo the subnets used in your cluster. E.g if your cluster nodes belong to the 192.168.2.0/24 subnet then "+

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/clastix/capsule v0.1.0
 	github.com/containernetworking/plugins v0.9.1
 	github.com/coreos/go-iptables v0.5.0
+	github.com/goombaio/namegenerator v0.0.0-20181006234301-989e774b106e
 	github.com/grandcat/zeroconf v1.0.0
 	github.com/gruntwork-io/gruntwork-cli v0.7.0
 	github.com/gruntwork-io/terratest v0.35.6

--- a/go.sum
+++ b/go.sum
@@ -686,6 +686,8 @@ github.com/googleapis/gnostic v0.4.1/go.mod h1:LRhVm6pbyptWbWbuZ38d1eyptfvIytN3i
 github.com/googleapis/gnostic v0.5.1/go.mod h1:6U4PtQXGIEt/Z3h5MAT7FNofLnw9vXk2cUuW7uA/OeU=
 github.com/googleapis/gnostic v0.5.5 h1:9fHAtK0uDfpveeqqo1hkEZJcFvYXAiCN3UutL8F9xHw=
 github.com/googleapis/gnostic v0.5.5/go.mod h1:7+EbHbldMins07ALC74bsA81Ovc97DwqyJO1AENw9kA=
+github.com/goombaio/namegenerator v0.0.0-20181006234301-989e774b106e h1:XmA6L9IPRdUr28a+SK/oMchGgQy159wvzXA5tJ7l+40=
+github.com/goombaio/namegenerator v0.0.0-20181006234301-989e774b106e/go.mod h1:AFIo+02s+12CEg8Gzz9kzhCbmbq6JcKNrhHffCGA9z4=
 github.com/gophercloud/gophercloud v0.1.0/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEoIEcSTewFxm1c5g8=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=

--- a/pkg/liqoctl/install/aks/aks_test.go
+++ b/pkg/liqoctl/install/aks/aks_test.go
@@ -53,7 +53,8 @@ var _ = Describe("Extract elements from AKS", func() {
 		cmd := &cobra.Command{}
 
 		GenerateFlags(cmd)
-		cmd.Flags().String("cluster-name", "", "Name to assign to the Liqo Cluster")
+		cmd.Flags().String("cluster-name", "", "")
+		cmd.Flags().Bool("generate-name", true, "")
 		cmd.Flags().String("reserved-subnets", "", "")
 
 		flags := cmd.Flags()

--- a/pkg/liqoctl/install/eks/eks_test.go
+++ b/pkg/liqoctl/install/eks/eks_test.go
@@ -54,7 +54,8 @@ var _ = Describe("Extract elements from EKS", func() {
 		cmd := &cobra.Command{}
 
 		GenerateFlags(cmd)
-		cmd.Flags().String("cluster-name", "", "Name to assign to the Liqo Cluster")
+		cmd.Flags().String("cluster-name", "", "")
+		cmd.Flags().Bool("generate-name", true, "")
 		cmd.Flags().String("reserved-subnets", "", "")
 
 		flags := cmd.Flags()

--- a/pkg/liqoctl/install/gke/gke_test.go
+++ b/pkg/liqoctl/install/gke/gke_test.go
@@ -50,7 +50,8 @@ var _ = Describe("Extract elements from GKE", func() {
 		cmd := &cobra.Command{}
 
 		GenerateFlags(cmd)
-		cmd.Flags().String("cluster-name", "", "Name to assign to the Liqo Cluster")
+		cmd.Flags().String("cluster-name", "", "")
+		cmd.Flags().Bool("generate-name", true, "")
 		cmd.Flags().String("reserved-subnets", "", "")
 
 		flags := cmd.Flags()

--- a/pkg/liqoctl/install/k3s/k3s_test.go
+++ b/pkg/liqoctl/install/k3s/k3s_test.go
@@ -51,7 +51,8 @@ var _ = Describe("Extract elements from K3S", func() {
 		cmd := &cobra.Command{}
 
 		GenerateFlags(cmd)
-		cmd.Flags().String("cluster-name", "", "Name to assign to the Liqo Cluster")
+		cmd.Flags().String("cluster-name", "", "")
+		cmd.Flags().Bool("generate-name", true, "")
 		cmd.Flags().String("reserved-subnets", "", "")
 
 		flags := cmd.Flags()

--- a/pkg/liqoctl/install/openshift/openshift_test.go
+++ b/pkg/liqoctl/install/openshift/openshift_test.go
@@ -44,7 +44,8 @@ var _ = Describe("Extract elements from OpenShift", func() {
 		cmd := &cobra.Command{}
 
 		GenerateFlags(cmd)
-		cmd.Flags().String("cluster-name", "", "Name to assign to the Liqo Cluster")
+		cmd.Flags().String("cluster-name", "", "")
+		cmd.Flags().Bool("generate-name", true, "")
 		cmd.Flags().String("reserved-subnets", "", "")
 
 		flags := cmd.Flags()

--- a/pkg/liqoctl/install/provider/provider_suite_test.go
+++ b/pkg/liqoctl/install/provider/provider_suite_test.go
@@ -33,6 +33,7 @@ func TestProvider(t *testing.T) {
 func newFlagSet() *pflag.FlagSet {
 	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
 	flags.String("cluster-name", "", "")
+	flags.Bool("generate-name", false, "")
 	flags.String("reserved-subnets", "", "")
 	return flags
 }
@@ -63,8 +64,8 @@ var _ = DescribeTable("ValidateGenericCommandArguments",
 		expectedValidationOutcome: Not(Succeed()),
 		expectedClusterName:       BeEmpty(),
 	}),
-	Entry("should generate a valid name if none is given", commandTestcase{
-		flags:                     map[string]string{},
+	Entry("should generate a valid name if --generate-name is set", commandTestcase{
+		flags:                     map[string]string{"generate-name": "true"},
 		expectedValidationOutcome: Succeed(),
 		expectedClusterName:       Not(BeEmpty()),
 	}),

--- a/pkg/liqoctl/install/provider/provider_suite_test.go
+++ b/pkg/liqoctl/install/provider/provider_suite_test.go
@@ -18,10 +18,54 @@ import (
 	"testing"
 
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
+	"github.com/spf13/pflag"
+
+	"github.com/liqotech/liqo/pkg/liqoctl/install/provider"
 )
 
 func TestProvider(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Provider Suite")
 }
+
+func newFlagSet() *pflag.FlagSet {
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	flags.String("cluster-name", "", "")
+	flags.String("reserved-subnets", "", "")
+	return flags
+}
+
+type commandTestcase struct {
+	flags                     map[string]string
+	expectedValidationOutcome OmegaMatcher
+	expectedClusterName       OmegaMatcher
+}
+
+var _ = DescribeTable("ValidateGenericCommandArguments",
+	func(t commandTestcase) {
+		flags := newFlagSet()
+		for flag, value := range t.flags {
+			Expect(flags.Set(flag, value)).To(Succeed())
+		}
+		provider := provider.GenericProvider{}
+		Expect(provider.ValidateGenericCommandArguments(flags)).To(t.expectedValidationOutcome)
+		Expect(provider.ClusterName).To(t.expectedClusterName)
+	},
+	Entry("should accept a valid name", commandTestcase{
+		flags:                     map[string]string{"cluster-name": "test-cluster123"},
+		expectedValidationOutcome: Succeed(),
+		expectedClusterName:       Equal("test-cluster123"),
+	}),
+	Entry("should not accept an invalid name", commandTestcase{
+		flags:                     map[string]string{"cluster-name": "Invalid cluster!"},
+		expectedValidationOutcome: Not(Succeed()),
+		expectedClusterName:       BeEmpty(),
+	}),
+	Entry("should generate a valid name if none is given", commandTestcase{
+		flags:                     map[string]string{},
+		expectedValidationOutcome: Succeed(),
+		expectedClusterName:       Not(BeEmpty()),
+	}),
+)


### PR DESCRIPTION
# Description

Makes `liqoctl install` generate a random name if none is provided. It uses the same algorithm as Docker.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Unit
- [x] E2E
