### PR TITLE
Liqoctl: Add Move Volume Command [2/4]

### DIFF
--- a/cmd/liqoctl/cmd/move.go
+++ b/cmd/liqoctl/cmd/move.go
@@ -44,11 +44,12 @@ func newMoveCommand(ctx context.Context) *cobra.Command {
 func newMoveVolumeCommand(ctx context.Context) *cobra.Command {
 	clusterArgs := &move.Args{}
 	var moveVolumeCmd = &cobra.Command{
-		Use:          "volume",
-		Short:        liqoctlMoveShortHelp,
-		Long:         liqoctlMoveLongHelp,
-		Args:         cobra.MinimumNArgs(1),
-		SilenceUsage: true,
+		Use:           "volume",
+		Short:         liqoctlMoveShortHelp,
+		Long:          liqoctlMoveLongHelp,
+		Args:          cobra.MinimumNArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clusterArgs.VolumeName = args[0]
 			return move.HandleMoveVolumeCommand(ctx, clusterArgs)

--- a/pkg/liqoctl/common/cluster.go
+++ b/pkg/liqoctl/common/cluster.go
@@ -98,9 +98,8 @@ type Cluster struct {
 	authToken          string
 }
 
-// NewCluster returns a new cluster object. The cluster has to be initialized before being consumed.
-func NewCluster(localK8sClient k8s.Interface, localCtrlRunClient, remoteCtrlRunClient client.Client,
-	restConfig *rest.Config, namespace, name string, printerColor pterm.Color) *Cluster {
+// NewPrinter creates a new printer.
+func NewPrinter(name string, printerColor pterm.Color) *Printer {
 	genericPrinter := pterm.PrefixPrinter{
 		Prefix: pterm.Prefix{},
 		Scope: pterm.Scope{
@@ -128,7 +127,7 @@ func NewCluster(localK8sClient k8s.Interface, localCtrlRunClient, remoteCtrlRunC
 			Style: pterm.NewStyle(printerColor),
 		})
 
-	printer := Printer{
+	return &Printer{
 		Info: genericPrinter.WithPrefix(pterm.Prefix{
 			Text:  "[INFO]",
 			Style: pterm.NewStyle(pterm.FgCyan),
@@ -150,6 +149,12 @@ func NewCluster(localK8sClient k8s.Interface, localCtrlRunClient, remoteCtrlRunC
 			TimerStyle:          &pterm.ThemeDefault.TimerStyle,
 		},
 	}
+}
+
+// NewCluster returns a new cluster object. The cluster has to be initialized before being consumed.
+func NewCluster(localK8sClient k8s.Interface, localCtrlRunClient, remoteCtrlRunClient client.Client,
+	restConfig *rest.Config, namespace, name string, printerColor pterm.Color) *Cluster {
+	printer := NewPrinter(name, printerColor)
 
 	pfo := &PortForwardOptions{
 		Namespace: namespace,
@@ -169,7 +174,7 @@ func NewCluster(localK8sClient k8s.Interface, localCtrlRunClient, remoteCtrlRunC
 	return &Cluster{
 		name:             name,
 		namespace:        namespace,
-		printer:          printer,
+		printer:          *printer,
 		locK8sClient:     localK8sClient,
 		locCtrlRunClient: localCtrlRunClient,
 		remCtrlRunClient: remoteCtrlRunClient,

--- a/pkg/liqoctl/move/consts.go
+++ b/pkg/liqoctl/move/consts.go
@@ -1,0 +1,23 @@
+// Copyright 2019-2022 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package move
+
+const (
+	liqoStorageNamespace = "liqo-storage"
+	resticRegistry       = "restic-registry"
+	resticServerImage    = "restic/rest-server:0.10.0"
+	resticImage          = "restic/restic:0.12.1"
+	resticPort           = 8000
+)

--- a/pkg/liqoctl/move/handler.go
+++ b/pkg/liqoctl/move/handler.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"fmt"
 
+	corev1 "k8s.io/api/core/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/liqotech/liqo/pkg/liqoctl/common"
@@ -38,24 +40,162 @@ type Args struct {
 func HandleMoveVolumeCommand(ctx context.Context, t *Args) error {
 	restConfig, err := common.GetLiqoctlRestConf()
 	if err != nil {
+		common.ErrorPrinter.Printf("Error while getting rest config: %v\n", err)
 		return err
 	}
 
-	fmt.Println("* Initializing... 🔌 ")
+	printer := common.NewPrinter("", common.Cluster1Color)
+
+	s, err := printer.Spinner.Start("Initializing")
+	utilruntime.Must(err)
+
 	k8sClient, err := client.New(restConfig, client.Options{})
 	if err != nil {
+		s.Fail("Failed to create k8s client %v", err)
 		return err
 	}
+	s.Success("Client initialized")
 
 	if t.ResticPassword == "" {
 		t.ResticPassword = utils.RandomString(16)
 	}
 
-	fmt.Println("* Processing Volume Moving... 💾 ")
-	return processMoveVolume(ctx, t, k8sClient)
+	return processMoveVolume(ctx, t, k8sClient, printer)
 }
 
-func processMoveVolume(ctx context.Context, t *Args, k8sClient client.Client) error {
-	// TODO
+func processMoveVolume(ctx context.Context, t *Args, k8sClient client.Client, printer *common.Printer) error {
+	// we need a context that is not canceled even if the user press Ctrl+C
+	deferCtx := context.Background()
+
+	s, err := printer.Spinner.Start("Running pre-flight checks")
+	utilruntime.Must(err)
+
+	var pvc corev1.PersistentVolumeClaim
+	if err := k8sClient.Get(ctx, client.ObjectKey{Namespace: t.Namespace, Name: t.VolumeName}, &pvc); err != nil {
+		s.Fail(fmt.Sprintf("Failed to get PVC %s/%s: %v", t.Namespace, t.VolumeName, err))
+		return err
+	}
+
+	err = checkNoMounter(ctx, k8sClient, &pvc)
+	if err != nil {
+		s.Fail("Failed to check mounter pod: ", err)
+		return err
+	}
+	s.Success("Pre-flight checks passed")
+
+	s, err = printer.Spinner.Start("Offloading the liqo-storage namespace")
+	utilruntime.Must(err)
+
+	var targetNode corev1.Node
+	if err := k8sClient.Get(ctx, client.ObjectKey{Name: t.TargetNode}, &targetNode); err != nil {
+		s.Fail("Failed to get target node: ", err)
+		return err
+	}
+	targetIsLocal := !utils.IsVirtualNode(&targetNode)
+
+	originIsLocal, originNode, err := isLocalVolume(ctx, k8sClient, &pvc)
+	if err != nil {
+		s.Fail("Failed to check if the volume is local: ", err)
+		return err
+	}
+
+	if err = offloadLiqoStorageNamespace(ctx, k8sClient, originNode, &targetNode); err != nil {
+		s.Fail("Failed to offload the liqo-storage namespace: ", err)
+		return err
+	}
+	s.Success("Liqo-storage namespace offloaded")
+
+	defer func() {
+		s, err = printer.Spinner.Start("Repatriating the liqo-storage namespace")
+		utilruntime.Must(err)
+
+		if err := repatriateLiqoStorageNamespace(deferCtx, k8sClient); err != nil {
+			s.Fail("Failed to repatriate the liqo-storage namespace: ", err)
+			return
+		}
+		s.Success("Repatriated the liqo-storage namespace")
+	}()
+
+	s, err = printer.Spinner.Start("Ensuring restic repository")
+	utilruntime.Must(err)
+
+	if err := ensureResticRepository(ctx, k8sClient, &pvc); err != nil {
+		s.Fail("Failed to ensure restic repository: ", err)
+		return err
+	}
+	s.Success("Ensured restic repository")
+
+	defer func() {
+		s, err = printer.Spinner.Start("Removing restic repository")
+		utilruntime.Must(err)
+
+		if err = deleteResticRepository(deferCtx, k8sClient); err != nil {
+			s.Fail("Failed to remove restic repository: ", err)
+			return
+		}
+		s.Success("Removed restic repository")
+	}()
+
+	s, err = printer.Spinner.Start("Waiting for restic repository to be up and running")
+	utilruntime.Must(err)
+
+	if err = waitForResticRepository(ctx, k8sClient); err != nil {
+		s.Fail("Failed to wait for restic repository to be up and running: ", ctx.Err())
+		return err
+	}
+	s.Success("Restic repository is up and running")
+
+	s, err = printer.Spinner.Start("Taking snapshot")
+	utilruntime.Must(err)
+
+	originResticRepositoryURL, err := getResticRepositoryURL(ctx, k8sClient, originIsLocal)
+	if err != nil {
+		s.Fail("Failed to get origin restic repository URL: ", err)
+		return err
+	}
+	if err = takeSnapshot(ctx, k8sClient, &pvc,
+		originResticRepositoryURL, t.ResticPassword); err != nil {
+		s.Fail("Failed to take snapshot: ", err)
+		return err
+	}
+	s.Success("Snapshot taken")
+
+	s, err = printer.Spinner.Start("Moving the volume")
+	utilruntime.Must(err)
+
+	newPvc, err := recreatePvc(ctx, k8sClient, &pvc)
+	if err != nil {
+		s.Fail("Failed to recreate PVC: ", err)
+		return err
+	}
+
+	targetResticRepositoryURL, err := getResticRepositoryURL(ctx, k8sClient, targetIsLocal)
+	if err != nil {
+		s.Fail("Failed to get target restic repository URL: ", err)
+		return err
+	}
+	if err = restoreSnapshot(ctx, k8sClient,
+		&pvc, newPvc, t.TargetNode,
+		targetResticRepositoryURL, t.ResticPassword); err != nil {
+		s.Fail("Failed to restore snapshot: ", err)
+		return err
+	}
+
+	s.Success("Restore completed")
 	return nil
+}
+
+func getResticRepositoryURL(ctx context.Context, cl client.Client, isLocal bool) (string, error) {
+	var namespace string
+	if isLocal {
+		namespace = liqoStorageNamespace
+	} else {
+		var err error
+		namespace, err = getRemoteStorageNamespaceName(ctx, cl, nil)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	return fmt.Sprintf("rest:http://%s.%s.svc.cluster.local:%d/", resticRegistry, namespace, resticPort), nil
 }

--- a/pkg/liqoctl/move/offloading.go
+++ b/pkg/liqoctl/move/offloading.go
@@ -1,0 +1,120 @@
+// Copyright 2019-2022 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package move
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	offv1alpha1 "github.com/liqotech/liqo/apis/offloading/v1alpha1"
+	liqoconst "github.com/liqotech/liqo/pkg/consts"
+	"github.com/liqotech/liqo/pkg/utils"
+)
+
+func offloadLiqoStorageNamespace(ctx context.Context, cl client.Client, originNode, targetNode *corev1.Node) error {
+	namespaceOffloading := &offv1alpha1.NamespaceOffloading{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      liqoconst.DefaultNamespaceOffloadingName,
+			Namespace: liqoStorageNamespace,
+		},
+		Spec: offv1alpha1.NamespaceOffloadingSpec{
+			NamespaceMappingStrategy: offv1alpha1.DefaultNameMappingStrategyType,
+			PodOffloadingStrategy:    offv1alpha1.LocalPodOffloadingStrategyType,
+			ClusterSelector: corev1.NodeSelector{
+				NodeSelectorTerms: []corev1.NodeSelectorTerm{
+					{
+						MatchExpressions: []corev1.NodeSelectorRequirement{
+							{
+								Key:      "kubernetes.io/hostname",
+								Operator: corev1.NodeSelectorOpIn,
+								Values:   getRemoteNodeNames(originNode, targetNode),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if err := cl.Create(ctx, namespaceOffloading); err != nil && !apierrors.IsAlreadyExists(err) {
+		return err
+	}
+	return nil
+}
+
+func repatriateLiqoStorageNamespace(ctx context.Context, cl client.Client) error {
+	namespaceOffloading := &offv1alpha1.NamespaceOffloading{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      liqoconst.DefaultNamespaceOffloadingName,
+			Namespace: liqoStorageNamespace,
+		},
+	}
+
+	return client.IgnoreNotFound(cl.Delete(ctx, namespaceOffloading))
+}
+
+func getRemoteNodeNames(nodes ...*corev1.Node) []string {
+	var remoteNodes []string
+	for _, node := range nodes {
+		if utils.IsVirtualNode(node) {
+			remoteNodes = append(remoteNodes, node.Name)
+		}
+	}
+	return remoteNodes
+}
+
+func getRemoteStorageNamespaceName(ctx context.Context, cl client.Client, backoff *wait.Backoff) (string, error) {
+	var nsOffloading offv1alpha1.NamespaceOffloading
+
+	if backoff == nil {
+		backoff = &wait.Backoff{
+			Steps:    20,
+			Duration: 500 * time.Millisecond,
+			Factor:   1.5,
+		}
+	}
+
+	err := retry.OnError(*backoff, func(e error) bool {
+		return true
+	}, func() error {
+		if err := cl.Get(ctx, client.ObjectKey{
+			Name:      liqoconst.DefaultNamespaceOffloadingName,
+			Namespace: liqoStorageNamespace}, &nsOffloading); err != nil {
+			return err
+		}
+
+		if nsOffloading.Status.OffloadingPhase != offv1alpha1.ReadyOffloadingPhaseType {
+			return fmt.Errorf("namespace offloading is not ready")
+		}
+		if nsOffloading.Status.RemoteNamespaceName == "" {
+			return fmt.Errorf("remote namespace name is not set")
+		}
+		return nil
+	})
+
+	if err != nil {
+		return "", err
+	}
+
+	return nsOffloading.Status.RemoteNamespaceName, nil
+}

--- a/pkg/liqoctl/move/restic.go
+++ b/pkg/liqoctl/move/restic.go
@@ -1,0 +1,234 @@
+// Copyright 2019-2022 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package move
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+func ensureResticRepository(ctx context.Context, cl client.Client, targetPvc *corev1.PersistentVolumeClaim) error {
+	svc := corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      resticRegistry,
+			Namespace: liqoStorageNamespace,
+		},
+	}
+	_, err := controllerutil.CreateOrUpdate(ctx, cl, &svc, func() error {
+		svc.Spec = corev1.ServiceSpec{
+			Selector: map[string]string{
+				"app": resticRegistry,
+			},
+			Ports: []corev1.ServicePort{
+				{
+					Port:       resticPort,
+					TargetPort: intstr.FromInt(resticPort),
+					Protocol:   corev1.ProtocolTCP,
+				},
+			},
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	statefulSet := appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      resticRegistry,
+			Namespace: liqoStorageNamespace,
+		},
+	}
+	_, err = controllerutil.CreateOrUpdate(ctx, cl, &statefulSet, func() error {
+		statefulSet.Spec = appsv1.StatefulSetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": resticRegistry,
+				},
+			},
+			ServiceName: resticRegistry,
+			Replicas:    pointer.Int32Ptr(1),
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app": resticRegistry,
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  resticRegistry,
+							Image: resticServerImage,
+							Env: []corev1.EnvVar{
+								{
+									Name:  "DISABLE_AUTHENTICATION",
+									Value: "1",
+								},
+								{
+									Name:  "OPTIONS",
+									Value: "--no-auth",
+								},
+							},
+							Ports: []corev1.ContainerPort{
+								{
+									ContainerPort: resticPort,
+								},
+							},
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "restic-registry-data",
+									MountPath: "/data",
+								},
+							},
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "restic-registry-data",
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{},
+							},
+						},
+					},
+				},
+			},
+			VolumeClaimTemplates: []corev1.PersistentVolumeClaim{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "restic-registry-data",
+					},
+					Spec: corev1.PersistentVolumeClaimSpec{
+						AccessModes: []corev1.PersistentVolumeAccessMode{
+							corev1.ReadWriteOnce,
+						},
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceStorage: targetPvc.Spec.Resources.Requests[corev1.ResourceStorage],
+							},
+						},
+					},
+				},
+			},
+		}
+		return nil
+	})
+	return err
+}
+
+func deleteResticRepository(ctx context.Context, cl client.Client) error {
+	if err := cl.Delete(ctx, &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      resticRegistry,
+			Namespace: liqoStorageNamespace,
+		},
+	}); client.IgnoreNotFound(err) != nil {
+		return err
+	}
+
+	if err := scaleResticRepository(ctx, cl); err != nil {
+		return err
+	}
+
+	if err := cl.Delete(ctx, &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      resticRegistry,
+			Namespace: liqoStorageNamespace,
+		},
+	}); client.IgnoreNotFound(err) != nil {
+		return err
+	}
+
+	return client.IgnoreNotFound(cl.Delete(ctx, &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "restic-registry-data-restic-registry-0",
+			Namespace: liqoStorageNamespace,
+		},
+	}))
+}
+
+func scaleResticRepository(ctx context.Context, cl client.Client) error {
+	statefulSet := appsv1.StatefulSet{}
+	if err := cl.Get(ctx, client.ObjectKey{
+		Name:      resticRegistry,
+		Namespace: liqoStorageNamespace,
+	}, &statefulSet); apierrors.IsNotFound(err) {
+		return nil
+	} else if err != nil {
+		return err
+	}
+
+	statefulSet.Spec.Replicas = pointer.Int32Ptr(0)
+	if err := cl.Update(ctx, &statefulSet); err != nil {
+		return err
+	}
+
+	timeoutCtx, cancel := context.WithTimeout(ctx, time.Minute)
+	defer cancel()
+	ticker := time.NewTicker(time.Second * 3)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-timeoutCtx.Done():
+			return fmt.Errorf("timeout waiting for restic repository to scale down")
+		case <-ticker.C:
+			if err := cl.Get(timeoutCtx, client.ObjectKey{
+				Name:      resticRegistry,
+				Namespace: liqoStorageNamespace,
+			}, &statefulSet); err != nil {
+				return err
+			}
+			if statefulSet.Status.ReadyReplicas == 0 {
+				return nil
+			}
+		}
+	}
+}
+
+func waitForResticRepository(ctx context.Context, cl client.Client) error {
+	ctx, cancel := context.WithTimeout(ctx, time.Minute*5)
+	defer cancel()
+	ticker := time.NewTicker(time.Second * 5)
+	defer ticker.Stop()
+
+	var statefulSet appsv1.StatefulSet
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			if err := cl.Get(ctx, client.ObjectKey{
+				Name:      resticRegistry,
+				Namespace: liqoStorageNamespace,
+			}, &statefulSet); err != nil {
+				return err
+			}
+
+			if statefulSet.Status.ReadyReplicas > 0 {
+				return nil
+			}
+		}
+	}
+}

