### PR TITLE
Simplify virtual kubelet flags handling

### DIFF
--- a/cmd/virtual-kubelet/main.go
+++ b/cmd/virtual-kubelet/main.go
@@ -40,16 +40,12 @@ func main() {
 
 	log.L = klogv2.New(nil)
 
-	opts := &root.Opts{}
-	if err := root.SetDefaultOpts(opts); err != nil {
-		klog.Fatal(err)
-	}
-
+	opts := root.NewOpts()
 	rootCmd := root.NewCommand(ctx, filepath.Base(os.Args[0]), opts)
 
 	root.InstallFlags(rootCmd.Flags(), opts)
 	rootCmd.PreRunE = func(cmd *cobra.Command, args []string) error {
-		if opts.Profiling {
+		if opts.EnableProfiling {
 			enableProfiling()
 		}
 		return nil

--- a/cmd/virtual-kubelet/root/flag.go
+++ b/cmd/virtual-kubelet/root/flag.go
@@ -19,41 +19,42 @@ import (
 
 	"github.com/spf13/pflag"
 	"k8s.io/klog/v2"
+
+	"github.com/liqotech/liqo/pkg/utils/restcfg"
 )
 
-func InstallFlags(flags *pflag.FlagSet, c *Opts) {
-	flags.StringVar(&c.HomeKubeconfig, "home-kubeconfig", c.HomeKubeconfig, "kube config file to use for connecting to the Kubernetes API server")
-	flags.StringVar(&c.NodeName, "nodename", c.NodeName, "kubernetes node name")
-	flags.StringVar(&c.MetricsAddr, "metrics-addr", c.MetricsAddr, "address to listen for metrics/stats requests")
+// InstallFlags configures the virtual kubelet flags.
+func InstallFlags(flags *pflag.FlagSet, o *Opts) {
+	flags.StringVar(&o.HomeKubeconfig, "home-kubeconfig", o.HomeKubeconfig, "kube config file to use for connecting to the Kubernetes API server")
+	flags.StringVar(&o.NodeName, "nodename", o.NodeName, "The name of the node registered by the virtual kubelet")
+	flags.StringVar(&o.TenantNamespace, "tenant-namespace", o.TenantNamespace, "The tenant namespace associated with the remote cluster")
+	flags.DurationVar(&o.InformerResyncPeriod, "resync-period", o.InformerResyncPeriod, "The resync period for the informers")
 
-	flags.UintVar(&c.PodWorkers, "pod-reflection-workers", c.PodWorkers, "the number of pod reflection workers")
-	flags.UintVar(&c.ServiceWorkers, "service-reflection-workers", c.ServiceWorkers, "the number of service reflection workers")
-	flags.UintVar(&c.EndpointSliceWorkers, "endpointslice-reflection-workers", c.EndpointSliceWorkers,
-		"the number of endpointslice reflection workers")
-	flags.UintVar(&c.ConfigMapWorkers, "configmap-reflection-workers", c.ConfigMapWorkers, "the number of configmap reflection workers")
-	flags.UintVar(&c.SecretWorkers, "secret-reflection-workers", c.SecretWorkers, "the number of secret reflection workers")
-	flags.UintVar(&c.PersistenVolumeClaimWorkers, "persistentvolumeclaim-reflection-workers", c.PersistenVolumeClaimWorkers,
-		"the number of persistentvolumeclaim reflection workers")
+	flags.StringVar(&o.HomeCluster.ClusterID, "home-cluster-id", o.HomeCluster.ClusterID, "The ID of the home cluster")
+	flags.StringVar(&o.HomeCluster.ClusterName, "home-cluster-name", o.HomeCluster.ClusterName, "The name of the home cluster")
+	flags.StringVar(&o.ForeignCluster.ClusterID, "foreign-cluster-id", o.ForeignCluster.ClusterID, "The ID of the foreign cluster")
+	flags.StringVar(&o.ForeignCluster.ClusterName, "foreign-cluster-name", o.ForeignCluster.ClusterName, "The name of the foreign cluster")
+	flags.StringVar(&o.LiqoIpamServer, "ipam-server", o.LiqoIpamServer, "The address to contact the IPAM module")
 
-	flags.DurationVar(&c.InformerResyncPeriod, "full-resync-period", c.InformerResyncPeriod,
-		"how often to perform a full resync of pods between kubernetes and the provider")
-	flags.DurationVar(&c.StartupTimeout, "startup-timeout", c.StartupTimeout, "How long to wait for the virtual-kubelet to start")
+	flags.Uint16Var(&o.ListenPort, "listen-port", o.ListenPort, "The port to listen to for requests from the Kubernetes API server")
+	flags.StringVar(&o.MetricsAddress, "metrics-address", o.MetricsAddress, "Address to listen for metrics/stats requests")
+	flags.BoolVar(&o.EnableProfiling, "enable-profiling", o.EnableProfiling, "Enable pprof profiling")
 
-	flags.StringVar(&c.ForeignCluster.ClusterID, "foreign-cluster-id", c.ForeignCluster.ClusterID, "The ID of the foreign cluster")
-	flags.StringVar(&c.ForeignCluster.ClusterName, "foreign-cluster-name", c.ForeignCluster.ClusterName, "The name of the foreign cluster")
-	flags.StringVar(&c.KubeletNamespace, "kubelet-namespace", c.KubeletNamespace, "The namespace of the virtual kubelet")
-	flags.StringVar(&c.HomeCluster.ClusterID, "home-cluster-id", c.HomeCluster.ClusterID, "The ID of the home cluster")
-	flags.StringVar(&c.HomeCluster.ClusterName, "home-cluster-name", c.HomeCluster.ClusterName, "The name of the home cluster")
-	flags.StringVar(&c.LiqoIpamServer, "ipam-server", c.LiqoIpamServer, "The server the Virtual Kubelet should "+
-		"connect to in order to contact the IPAM module")
-	flags.BoolVar(&c.Profiling, "enable-profiling", c.Profiling, "Enable pprof profiling")
+	flags.UintVar(&o.PodWorkers, "pod-reflection-workers", o.PodWorkers, "The number of pod reflection workers")
+	flags.UintVar(&o.ServiceWorkers, "service-reflection-workers", o.ServiceWorkers, "The number of service reflection workers")
+	flags.UintVar(&o.EndpointSliceWorkers, "endpointslice-reflection-workers", o.EndpointSliceWorkers,
+		"The number of endpointslice reflection workers")
+	flags.UintVar(&o.ConfigMapWorkers, "configmap-reflection-workers", o.ConfigMapWorkers, "The number of configmap reflection workers")
+	flags.UintVar(&o.SecretWorkers, "secret-reflection-workers", o.SecretWorkers, "The number of secret reflection workers")
+	flags.UintVar(&o.PersistenVolumeClaimWorkers, "persistentvolumeclaim-reflection-workers", o.PersistenVolumeClaimWorkers,
+		"The number of persistentvolumeclaim reflection workers")
 
-	flags.Var(&c.NodeExtraAnnotations, "node-extra-annotations", "Extra annotations to add to the Virtual Node")
-	flags.Var(&c.NodeExtraLabels, "node-extra-labels", "Extra labels to add to the Virtual Node")
+	flags.Var(&o.NodeExtraAnnotations, "node-extra-annotations", "Extra annotations to add to the Virtual Node")
+	flags.Var(&o.NodeExtraLabels, "node-extra-labels", "Extra labels to add to the Virtual Node")
 
-	flags.BoolVar(&c.EnableStorage, "enable-storage", false, "Enable the Liqo storage reflection")
-	flags.StringVar(&c.VirtualStorageClassName, "virtual-storage-class-name", "liqo", "Name of the virtual storage class")
-	flags.StringVar(&c.RemoteRealStorageClassName, "remote-real-storage-class-name", "", "Name of the real storage class to use for the actual volumes")
+	flags.BoolVar(&o.EnableStorage, "enable-storage", false, "Enable the Liqo storage reflection")
+	flags.StringVar(&o.VirtualStorageClassName, "virtual-storage-class-name", "liqo", "Name of the virtual storage class")
+	flags.StringVar(&o.RemoteRealStorageClassName, "remote-real-storage-class-name", "", "Name of the real storage class to use for the actual volumes")
 
 	flagset := flag.NewFlagSet("klog", flag.PanicOnError)
 	klog.InitFlags(flagset)
@@ -61,4 +62,8 @@ func InstallFlags(flags *pflag.FlagSet, c *Opts) {
 		f.Name = "klog." + f.Name
 		flags.AddGoFlag(f)
 	})
+
+	flagset = flag.NewFlagSet("restcfg", flag.PanicOnError)
+	restcfg.InitFlags(flagset)
+	flags.AddGoFlagSet(flagset)
 }

--- a/cmd/virtual-kubelet/root/http.go
+++ b/cmd/virtual-kubelet/root/http.go
@@ -168,7 +168,7 @@ func getAPIConfig(c *Opts) *apiServerConfig {
 	}
 
 	config.Addr = fmt.Sprintf(":%d", c.ListenPort)
-	config.MetricsAddr = c.MetricsAddr
+	config.MetricsAddr = c.MetricsAddress
 
 	return &config
 }

--- a/cmd/virtual-kubelet/root/opts.go
+++ b/cmd/virtual-kubelet/root/opts.go
@@ -17,10 +17,9 @@ package root
 import (
 	"fmt"
 	"os"
-	"strconv"
 	"time"
 
-	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
 
 	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
 	"github.com/liqotech/liqo/pkg/consts"
@@ -31,8 +30,8 @@ import (
 const (
 	DefaultNodeName             = "virtual-kubelet"
 	DefaultInformerResyncPeriod = 10 * time.Hour
-	DefaultMetricsAddr          = ":10255"
 	DefaultListenPort           = 10250
+	DefaultMetricsAddress       = ":10255"
 
 	DefaultPodWorkers                  = 10
 	DefaultServiceWorkers              = 3
@@ -40,26 +39,26 @@ const (
 	DefaultConfigMapWorkers            = 3
 	DefaultSecretWorkers               = 3
 	DefaultPersistenVolumeClaimWorkers = 3
-
-	DefaultKubeletNamespace = "default"
-	DefaultLiqoIpamServer   = consts.NetworkManagerServiceName
 )
 
 // Opts stores all the options for configuring the root virtual-kubelet command.
 // It is used for setting flag values.
-//
-// You can set the default options by creating a new `Opts` struct and passing
-// it into `SetDefaultOpts`.
 type Opts struct {
-	// Sets the port to listen for requests from the Kubernetes API server
-	ListenPort int32
-
-	// Node name to use when creating a node in Kubernetes
-	NodeName string
-
 	HomeKubeconfig string
 
-	MetricsAddr string
+	// Node name to use when creating a node in Kubernetes
+	NodeName             string
+	TenantNamespace      string
+	InformerResyncPeriod time.Duration
+
+	HomeCluster    discoveryv1alpha1.ClusterIdentity
+	ForeignCluster discoveryv1alpha1.ClusterIdentity
+	LiqoIpamServer string
+
+	// Sets the port to listen for requests from the Kubernetes API server
+	ListenPort      uint16
+	MetricsAddress  string
+	EnableProfiling bool
 
 	// Number of workers to use to handle pod notifications and resource reflection
 	PodWorkers                  uint
@@ -69,19 +68,6 @@ type Opts struct {
 	SecretWorkers               uint
 	PersistenVolumeClaimWorkers uint
 
-	InformerResyncPeriod time.Duration
-
-	// Startup Timeout is how long to wait for the kubelet to start
-	StartupTimeout time.Duration
-
-	ForeignCluster   discoveryv1alpha1.ClusterIdentity
-	HomeCluster      discoveryv1alpha1.ClusterIdentity
-	KubeletNamespace string
-
-	LiqoIpamServer string
-
-	Profiling bool
-
 	NodeExtraAnnotations argsutils.StringMap
 	NodeExtraLabels      argsutils.StringMap
 
@@ -90,62 +76,25 @@ type Opts struct {
 	RemoteRealStorageClassName string
 }
 
-// SetDefaultOpts sets default options for unset values on the passed in option struct.
-// Fields tht are already set will not be modified.
-func SetDefaultOpts(c *Opts) error {
-	if c.InformerResyncPeriod == 0 {
-		c.InformerResyncPeriod = DefaultInformerResyncPeriod
-	}
+// NewOpts returns an Opts struct with the default values set.
+func NewOpts() *Opts {
+	return &Opts{
+		HomeKubeconfig:       os.Getenv("KUBECONFIG"),
+		NodeName:             DefaultNodeName,
+		TenantNamespace:      corev1.NamespaceDefault,
+		InformerResyncPeriod: DefaultInformerResyncPeriod,
 
-	if c.MetricsAddr == "" {
-		c.MetricsAddr = DefaultMetricsAddr
-	}
+		LiqoIpamServer: fmt.Sprintf("%v:%v", consts.NetworkManagerServiceName, consts.NetworkManagerIpamPort),
 
-	if c.PodWorkers == 0 {
-		c.PodWorkers = DefaultPodWorkers
-	}
+		ListenPort:      DefaultListenPort,
+		MetricsAddress:  DefaultMetricsAddress,
+		EnableProfiling: false,
 
-	if c.ServiceWorkers == 0 {
-		c.ServiceWorkers = DefaultServiceWorkers
+		PodWorkers:                  DefaultPodWorkers,
+		ServiceWorkers:              DefaultServiceWorkers,
+		EndpointSliceWorkers:        DefaultEndpointSliceWorkers,
+		ConfigMapWorkers:            DefaultConfigMapWorkers,
+		SecretWorkers:               DefaultSecretWorkers,
+		PersistenVolumeClaimWorkers: DefaultPersistenVolumeClaimWorkers,
 	}
-
-	if c.EndpointSliceWorkers == 0 {
-		c.EndpointSliceWorkers = DefaultEndpointSliceWorkers
-	}
-
-	if c.ConfigMapWorkers == 0 {
-		c.ConfigMapWorkers = DefaultConfigMapWorkers
-	}
-
-	if c.SecretWorkers == 0 {
-		c.SecretWorkers = DefaultSecretWorkers
-	}
-
-	if c.PersistenVolumeClaimWorkers == 0 {
-		c.PersistenVolumeClaimWorkers = DefaultPersistenVolumeClaimWorkers
-	}
-
-	if c.ListenPort == 0 {
-		if kp := os.Getenv("KUBELET_PORT"); kp != "" {
-			p, err := strconv.ParseInt(kp, 10, 32)
-			if err != nil {
-				return errors.Wrap(err, "error parsing KUBELET_PORT environment variable")
-			}
-			c.ListenPort = int32(p)
-		} else {
-			c.ListenPort = DefaultListenPort
-		}
-	}
-
-	if c.KubeletNamespace == "" {
-		c.KubeletNamespace = DefaultKubeletNamespace
-	}
-	if c.HomeKubeconfig == "" {
-		c.HomeKubeconfig = os.Getenv("KUBECONFIG")
-	}
-	if c.LiqoIpamServer == "" {
-		c.LiqoIpamServer = fmt.Sprintf("%v:%v", consts.NetworkManagerServiceName, consts.NetworkManagerIpamPort)
-	}
-
-	return nil
 }

--- a/pkg/virtualKubelet/liqoNodeProvider/nodeProvider.go
+++ b/pkg/virtualKubelet/liqoNodeProvider/nodeProvider.go
@@ -35,7 +35,7 @@ type LiqoNodeProvider struct {
 
 	nodeName         string
 	foreignClusterID string
-	kubeletNamespace string
+	tenantNamespace  string
 	resyncPeriod     time.Duration
 
 	networkReady bool

--- a/pkg/virtualKubelet/liqoNodeProvider/resourceWatcher.go
+++ b/pkg/virtualKubelet/liqoNodeProvider/resourceWatcher.go
@@ -36,7 +36,7 @@ import (
 // update the virtual node.
 func (p *LiqoNodeProvider) StartProvider(ctx context.Context) (ready chan struct{}) {
 	resource := "resourceoffers"
-	namespace := p.kubeletNamespace
+	namespace := p.tenantNamespace
 
 	sharingInformerFactory := dynamicinformer.NewFilteredDynamicSharedInformerFactory(
 		p.dynClient, p.resyncPeriod, namespace, func(opt *metav1.ListOptions) {

--- a/pkg/virtualKubelet/liqoNodeProvider/setup.go
+++ b/pkg/virtualKubelet/liqoNodeProvider/setup.go
@@ -41,13 +41,14 @@ const (
 // InitConfig is the config passed to initialize the LiqoNodeProvider.
 type InitConfig struct {
 	HomeConfig      *rest.Config
+	RemoteConfig    *rest.Config
 	HomeClusterID   string
 	RemoteClusterID string
 	Namespace       string
 
 	NodeName         string
 	InternalIP       string
-	DaemonPort       int32
+	DaemonPort       uint16
 	Version          string
 	ExtraLabels      map[string]string
 	ExtraAnnotations map[string]string
@@ -74,7 +75,7 @@ func NewLiqoNodeProvider(cfg *InitConfig) *LiqoNodeProvider {
 
 		nodeName:         cfg.NodeName,
 		foreignClusterID: cfg.RemoteClusterID,
-		kubeletNamespace: cfg.Namespace,
+		tenantNamespace:  cfg.Namespace,
 	}
 }
 
@@ -113,7 +114,7 @@ func node(cfg *InitConfig) *corev1.Node {
 				OperatingSystem: linuxos,
 			},
 			Addresses:       []corev1.NodeAddress{{Type: corev1.NodeInternalIP, Address: cfg.InternalIP}},
-			DaemonEndpoints: corev1.NodeDaemonEndpoints{KubeletEndpoint: corev1.DaemonEndpoint{Port: cfg.DaemonPort}},
+			DaemonEndpoints: corev1.NodeDaemonEndpoints{KubeletEndpoint: corev1.DaemonEndpoint{Port: int32(cfg.DaemonPort)}},
 			Capacity:        corev1.ResourceList{},
 			Allocatable:     corev1.ResourceList{},
 			Conditions:      UnknownNodeConditions(),

--- a/pkg/vkMachinery/forge/forge.go
+++ b/pkg/vkMachinery/forge/forge.go
@@ -119,12 +119,11 @@ func forgeVKContainers(
 		stringifyArgument("--foreign-cluster-id", remoteCluster.ClusterID),
 		stringifyArgument("--foreign-cluster-name", remoteCluster.ClusterName),
 		stringifyArgument("--nodename", nodeName),
-		stringifyArgument("--kubelet-namespace", vkNamespace),
+		stringifyArgument("--tenant-namespace", vkNamespace),
 		stringifyArgument("--home-cluster-id", homeCluster.ClusterID),
 		stringifyArgument("--home-cluster-name", homeCluster.ClusterName),
 		stringifyArgument("--ipam-server",
 			fmt.Sprintf("%v.%v:%v", liqoconst.NetworkManagerServiceName, liqoNamespace, liqoconst.NetworkManagerIpamPort)),
-		"--klog.v=4",
 	}
 
 	if len(resourceOffer.Spec.StorageClasses) > 0 {


### PR DESCRIPTION
# Description

This PR starts to uniform and simplify flags handling in the virtual kubelet. Ref. #956
It also anticipates the retrieval of the remote restcfg, so that it can be shared both by the node and the pod provider.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Existing
