### PR TITLE
Enable/disable liqo networking

### DIFF
--- a/apis/discovery/v1alpha1/foreigncluster_types.go
+++ b/apis/discovery/v1alpha1/foreigncluster_types.go
@@ -1,4 +1,4 @@
-// Copyright 2019-2021 The Liqo Authors
+// Copyright 2019-2022 The Liqo Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/discovery/v1alpha1/foreigncluster_types.go
+++ b/apis/discovery/v1alpha1/foreigncluster_types.go
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 The Liqo Authors
+// Copyright 2019-2021 The Liqo Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -66,6 +66,18 @@ const (
 	PeeringEnabledYes PeeringEnabledType = "Yes"
 )
 
+// NetworkingEnabledType indicates the desired state for the network interconnection with this remote cluster.
+type NetworkingEnabledType string
+
+const (
+	// NetworkingEnabledNo indicates to not handle the network interconnection with this remote cluster.
+	NetworkingEnabledNo NetworkingEnabledType = "No"
+	// NetworkingEnabledYes indicates to handle the network interconnection with this remote cluster.
+	NetworkingEnabledYes NetworkingEnabledType = "Yes"
+	// NetworkingEnabledNone is a placeholder to be used when the state of the networking is not known.
+	NetworkingEnabledNone NetworkingEnabledType = "None"
+)
+
 // ForeignClusterSpec defines the desired state of ForeignCluster.
 type ForeignClusterSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
