### PR TITLE
Fix Local Pvc Naming

### DIFF
--- a/pkg/consts/storage.go
+++ b/pkg/consts/storage.go
@@ -20,4 +20,9 @@ const (
 
 	// StorageAvailableLabel is the label used to mark if the liqo storage is available on a virtual node.
 	StorageAvailableLabel = "storage.liqo.io/available"
+
+	// VirtualPvcNamespaceLabel is the label used to mark the namespace of a virtual PVC.
+	VirtualPvcNamespaceLabel = "storage.liqo.io/virtual-pvc-namespace"
+	// VirtualPvcNameLabel is the label used to mark the name of a virtual PVC.
+	VirtualPvcNameLabel = "storage.liqo.io/virtual-pvc-name"
 )

--- a/pkg/liqo-controller-manager/storageprovisioner/delete.go
+++ b/pkg/liqo-controller-manager/storageprovisioner/delete.go
@@ -27,7 +27,7 @@ import (
 func (p *liqoLocalStorageProvisioner) Delete(ctx context.Context, volume *v1.PersistentVolume) error {
 	realPvc := v1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      volume.Spec.ClaimRef.Name,
+			Name:      string(volume.Spec.ClaimRef.UID),
 			Namespace: p.storageNamespace,
 		},
 	}


### PR DESCRIPTION
# Description

This pr fixes an issue that caused names collision if multiple PVC with that same name were created in different namespaces and scheduled on the local cluster.

# How Has This Been Tested?

- [x] locally on KinD
- [x] unit test
