### PR TITLE
Virtual kubelet: add shadow pod label to offloaded pods

### DIFF
--- a/pkg/liqo-controller-manager/resource-request-controller/local-resource-monitor.go
+++ b/pkg/liqo-controller-manager/resource-request-controller/local-resource-monitor.go
@@ -25,6 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
@@ -376,23 +377,15 @@ func getPodTransitionState(oldPod, newPod *corev1.Pod) PodTransition {
 
 // this function is used to filter and ignore virtual nodes at informer level.
 func noVirtualNodesFilter(options *metav1.ListOptions) {
-	var values []string
-	values = append(values, consts.TypeNode)
-	req, err := labels.NewRequirement(consts.TypeLabel, selection.NotEquals, values)
-	if err != nil {
-		return
-	}
+	req, err := labels.NewRequirement(consts.TypeLabel, selection.NotEquals, []string{consts.TypeNode})
+	utilruntime.Must(err)
 	options.LabelSelector = labels.NewSelector().Add(*req).String()
 }
 
 // this function is used to filter and ignore shadow pods at informer level.
 func noShadowPodsFilter(options *metav1.ListOptions) {
-	var values []string
-	values = append(values, consts.LocalPodLabelValue)
-	req, err := labels.NewRequirement(consts.LocalPodLabelKey, selection.NotEquals, values)
-	if err != nil {
-		return
-	}
+	req, err := labels.NewRequirement(consts.LocalPodLabelKey, selection.NotEquals, []string{consts.LocalPodLabelValue})
+	utilruntime.Must(err)
 	options.LabelSelector = labels.NewSelector().Add(*req).String()
 }
 

--- a/pkg/liqo-controller-manager/resource-request-controller/testutils_test.go
+++ b/pkg/liqo-controller-manager/resource-request-controller/testutils_test.go
@@ -110,7 +110,6 @@ func createNewPod(ctx context.Context, podName, clusterID string, shadow bool, c
 		},
 	}
 	if clusterID != "" {
-		pod.Labels[forge.LiqoOutgoingKey] = "test"
 		pod.Labels[forge.LiqoOriginClusterIDKey] = clusterID
 	}
 	if shadow {

--- a/pkg/virtualKubelet/forge/meta.go
+++ b/pkg/virtualKubelet/forge/meta.go
@@ -22,8 +22,6 @@ import (
 )
 
 const (
-	// LiqoOutgoingKey is a label to set on all offloaded resources (deprecated).
-	LiqoOutgoingKey = "virtualkubelet.liqo.io/outgoing"
 	// LiqoOriginClusterIDKey is the key of a label identifying the origin cluster of a reflected resource.
 	LiqoOriginClusterIDKey = "virtualkubelet.liqo.io/origin"
 	// LiqoDestinationClusterIDKey is the key of a label identifying the destination cluster of a reflected resource.

--- a/pkg/virtualKubelet/reflection/workload/workload_suite_test.go
+++ b/pkg/virtualKubelet/reflection/workload/workload_suite_test.go
@@ -113,3 +113,9 @@ func CreateShadowPod(client liqoclient.Interface, pod *vkv1alpha1.ShadowPod) *vk
 	ExpectWithOffset(1, errpod).ToNot(HaveOccurred())
 	return pod
 }
+
+func UpdatePod(client kubernetes.Interface, pod *corev1.Pod) *corev1.Pod {
+	pod, errpod := client.CoreV1().Pods(pod.GetNamespace()).Update(ctx, pod, metav1.UpdateOptions{})
+	ExpectWithOffset(1, errpod).ToNot(HaveOccurred())
+	return pod
+}


### PR DESCRIPTION
# Description

This PR reintroduces the addition of the shadow pod label to offloaded pods through the virtual kubelet. This allows to reduce the overall RAM requirements of the different components, thanks to filtering at informer level.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Manual testing
- [x] Unit testing (new + existing)
- [x] E2E testing (existing)

