### PR TITLE
Fix ClusterName Handling in liqoctl

### DIFF
--- a/pkg/consts/clusterid.go
+++ b/pkg/consts/clusterid.go
@@ -21,6 +21,8 @@ const (
 	ClusterIDLabelName = "clusterID"
 	// ClusterIDConfigMapKey is the key of the configmap where the cluster-id is stored.
 	ClusterIDConfigMapKey = "CLUSTER_ID"
+	// ClusterNameConfigMapKey is the key of the configmap where the cluster-name is stored.
+	ClusterNameConfigMapKey = "CLUSTER_NAME"
 )
 
 // ClusterIDConfigMapSelector returns the selector for the configmap where the cluster-id is stored.

--- a/pkg/liqoctl/add/handler.go
+++ b/pkg/liqoctl/add/handler.go
@@ -89,10 +89,11 @@ func processAddCluster(ctx context.Context, t *ClusterArgs, clientSet kubernetes
 		return err
 	}
 
-	clusterID, err := utils.GetClusterIDWithControllerClient(ctx, k8sClient, t.Namespace)
+	clusterIdentity, err := utils.GetClusterIdentityWithControllerClient(ctx, k8sClient, t.Namespace)
 	if err != nil {
 		return err
 	}
+	clusterID := clusterIdentity.ClusterID
 	// Check clusterIDs are not equal. If they are, abort.
 	if clusterID == t.ClusterID {
 		return fmt.Errorf(sameClusterError)

--- a/pkg/liqoctl/generate/handler.go
+++ b/pkg/liqoctl/generate/handler.go
@@ -67,10 +67,11 @@ func processGenerateCommand(ctx context.Context, clientSet client.Client, liqoNa
 		return "", err
 	}
 
-	clusterID, err := utils.GetClusterIDWithControllerClient(ctx, clientSet, liqoNamespace)
+	clusterIdentity, err := utils.GetClusterIdentityWithControllerClient(ctx, clientSet, liqoNamespace)
 	if err != nil {
 		return "", err
 	}
+	clusterID := clusterIdentity.ClusterID
 
 	// Retrieve the liqo controller manager deployment args
 	args, err := RetrieveLiqoControllerManagerDeploymentArgs(ctx, clientSet, liqoNamespace)

--- a/pkg/liqoctl/install/aks/provider.go
+++ b/pkg/liqoctl/install/aks/provider.go
@@ -74,11 +74,6 @@ func NewProvider() provider.InstallProviderInterface {
 
 // ValidateCommandArguments validates specific arguments passed to the install command.
 func (k *aksProvider) ValidateCommandArguments(flags *flag.FlagSet) (err error) {
-	err = k.ValidateGenericCommandArguments(flags)
-	if err != nil {
-		return err
-	}
-
 	k.subscriptionID, err = flags.GetString(subscriptionIDFlag)
 	if err != nil {
 		return err
@@ -105,7 +100,10 @@ func (k *aksProvider) ValidateCommandArguments(flags *flag.FlagSet) (err error) 
 	}
 	klog.V(3).Infof("AKS ResourceName: %v", k.resourceName)
 
-	if k.ClusterName == "" {
+	// if the cluster name has not been provided (and set in the pre-checks)
+	// and we have not to generate it,
+	// we default it to the cloud provider resource name.
+	if k.ClusterName == "" && !k.GenerateClusterName {
 		k.ClusterName = k.resourceName
 	}
 

--- a/pkg/liqoctl/install/eks/provider.go
+++ b/pkg/liqoctl/install/eks/provider.go
@@ -75,11 +75,6 @@ func NewProvider() provider.InstallProviderInterface {
 
 // ValidateCommandArguments validates specific arguments passed to the install command.
 func (k *eksProvider) ValidateCommandArguments(flags *flag.FlagSet) (err error) {
-	err = k.ValidateGenericCommandArguments(flags)
-	if err != nil {
-		return err
-	}
-
 	k.region, err = flags.GetString(regionFlag)
 	if err != nil {
 		return err
@@ -92,7 +87,10 @@ func (k *eksProvider) ValidateCommandArguments(flags *flag.FlagSet) (err error) 
 	}
 	klog.V(3).Infof("EKS ClusterName: %v", k.eksClusterName)
 
-	if k.ClusterName == "" {
+	// if the cluster name has not been provided (and set in the pre-checks)
+	// and we have not to generate it,
+	// we default it to the cloud provider resource name.
+	if k.ClusterName == "" && !k.GenerateClusterName {
 		k.ClusterName = k.eksClusterName
 	}
 

--- a/pkg/liqoctl/install/gke/provider.go
+++ b/pkg/liqoctl/install/gke/provider.go
@@ -69,11 +69,6 @@ func NewProvider() provider.InstallProviderInterface {
 
 // ValidateCommandArguments validates specific arguments passed to the install command.
 func (k *gkeProvider) ValidateCommandArguments(flags *flag.FlagSet) (err error) {
-	err = k.ValidateGenericCommandArguments(flags)
-	if err != nil {
-		return err
-	}
-
 	k.credentialsPath, err = flags.GetString(credentialsPathFlag)
 	if err != nil {
 		return err
@@ -194,7 +189,10 @@ func (k *gkeProvider) parseClusterOutput(cluster *container.Cluster) {
 	k.serviceCIDR = cluster.ServicesIpv4Cidr
 	k.podCIDR = cluster.ClusterIpv4Cidr
 
-	if k.ClusterName == "" {
+	// if the cluster name has not been provided (and set in the pre-checks)
+	// and we have not to generate it,
+	// we default it to the cloud provider resource name.
+	if k.ClusterName == "" && !k.GenerateClusterName {
 		k.ClusterName = cluster.Name
 	}
 

--- a/pkg/liqoctl/install/handler.go
+++ b/pkg/liqoctl/install/handler.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 
 	"github.com/liqotech/liqo/pkg/liqoctl/common"
@@ -56,8 +57,23 @@ func HandleInstallCommand(ctx context.Context, cmd *cobra.Command, baseCommand, 
 		return err
 	}
 
+	oldClusterName, err := installutils.GetOldClusterName(ctx, kubernetes.NewForConfigOrDie(config))
+	if err != nil {
+		return err
+	}
+
 	fmt.Printf("* Retrieving cluster configuration from cluster provider... 📜  \n")
+	err = providerInstance.PreValidateGenericCommandArguments(cmd.Flags())
+	if err != nil {
+		return err
+	}
+
 	err = providerInstance.ValidateCommandArguments(cmd.Flags())
+	if err != nil {
+		return err
+	}
+
+	err = providerInstance.PostValidateGenericCommandArguments(oldClusterName)
 	if err != nil {
 		return err
 	}

--- a/pkg/liqoctl/install/k3s/provider.go
+++ b/pkg/liqoctl/install/k3s/provider.go
@@ -75,11 +75,6 @@ func NewProvider() provider.InstallProviderInterface {
 
 // ValidateCommandArguments validates specific arguments passed to the install command.
 func (k *k3sProvider) ValidateCommandArguments(flags *flag.FlagSet) (err error) {
-	err = k.ValidateGenericCommandArguments(flags)
-	if err != nil {
-		return err
-	}
-
 	k.podCIDR, err = flags.GetString(podCidrFlag)
 	if err != nil {
 		return err

--- a/pkg/liqoctl/install/kubeadm/provider.go
+++ b/pkg/liqoctl/install/kubeadm/provider.go
@@ -41,7 +41,7 @@ func NewProvider() provider.InstallProviderInterface {
 
 // ValidateCommandArguments validates specific arguments passed to the install command.
 func (k *Kubeadm) ValidateCommandArguments(flags *flag.FlagSet) (err error) {
-	return k.ValidateGenericCommandArguments(flags)
+	return nil
 }
 
 // ExtractChartParameters fetches the parameters used to customize the Liqo installation on a specific cluster of a

--- a/pkg/liqoctl/install/openshift/provider.go
+++ b/pkg/liqoctl/install/openshift/provider.go
@@ -59,11 +59,6 @@ func NewProvider() provider.InstallProviderInterface {
 
 // ValidateCommandArguments validates specific arguments passed to the install command.
 func (k *openshiftProvider) ValidateCommandArguments(flags *flag.FlagSet) (err error) {
-	err = k.ValidateGenericCommandArguments(flags)
-	if err != nil {
-		return err
-	}
-
 	return nil
 }
 

--- a/pkg/liqoctl/install/provider/interface.go
+++ b/pkg/liqoctl/install/provider/interface.go
@@ -23,8 +23,14 @@ import (
 
 // InstallProviderInterface defines the methods required to support the Liqo install for a given provider.
 type InstallProviderInterface interface {
+	// PreValidateGenericCommandArguments validates the flags passed to a generic provider,
+	// before the specific provider validation.
+	PreValidateGenericCommandArguments(*flag.FlagSet) error
 	// ValidateCommandArguments validates the flags passed as arguments to the install command
 	ValidateCommandArguments(*flag.FlagSet) error
+	// PostValidateGenericCommandArguments validates the flags passed to a generic provider,
+	// after the specific provider validation.
+	PostValidateGenericCommandArguments(oldClusterName string) error
 	// ExtractChartParameters retrieves the install parameters required for a correct installation. This may require
 	// instantiating extra clients to interact with cloud provider or the target cluster.
 	ExtractChartParameters(context.Context, *rest.Config, *CommonArguments) error

--- a/pkg/liqoctl/install/utils/oldparams.go
+++ b/pkg/liqoctl/install/utils/oldparams.go
@@ -1,0 +1,30 @@
+// Copyright 2019-2021 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package installutils
+
+import (
+	"context"
+
+	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/liqotech/liqo/pkg/utils"
+)
+
+// GetOldClusterName returns the cluster name used in the previous installation (if any).
+func GetOldClusterName(ctx context.Context, k8sClient kubernetes.Interface) (string, error) {
+	clusterName, err := utils.GetClusterName(ctx, k8sClient, LiqoNamespace)
+	return clusterName, client.IgnoreNotFound(err)
+}

--- a/test/e2e/testutils/tester/tester.go
+++ b/test/e2e/testutils/tester/tester.go
@@ -35,6 +35,7 @@ import (
 	offv1alpha1 "github.com/liqotech/liqo/apis/offloading/v1alpha1"
 	sharingv1alpha1 "github.com/liqotech/liqo/apis/sharing/v1alpha1"
 	virtualKubeletv1alpha1 "github.com/liqotech/liqo/apis/virtualkubelet/v1alpha1"
+	"github.com/liqotech/liqo/pkg/utils"
 	"github.com/liqotech/liqo/test/e2e/testconsts"
 	testutils "github.com/liqotech/liqo/test/e2e/testutils/util"
 )
@@ -129,7 +130,7 @@ func createTester(ctx context.Context, ignoreClusterIDError bool) (*Tester, erro
 			HomeCluster:    i == 1,
 		}
 		c.NativeClient = kubernetes.NewForConfigOrDie(c.Config)
-		c.ClusterID, err = testutils.GetClusterID(ctx, c.NativeClient, namespace)
+		c.ClusterID, err = utils.GetClusterID(ctx, c.NativeClient, namespace)
 		if err != nil && !ignoreClusterIDError {
 			return nil, err
 		}

--- a/test/e2e/testutils/util/get_test_variable.go
+++ b/test/e2e/testutils/util/get_test_variable.go
@@ -15,20 +15,16 @@
 package util
 
 import (
-	"context"
-	"fmt"
 	"os"
 	"strconv"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	utils "github.com/liqotech/liqo/pkg/utils"
 	"github.com/liqotech/liqo/test/e2e/testconsts"
 )
 
@@ -62,15 +58,6 @@ func GetControllerClient(scheme *runtime.Scheme, config *rest.Config) client.Cli
 		klog.Fatal(err)
 	}
 	return controllerClient
-}
-
-// GetClusterID provides the clusterID for the cluster associated with the client.
-func GetClusterID(ctx context.Context, cl kubernetes.Interface, namespace string) (string, error) {
-	clusterID, err := utils.GetClusterIDWithNativeClient(ctx, cl, namespace)
-	if err != nil {
-		return "", fmt.Errorf("an error occurred while getting cluster-id configmap %w", err)
-	}
-	return clusterID, nil
 }
 
 // CheckIfTestIsSkipped checks if the number of clusters required by the test is less than


### PR DESCRIPTION
# Description

This pr fixes how `liqoctl` handles the cluster names.

In particular:

* during installations:
  * if no name is provided and the generate name flag is not set, use the name retrieved from the cloud provider (if any)
* during upgrades:
  * if generate name is provided, use the old cluster name
  * if the name is not provided, use the old cluster name
  * if a new name is provided, use the new one

# How Has This Been Tested?

- [x] add new unit tests
- [x] locally on KinD
