### PR TITLE
Fix Certificate generation on K3s and OpenShift

### DIFF
--- a/cmd/init-virtual-kubelet/main.go
+++ b/cmd/init-virtual-kubelet/main.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
 
+	liqonetutils "github.com/liqotech/liqo/pkg/liqonet/utils"
 	"github.com/liqotech/liqo/pkg/utils"
 	vk "github.com/liqotech/liqo/pkg/vkMachinery"
 	"github.com/liqotech/liqo/pkg/vkMachinery/csr"
@@ -62,6 +63,11 @@ func main() {
 		klog.Fatal("Unable to create CSR: POD_NAME undefined")
 	}
 
+	podIP, err := liqonetutils.GetPodIP()
+	if err != nil {
+		klog.Fatal(err)
+	}
+
 	namespace, ok := os.LookupEnv("POD_NAMESPACE")
 	if !ok {
 		klog.Fatal("Unable to create CSR: POD_NAMESPACE undefined")
@@ -91,7 +97,7 @@ func main() {
 	}
 
 	// Generate Key and CSR files in PEM format
-	if err := csr.CreateCSRResource(ctx, name, client, nodeName, namespace, distribution); err != nil {
+	if err := csr.CreateCSRResource(ctx, name, client, nodeName, namespace, distribution, podIP); err != nil {
 		klog.Fatalf("Unable to create CSR: %s", err)
 	}
 

--- a/pkg/vkMachinery/csr/const.go
+++ b/pkg/vkMachinery/csr/const.go
@@ -17,8 +17,7 @@ package csr
 const (
 	kubeletServingSignerName    = "kubernetes.io/kubelet-serving"
 	kubeletAPIServingSignerName = "kubernetes.io/kube-apiserver-client-kubelet"
-)
-
-const (
-	csrSecretLabel = "liqo.io/virtual-kubelet-csr-secret" // nolint:gosec // not a credential
+	csrSecretLabel              = "liqo.io/virtual-kubelet-csr-secret" // nolint:gosec // not a credential
+	csrNodeGroup                = "system:nodes"
+	csrNodeGroupMember          = "system:node:"
 )

--- a/pkg/vkMachinery/csr/creation.go
+++ b/pkg/vkMachinery/csr/creation.go
@@ -16,6 +16,7 @@ package csr
 
 import (
 	"context"
+	"net"
 
 	certificatesv1 "k8s.io/api/certificates/v1"
 	errors "k8s.io/apimachinery/pkg/api/errors"
@@ -26,8 +27,8 @@ import (
 
 // CreateCSRResource creates a CSR Resource for a new Virtual Kubelet instance.
 func CreateCSRResource(ctx context.Context,
-	name string, client kubernetes.Interface, nodeName, namespace, distribution string) error {
-	csrPem, keyPem, err := generateVKCertificateBundle(name)
+	name string, client kubernetes.Interface, nodeName, namespace, distribution string, podIP net.IP) error {
+	csrPem, keyPem, err := generateVKCertificateBundle(name, podIP)
 	var csrResource *certificatesv1.CertificateSigningRequest
 	if err != nil {
 		return err

--- a/pkg/vkMachinery/csr/generation_test.go
+++ b/pkg/vkMachinery/csr/generation_test.go
@@ -1,0 +1,81 @@
+// Copyright 2019-2021 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package csr
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"net"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Assert the correctness of the virtual-node CSR", func() {
+	var (
+		podNameT string
+		podIP    net.IP
+		csrPEM   []byte
+		keyPEM   []byte
+		csr      *x509.CertificateRequest
+		csrBlock *pem.Block
+	)
+	When("Requesting a certificate for a virtual node", func() {
+		BeforeEach(func() {
+			podNameT = "podName"
+			podIP = net.ParseIP("10.0.0.1").To4()
+		})
+
+		JustBeforeEach(func() {
+			csrPEM, keyPEM, err = generateVKCertificateBundle(podNameT, podIP)
+		})
+
+		It("Should not trigger any error", func() {
+			Expect(err).NotTo(HaveOccurred())
+			Expect(csrPEM).NotTo(BeNil())
+			Expect(keyPEM).NotTo(BeNil())
+		})
+
+		Context("When decoding the certificate", func() {
+
+			BeforeEach(func() {
+				csrBlock, _ = pem.Decode(csrPEM)
+				csr, err = x509.ParseCertificateRequest(csrBlock.Bytes)
+			})
+
+			It("Should be a valid x509 certificate", func() {
+				Expect(csrBlock).NotTo(BeNil())
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("Should include the right subject alternative names (SAN)", func() {
+				Expect(csr.IPAddresses).To(HaveLen(1))
+				Expect(csr.DNSNames).To(HaveLen(1))
+				Expect(csr.IPAddresses[0]).To(BeEquivalentTo(podIP))
+				Expect(csr.DNSNames[0]).To(BeEquivalentTo(podNameT))
+			})
+
+			It("Should include the right Common Name (CN)", func() {
+				Expect(csr.Subject.CommonName).To(BeEquivalentTo(csrNodeGroupMember + podNameT))
+			})
+
+			It("Should include the right list of Organizations (O)", func() {
+				Expect(csr.Subject.Organization).To(HaveLen(1))
+				Expect(csr.Subject.Organization[0]).To(BeEquivalentTo(csrNodeGroup))
+			})
+		})
+
+	})
+})


### PR DESCRIPTION
# Description

This PR fixes the certificate generation for the virtual node by adding the podIP in the SAN field. This PR fixes kubectl logs and exec on K3s and OpenShift.

# How Has This Been Tested?

- [x] Unit Test
- [x] E2E
