### PR TITLE
Mutating webhook: add shadow pod label to offloaded pods

### DIFF
--- a/cmd/liqonet/route-operator.go
+++ b/cmd/liqonet/route-operator.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
@@ -87,7 +88,9 @@ func runRouteOperator(commonFlags *liqonetCommonFlags, routeFlags *routeOperator
 	// Asking the api-server to only inform the operator for the pods running in a node different from
 	// the virtual nodes. We want to process only the pods running on the local cluster and not the ones
 	// offloaded to a remote cluster.
-	smcLabelRequirement, err := labels.NewRequirement(liqoconst.LocalPodLabelKey, selection.DoesNotExist, []string{})
+	smcLabelRequirement, err := labels.NewRequirement(liqoconst.LocalPodLabelKey, selection.NotEquals, []string{liqoconst.TypeNode})
+	utilruntime.Must(err)
+
 	if err != nil {
 		klog.Errorf("unable to create label requirement: %v", err)
 		os.Exit(1)

--- a/deployments/liqo/templates/liqo-webhook.yaml
+++ b/deployments/liqo/templates/liqo-webhook.yaml
@@ -31,7 +31,7 @@ webhooks:
         path: "/mutate"
         port: 443
     rules:
-      - operations: ["CREATE"]
+      - operations: ["CREATE", "UPDATE"]
         apiGroups: [""]
         apiVersions: ["v1"]
         resources: ["pods"]

--- a/pkg/liqo-controller-manager/resource-request-controller/local-resource-monitor.go
+++ b/pkg/liqo-controller-manager/resource-request-controller/local-resource-monitor.go
@@ -25,6 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
@@ -376,23 +377,15 @@ func getPodTransitionState(oldPod, newPod *corev1.Pod) PodTransition {
 
 // this function is used to filter and ignore virtual nodes at informer level.
 func noVirtualNodesFilter(options *metav1.ListOptions) {
-	var values []string
-	values = append(values, consts.TypeNode)
-	req, err := labels.NewRequirement(consts.TypeLabel, selection.NotEquals, values)
-	if err != nil {
-		return
-	}
+	req, err := labels.NewRequirement(consts.TypeLabel, selection.NotEquals, []string{consts.TypeNode})
+	utilruntime.Must(err)
 	options.LabelSelector = labels.NewSelector().Add(*req).String()
 }
 
 // this function is used to filter and ignore shadow pods at informer level.
 func noShadowPodsFilter(options *metav1.ListOptions) {
-	var values []string
-	values = append(values, consts.LocalPodLabelValue)
-	req, err := labels.NewRequirement(consts.LocalPodLabelKey, selection.NotEquals, values)
-	if err != nil {
-		return
-	}
+	req, err := labels.NewRequirement(consts.LocalPodLabelKey, selection.NotEquals, []string{consts.LocalPodLabelValue})
+	utilruntime.Must(err)
 	options.LabelSelector = labels.NewSelector().Add(*req).String()
 }
 

--- a/pkg/mutate/labels.go
+++ b/pkg/mutate/labels.go
@@ -1,0 +1,57 @@
+// Copyright 2019-2022 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mutate
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/liqotech/liqo/pkg/consts"
+)
+
+// mutateShadowPodLabel mutates a pod object, adding the shadow pod label depending on whether it has been scheduled on a virtual node.
+func mutateShadowPodLabel(ctx context.Context, c client.Client, pod *corev1.Pod) error {
+	nodeName := pod.Spec.NodeName
+	if nodeName == "" {
+		klog.V(5).Infof("Skipping shadow pod label addition for pod %q, as not yet assigned to any node", klog.KObj(pod))
+		return nil
+	}
+
+	var node corev1.Node
+	if err := c.Get(ctx, types.NamespacedName{Name: nodeName}, &node); err != nil {
+		if client.IgnoreNotFound(err) != nil {
+			return fmt.Errorf("failed to retrieve node %q hosting pod %q: %w", klog.KObj(&node), klog.KObj(pod), err)
+		}
+
+		// Do not raise an error in case the node is not found, as that would abort the creation of a pod assigned to a non-existing node
+		klog.Warningf("Skipping shadow pod label addition for pod %q, as hosting node %q not found", klog.KObj(pod), klog.KObj(&node))
+		return nil
+	}
+
+	if value, found := node.Labels[consts.TypeLabel]; !found || value != consts.TypeNode {
+		klog.V(5).Infof("Skipping shadow pod label addition for pod %q, as assigned to non-liqo node %q", klog.KObj(pod), klog.KObj(&node))
+		delete(pod.Labels, consts.LocalPodLabelKey)
+		return nil
+	}
+
+	klog.V(5).Infof("Adding shadow pod label to pod %q, as assigned to liqo node %q", klog.KObj(pod), klog.KObj(&node))
+	pod.Labels[consts.LocalPodLabelKey] = consts.LocalPodLabelValue
+	return nil
+}

--- a/pkg/mutate/labels_test.go
+++ b/pkg/mutate/labels_test.go
@@ -1,0 +1,102 @@
+// Copyright 2019-2022 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mutate
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/liqotech/liqo/pkg/consts"
+)
+
+var _ = Describe("Pod labels mutations", func() {
+	Describe("shadow pod label", func() {
+		const nodeName = "node"
+
+		var (
+			ctx           context.Context
+			clientBuilder fake.ClientBuilder
+
+			original, mutated corev1.Pod
+			node              corev1.Node
+
+			err error
+		)
+
+		BeforeEach(func() {
+			ctx = context.Background()
+			clientBuilder = *fake.NewClientBuilder().WithScheme(scheme.Scheme)
+			original = corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "bar", Labels: map[string]string{"other-key": "other-value"}}}
+			node = corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: nodeName}}
+		})
+
+		JustBeforeEach(func() {
+			mutated = *original.DeepCopy()
+			c := clientBuilder.WithObjects(&node).Build()
+			err = mutateShadowPodLabel(ctx, c, &mutated)
+		})
+
+		Context("the pod has not yet been assigned to a node", func() {
+			It("should succeed", func() { Expect(err).ToNot(HaveOccurred()) })
+			It("should not mutate the pod, including the labels", func() { Expect(mutated).To(Equal(original)) })
+		})
+
+		Context("the pod has been assigned to a non-existing node", func() {
+			BeforeEach(func() { original.Spec.NodeName = "not-existing" })
+			It("should succeed", func() { Expect(err).ToNot(HaveOccurred()) })
+			It("should not mutate the pod, including the labels", func() { Expect(mutated).To(Equal(original)) })
+		})
+
+		Context("the pod has been assigned to an existing node", func() {
+			BeforeEach(func() { original.Spec.NodeName = nodeName })
+
+			When("the node is a standard worker", func() {
+				When("the pod does not have the shadow pod label", func() {
+					It("should succeed", func() { Expect(err).ToNot(HaveOccurred()) })
+					It("should not mutate the pod, including the labels", func() { Expect(mutated).To(Equal(original)) })
+				})
+				When("the pod has the shadow pod label", func() {
+					BeforeEach(func() { original.Labels[consts.LocalPodLabelKey] = consts.LocalPodLabelValue })
+					It("should succeed", func() { Expect(err).ToNot(HaveOccurred()) })
+					It("should remove that label", func() { Expect(mutated.Labels).ToNot(HaveKey(consts.LocalPodLabelKey)) })
+				})
+			})
+
+			When("the node is a liqo node", func() {
+				BeforeEach(func() { node.Labels = map[string]string{consts.TypeLabel: consts.TypeNode} })
+				When("the pod does not have the shadow pod label", func() {
+					It("should succeed", func() { Expect(err).ToNot(HaveOccurred()) })
+					It("should add the shadow pod label", func() {
+						Expect(mutated.Labels).To(HaveKeyWithValue(consts.LocalPodLabelKey, consts.LocalPodLabelValue))
+					})
+					It("should not mutate other existing pod label", func() {
+						Expect(mutated.Labels).To(HaveKeyWithValue("other-key", "other-value"))
+					})
+				})
+				When("the pod has the shadow pod label", func() {
+					BeforeEach(func() { original.Labels[consts.LocalPodLabelKey] = consts.LocalPodLabelValue })
+					It("should succeed", func() { Expect(err).ToNot(HaveOccurred()) })
+					It("should not mutate the pod, including the labels", func() { Expect(mutated).To(Equal(original)) })
+				})
+			})
+		})
+	})
+})