@@ -83,6 +95,11 @@ type ForeignClusterSpec struct {
 	// +kubebuilder:default="Auto"
 	// +kubebuilder:validation:Optional
 	IncomingPeeringEnabled PeeringEnabledType `json:"incomingPeeringEnabled"`
+	// Indicates if Liqo has to handle the network interconnection with the remote cluster.
+	// +kubebuilder:validation:Enum="No";"Yes"
+	// +kubebuilder:default="Yes"
+	// +kubebuilder:validation:Optional
+	NetworkingEnabled NetworkingEnabledType `json:"networkingEnabled,omitempty"`
 	// URL where to contact foreign Auth service.
 	// +kubebuilder:validation:Pattern=`https:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)`
 	ForeignAuthURL string `json:"foreignAuthUrl"`

--- a/deployments/liqo/crds/discovery.liqo.io_foreignclusters.yaml
+++ b/deployments/liqo/crds/discovery.liqo.io_foreignclusters.yaml
@@ -97,6 +97,14 @@ spec:
                 description: Indicates if the local cluster has to skip the tls verification
                   over the remote Authentication Service or not.
                 type: boolean
+              networkingEnabled:
+                default: "Yes"
+                description: Indicates if Liqo has to handle the network interconnection
+                  with the remote cluster.
+                enum:
+                - "No"
+                - "Yes"
+                type: string
               outgoingPeeringEnabled:
                 default: Auto
                 description: Enable the peering process to the remote cluster.

--- a/internal/crdReplicator/networkingState.go
+++ b/internal/crdReplicator/networkingState.go
@@ -1,0 +1,61 @@
+// Copyright 2019-2022 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package crdreplicator
+
+import (
+	"k8s.io/klog/v2"
+
+	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
+	netv1alpha1 "github.com/liqotech/liqo/apis/net/v1alpha1"
+	"github.com/liqotech/liqo/internal/crdReplicator/resources"
+)
+
+// getNetworkingState returns the state of the networking for a cluster given its clusterID.
+func (c *Controller) getNetworkingState(clusterID string) discoveryv1alpha1.NetworkingEnabledType {
+	c.networkingStateMutex.RLock()
+	defer c.networkingStateMutex.RUnlock()
+	if state, ok := c.networkingStates[clusterID]; ok {
+		return state
+	}
+	return discoveryv1alpha1.NetworkingEnabledNone
+}
+
+// setNetworkingState sets the networking state for a given clusterID.
+func (c *Controller) setNetworkingState(clusterID string, state discoveryv1alpha1.NetworkingEnabledType) {
+	c.networkingStateMutex.RLock()
+	defer c.networkingStateMutex.RUnlock()
+	if c.networkingStates == nil {
+		c.networkingStates = map[string]discoveryv1alpha1.NetworkingEnabledType{}
+	}
+	c.networkingStates[clusterID] = state
+}
+
+// isNetworkingEnabled indicates if the replication for the networkconfigs has to be enabled based on the state
+// of the networking.
+func isNetworkingEnabled(networkingState discoveryv1alpha1.NetworkingEnabledType, resource *resources.Resource) bool {
+	// We are interested only for the networkconfigs resources.
+	if resource.GroupVersionResource != netv1alpha1.NetworkConfigGroupVersionResource {
+		return true
+	}
+	switch networkingState {
+	case discoveryv1alpha1.NetworkingEnabledNone, discoveryv1alpha1.NetworkingEnabledNo:
+		return false
+	case discoveryv1alpha1.NetworkingEnabledYes:
+		return true
+	default:
+		klog.Warning("Unknown networking state %v", resource.PeeringPhase)
+		return false
+	}
+}

--- a/internal/crdReplicator/reflection/handler.go
+++ b/internal/crdReplicator/reflection/handler.go
@@ -302,6 +302,7 @@ func (r *Reflector) ensureLocalFinalizer(ctx context.Context, gvr schema.GroupVe
 }
 
 // mutateLabelsForRemote mutates the labels map adding the ones for the remote cluster.
+// the ownership of the resource is removed as it would not make sense in a remote cluster.
 func (r *Reflector) mutateLabelsForRemote(labels map[string]string) map[string]string {
 	// We don't check if the map is nil, since it has to be initialized because we use the labels to filter the resources
 	// which need to be replicated.
@@ -312,6 +313,10 @@ func (r *Reflector) mutateLabelsForRemote(labels map[string]string) map[string]s
 	labels[consts.ReplicationStatusLabel] = strconv.FormatBool(true)
 	// setting originID i.e clusterID of home cluster
 	labels[consts.ReplicationOriginLabel] = r.localClusterID
+
+	// delete the ownership label if any.
+	delete(labels, consts.LocalResourceOwnership)
+
 	return labels
 }
 

--- a/internal/crdReplicator/reflection/handler_test.go
+++ b/internal/crdReplicator/reflection/handler_test.go
@@ -210,6 +210,7 @@ var _ = Describe("Handler tests", func() {
 				Labels: map[string]string{
 					consts.ReplicationRequestedLabel:   strconv.FormatBool(true),
 					consts.ReplicationDestinationLabel: reflector.remoteClusterID,
+					consts.LocalResourceOwnership:      "tester",
 					"foo":                              "bar"},
 			}
 			localBefore.Spec = netv1alpha1.NetworkConfigSpec{RemoteCluster: remoteCluster}
@@ -259,6 +260,7 @@ var _ = Describe("Handler tests", func() {
 				Expect(remoteAfter.Labels).To(HaveKeyWithValue(consts.ReplicationDestinationLabel, reflector.remoteClusterID))
 				Expect(remoteAfter.Labels).To(HaveKeyWithValue(consts.ReplicationOriginLabel, localCluster.ClusterID))
 				Expect(remoteAfter.Labels).To(HaveKeyWithValue(consts.ReplicationStatusLabel, strconv.FormatBool(true)))
+				Expect(remoteAfter.Labels).NotTo(HaveKey(consts.LocalResourceOwnership))
 				Expect(remoteAfter.Labels).To(HaveKeyWithValue("foo", "bar"))
 			})
 			It("the annotations should have been correctly replicated to the remote object", func() {

--- a/internal/liqonet/network-manager/netcfgcreator/netcfgcreator.go
+++ b/internal/liqonet/network-manager/netcfgcreator/netcfgcreator.go
@@ -39,6 +39,8 @@ import (
 	traceutils "github.com/liqotech/liqo/pkg/utils/trace"
 )
 
+const componentName = "netcfgCreator"
+
 // NetworkConfigCreator reconciles ForeignCluster objects to enforce the respective NetworkConfigs.
 type NetworkConfigCreator struct {
 	client.Client
@@ -90,15 +92,20 @@ func (ncc *NetworkConfigCreator) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{}, nil
 	}
 
+	if !foreigncluster.IsNetworkingEnabled(&fc) {
+		klog.V(4).Infof("Networking for cluster %q is disabled, hence no need to create the networkconfig", req.Name)
+	}
+
 	// Add the ForeignCluster to the list of known ones.
 	ncc.foreignClusters.Add(req.NamespacedName.Name)
 
-	// A peering is (being) established, hence we need to ensure the network interconnection.
-	if fc.GetDeletionTimestamp().IsZero() && (foreigncluster.IsIncomingJoined(&fc) || foreigncluster.IsOutgoingJoined(&fc)) {
+	// A peering is (being) established and networking is enabled, hence we need to ensure the network interconnection.
+	if fc.GetDeletionTimestamp().IsZero() && foreigncluster.IsNetworkingEnabled(&fc) &&
+		(foreigncluster.IsIncomingJoined(&fc) || foreigncluster.IsOutgoingJoined(&fc)) {
 		return ctrl.Result{}, ncc.EnforceNetworkConfigPresence(ctx, &fc)
 	}
 
-	// A peering is not established, hence we need to tear down the network interconnection.
+	// A peering is not established or the networking has been disabled, hence we need to tear down the network interconnection.
 	return ctrl.Result{}, ncc.EnforceNetworkConfigAbsence(ctx, &fc)
 }
 

--- a/pkg/consts/replication.go
+++ b/pkg/consts/replication.go
@@ -39,4 +39,9 @@ const (
 	LocalPodLabelKey = "liqo.io/shadowPod"
 	// LocalPodLabelValue value of the label added to the local pods that have been offloaded/replicated to a remote cluster.
 	LocalPodLabelValue = "true"
+
+	// LocalResourceOwnership label key added to a resource when it is owned by a local component.
+	// Ex. Local networkconfigs are owned by the component that creates them. If the resource is replicated in
+	// a remote cluster this label is removed by the CRDReplicator.
+	LocalResourceOwnership = "liqo.io/ownership"
 )

--- a/pkg/utils/foreignCluster/networking.go
+++ b/pkg/utils/foreignCluster/networking.go
@@ -1,0 +1,27 @@
+// Copyright 2019-2022 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package foreigncluster
+
+import discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
+
+// IsNetworkingEnabled checks if the networking is enabled (i.e. set to "Yes").
+func IsNetworkingEnabled(foreignCluster *discoveryv1alpha1.ForeignCluster) bool {
+	return foreignCluster.Spec.NetworkingEnabled == discoveryv1alpha1.NetworkingEnabledYes
+}
+
+// GetNetworkingState returns the state of the networking. Networking can be enabled or disabled.
+func GetNetworkingState(foreignCluster *discoveryv1alpha1.ForeignCluster) discoveryv1alpha1.NetworkingEnabledType {
+	return foreignCluster.Spec.NetworkingEnabled
+}


### PR DESCRIPTION
# Description

This PR adds a new feature that makes possible to disable the liqo networking by just setting the `NetworkingEnabled` field in the `foreigncluster` resource to `No`.

Behavior of the CRDReplicator component when the field `NetworkingEnabled` is set to:

- `Yes`: the network resource is replicated in to the remote cluster;
- `No`: the network resource is not replicated in to the remote cluster;
- `Yes` to `No`: the reflector for the network resources for the given cluster is stopped if running;
- `No` to `Yes`: the reflector for the network resources for the given cluster is started and the network resource is replicated in to the remote cluster.

Behavior of the Network-Manager component when the field `NetworkingEnabled` is set to:

- `Yes`: the local network resource is created for the remote cluster;
- `No`: the  local network resource is not created for the remote cluster;
- `Yes` to `No`: the local network resource previously created for the remote cluster is removed;
- `No` to `Yes`: the local network resource is created for the remote cluster.

Fixes #(issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Unit tests

