### PR TITLE
Authentication: modify transport to leverage persistent connections

### DIFF
--- a/pkg/discoverymanager/discovery.go
+++ b/pkg/discoverymanager/discovery.go
@@ -16,6 +16,8 @@ package discovery
 
 import (
 	"context"
+	"crypto/tls"
+	"net/http"
 	"sync"
 	"time"
 
@@ -58,6 +60,8 @@ type Controller struct {
 
 	mdnsServerAuth *zeroconf.Server
 	mdnsConfig     MDNSConfig
+
+	insecureTransport *http.Transport
 }
 
 // NewDiscoveryCtrl returns a new discovery controller.
@@ -72,6 +76,8 @@ func NewDiscoveryCtrl(cl, namespacedClient client.Client, namespace string,
 
 		mdnsConfig:     config,
 		dialTCPTimeout: dialTCPTimeout,
+
+		insecureTransport: &http.Transport{IdleConnTimeout: 10 * time.Minute, TLSClientConfig: &tls.Config{InsecureSkipVerify: true}},
 	}
 }
 

--- a/pkg/discoverymanager/foreign.go
+++ b/pkg/discoverymanager/foreign.go
@@ -16,6 +16,7 @@ package discovery
 
 import (
 	"context"
+	"net/http"
 
 	k8serror "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -65,13 +66,13 @@ func (discovery *Controller) updateForeignLAN(data *discoveryData) {
 // for each cluster retrieved with DNS discovery, if it is not the local cluster, check if it is already known, if not
 // create it. In both cases update the ForeignCluster TTL
 // This function also sets an owner reference and a label to the ForeignCluster pointing to the SearchDomain CR.
-func UpdateForeignWAN(ctx context.Context,
+func UpdateForeignWAN(ctx context.Context, transport *http.Transport,
 	cl client.Client, localCluster v1alpha1.ClusterIdentity,
 	data []*AuthData, sd *v1alpha1.SearchDomain) []*v1alpha1.ForeignCluster {
 	createdUpdatedForeign := []*v1alpha1.ForeignCluster{}
 	discoveryType := discoveryPkg.WanDiscovery
 	for _, authData := range data {
-		clusterInfo, err := utils.GetClusterInfo(defaultInsecureSkipTLSVerify, authData.getURL())
+		clusterInfo, err := utils.GetClusterInfo(ctx, transport, authData.getURL())
 		if err != nil {
 			klog.Error(err)
 			continue

--- a/pkg/discoverymanager/resolve.go
+++ b/pkg/discoverymanager/resolve.go
@@ -70,7 +70,7 @@ func (discovery *Controller) resolve(ctx context.Context, service, domain string
 						klog.Error(err)
 						continue
 					}
-					dData.ClusterInfo, err = discovery.getClusterInfo(defaultInsecureSkipTLSVerify, dData.AuthData)
+					dData.ClusterInfo, err = discovery.getClusterInfo(ctx, dData.AuthData)
 					if err != nil {
 						klog.Error(err)
 						continue
@@ -94,8 +94,8 @@ func (discovery *Controller) resolve(ctx context.Context, service, domain string
 	<-ctx.Done()
 }
 
-func (discovery *Controller) getClusterInfo(insecureSkipTLSVerify bool, authData *AuthData) (*auth.ClusterInfo, error) {
-	ids, err := utils.GetClusterInfo(insecureSkipTLSVerify, authData.getURL())
+func (discovery *Controller) getClusterInfo(ctx context.Context, authData *AuthData) (*auth.ClusterInfo, error) {
+	ids, err := utils.GetClusterInfo(ctx, discovery.insecureTransport, authData.getURL())
 	if err != nil {
 		klog.Error(err)
 		return nil, err

--- a/pkg/discoverymanager/utils/utils.go
+++ b/pkg/discoverymanager/utils/utils.go
@@ -18,7 +18,6 @@ package utils
 
 import (
 	"context"
-	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -37,15 +36,12 @@ const (
 
 // GetClusterInfo contacts the remote cluster to get its info,
 // it returns also if the remote cluster exposes a trusted certificate.
-func GetClusterInfo(skipTLSVerify bool, url string) (*auth.ClusterInfo, error) {
-	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: skipTLSVerify},
-	}
+func GetClusterInfo(ctx context.Context, transport *http.Transport, url string) (*auth.ClusterInfo, error) {
 	client := &http.Client{
-		Transport: tr,
+		Transport: transport,
 		Timeout:   HTTPRequestTimeout,
 	}
-	resp, err := httpGet(context.TODO(), client, fmt.Sprintf("%s%s", url, auth.IdsURI))
+	resp, err := httpGet(ctx, client, fmt.Sprintf("%s%s", url, auth.IdsURI))
 	if err != nil {
 		return nil, err
 	}
@@ -67,7 +63,7 @@ func GetClusterInfo(skipTLSVerify bool, url string) (*auth.ClusterInfo, error) {
 }
 
 func httpGet(ctx context.Context, client *http.Client, url string) (resp *http.Response, err error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
 	if err != nil {
 		klog.Error(err)
 		return nil, err

--- a/pkg/liqo-controller-manager/foreign-cluster-operator/clusterIdentityDefaulting.go
+++ b/pkg/liqo-controller-manager/foreign-cluster-operator/clusterIdentityDefaulting.go
@@ -15,6 +15,8 @@
 package foreignclusteroperator
 
 import (
+	"context"
+
 	"k8s.io/klog/v2"
 
 	"github.com/liqotech/liqo/apis/discovery/v1alpha1"
@@ -31,9 +33,9 @@ func (r *ForeignClusterReconciler) needsClusterIdentityDefaulting(fc *v1alpha1.F
 // clusterIdentityDefaulting loads the default values for that ForeignCluster basing on the AuthUrl value, an HTTP request
 // is sent and the retrieved values are applied for the following fields (if they are empty):
 // ClusterIdentity.ClusterID, ClusterIdentity.ClusterName.
-func (r *ForeignClusterReconciler) clusterIdentityDefaulting(fc *v1alpha1.ForeignCluster) error {
+func (r *ForeignClusterReconciler) clusterIdentityDefaulting(ctx context.Context, fc *v1alpha1.ForeignCluster) error {
 	klog.V(4).Infof("Defaulting ClusterIdentity values for ForeignCluster %v", fc.Name)
-	ids, err := utils.GetClusterInfo(foreignclusterutils.InsecureSkipTLSVerify(fc), fc.Spec.ForeignAuthURL)
+	ids, err := utils.GetClusterInfo(ctx, r.transport(foreignclusterutils.InsecureSkipTLSVerify(fc)), fc.Spec.ForeignAuthURL)
 	if err != nil {
 		klog.Error(err)
 		return err

--- a/pkg/liqo-controller-manager/foreign-cluster-operator/foreign-cluster-controller.go
+++ b/pkg/liqo-controller-manager/foreign-cluster-operator/foreign-cluster-controller.go
@@ -17,6 +17,7 @@ package foreignclusteroperator
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -100,6 +101,9 @@ type ForeignClusterReconciler struct {
 	IdentityManager  identitymanager.IdentityManager
 
 	PeeringPermission peeringRoles.PeeringPermission
+
+	InsecureTransport *http.Transport
+	SecureTransport   *http.Transport
 }
 
 // clusterRole

--- a/pkg/liqo-controller-manager/foreign-cluster-operator/validator.go
+++ b/pkg/liqo-controller-manager/foreign-cluster-operator/validator.go
@@ -35,7 +35,7 @@ func (r *ForeignClusterReconciler) validateForeignCluster(ctx context.Context,
 	if r.needsClusterIdentityDefaulting(foreignCluster) {
 		// this ForeignCluster has not all the cluster identity fields (clusterID and clusterName),
 		// get them from the foreignAuthUrl.
-		if err := r.clusterIdentityDefaulting(foreignCluster); err != nil {
+		if err := r.clusterIdentityDefaulting(ctx, foreignCluster); err != nil {
 			klog.Error(err)
 			return false, ctrl.Result{
 				Requeue:      true,

--- a/pkg/liqo-controller-manager/search-domain-operator/search-domain-controller.go
+++ b/pkg/liqo-controller-manager/search-domain-operator/search-domain-controller.go
@@ -16,6 +16,7 @@ package searchdomainoperator
 
 import (
 	"context"
+	"net/http"
 	"time"
 
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -37,6 +38,8 @@ type SearchDomainReconciler struct {
 
 	LocalCluster discoveryv1alpha1.ClusterIdentity
 	DNSAddress   string
+
+	InsecureTransport *http.Transport
 }
 
 // Reconcile reconciles SearchDomain resources.
@@ -64,7 +67,7 @@ func (r *SearchDomainReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			RequeueAfter: r.ResyncPeriod,
 		}, err
 	}
-	discovery.UpdateForeignWAN(ctx, r.Client, r.LocalCluster, authData, &sd)
+	discovery.UpdateForeignWAN(ctx, r.InsecureTransport, r.Client, r.LocalCluster, authData, &sd)
 
 	klog.Info("SearchDomain " + req.Name + " successfully reconciled")
 	return ctrl.Result{


### PR DESCRIPTION
# Description

This PR changes the HTTP client generation to always use the same transport, in order to reuse the same underlying connection when possible and reduce the handshake delay in high-latency WANs.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] Existing
- [X] Manual testing
