### PR TITLE
Cache unit tests in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -126,6 +126,7 @@ jobs:
       with:
         options: |
           --mount type=bind,src=${{ github.workspace }},dst=/go/src/liqotech/liqo
+          --mount type=bind,src=/home/runner/.cache,dst=/root/.cache
           --workdir /go/src/liqotech/liqo
           --privileged=true
         image: liqo/liqo-test:${{ needs.configure.outputs.commit-ref }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,6 +103,23 @@ jobs:
 
     - name: Fetch External CRDs
       run: make fetch-external-crds
+    
+    - name: Load Go build cache
+      uses: actions/cache@v2
+      with:
+        # In order:
+        # * Module download cache
+        # * Build cache (Linux)
+        # * Build cache (Mac)
+        # * Build cache (Windows)
+        path: |
+          ~/go/pkg/mod
+          ~/.cache/go-build
+          ~/Library/Caches/go-build
+          %LocalAppData%\go-build
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
 
     - name: Launch Test (Docker Container)
       uses: addnab/docker-run-action@v3


### PR DESCRIPTION
# Description

Adds Go build caching to the CI workflow (see eg. https://github.com/mvdan/github-actions-golang#how-do-i-set-up-caching-between-builds). This allows us to "skip" building and running tests for components that haven't changed.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B
