### PR TITLE
controller: fix resource update bug

### DIFF
--- a/pkg/liqo-controller-manager/resource-request-controller/local-resource-monitor.go
+++ b/pkg/liqo-controller-manager/resource-request-controller/local-resource-monitor.go
@@ -329,15 +329,15 @@ func subResources(currentResources, toSub corev1.ResourceList) {
 // updateResources is a utility function to update resources.
 func updateResources(currentResources, oldResources, newResources corev1.ResourceList) {
 	for resourceName, quantity := range newResources {
+		value := currentResources[resourceName]
 		if oldQuantity, exists := oldResources[resourceName]; exists {
-			value := currentResources[resourceName]
-			quantityToUpdate := resource.NewQuantity(quantity.Value()-oldQuantity.Value(),
+			difference := resource.NewQuantity(quantity.Value()-oldQuantity.Value(),
 				quantity.Format)
-			value.Add(*quantityToUpdate)
-			currentResources[resourceName] = value
+			value.Add(*difference)
 		} else {
-			currentResources[resourceName] = quantity
+			value.Add(quantity)
 		}
+		currentResources[resourceName] = value
 	}
 }
 


### PR DESCRIPTION
# Description

Fixes an error in the resource update algorithm - previously, when receiving a new resource type on a node it would overwrite the cluster resources rather than adding the new resources.

Fixes #1052

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Manual tests
- [x] Unit tests
