### PR TITLE
Disable vet in unit tests

### DIFF
--- a/build/liqo-test/Dockerfile
+++ b/build/liqo-test/Dockerfile
@@ -18,4 +18,4 @@ RUN apt-get update && apt-get install iptables iproute2 -y
 # Install goimports
 RUN GO111MODULE="on" go get -u github.com/ory/go-acc
 
-ENTRYPOINT go-acc ./... --ignore liqo/test/e2e
+ENTRYPOINT go-acc ./... --ignore liqo/test/e2e -- -vet=off


### PR DESCRIPTION
# Description

Disables running `go vet` in unit tests to make them faster. Note that `go vet` is already enabled by default in golangci-lint: https://golangci-lint.run/usage/linters/

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Unit tests