### PR TITLE
Bump Capsule Chart Version to v0.1.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ GOBIN=$(shell go env GOBIN)
 endif
 
 # Set the capsule version to use
-CAPSULE_VERSION = v0.1.0
+CAPSULE_VERSION = v0.1.1
 
 generate: generate-controller generate-groups rbacs manifests fmt
 

--- a/deployments/liqo/Chart.lock
+++ b/deployments/liqo/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: capsule
   repository: https://clastix.github.io/charts
-  version: 0.1.3
-digest: sha256:20170bb3b20404a0ac8cbfe501b23983dcb74df74c5b0257d97fadba03761277
-generated: "2021-11-16T15:38:50.73105379Z"
+  version: 0.1.6
+digest: sha256:1348d1329146be27b55a37f324210d2687cd57ea6a8897338d3fd791e10d21a7
+generated: "2022-01-21T09:20:13.099385122Z"

--- a/deployments/liqo/Chart.yaml
+++ b/deployments/liqo/Chart.yaml
@@ -23,6 +23,6 @@ version: "0.1"
 
 dependencies:
 - name: capsule
-  version: v0.1.3
+  version: v0.1.6
   repository: https://clastix.github.io/charts
   condition: capsule.install

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Azure/go-autorest/autorest v0.11.19
 	github.com/Azure/go-autorest/autorest/azure/auth v0.5.8
 	github.com/aws/aws-sdk-go v1.39.4
-	github.com/clastix/capsule v0.1.0
+	github.com/clastix/capsule v0.1.1
 	github.com/containernetworking/plugins v1.0.1
 	github.com/coreos/go-iptables v0.6.0
 	github.com/goombaio/namegenerator v0.0.0-20181006234301-989e774b106e

--- a/go.sum
+++ b/go.sum
@@ -268,8 +268,8 @@ github.com/cilium/ebpf v0.4.0/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJ
 github.com/cilium/ebpf v0.6.2/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJXRs=
 github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible/go.mod h1:nmEj6Dob7S7YxXgwXpfOuvO54S+tGdZdw9fuRZt25Ag=
 github.com/circonus-labs/circonusllhist v0.1.3/go.mod h1:kMXHVDlOchFAehlya5ePtbp5jckzBHf4XRpQvBOLI+I=
-github.com/clastix/capsule v0.1.0 h1:JCnLSINI+SBlYoXk0R+7tyeoPQIfQzzLM6sJDijmjfo=
-github.com/clastix/capsule v0.1.0/go.mod h1:bPatitk0h7nk280P9IQAVaVamcrJz2f/SWVfcJ9a1KE=
+github.com/clastix/capsule v0.1.1 h1:8WaXauILFqxY40EnLHvPPuGpLc95IrZOc9GSyi1akTk=
+github.com/clastix/capsule v0.1.1/go.mod h1:bPatitk0h7nk280P9IQAVaVamcrJz2f/SWVfcJ9a1KE=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=

--- a/test/e2e/postinstall/basic_test.go
+++ b/test/e2e/postinstall/basic_test.go
@@ -17,7 +17,6 @@ package postinstall
 import (
 	"context"
 	"fmt"
-	"strings"
 	"testing"
 	"time"
 
@@ -71,11 +70,6 @@ var _ = Describe("Liqo E2E", func() {
 					Expect(err).ToNot(HaveOccurred())
 					for _, pod := range pods.Items {
 						Expect(pod.Status.ContainerStatuses).ToNot(BeEmpty())
-						if strings.Contains(pod.GetName(), "capsule") {
-							// the capsule controller manager is restarted every time liqo is installed
-							Expect(pod.Status.ContainerStatuses[0].RestartCount).To(BeNumerically("==", 1))
-							continue
-						}
 						Expect(pod.Status.ContainerStatuses[0].RestartCount).To(BeNumerically("==", 0))
 					}
 


### PR DESCRIPTION
# Description

This pr bumps the capsule char version to v0.1.3 and the capsule go package to v0.1.1

# How Has This Been Tested?

- [x] locally
- [x] existing unit and e2e tests
