### PR TITLE
Virtual kubelet: add fields to pod translation

### DIFF
--- a/pkg/virtualKubelet/forge/pods.go
+++ b/pkg/virtualKubelet/forge/pods.go
@@ -105,6 +105,8 @@ func RemotePodSpec(local, remote *corev1.PodSpec) corev1.PodSpec {
 	remote.Subdomain = local.Subdomain
 	remote.TopologySpreadConstraints = local.TopologySpreadConstraints
 	remote.RestartPolicy = local.RestartPolicy
+	remote.AutomountServiceAccountToken = local.AutomountServiceAccountToken
+	remote.SecurityContext = local.SecurityContext
 
 	return *remote
 }


### PR DESCRIPTION
# Description

This PR adds two missing fields to the pods translated by the virtual kubelet.
