### PR TITLE
Liqoctl: Add Move Volume Command [1/4]

### DIFF
--- a/cmd/liqoctl/cmd/move.go
+++ b/cmd/liqoctl/cmd/move.go
@@ -1,0 +1,68 @@
+// Copyright 2019-2022 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+
+	"github.com/liqotech/liqo/pkg/liqoctl/move"
+)
+
+const (
+	// liqoctlMoveShortHelp contains the short help string for liqoctl move command.
+	liqoctlMoveShortHelp = "Move liqo volumes to other clusters"
+	// liqoctlMoveLongHelp contains the Long help string for liqoctl move command.
+	liqoctlMoveLongHelp = `Move liqo volumes to other clusters`
+)
+
+// moveCmd represents the move command.
+func newMoveCommand(ctx context.Context) *cobra.Command {
+	var moveCmd = &cobra.Command{
+		Use:   "move",
+		Short: liqoctlMoveShortHelp,
+		Long:  liqoctlMoveLongHelp,
+	}
+	moveCmd.AddCommand(newMoveVolumeCommand(ctx))
+	return moveCmd
+}
+
+func newMoveVolumeCommand(ctx context.Context) *cobra.Command {
+	clusterArgs := &move.Args{}
+	var moveVolumeCmd = &cobra.Command{
+		Use:          "volume",
+		Short:        liqoctlMoveShortHelp,
+		Long:         liqoctlMoveLongHelp,
+		Args:         cobra.MinimumNArgs(1),
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clusterArgs.VolumeName = args[0]
+			return move.HandleMoveVolumeCommand(ctx, clusterArgs)
+		},
+	}
+
+	moveVolumeCmd.Flags().StringVarP(&clusterArgs.Namespace, "namespace", "n", "",
+		"the namespace where the target PVC is stored")
+	moveVolumeCmd.Flags().StringVar(&clusterArgs.TargetNode, "node", "",
+		"the target node where the PVC will be moved")
+	moveVolumeCmd.Flags().StringVar(&clusterArgs.ResticPassword, "restic-password", "",
+		"the restic password to be used to for the restic repository")
+
+	utilruntime.Must(moveVolumeCmd.MarkFlagRequired("namespace"))
+	utilruntime.Must(moveVolumeCmd.MarkFlagRequired("node"))
+	return moveVolumeCmd
+}

--- a/cmd/liqoctl/cmd/root.go
+++ b/cmd/liqoctl/cmd/root.go
@@ -57,5 +57,6 @@ func NewRootCommand(ctx context.Context) *cobra.Command {
 	rootCmd.AddCommand(newVersionCommand())
 	rootCmd.AddCommand(newStatusCommand(ctx))
 	rootCmd.AddCommand(newOffloadCommand(ctx))
+	rootCmd.AddCommand(newMoveCommand(ctx))
 	return rootCmd
 }

--- a/pkg/liqoctl/move/doc.go
+++ b/pkg/liqoctl/move/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2019-2022 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package move contains the logic to move volumes between clusters.
+package move

--- a/pkg/liqoctl/move/handler.go
+++ b/pkg/liqoctl/move/handler.go
@@ -1,0 +1,61 @@
+// Copyright 2019-2022 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package move
+
+import (
+	"context"
+	"fmt"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/liqotech/liqo/pkg/liqoctl/common"
+	"github.com/liqotech/liqo/pkg/utils"
+)
+
+// Args encapsulates arguments required to move a resource.
+type Args struct {
+	VolumeName string
+	Namespace  string
+	TargetNode string
+
+	ResticPassword string
+}
+
+// HandleMoveVolumeCommand handles the move volume command,
+// configuring all the resources required to move a liqo volume.
+func HandleMoveVolumeCommand(ctx context.Context, t *Args) error {
+	restConfig, err := common.GetLiqoctlRestConf()
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("* Initializing... 🔌 ")
+	k8sClient, err := client.New(restConfig, client.Options{})
+	if err != nil {
+		return err
+	}
+
+	if t.ResticPassword == "" {
+		t.ResticPassword = utils.RandomString(16)
+	}
+
+	fmt.Println("* Processing Volume Moving... 💾 ")
+	return processMoveVolume(ctx, t, k8sClient)
+}
+
+func processMoveVolume(ctx context.Context, t *Args, k8sClient client.Client) error {
+	// TODO
+	return nil
+}

--- a/pkg/utils/random.go
+++ b/pkg/utils/random.go
@@ -1,0 +1,28 @@
+// Copyright 2019-2022 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import "math/rand"
+
+const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+// RandomString generates a random string of the given length.
+func RandomString(n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = letterBytes[rand.Int63()%int64(len(letterBytes))] // nolint:gosec // don't need crypto/rand
+	}
+	return string(b)
+}


### PR DESCRIPTION
# Description

This pr adds the new `liqoctl move volume` command to the CLI tool. The command internals will be implemented in the next pr.

Ref. #1071 
