### PR TITLE
Fix liqoctl offload accept-deny labels

### DIFF
--- a/pkg/liqoctl/offload/consts.go
+++ b/pkg/liqoctl/offload/consts.go
@@ -19,7 +19,7 @@ const (
 	LiqoctlOffloadShortHelp = "Offload a namespace to remote clusters"
 	// LiqoctlOffloadLongHelp contains the Long help string for liqoctl Offload command.
 	LiqoctlOffloadLongHelp = `Offload a namespace to remote clusters with the default values:
-$ liqoctl Offload cluster my-cluster
+$ liqoctl offload namespace liqo-demo
 
 To just enable service reflection, offload a namespace with the EnforceSameName namespace mapping strategy and
 and a Local --pod-offloading-strategy.
@@ -39,13 +39,12 @@ kubectl get namespaceoffloading -n %s %s
 	// PodOffloadingStrategyFlag specifies the pod offloading strategy flag name.
 	PodOffloadingStrategyFlag = "pod-offloading-strategy"
 	// PodOffloadingStrategyHelp specifies the help message for the PodOffloadingStrategy flag.
-	PodOffloadingStrategyHelp = "Select the desired pod offloading strategy (Local, LocalAndRemote, Remote) " +
-		"(default: LocalAndRemote)"
+	PodOffloadingStrategyHelp = "Select the desired pod offloading strategy (Local, LocalAndRemote, Remote) "
+
 	// NamespaceMappingStrategyFlag specifies the namespace mapping flag name.
 	NamespaceMappingStrategyFlag = "namespace-mapping-strategy"
 	// NamespaceMappingStrategyHelp specifies the help message for the NamespaceMappingStrategy flag.
-	NamespaceMappingStrategyHelp = "Select the desired namespace mapping strategy (EnforceSameName, DefaultName) " +
-		"(default: DefaultName)"
+	NamespaceMappingStrategyHelp = "Select the desired namespace mapping strategy (EnforceSameName, DefaultName) "
 
 	// AcceptedLabelsFlag specifies the accepted labels flag name.
 	AcceptedLabelsFlag = "accepted-cluster-labels"

--- a/pkg/liqoctl/offload/namespace_test.go
+++ b/pkg/liqoctl/offload/namespace_test.go
@@ -20,6 +20,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -41,7 +42,7 @@ var _ = Describe("Test the generate command works as expected", func() {
 		parameters     []string
 		acceptedLabels args.StringMap
 		deniedLabels   args.StringMap
-		expected       *v1alpha1.NamespaceOffloading
+		expected       v1alpha1.NamespaceOffloading
 	}
 
 	DescribeTable("A generate command is performed",
@@ -51,14 +52,23 @@ var _ = Describe("Test the generate command works as expected", func() {
 			cmd.PersistentFlags().String(PodOffloadingStrategyFlag, string(v1alpha1.LocalAndRemotePodOffloadingStrategyType), "")
 			cmd.PersistentFlags().String(NamespaceMappingStrategyFlag, string(v1alpha1.DefaultNameMappingStrategyType), "")
 			Expect(cmd.Execute()).To(Succeed())
-			Expect(forgeNamespaceOffloading(cmd, tc.args, tc.acceptedLabels, tc.deniedLabels)).To(Equal(tc.expected))
+			nsOffloading := forgeNamespaceOffloading(cmd, tc.args, tc.acceptedLabels, tc.deniedLabels)
+			Expect(nsOffloading.ObjectMeta).To(MatchFields(IgnoreExtras, Fields{
+				"Name":      Equal(tc.expected.Name),
+				"Namespace": Equal(tc.expected.Namespace),
+			}))
+			Expect(nsOffloading.Spec).To(MatchFields(IgnoreExtras, Fields{
+				"NamespaceMappingStrategy": Equal(tc.expected.Spec.NamespaceMappingStrategy),
+				"PodOffloadingStrategy":    Equal(tc.expected.Spec.PodOffloadingStrategy),
+				"ClusterSelector":          Equal(tc.expected.Spec.ClusterSelector),
+			}))
 		},
 		Entry("Offload namespace with default parameters", testCase{
 			[]string{"test"},
 			[]string{},
 			args.StringMap{StringMap: map[string]string{}},
 			args.StringMap{StringMap: map[string]string{}},
-			&v1alpha1.NamespaceOffloading{
+			v1alpha1.NamespaceOffloading{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      liqoconst.DefaultNamespaceOffloadingName,
 					Namespace: "test",
@@ -88,7 +98,7 @@ var _ = Describe("Test the generate command works as expected", func() {
 				args.StringMap{StringMap: map[string]string{
 					"denied": "true",
 				}},
-				&v1alpha1.NamespaceOffloading{
+				v1alpha1.NamespaceOffloading{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      liqoconst.DefaultNamespaceOffloadingName,
 						Namespace: "test",
@@ -132,7 +142,7 @@ var _ = Describe("Test the generate command works as expected", func() {
 			args.StringMap{StringMap: map[string]string{
 				"denied": "true",
 			}},
-			&v1alpha1.NamespaceOffloading{
+			v1alpha1.NamespaceOffloading{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      liqoconst.DefaultNamespaceOffloadingName,
 					Namespace: "test",
@@ -176,7 +186,7 @@ var _ = Describe("Test the generate command works as expected", func() {
 					"test": "true",
 				}},
 				args.StringMap{StringMap: map[string]string{}},
-				&v1alpha1.NamespaceOffloading{
+				v1alpha1.NamespaceOffloading{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      liqoconst.DefaultNamespaceOffloadingName,
 						Namespace: "test",
@@ -189,14 +199,14 @@ var _ = Describe("Test the generate command works as expected", func() {
 								{
 									MatchExpressions: []corev1.NodeSelectorRequirement{
 										{
-											Key:      "test",
-											Operator: corev1.NodeSelectorOpIn,
-											Values:   []string{"true"},
-										},
-										{
 											Key:      liqoconst.TypeLabel,
 											Operator: corev1.NodeSelectorOpIn,
 											Values:   []string{liqoconst.TypeNode},
+										},
+										{
+											Key:      "test",
+											Operator: corev1.NodeSelectorOpIn,
+											Values:   []string{"true"},
 										},
 									},
 								},
@@ -215,7 +225,7 @@ var _ = Describe("Test the generate command works as expected", func() {
 				args.StringMap{StringMap: map[string]string{
 					"test": "true",
 				}},
-				&v1alpha1.NamespaceOffloading{
+				v1alpha1.NamespaceOffloading{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      liqoconst.DefaultNamespaceOffloadingName,
 						Namespace: "test",

--- a/pkg/liqoctl/offload/namespace_test.go
+++ b/pkg/liqoctl/offload/namespace_test.go
@@ -76,46 +76,51 @@ var _ = Describe("Test the generate command works as expected", func() {
 				},
 			},
 		}),
-		Entry("Offload namespace with accepted, custom pod-offloading and namespace mapping strategy", testCase{
-			[]string{"test"},
-			[]string{
-				"--pod-offloading-strategy=Local",
-			},
-			args.StringMap{StringMap: map[string]string{
-				"accepted": "true",
-			}},
-			args.StringMap{StringMap: map[string]string{
-				"denied": "true",
-			}},
-			&v1alpha1.NamespaceOffloading{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      liqoconst.DefaultNamespaceOffloadingName,
-					Namespace: "test",
+		Entry("Offload namespace with accepted/denied labels, custom pod-offloading and namespace mapping strategy",
+			testCase{
+				[]string{"test"},
+				[]string{
+					"--pod-offloading-strategy=Local",
 				},
-				Spec: v1alpha1.NamespaceOffloadingSpec{
-					NamespaceMappingStrategy: v1alpha1.DefaultNameMappingStrategyType,
-					PodOffloadingStrategy:    v1alpha1.LocalPodOffloadingStrategyType,
-					ClusterSelector: corev1.NodeSelector{
-						NodeSelectorTerms: []corev1.NodeSelectorTerm{
-							{
-								MatchExpressions: []corev1.NodeSelectorRequirement{{
-									Key:      "accepted",
-									Operator: corev1.NodeSelectorOpIn,
-									Values:   []string{"true"},
+				args.StringMap{StringMap: map[string]string{
+					"accepted": "true",
+				}},
+				args.StringMap{StringMap: map[string]string{
+					"denied": "true",
+				}},
+				&v1alpha1.NamespaceOffloading{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      liqoconst.DefaultNamespaceOffloadingName,
+						Namespace: "test",
+					},
+					Spec: v1alpha1.NamespaceOffloadingSpec{
+						NamespaceMappingStrategy: v1alpha1.DefaultNameMappingStrategyType,
+						PodOffloadingStrategy:    v1alpha1.LocalPodOffloadingStrategyType,
+						ClusterSelector: corev1.NodeSelector{
+							NodeSelectorTerms: []corev1.NodeSelectorTerm{
+								{
+									MatchExpressions: []corev1.NodeSelectorRequirement{
+										{
+											Key:      liqoconst.TypeLabel,
+											Operator: corev1.NodeSelectorOpIn,
+											Values:   []string{liqoconst.TypeNode},
+										},
+										{
+											Key:      "accepted",
+											Operator: corev1.NodeSelectorOpIn,
+											Values:   []string{"true"},
+										},
+										{
+											Key:      "denied",
+											Operator: corev1.NodeSelectorOpNotIn,
+											Values:   []string{"true"},
+										},
+									},
 								},
-								},
-							},
-							{
-								MatchExpressions: []corev1.NodeSelectorRequirement{{
-									Key:      "denied",
-									Operator: corev1.NodeSelectorOpNotIn,
-									Values:   []string{"true"},
-								}},
-							},
-						}},
+							}},
+					},
 				},
-			},
-		}),
+			}),
 		Entry("Offload namespace with default parameters", testCase{
 			[]string{"test"},
 			[]string{
@@ -138,19 +143,23 @@ var _ = Describe("Test the generate command works as expected", func() {
 					ClusterSelector: corev1.NodeSelector{
 						NodeSelectorTerms: []corev1.NodeSelectorTerm{
 							{
-								MatchExpressions: []corev1.NodeSelectorRequirement{{
-									Key:      "accepted",
-									Operator: corev1.NodeSelectorOpIn,
-									Values:   []string{"true"},
+								MatchExpressions: []corev1.NodeSelectorRequirement{
+									{
+										Key:      liqoconst.TypeLabel,
+										Operator: corev1.NodeSelectorOpIn,
+										Values:   []string{liqoconst.TypeNode},
+									},
+									{
+										Key:      "accepted",
+										Operator: corev1.NodeSelectorOpIn,
+										Values:   []string{"true"},
+									},
+									{
+										Key:      "denied",
+										Operator: corev1.NodeSelectorOpNotIn,
+										Values:   []string{"true"},
+									},
 								},
-								},
-							},
-							{
-								MatchExpressions: []corev1.NodeSelectorRequirement{{
-									Key:      "denied",
-									Operator: corev1.NodeSelectorOpNotIn,
-									Values:   []string{"true"},
-								}},
 							},
 						}},
 				},
@@ -178,11 +187,17 @@ var _ = Describe("Test the generate command works as expected", func() {
 						ClusterSelector: corev1.NodeSelector{
 							NodeSelectorTerms: []corev1.NodeSelectorTerm{
 								{
-									MatchExpressions: []corev1.NodeSelectorRequirement{{
-										Key:      "test",
-										Operator: corev1.NodeSelectorOpIn,
-										Values:   []string{"true"},
-									},
+									MatchExpressions: []corev1.NodeSelectorRequirement{
+										{
+											Key:      "test",
+											Operator: corev1.NodeSelectorOpIn,
+											Values:   []string{"true"},
+										},
+										{
+											Key:      liqoconst.TypeLabel,
+											Operator: corev1.NodeSelectorOpIn,
+											Values:   []string{liqoconst.TypeNode},
+										},
 									},
 								},
 							}},
@@ -211,11 +226,18 @@ var _ = Describe("Test the generate command works as expected", func() {
 						ClusterSelector: corev1.NodeSelector{
 							NodeSelectorTerms: []corev1.NodeSelectorTerm{
 								{
-									MatchExpressions: []corev1.NodeSelectorRequirement{{
-										Key:      "test",
-										Operator: corev1.NodeSelectorOpNotIn,
-										Values:   []string{"true"},
-									},
+
+									MatchExpressions: []corev1.NodeSelectorRequirement{
+										{
+											Key:      liqoconst.TypeLabel,
+											Operator: corev1.NodeSelectorOpIn,
+											Values:   []string{liqoconst.TypeNode},
+										},
+										{
+											Key:      "test",
+											Operator: corev1.NodeSelectorOpNotIn,
+											Values:   []string{"true"},
+										},
 									},
 								},
 							}},

--- a/test/e2e/postinstall/basic_test.go
+++ b/test/e2e/postinstall/basic_test.go
@@ -89,13 +89,15 @@ var _ = Describe("Liqo E2E", func() {
 						})
 						Expect(err).ToNot(HaveOccurred())
 						return tenantNsList.Items
-					}, timeout, interval).Should(HaveLen(1))
+					}, timeout, interval).Should(HaveLen(testContext.ClustersNumber - 1))
 
-					Eventually(func() bool {
-						readyPods, notReadyPods, err := util.ArePodsUp(ctx, cluster.NativeClient, tenantNsList.Items[0].Name)
-						klog.Infof("Tenant pods status: %d ready, %d not ready", len(readyPods), len(notReadyPods))
-						return err == nil && len(notReadyPods) == 0 && len(readyPods) == 1
-					}, timeout, interval).Should(BeTrue())
+					for _, tenantNs := range tenantNsList.Items {
+						Eventually(func() bool {
+							readyPods, notReadyPods, err := util.ArePodsUp(ctx, cluster.NativeClient, tenantNs.Name)
+							klog.Infof("Tenant pods status: %d ready, %d not ready", len(readyPods), len(notReadyPods))
+							return err == nil && len(notReadyPods) == 0 && len(readyPods) == 1
+						}, timeout, interval).Should(BeTrue())
+					}
 				},
 				PodsUpAndRunningTableEntries...,
 			)


### PR DESCRIPTION
# Description

This PR fixes the liqoctl behavior when dealing with accepted and denied labels. The labels are now inserted in the namespaceOffloading as terms of the same expression and evaluated in an AND operation.

# How Has This Been Tested?

- [x] Unit Test
