### PR TITLE
Improve informer-level filtering to reduce resource consumption

### DIFF
--- a/internal/liqonet/route-operator/symmetricRoutingOperator_test.go
+++ b/internal/liqonet/route-operator/symmetricRoutingOperator_test.go
@@ -297,28 +297,4 @@ var _ = Describe("SymmetricRoutingOperator", func() {
 			})
 		})
 	})
-
-	Describe("testing podFilter function", func() {
-		Context("when object is not a pod", func() {
-			It("should return false", func() {
-				// Create a service object
-				s := corev1.Service{}
-				ok := src.podFilter(&s)
-				Expect(ok).Should(BeFalse())
-			})
-		})
-
-		Context("when pod is running on different node than operator", func() {
-			It("podIP is not set, should return false", func() {
-				ok := src.podFilter(srcTestPod)
-				Expect(ok).Should(BeFalse())
-			})
-
-			It("podIP is set, should return true", func() {
-				srcTestPod.Status.PodIP = srcPodIP
-				ok := src.podFilter(srcTestPod)
-				Expect(ok).Should(BeTrue())
-			})
-		})
-	})
 })

--- a/pkg/consts/replication.go
+++ b/pkg/consts/replication.go
@@ -40,6 +40,11 @@ const (
 	// LocalPodLabelValue value of the label added to the local pods that have been offloaded/replicated to a remote cluster.
 	LocalPodLabelValue = "true"
 
+	// ManagedByLabelKey is the label key used to indicate that a given resource is managed by another one.
+	ManagedByLabelKey = "liqo.io/managed-by"
+	// ManagedByShadowPodValue it the label value used to indicate that a given resource is managed by a ShadowPod.
+	ManagedByShadowPodValue = "shadowpod"
+
 	// LocalResourceOwnership label key added to a resource when it is owned by a local component.
 	// Ex. Local networkconfigs are owned by the component that creates them. If the resource is replicated in
 	// a remote cluster this label is removed by the CRDReplicator.

--- a/pkg/liqo-controller-manager/resource-request-controller/resourceRequest_operator_test.go
+++ b/pkg/liqo-controller-manager/resource-request-controller/resourceRequest_operator_test.go
@@ -520,7 +520,7 @@ var _ = Describe("ResourceRequest Operator", func() {
 				return checkResourceOfferUpdate(ctx, homeCluster, nodeList, podList, k8sClient)
 			}, timeout, interval).Should(BeTrue())
 			By("Checking correct update of resource after pod changing Status")
-			podWithoutLabel, err = setPodReadyStatus(ctx, podWithoutLabel, false, clientset)
+			podWithoutLabel, err = setPodPhase(ctx, podWithoutLabel, corev1.PodFailed, clientset)
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(func() bool {
 				nodeList := []corev1.ResourceList{
@@ -530,7 +530,7 @@ var _ = Describe("ResourceRequest Operator", func() {
 				return checkResourceOfferUpdate(ctx, homeCluster, nodeList, podList, k8sClient)
 			}, timeout, interval).Should(BeTrue())
 			// set the pod ready again
-			podWithoutLabel, err = setPodReadyStatus(ctx, podWithoutLabel, true, clientset)
+			podWithoutLabel, err = setPodPhase(ctx, podWithoutLabel, corev1.PodRunning, clientset)
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(func() bool {
 				nodeList := []corev1.ResourceList{
@@ -572,7 +572,7 @@ var _ = Describe("ResourceRequest Operator", func() {
 				return checkResourceOfferUpdate(ctx, homeCluster, nodeList, podList, k8sClient)
 			}, timeout, interval).Should(BeTrue())
 			By("Checking change ready status for offloaded pod. Expected no change in offer.")
-			_, err = setPodReadyStatus(ctx, podOffloaded, false, clientset)
+			_, err = setPodPhase(ctx, podOffloaded, corev1.PodFailed, clientset)
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(func() bool {
 				nodeList := []corev1.ResourceList{

--- a/pkg/liqo-controller-manager/resource-request-controller/testutils_test.go
+++ b/pkg/liqo-controller-manager/resource-request-controller/testutils_test.go
@@ -121,12 +121,7 @@ func createNewPod(ctx context.Context, podName, clusterID string, shadow bool, c
 	}
 	// set Status Ready
 	pod.Status = corev1.PodStatus{
-		Conditions: []corev1.PodCondition{
-			0: {
-				Type:   corev1.PodReady,
-				Status: corev1.ConditionTrue,
-			},
-		},
+		Phase: corev1.PodRunning,
 	}
 	pod, err = clientset.CoreV1().Pods("default").UpdateStatus(ctx, pod, metav1.UpdateOptions{})
 	if err != nil {
@@ -135,23 +130,11 @@ func createNewPod(ctx context.Context, podName, clusterID string, shadow bool, c
 	return pod, nil
 }
 
-// setPodReadyStatus enforces a status ready/not ready to a pod passed as the *pod* parameter. The readiness/not readiness is
+// setPodPhase enforces a status ready/not ready to a pod passed as the *pod* parameter. The readiness/not readiness is
 // enforced by the *status* bool (true is ready, false is not ready).
-func setPodReadyStatus(ctx context.Context, pod *corev1.Pod, status bool, clientset kubernetes.Interface) (*corev1.Pod, error) {
-	for key, value := range pod.Status.Conditions {
-		if value.Type == corev1.PodReady {
-			if status {
-				pod.Status.Conditions[key].Status = corev1.ConditionTrue
-			} else {
-				pod.Status.Conditions[key].Status = corev1.ConditionFalse
-			}
-		}
-	}
-	pod, err := clientset.CoreV1().Pods("default").UpdateStatus(ctx, pod, metav1.UpdateOptions{})
-	if err != nil {
-		return nil, err
-	}
-	return pod, err
+func setPodPhase(ctx context.Context, pod *corev1.Pod, phase corev1.PodPhase, clientset kubernetes.Interface) (*corev1.Pod, error) {
+	pod.Status.Phase = phase
+	return clientset.CoreV1().Pods("default").UpdateStatus(ctx, pod, metav1.UpdateOptions{})
 }
 
 // setNodeReadyStatus enforces a status ready/not ready to a node passed as the *node* parameter. The readiness/not readiness is

--- a/pkg/liqo-controller-manager/shadowpod-controller/shadowpod_controller.go
+++ b/pkg/liqo-controller-manager/shadowpod-controller/shadowpod_controller.go
@@ -20,6 +20,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/klog/v2"
@@ -31,6 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	vkv1alpha1 "github.com/liqotech/liqo/apis/virtualkubelet/v1alpha1"
+	"github.com/liqotech/liqo/pkg/consts"
 	liqoerrors "github.com/liqotech/liqo/pkg/utils/errors"
 )
 
@@ -62,7 +64,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        nsName.Name,
 			Namespace:   nsName.Namespace,
-			Labels:      shadowPod.Labels,
+			Labels:      labels.Merge(shadowPod.Labels, labels.Set{consts.ManagedByLabelKey: consts.ManagedByShadowPodValue}),
 			Annotations: shadowPod.Annotations,
 		},
 		Spec: shadowPod.Spec.Pod,

--- a/pkg/liqo-controller-manager/shadowpod-controller/shadowpod_controller_test.go
+++ b/pkg/liqo-controller-manager/shadowpod-controller/shadowpod_controller_test.go
@@ -31,6 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	vkv1alpha1 "github.com/liqotech/liqo/apis/virtualkubelet/v1alpha1"
+	"github.com/liqotech/liqo/pkg/consts"
 	shadowpodctrl "github.com/liqotech/liqo/pkg/liqo-controller-manager/shadowpod-controller"
 )
 
@@ -156,8 +157,12 @@ var _ = Describe("Reconcile", func() {
 			pod := corev1.Pod{}
 			Expect(k8sClient.Get(ctx, req.NamespacedName, &pod)).To(Succeed())
 			Expect(pod.GetName()).To(Equal(testShadowPod.GetName()))
-			Expect(pod.GetLabels()).To(Equal(testShadowPod.GetLabels()))
 			Expect(pod.GetAnnotations()).To(Equal(testShadowPod.GetAnnotations()))
+
+			for key, value := range testShadowPod.GetLabels() {
+				Expect(pod.GetLabels()).To(HaveKeyWithValue(key, value))
+			}
+			Expect(pod.GetLabels()).To(HaveKeyWithValue(consts.ManagedByLabelKey, consts.ManagedByShadowPodValue))
 		})
 
 		It("should set pod spec to shadowpod pod spec", func() {


### PR DESCRIPTION
# Description

This PR is a follow-up of #1102 and introduces additional informer-level filters to reduce the number of events processed by the home cluster (and cached objects) when offloading remote pods. Specifically:
* route operator: filter-out pods with no IP assigned yet (this prevents the transient while waiting for the VK to label remote pods).
* resource monitor: filter-out non running pods, to simplify the overall logic and prevent the transient while waiting for the VK to label remote pods. 
* shadowpod operator: filter out pods not created through a shadowpod.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Unit testing
- [x] E2E testing
