### PR TITLE
Minor fixes

### DIFF
--- a/pkg/liqoctl/install/kubeadm/provider.go
+++ b/pkg/liqoctl/install/kubeadm/provider.go
@@ -79,6 +79,7 @@ func (k *Kubeadm) UpdateChartValues(values map[string]interface{}) {
 	values["discovery"] = map[string]interface{}{
 		"config": map[string]interface{}{
 			"clusterLabels": installutils.GetInterfaceMap(k.ClusterLabels),
+			"clusterName":   k.ClusterName,
 		},
 	}
 }

--- a/pkg/virtualKubelet/liqoNodeProvider/setup.go
+++ b/pkg/virtualKubelet/liqoNodeProvider/setup.go
@@ -31,7 +31,7 @@ import (
 
 const (
 	linuxos      = "Linux"
-	architecture = "arm64"
+	architecture = "amd64"
 
 	labelNodeExcludeBalancersAlpha = "alpha.service-controller.kubernetes.io/exclude-balancer"
 	roleLabelKey                   = "kubernetes.io/role"


### PR DESCRIPTION
# Description

This PR fixes a typo in the virtual kubelet architecture label, and the missing cluster label configuration in `liqoctl install kubeadm`.