--- a/pkg/mutate/mutate_suite_test.go
+++ b/pkg/mutate/mutate_suite_test.go
@@ -1,0 +1,37 @@
+// Copyright 2019-2022 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mutate
+
+import (
+	"flag"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/klog/v2"
+)
+
+func TestWebhookManager(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Webhook Suite")
+}
+
+var _ = BeforeSuite(func() {
+	klog.SetOutput(GinkgoWriter)
+	flagset := flag.NewFlagSet("klog", flag.PanicOnError)
+	klog.InitFlags(flagset)
+	Expect(flagset.Set("v", "5")).To(Succeed())
+	klog.LogToStderr(false)
+})

--- a/pkg/mutate/server.go
+++ b/pkg/mutate/server.go
@@ -41,14 +41,12 @@ type MutationServer struct {
 
 	webhookClient client.Client
 	config        *MutationConfig
-	ctx           context.Context
 }
 
 // NewMutationServer creates a new mutation server.
 func NewMutationServer(ctx context.Context, c *MutationConfig) (*MutationServer, error) {
 	s := &MutationServer{}
 	s.config = c
-	s.ctx = ctx
 
 	// This scheme is necessary for the WebhookClient.
 	scheme := runtime.NewScheme()
@@ -84,7 +82,7 @@ func (s *MutationServer) handleMutate(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// mutate the request
-	mutated, err := s.Mutate(body)
+	mutated, err := s.Mutate(r.Context(), body)
 	if err != nil {
 		klog.Error(err)
 		standardErrMessage := fmt.Errorf("unable to correctly mutate the request")

--- a/pkg/mutate/webhook_test.go
+++ b/pkg/mutate/webhook_test.go
@@ -16,7 +16,6 @@ package mutate
 
 import (
 	"fmt"
-	"testing"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
@@ -29,11 +28,6 @@ import (
 	testutils "github.com/liqotech/liqo/pkg/mutate/testUtils"
 	"github.com/liqotech/liqo/pkg/utils"
 )
-
-func TestWebhookManager(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "Webhook Suite")
-}
 
 var _ = Describe("Webhook", func() {
 


### PR DESCRIPTION
# Description

This PR reintroduces the addition of the shadow pod label to offloaded pods, which is now performed by the mutating webhook. This allows to reduce the overall RAM requirements of the different components, thanks to filtering at informer level.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Unit testing (new + existing)
- [ ] E2E testing (existing)
