### PR TITLE
Virtual Kubelet: introduce node ping check

### DIFF
--- a/cmd/virtual-kubelet/root/flag.go
+++ b/cmd/virtual-kubelet/root/flag.go
@@ -49,6 +49,12 @@ func InstallFlags(flags *pflag.FlagSet, o *Opts) {
 	flags.UintVar(&o.PersistenVolumeClaimWorkers, "persistentvolumeclaim-reflection-workers", o.PersistenVolumeClaimWorkers,
 		"The number of persistentvolumeclaim reflection workers")
 
+	flags.DurationVar(&o.NodeLeaseDuration, "node-lease-duration", o.NodeLeaseDuration, "The duration of the node leases")
+	flags.DurationVar(&o.NodePingInterval, "node-ping-interval", o.NodePingInterval,
+		"The interval the reachability of the remote API server is verified to assess node readiness")
+	flags.DurationVar(&o.NodePingTimeout, "node-ping-timeout", o.NodePingTimeout,
+		"The timeout of the remote API server reachability check")
+
 	flags.Var(&o.NodeExtraAnnotations, "node-extra-annotations", "Extra annotations to add to the Virtual Node")
 	flags.Var(&o.NodeExtraLabels, "node-extra-labels", "Extra labels to add to the Virtual Node")
 

--- a/cmd/virtual-kubelet/root/opts.go
+++ b/cmd/virtual-kubelet/root/opts.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/virtual-kubelet/virtual-kubelet/node"
 	corev1 "k8s.io/api/core/v1"
 
 	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
@@ -39,6 +40,8 @@ const (
 	DefaultConfigMapWorkers            = 3
 	DefaultSecretWorkers               = 3
 	DefaultPersistenVolumeClaimWorkers = 3
+
+	DefaultNodePingTimeout = 1 * time.Second
 )
 
 // Opts stores all the options for configuring the root virtual-kubelet command.
@@ -68,6 +71,10 @@ type Opts struct {
 	SecretWorkers               uint
 	PersistenVolumeClaimWorkers uint
 
+	NodeLeaseDuration time.Duration
+	NodePingInterval  time.Duration
+	NodePingTimeout   time.Duration
+
 	NodeExtraAnnotations argsutils.StringMap
 	NodeExtraLabels      argsutils.StringMap
 
@@ -96,5 +103,9 @@ func NewOpts() *Opts {
 		ConfigMapWorkers:            DefaultConfigMapWorkers,
 		SecretWorkers:               DefaultSecretWorkers,
 		PersistenVolumeClaimWorkers: DefaultPersistenVolumeClaimWorkers,
+
+		NodeLeaseDuration: node.DefaultLeaseDuration * time.Second,
+		NodePingInterval:  node.DefaultPingInterval,
+		NodePingTimeout:   DefaultNodePingTimeout,
 	}
 }

--- a/cmd/virtual-kubelet/root/root.go
+++ b/cmd/virtual-kubelet/root/root.go
@@ -143,7 +143,8 @@ func runRootCommand(ctx context.Context, c *Opts) error {
 	nodeRunner, err := node.NewNodeController(
 		nodeProvider, nodeProvider.GetNode(),
 		localClient.CoreV1().Nodes(),
-		node.WithNodeEnableLeaseV1(localClient.CoordinationV1().Leases(corev1.NamespaceNodeLease), node.DefaultLeaseDuration),
+		node.WithNodeEnableLeaseV1(localClient.CoordinationV1().Leases(corev1.NamespaceNodeLease), int32(c.NodeLeaseDuration.Seconds())),
+		node.WithNodePingInterval(c.NodePingInterval), node.WithNodePingTimeout(c.NodePingTimeout),
 		node.WithNodeStatusUpdateErrorHandler(
 			func(ctx context.Context, err error) error {
 				klog.Info("node setting up")

--- a/pkg/virtualKubelet/liqoNodeProvider/nodeProvider_test.go
+++ b/pkg/virtualKubelet/liqoNodeProvider/nodeProvider_test.go
@@ -85,6 +85,7 @@ var _ = Describe("NodeProvider", func() {
 			Namespace: kubeletNamespace,
 
 			HomeConfig:      cluster.GetCfg(),
+			RemoteConfig:    cluster.GetCfg(), /* not actually used in tests */
 			RemoteClusterID: foreignClusterID,
 
 			PodProviderStopper: podStopper,

--- a/pkg/virtualKubelet/liqoNodeProvider/reconciler.go
+++ b/pkg/virtualKubelet/liqoNodeProvider/reconciler.go
@@ -245,7 +245,7 @@ func (p *LiqoNodeProvider) handleResourceOfferDelete(resourceOffer *sharingv1alp
 	}
 
 	// delete the node
-	if err := client.IgnoreNotFound(p.client.CoreV1().Nodes().Delete(ctx, p.node.GetName(), metav1.DeleteOptions{})); err != nil {
+	if err := client.IgnoreNotFound(p.localClient.CoreV1().Nodes().Delete(ctx, p.node.GetName(), metav1.DeleteOptions{})); err != nil {
 		klog.Errorf("error deleting node: %v", err)
 		return err
 	}

--- a/pkg/virtualKubelet/liqoNodeProvider/setup.go
+++ b/pkg/virtualKubelet/liqoNodeProvider/setup.go
@@ -22,6 +22,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -59,12 +60,10 @@ type InitConfig struct {
 
 // NewLiqoNodeProvider creates and returns a new LiqoNodeProvider.
 func NewLiqoNodeProvider(cfg *InitConfig) *LiqoNodeProvider {
-	client := kubernetes.NewForConfigOrDie(cfg.HomeConfig)
-	dynClient := dynamic.NewForConfigOrDie(cfg.HomeConfig)
-
 	return &LiqoNodeProvider{
-		client:    client,
-		dynClient: dynClient,
+		localClient:           kubernetes.NewForConfigOrDie(cfg.HomeConfig),
+		remoteDiscoveryClient: discovery.NewDiscoveryClientForConfigOrDie(cfg.RemoteConfig),
+		dynClient:             dynamic.NewForConfigOrDie(cfg.HomeConfig),
 
 		node:              node(cfg),
 		terminating:       false,

--- a/pkg/virtualKubelet/liqoNodeProvider/utils.go
+++ b/pkg/virtualKubelet/liqoNodeProvider/utils.go
@@ -64,7 +64,7 @@ func (p *LiqoNodeProvider) patchNode(changeFunc func(node *v1.Node) error) error
 		return err
 	}
 
-	p.node, err = p.client.CoreV1().Nodes().Patch(context.TODO(),
+	p.node, err = p.localClient.CoreV1().Nodes().Patch(context.TODO(),
 		p.node.Name, types.JSONPatchType, bytes, metav1.PatchOptions{})
 	if err != nil {
 		klog.Error(err)


### PR DESCRIPTION
# Description

This PR introduces a ping check in the virtual kubelet, to ensure the node is marked as not ready in case the remote API server is no longer reachable. The ping check is performed towards the remote `/livez` endpoint, by default every 10s (with 1s timeout). Whenever the ping check fails, the node lease stops to be updated by the virtual kubelet, and the node is marked as not ready (similarly, when it succeeds the lease is updated again). 

```
  Type                 Status    LastHeartbeatTime                 LastTransitionTime                Reason              Message
  ----                 ------    -----------------                 ------------------                ------              -------
  Ready                Unknown   Mon, 06 Dec 2021 10:52:58 +0000   Mon, 06 Dec 2021 10:53:55 +0000   NodeStatusUnknown   Kubelet stopped posting node status.
  MemoryPressure       Unknown   Mon, 06 Dec 2021 10:52:58 +0000   Mon, 06 Dec 2021 10:53:55 +0000   NodeStatusUnknown   Kubelet stopped posting node status.
  DiskPressure         Unknown   Mon, 06 Dec 2021 10:52:58 +0000   Mon, 06 Dec 2021 10:53:55 +0000   NodeStatusUnknown   Kubelet stopped posting node status.
  PIDPressure          Unknown   Mon, 06 Dec 2021 10:52:58 +0000   Mon, 06 Dec 2021 10:53:55 +0000   NodeStatusUnknown   Kubelet stopped posting node status.
  NetworkUnavailable   False     Mon, 06 Dec 2021 10:52:58 +0000   Mon, 06 Dec 2021 10:32:33 +0000   LiqoNetworkingUp    The Liqo cluster interconnection is established
```

Ref. #1010 

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] Manually, with kind clusters