--- a/pkg/liqoctl/move/restorer.go
+++ b/pkg/liqoctl/move/restorer.go
@@ -1,0 +1,112 @@
+// Copyright 2019-2022 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package move
+
+import (
+	"context"
+	"fmt"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func restoreSnapshot(ctx context.Context, cl client.Client,
+	oldPvc, newPvc *corev1.PersistentVolumeClaim, nodeName, resticRepositoryURL, resticPassword string) error {
+	job, err := createRestorerJob(ctx, cl, oldPvc, newPvc, nodeName, resticRepositoryURL, resticPassword)
+	if err != nil {
+		return err
+	}
+
+	return waitForJob(ctx, cl, job)
+}
+
+func createRestorerJob(ctx context.Context, cl client.Client,
+	oldPvc, newPvc *corev1.PersistentVolumeClaim,
+	nodeName, resticRepositoryURL, resticPassword string) (*batchv1.Job, error) {
+	job := batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "liqo-restorer-",
+			Namespace:    oldPvc.GetNamespace(),
+		},
+		Spec: batchv1.JobSpec{
+			TTLSecondsAfterFinished: pointer.Int32Ptr(10),
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Affinity: &corev1.Affinity{
+						NodeAffinity: &corev1.NodeAffinity{
+							RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+								NodeSelectorTerms: []corev1.NodeSelectorTerm{
+									{
+										MatchExpressions: []corev1.NodeSelectorRequirement{
+											{
+												Key:      "kubernetes.io/hostname",
+												Operator: corev1.NodeSelectorOpIn,
+												Values:   []string{nodeName},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					Containers: []corev1.Container{
+						{
+							Name:            "restic",
+							Image:           resticImage,
+							ImagePullPolicy: corev1.PullIfNotPresent,
+							Args: []string{
+								"-r",
+								fmt.Sprintf("%s%s", resticRepositoryURL, oldPvc.GetUID()),
+								"restore", "latest",
+								"--target", "/restore",
+							},
+							Env: []corev1.EnvVar{
+								{
+									Name:  "RESTIC_PASSWORD",
+									Value: resticPassword,
+								},
+							},
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "restore",
+									MountPath: "/restore",
+								},
+							},
+						},
+					},
+					RestartPolicy: corev1.RestartPolicyOnFailure,
+					Volumes: []corev1.Volume{
+						{
+							Name: "restore",
+							VolumeSource: corev1.VolumeSource{
+								PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+									ClaimName: newPvc.GetName(),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if err := cl.Create(ctx, &job); err != nil {
+		return nil, err
+	}
+	return &job, nil
+}

--- a/pkg/liqoctl/move/snapshotter.go
+++ b/pkg/liqoctl/move/snapshotter.go
@@ -1,0 +1,144 @@
+// Copyright 2019-2022 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package move
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func takeSnapshot(ctx context.Context, cl client.Client,
+	pvc *corev1.PersistentVolumeClaim, resticRepositoryURL, resticPassword string) error {
+	job, err := createSnapshotterJob(ctx, cl, pvc, resticRepositoryURL, resticPassword)
+	if err != nil {
+		return err
+	}
+
+	return waitForJob(ctx, cl, job)
+}
+
+func createSnapshotterJob(ctx context.Context, cl client.Client,
+	pvc *corev1.PersistentVolumeClaim, resticRepositoryURL, resticPassword string) (*batchv1.Job, error) {
+	var pv corev1.PersistentVolume
+	if err := cl.Get(ctx, client.ObjectKey{Name: pvc.Spec.VolumeName}, &pv); err != nil {
+		return nil, err
+	}
+
+	job := batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "liqo-snapshotter-",
+			Namespace:    pvc.GetNamespace(),
+		},
+		Spec: batchv1.JobSpec{
+			TTLSecondsAfterFinished: pointer.Int32Ptr(10),
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
+						{
+							Name:            "restic-init",
+							Image:           resticImage,
+							ImagePullPolicy: corev1.PullIfNotPresent,
+							Args: []string{
+								"-r",
+								fmt.Sprintf("%s%s", resticRepositoryURL, pvc.GetUID()),
+								"init",
+							},
+							Env: []corev1.EnvVar{
+								{
+									Name:  "RESTIC_PASSWORD",
+									Value: resticPassword,
+								},
+							},
+						},
+					},
+					Containers: []corev1.Container{
+						{
+							Name:            "restic",
+							Image:           resticImage,
+							ImagePullPolicy: corev1.PullIfNotPresent,
+							Args: []string{
+								"-r",
+								fmt.Sprintf("%s%s", resticRepositoryURL, pvc.GetUID()),
+								"backup", ".",
+								"--host", "liqo",
+							},
+							Env: []corev1.EnvVar{
+								{
+									Name:  "RESTIC_PASSWORD",
+									Value: resticPassword,
+								},
+							},
+							WorkingDir: "/backup",
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "backup",
+									MountPath: "/backup",
+								},
+							},
+						},
+					},
+					RestartPolicy: corev1.RestartPolicyOnFailure,
+					Volumes: []corev1.Volume{
+						{
+							Name: "backup",
+							VolumeSource: corev1.VolumeSource{
+								PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+									ClaimName: pvc.GetName(),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if err := cl.Create(ctx, &job); err != nil {
+		return nil, err
+	}
+	return &job, nil
+}
+
+func waitForJob(ctx context.Context, cl client.Client, job *batchv1.Job) error {
+	ctx, cancel := context.WithTimeout(ctx, time.Minute*5)
+	defer cancel()
+	ticker := time.NewTicker(time.Second * 5)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			if err := cl.Get(ctx, client.ObjectKey{
+				Name:      job.GetName(),
+				Namespace: job.GetNamespace(),
+			}, job); err != nil {
+				continue
+			}
+
+			if job.Status.Succeeded > 0 {
+				return nil
+			}
+		}
+	}
+}

--- a/pkg/liqoctl/move/volumeutils.go
+++ b/pkg/liqoctl/move/volumeutils.go
@@ -1,0 +1,98 @@
+// Copyright 2019-2022 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package move
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/liqotech/liqo/pkg/utils"
+)
+
+func isLocalVolume(ctx context.Context, cl client.Client, pvc *corev1.PersistentVolumeClaim) (bool, *corev1.Node, error) {
+	if pvc.Annotations == nil {
+		return false, nil, fmt.Errorf("pvc %s/%s has no annotations, cannot determine on which cluster is stored", pvc.Namespace, pvc.Name)
+	}
+	nodeName, found := pvc.Annotations["volume.kubernetes.io/selected-node"]
+	if !found {
+		return false, nil, fmt.Errorf("pvc %s/%s has no selected-node annotation, cannot determine on which cluster is stored", pvc.Namespace, pvc.Name)
+	}
+
+	node := corev1.Node{}
+	if err := cl.Get(ctx, client.ObjectKey{Name: nodeName}, &node); err != nil {
+		return false, nil, err
+	}
+
+	return !utils.IsVirtualNode(&node), &node, nil
+}
+
+func checkNoMounter(ctx context.Context, cl client.Client, pvc *corev1.PersistentVolumeClaim) error {
+	var podList corev1.PodList
+	if err := cl.List(ctx, &podList, client.InNamespace(pvc.Namespace)); err != nil {
+		return err
+	}
+
+	for i := range podList.Items {
+		pod := &podList.Items[i]
+		for j := range pod.Spec.Volumes {
+			volume := &pod.Spec.Volumes[j]
+			if volume.PersistentVolumeClaim != nil && volume.PersistentVolumeClaim.ClaimName == pvc.Name {
+				return fmt.Errorf("the volume (%s/%s) must not to be mounted by any pod, but found mounter pod %s/%s",
+					pvc.Namespace, pvc.Name, pod.Namespace, pod.Name)
+			}
+		}
+	}
+
+	return nil
+}
+
+func recreatePvc(ctx context.Context, cl client.Client, oldPvc *corev1.PersistentVolumeClaim) (*corev1.PersistentVolumeClaim, error) {
+	newPvc := corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      oldPvc.Name,
+			Namespace: oldPvc.Namespace,
+			Labels:    oldPvc.Labels,
+		},
+		Spec: *oldPvc.Spec.DeepCopy(),
+	}
+	newPvc.Spec.VolumeName = ""
+
+	if err := cl.Delete(ctx, oldPvc); err != nil {
+		return nil, err
+	}
+
+	if err := retry.OnError(
+		wait.Backoff{
+			Duration: 500 * time.Millisecond,
+			Factor:   1.1,
+			Steps:    100,
+		},
+		apierrors.IsAlreadyExists,
+		func() error {
+			return cl.Create(ctx, &newPvc)
+		}); err != nil {
+		return nil, err
+	}
+
+	return &newPvc, nil
+}


### PR DESCRIPTION
# Description

This pr implements the internal of the new `liqoctl move volume` command.

In particular:
1. ensures that the volume is not mounted
2. creates a new Restic server
3. offloads the liqo-storage namespace
4. creates a snapshotter job to backup the volume in the old cluster
5. creates a restorer job to restore the volume in the new cluster
6. deletes the Restic server

Ref. #1071 
