### PR TITLE
liqoctl connect

### DIFF
--- a/apis/net/v1alpha1/groupversion_info.go
+++ b/apis/net/v1alpha1/groupversion_info.go
@@ -30,23 +30,27 @@ var (
 	TunnelEndpointGroupResource = schema.GroupResource{Group: GroupVersion.Group,
 		Resource: "tunnelendpoints"}
 
-	// TunnelEndpointGroupVersionResource is group resource version used to tunnelEndpoint objects.
+	// TunnelEndpointGroupVersionResource is group version resource used by dynamic client.
 	TunnelEndpointGroupVersionResource = schema.GroupVersionResource{Group: GroupVersion.Group,
 		Version:  GroupVersion.Version,
 		Resource: "tunnelendpoints"}
 
-	// NetworkConfigGroupResource is group resource used to register network configs.
+	// NetworkConfigGroupResource is group resource used to register networkconfigs.
 	NetworkConfigGroupResource = schema.GroupResource{Group: GroupVersion.Group,
-		Resource: "networkconfigs"}
+		Resource: ResourceNetworkConfigs}
 
-	// NetworkConfigGroupVersionResource is group resource version used to networkConfig objects.
+	// NetworkConfigGroupVersionResource is group version resource used by dynamic client.
 	NetworkConfigGroupVersionResource = schema.GroupVersionResource{Group: GroupVersion.Group,
 		Version:  GroupVersion.Version,
-		Resource: "networkconfigs"}
+		Resource: ResourceNetworkConfigs}
 
 	// IpamGroupResource is group resource used to register ipamstorages.
-	IpamGroupResource = schema.GroupVersionResource{Group: GroupVersion.Group, Version: GroupVersion.Version,
-		Resource: "ipamstorages"}
+	IpamGroupResource = schema.GroupResource{Group: GroupVersion.Group,
+		Resource: ResourceIpamStorages}
+
+	// IpamGroupVersionResource is group version resource used by dynamic client.
+	IpamGroupVersionResource = schema.GroupVersionResource{Group: GroupVersion.Group, Version: GroupVersion.Version,
+		Resource: ResourceIpamStorages}
 
 	// NatMappingGroupResource is group resource used to register natmappings.
 	NatMappingGroupResource = schema.GroupVersionResource{Group: GroupVersion.Group, Version: GroupVersion.Version,

--- a/apis/net/v1alpha1/ipamstorage_types.go
+++ b/apis/net/v1alpha1/ipamstorage_types.go
@@ -21,6 +21,9 @@ import (
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
+// ResourceIpamStorages the name of the ipamstorages resources.
+var ResourceIpamStorages = "ipamstorages"
+
 // Subnets type contains relevant networks related to a remote cluster.
 type Subnets struct {
 	// Network used in the remote cluster for local Pods. Default is "None": this means remote cluster uses local cluster PodCIDR.

--- a/apis/net/v1alpha1/networkconfig_types.go
+++ b/apis/net/v1alpha1/networkconfig_types.go
@@ -23,6 +23,9 @@ import (
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
+// ResourceNetworkConfigs the name of the networmconfigs resources.
+var ResourceNetworkConfigs = "networkconfigs"
+
 // NetworkConfigSpec defines the desired state of NetworkConfig.
 type NetworkConfigSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster

--- a/cmd/liqoctl/cmd/connect.go
+++ b/cmd/liqoctl/cmd/connect.go
@@ -1,0 +1,48 @@
+// Copyright 2019-2022 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+
+	"github.com/liqotech/liqo/pkg/liqoctl/connect"
+)
+
+func newConnectCommand(ctx context.Context) *cobra.Command {
+	var params = connect.Args{}
+
+	cmd := &cobra.Command{
+		Use:   "connect",
+		Short: "Connects two clusters using a vpn tunnel",
+		Long: `When clusters are in private networks and the API server of those clusters can not be reached directly.
+						The connect command is used to configure the liqo components on both clusters in order to create a vpn 
+						tunnel between them and expose the API servers through a proxy in order to be reachable from the clusters
+						using the vpn connection.
+		`,
+		SilenceErrors: true,
+		SilenceUsage:  true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return params.Handler(ctx)
+		},
+	}
+	cmd.Flags().StringVarP(&params.Cluster1Namespace, "namespace1", "", "liqo", "Namespace Liqo is running in cluster 1")
+	cmd.Flags().StringVarP(&params.Cluster2Namespace, "namespace2", "", "liqo", "Namespace Liqo is running in cluster 2")
+	cmd.Flags().StringVarP(&params.Cluster1Kubeconfig, "config1", "", "", "Kubeconfig of cluster 1")
+	cmd.Flags().StringVarP(&params.Cluster2Kubeconfig, "config2", "", "", "Kubeconfig of cluster 2")
+
+	return cmd
+}

--- a/cmd/liqoctl/cmd/root.go
+++ b/cmd/liqoctl/cmd/root.go
@@ -57,6 +57,7 @@ func NewRootCommand(ctx context.Context) *cobra.Command {
 	rootCmd.AddCommand(newVersionCommand())
 	rootCmd.AddCommand(newStatusCommand(ctx))
 	rootCmd.AddCommand(newOffloadCommand(ctx))
+	rootCmd.AddCommand(newConnectCommand(ctx))
 	rootCmd.AddCommand(newMoveCommand(ctx))
 	return rootCmd
 }

--- a/cmd/liqonet/gateway-operator.go
+++ b/cmd/liqonet/gateway-operator.go
@@ -31,6 +31,7 @@ import (
 	liqoconst "github.com/liqotech/liqo/pkg/consts"
 	liqonetns "github.com/liqotech/liqo/pkg/liqonet/netns"
 	"github.com/liqotech/liqo/pkg/liqonet/utils"
+	"github.com/liqotech/liqo/pkg/liqonet/utils/links"
 	"github.com/liqotech/liqo/pkg/utils/mapper"
 	"github.com/liqotech/liqo/pkg/utils/restcfg"
 )
@@ -144,7 +145,7 @@ func runGatewayOperator(commonFlags *liqonetCommonFlags, gatewayFlags *gatewayOp
 			klog.Errorf("an error occurred while deleting netns {%s}: %v", liqoconst.GatewayNetnsName, err)
 		}
 		klog.Info("cleaning up wireguard tunnel interface")
-		if err := utils.DeleteIFaceByName(liqoconst.DeviceName); err != nil {
+		if err := links.DeleteIFaceByName(liqoconst.DeviceName); err != nil {
 			klog.Errorf("an error occurred while deleting iface {%s}: %v", liqoconst.DriverName, err)
 		}
 		os.Exit(1)

--- a/cmd/liqonet/gateway-operator.go
+++ b/cmd/liqonet/gateway-operator.go
@@ -30,7 +30,6 @@ import (
 	tunneloperator "github.com/liqotech/liqo/internal/liqonet/tunnel-operator"
 	liqoconst "github.com/liqotech/liqo/pkg/consts"
 	liqonetns "github.com/liqotech/liqo/pkg/liqonet/netns"
-	tunnelwg "github.com/liqotech/liqo/pkg/liqonet/tunnel/wireguard"
 	"github.com/liqotech/liqo/pkg/liqonet/utils"
 	"github.com/liqotech/liqo/pkg/utils/mapper"
 	"github.com/liqotech/liqo/pkg/utils/restcfg"
@@ -145,8 +144,8 @@ func runGatewayOperator(commonFlags *liqonetCommonFlags, gatewayFlags *gatewayOp
 			klog.Errorf("an error occurred while deleting netns {%s}: %v", liqoconst.GatewayNetnsName, err)
 		}
 		klog.Info("cleaning up wireguard tunnel interface")
-		if err := utils.DeleteIFaceByName(tunnelwg.DeviceName); err != nil {
-			klog.Errorf("an error occurred while deleting iface {%s}: %v", tunnelwg.DriverName, err)
+		if err := utils.DeleteIFaceByName(liqoconst.DeviceName); err != nil {
+			klog.Errorf("an error occurred while deleting iface {%s}: %v", liqoconst.DriverName, err)
 		}
 		os.Exit(1)
 	}

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/openshift/api v0.0.0-20210521075222-e273a339932a
 	github.com/openshift/client-go v0.0.0-20210521082421-73d9475a9142
 	github.com/pkg/errors v0.9.1
+	github.com/pterm/pterm v0.12.36
 	github.com/spf13/cobra v1.3.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.0
@@ -46,6 +47,7 @@ require (
 	k8s.io/api v0.23.3
 	k8s.io/apiextensions-apiserver v0.23.2
 	k8s.io/apimachinery v0.23.3
+	k8s.io/cli-runtime v0.23.3
 	k8s.io/client-go v0.23.3
 	k8s.io/component-helpers v0.23.3
 	k8s.io/klog/v2 v2.30.0
@@ -81,6 +83,7 @@ require (
 	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
 	github.com/acomagu/bufpipe v1.0.3 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20200428143746-21a406dcc535 // indirect
+	github.com/atomicgo/cursor v0.0.1 // indirect
 	github.com/avast/retry-go v3.0.0+incompatible // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver v3.5.1+incompatible // indirect
@@ -128,6 +131,7 @@ require (
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/googleapis/gax-go/v2 v2.1.1 // indirect
 	github.com/googleapis/gnostic v0.5.5 // indirect
+	github.com/gookit/color v1.4.2 // indirect
 	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/gosuri/uitable v0.0.4 // indirect
 	github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7 // indirect
@@ -151,7 +155,7 @@ require (
 	github.com/mailru/easyjson v0.7.6 // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
-	github.com/mattn/go-runewidth v0.0.9 // indirect
+	github.com/mattn/go-runewidth v0.0.13 // indirect
 	github.com/mattn/go-zglob v0.0.2-0.20190814121620-e3c945676326 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
 	github.com/mdlayher/genetlink v1.0.0 // indirect
@@ -180,6 +184,7 @@ require (
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.28.0 // indirect
 	github.com/prometheus/procfs v0.6.0 // indirect
+	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/rubenv/sql-migrate v0.0.0-20210614095031-55d5740dbbcc // indirect
 	github.com/russross/blackfriday v1.5.2 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
@@ -195,6 +200,7 @@ require (
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
 	github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca // indirect
+	github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778 // indirect
 	go.opencensus.io v0.23.0 // indirect
 	go.starlark.net v0.0.0-20200306205701-8dd3e2ee1dd5 // indirect
 	go4.org/intern v0.0.0-20210108033219-3eb7198706b2 // indirect
@@ -202,7 +208,7 @@ require (
 	golang.org/x/crypto v0.0.0-20211117183948-ae814b36b871 // indirect
 	golang.org/x/net v0.0.0-20220107192237-5cfca573fb4d // indirect
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8 // indirect
-	golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b // indirect
+	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac // indirect
 	golang.zx2c4.com/wireguard v0.0.20200121 // indirect
@@ -214,7 +220,6 @@ require (
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	k8s.io/apiserver v0.23.2 // indirect
-	k8s.io/cli-runtime v0.23.3 // indirect
 	k8s.io/component-base v0.23.3 // indirect
 	k8s.io/kube-openapi v0.0.0-20211115234752-e816edb12b65 // indirect
 	oras.land/oras-go v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -113,6 +113,12 @@ github.com/DATA-DOG/go-sqlmock v1.5.0/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd h1:sjQovDkwrZp8u+gxLtPgKGjk5hCxuy2hrRejBTA9xFU=
 github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd/go.mod h1:64YHyfSL2R96J44Nlwm39UHepQbyR5q10x7iYa1ks2E=
+github.com/MarvinJWendt/testza v0.1.0/go.mod h1:7AxNvlfeHP7Z/hDQ5JtE3OKYT3XFUeLCDE2DQninSqs=
+github.com/MarvinJWendt/testza v0.2.1/go.mod h1:God7bhG8n6uQxwdScay+gjm9/LnO4D3kkcZX4hv9Rp8=
+github.com/MarvinJWendt/testza v0.2.8/go.mod h1:nwIcjmr0Zz+Rcwfh3/4UhBp7ePKVhuBExvZqnKYWlII=
+github.com/MarvinJWendt/testza v0.2.10/go.mod h1:pd+VWsoGUiFtq+hRKSU1Bktnn+DMCSrDrXDpX2bG66k=
+github.com/MarvinJWendt/testza v0.2.12 h1:/PRp/BF+27t2ZxynTiqj0nyND5PbOtfJS0SuTuxmgeg=
+github.com/MarvinJWendt/testza v0.2.12/go.mod h1:JOIegYyV7rX+7VZ9r77L/eH6CfJHHzXjB69adAhzZkI=
 github.com/Masterminds/goutils v1.1.0/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
 github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
@@ -203,6 +209,8 @@ github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:l
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/asaskevich/govalidator v0.0.0-20200428143746-21a406dcc535 h1:4daAzAu0S6Vi7/lbWECcX0j45yZReDZ56BQsrVBOEEY=
 github.com/asaskevich/govalidator v0.0.0-20200428143746-21a406dcc535/go.mod h1:oGkLhpf+kjZl6xBf758TQhh5XrAeiJv/7FRz/2spLIg=
+github.com/atomicgo/cursor v0.0.1 h1:xdogsqa6YYlLfM+GyClC/Lchf7aiMerFiZQn7soTOoU=
+github.com/atomicgo/cursor v0.0.1/go.mod h1:cBON2QmmrysudxNBFthvMtN32r3jxVRIvzkUiF/RuIk=
 github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHSxpiH9JdtuBj0=
 github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
 github.com/aws/aws-lambda-go v1.13.3/go.mod h1:4UKl9IzQMoD+QF79YdCuzCwp8VbmG4VAQwij/eHl5CU=
@@ -765,6 +773,8 @@ github.com/googleapis/gnostic v0.4.1/go.mod h1:LRhVm6pbyptWbWbuZ38d1eyptfvIytN3i
 github.com/googleapis/gnostic v0.5.1/go.mod h1:6U4PtQXGIEt/Z3h5MAT7FNofLnw9vXk2cUuW7uA/OeU=
 github.com/googleapis/gnostic v0.5.5 h1:9fHAtK0uDfpveeqqo1hkEZJcFvYXAiCN3UutL8F9xHw=
 github.com/googleapis/gnostic v0.5.5/go.mod h1:7+EbHbldMins07ALC74bsA81Ovc97DwqyJO1AENw9kA=
+github.com/gookit/color v1.4.2 h1:tXy44JFSFkKnELV6WaMo/lLfu/meqITX3iAV52do7lk=
+github.com/gookit/color v1.4.2/go.mod h1:fqRyamkC1W8uxl+lxCQxOT09l/vYfZ+QeiX3rKQHCoQ=
 github.com/goombaio/namegenerator v0.0.0-20181006234301-989e774b106e h1:XmA6L9IPRdUr28a+SK/oMchGgQy159wvzXA5tJ7l+40=
 github.com/goombaio/namegenerator v0.0.0-20181006234301-989e774b106e/go.mod h1:AFIo+02s+12CEg8Gzz9kzhCbmbq6JcKNrhHffCGA9z4=
 github.com/gophercloud/gophercloud v0.1.0/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEoIEcSTewFxm1c5g8=
@@ -918,6 +928,8 @@ github.com/klauspost/compress v1.12.3/go.mod h1:8dP1Hq4DHOhN9w426knH3Rhby4rFm6D8
 github.com/klauspost/compress v1.13.0/go.mod h1:8dP1Hq4DHOhN9w426knH3Rhby4rFm6D8eO+e+Dq5Gzg=
 github.com/klauspost/compress v1.13.6 h1:P76CopJELS0TiO2mebmnzgWaajssP/EszplttgQxcgc=
 github.com/klauspost/compress v1.13.6/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
+github.com/klauspost/cpuid/v2 v2.0.9 h1:lgaqFMSdTdQYdZ04uHyN2d/eKdOMyi2YLSvlQIBFYa4=
+github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
@@ -990,8 +1002,9 @@ github.com/mattn/go-oci8 v0.1.1/go.mod h1:wjDx6Xm9q7dFtHJvIlrI99JytznLw5wQ4R+9mN
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-runewidth v0.0.7/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
-github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
+github.com/mattn/go-runewidth v0.0.13 h1:lTGmDsbAYt5DmK6OnoV7EuIF1wEIFAcxld6ypU4OSgU=
+github.com/mattn/go-runewidth v0.0.13/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/mattn/go-shellwords v1.0.3/go.mod h1:3xCvwCdWdlDJUrvuMn7Wuy9eWs4pE8vqg+NOMyg4B2o=
 github.com/mattn/go-shellwords v1.0.6/go.mod h1:3xCvwCdWdlDJUrvuMn7Wuy9eWs4pE8vqg+NOMyg4B2o=
 github.com/mattn/go-shellwords v1.0.11/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lLtQsUlTZDWQ8Y=
@@ -1231,8 +1244,17 @@ github.com/prometheus/procfs v0.2.0/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4O
 github.com/prometheus/procfs v0.6.0 h1:mxy4L2jP6qMonqmq+aTtOx1ifVWUgG/TAmntgbh3xv4=
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
+github.com/pterm/pterm v0.12.27/go.mod h1:PhQ89w4i95rhgE+xedAoqous6K9X+r6aSOI2eFF7DZI=
+github.com/pterm/pterm v0.12.29/go.mod h1:WI3qxgvoQFFGKGjGnJR849gU0TsEOvKn5Q8LlY1U7lg=
+github.com/pterm/pterm v0.12.30/go.mod h1:MOqLIyMOgmTDz9yorcYbcw+HsgoZo3BQfg2wtl3HEFE=
+github.com/pterm/pterm v0.12.31/go.mod h1:32ZAWZVXD7ZfG0s8qqHXePte42kdz8ECtRyEejaWgXU=
+github.com/pterm/pterm v0.12.33/go.mod h1:x+h2uL+n7CP/rel9+bImHD5lF3nM9vJj80k9ybiiTTE=
+github.com/pterm/pterm v0.12.36 h1:Ui5zZj7xA8lXR0CxWXlKGCQMW1cZVUMOS8jEXs6ur/g=
+github.com/pterm/pterm v0.12.36/go.mod h1:NjiL09hFhT/vWjQHSj1athJpx6H8cjpHXNAK5bUw8T8=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uYEyJGbgTkfkS4+E/PavXkNJcbFIpEtjt2B0KDQ5+9M=
+github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
+github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-charset v0.0.0-20180617210344-2471d30d28b4/go.mod h1:qgYeAmZ5ZIpBWTGllZSQnw97Dj+woV0toclVaRGI8pc=
@@ -1375,6 +1397,8 @@ github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQ
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca h1:1CFlNzQhALwjS9mBAUkycX616GzgsuYUOCHA5+HSlXI=
 github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca/go.mod h1:ce1O1j6UtZfjr22oyGxGLbauSBp2YVXpARAosm7dHBg=
+github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778 h1:QldyIu/L63oPpyvQmHgvgickp1Yw510KJOqX7H24mg8=
+github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778/go.mod h1:2MuV+tbUrU1zIOPMxZ5EncGwgmMJsa+9ucAQZXxsObs=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
@@ -1766,6 +1790,7 @@ golang.org/x/sys v0.0.0-20210831042530-f4d43177bf5e/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210908233432-aa78b53d3365/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211007075335-d3039528d8ac/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211013075003-97ac67df715c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211029165221-6e7872819dc8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211124211545-fe61309f8881/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -1775,8 +1800,9 @@ golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
-golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b h1:9zKuko04nR4gjZ4+DNjHqRlAJqbJETHwiNKDqTfOjfE=
 golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
+golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 h1:JGgROgKl9N8DuW20oFS5gxc+lE67/N3FcwmBPMe7ArY=
+golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/internal/crdReplicator/crdReplicator_operator_test.go
+++ b/internal/crdReplicator/crdReplicator_operator_test.go
@@ -30,7 +30,6 @@ import (
 	netv1alpha1 "github.com/liqotech/liqo/apis/net/v1alpha1"
 	sharingv1alpha1 "github.com/liqotech/liqo/apis/sharing/v1alpha1"
 	"github.com/liqotech/liqo/pkg/consts"
-	"github.com/liqotech/liqo/pkg/liqonet/tunnel/wireguard"
 	peeringconditionsutils "github.com/liqotech/liqo/pkg/utils/peeringConditions"
 )
 
@@ -139,7 +138,7 @@ var _ = Describe("CRD Replicator Operator Tests", func() {
 			ObjectMeta: metav1.ObjectMeta{Name: networkConfigName, Namespace: localNamespace, Labels: labels()},
 			Spec: netv1alpha1.NetworkConfigSpec{
 				RemoteCluster: remoteCluster, PodCIDR: "1.1.1.0/24", ExternalCIDR: "1.1.2.0/24",
-				EndpointIP: "1.1.1.1", BackendType: wireguard.DriverName, BackendConfig: map[string]string{},
+				EndpointIP: "1.1.1.1", BackendType: consts.DriverName, BackendConfig: map[string]string{},
 			},
 		}
 	})

--- a/internal/liqonet/network-manager/netcfgcreator/netcfgcreator_test.go
+++ b/internal/liqonet/network-manager/netcfgcreator/netcfgcreator_test.go
@@ -30,7 +30,6 @@ import (
 	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
 	netv1alpha1 "github.com/liqotech/liqo/apis/net/v1alpha1"
 	"github.com/liqotech/liqo/pkg/consts"
-	"github.com/liqotech/liqo/pkg/liqonet/tunnel/wireguard"
 	liqoerrors "github.com/liqotech/liqo/pkg/utils/errors"
 	peeringconditionsutils "github.com/liqotech/liqo/pkg/utils/peeringConditions"
 	"github.com/liqotech/liqo/pkg/utils/syncset"
@@ -162,9 +161,9 @@ var _ = Describe("NetworkConfigCreator Controller", func() {
 					Expect(netcfg.Spec.PodCIDR).To(BeIdenticalTo("192.168.0.0/24"))
 					Expect(netcfg.Spec.ExternalCIDR).To(BeIdenticalTo("192.168.1.0/24"))
 					Expect(netcfg.Spec.EndpointIP).To(BeIdenticalTo("1.1.1.1"))
-					Expect(netcfg.Spec.BackendType).To(BeIdenticalTo(wireguard.DriverName))
-					Expect(netcfg.Spec.BackendConfig).To(HaveKeyWithValue(wireguard.PublicKey, "public-key"))
-					Expect(netcfg.Spec.BackendConfig).To(HaveKeyWithValue(wireguard.ListeningPort, "9999"))
+					Expect(netcfg.Spec.BackendType).To(BeIdenticalTo(consts.DriverName))
+					Expect(netcfg.Spec.BackendConfig).To(HaveKeyWithValue(consts.PublicKey, "public-key"))
+					Expect(netcfg.Spec.BackendConfig).To(HaveKeyWithValue(consts.ListeningPort, "9999"))
 				}
 
 				AssertNetworkConfigCorrectness := func() func() {

--- a/internal/liqonet/network-manager/netcfgcreator/networkconfig.go
+++ b/internal/liqonet/network-manager/netcfgcreator/networkconfig.go
@@ -31,7 +31,6 @@ import (
 	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
 	netv1alpha1 "github.com/liqotech/liqo/apis/net/v1alpha1"
 	"github.com/liqotech/liqo/pkg/consts"
-	"github.com/liqotech/liqo/pkg/liqonet/tunnel/wireguard"
 	foreignclusterutils "github.com/liqotech/liqo/pkg/utils/foreignCluster"
 )
 
@@ -193,13 +192,13 @@ func (ncc *NetworkConfigCreator) populateNetworkConfig(netcfg *netv1alpha1.Netwo
 	netcfg.Spec.PodCIDR = ncc.PodCIDR
 	netcfg.Spec.ExternalCIDR = ncc.ExternalCIDR
 	netcfg.Spec.EndpointIP = wgEndpointIP
-	netcfg.Spec.BackendType = wireguard.DriverName
+	netcfg.Spec.BackendType = consts.DriverName
 
 	if netcfg.Spec.BackendConfig == nil {
 		netcfg.Spec.BackendConfig = map[string]string{}
 	}
-	netcfg.Spec.BackendConfig[wireguard.PublicKey] = ncc.secretWatcher.WiregardPublicKey()
-	netcfg.Spec.BackendConfig[wireguard.ListeningPort] = wgEndpointPort
+	netcfg.Spec.BackendConfig[consts.PublicKey] = ncc.secretWatcher.WiregardPublicKey()
+	netcfg.Spec.BackendConfig[consts.ListeningPort] = wgEndpointPort
 
 	return controllerutil.SetControllerReference(fc, netcfg, ncc.Scheme)
 }

--- a/internal/liqonet/network-manager/netcfgcreator/networkconfig_test.go
+++ b/internal/liqonet/network-manager/netcfgcreator/networkconfig_test.go
@@ -30,7 +30,6 @@ import (
 	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
 	netv1alpha1 "github.com/liqotech/liqo/apis/net/v1alpha1"
 	"github.com/liqotech/liqo/pkg/consts"
-	"github.com/liqotech/liqo/pkg/liqonet/tunnel/wireguard"
 	foreignclusterutils "github.com/liqotech/liqo/pkg/utils/foreignCluster"
 )
 
@@ -258,9 +257,9 @@ var _ = Describe("Network config functions", func() {
 				Expect(netcfg.Spec.PodCIDR).To(BeIdenticalTo("192.168.0.0/24"))
 				Expect(netcfg.Spec.ExternalCIDR).To(BeIdenticalTo("192.168.1.0/24"))
 				Expect(netcfg.Spec.EndpointIP).To(BeIdenticalTo("1.1.1.1"))
-				Expect(netcfg.Spec.BackendType).To(BeIdenticalTo(wireguard.DriverName))
-				Expect(netcfg.Spec.BackendConfig).To(HaveKeyWithValue(wireguard.PublicKey, "public-key"))
-				Expect(netcfg.Spec.BackendConfig).To(HaveKeyWithValue(wireguard.ListeningPort, "9999"))
+				Expect(netcfg.Spec.BackendType).To(BeIdenticalTo(consts.DriverName))
+				Expect(netcfg.Spec.BackendConfig).To(HaveKeyWithValue(consts.PublicKey, "public-key"))
+				Expect(netcfg.Spec.BackendConfig).To(HaveKeyWithValue(consts.ListeningPort, "9999"))
 			}
 
 			When("the network config associated with the given foreign cluster does not exist", func() {

--- a/internal/liqonet/network-manager/netcfgcreator/secretwatcher.go
+++ b/internal/liqonet/network-manager/netcfgcreator/secretwatcher.go
@@ -26,7 +26,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
-	"github.com/liqotech/liqo/pkg/liqonet/tunnel/wireguard"
+	"github.com/liqotech/liqo/pkg/consts"
 	"github.com/liqotech/liqo/pkg/utils/getters"
 	liqolabels "github.com/liqotech/liqo/pkg/utils/labels"
 )
@@ -111,7 +111,7 @@ func (sw *SecretWatcher) handle(secret *corev1.Secret, rli workqueue.RateLimitin
 	sw.Lock()
 	defer sw.Unlock()
 
-	pubKey, err := getters.RetrieveWGPubKeyFromSecret(secret, wireguard.PublicKey)
+	pubKey, err := getters.RetrieveWGPubKeyFromSecret(secret, consts.PublicKey)
 	if err != nil {
 		klog.Error(err)
 		return

--- a/internal/liqonet/network-manager/netcfgcreator/secretwatcher_test.go
+++ b/internal/liqonet/network-manager/netcfgcreator/secretwatcher_test.go
@@ -24,7 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/workqueue"
 
-	"github.com/liqotech/liqo/pkg/liqonet/tunnel/wireguard"
+	"github.com/liqotech/liqo/pkg/consts"
 )
 
 var _ = Describe("Secret Watcher functions", func() {
@@ -48,7 +48,7 @@ var _ = Describe("Secret Watcher functions", func() {
 
 		When("given a valid secret", func() {
 			BeforeEach(func() {
-				secret.Data = map[string][]byte{wireguard.PublicKey: []byte(key)}
+				secret.Data = map[string][]byte{consts.PublicKey: []byte(key)}
 			})
 
 			When("not yet initialized", func() {

--- a/internal/liqonet/network-manager/netcfgcreator/servicewatcher.go
+++ b/internal/liqonet/network-manager/netcfgcreator/servicewatcher.go
@@ -27,7 +27,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	liqoconst "github.com/liqotech/liqo/pkg/consts"
-	"github.com/liqotech/liqo/pkg/liqonet/tunnel/wireguard"
 	"github.com/liqotech/liqo/pkg/utils/getters"
 	liqolabels "github.com/liqotech/liqo/pkg/utils/labels"
 )
@@ -117,7 +116,7 @@ func (sw *ServiceWatcher) handle(service *corev1.Service, rli workqueue.RateLimi
 	var err error
 
 	if ip, port, err = getters.RetrieveWGEPFromService(service, liqoconst.GatewayServiceAnnotationKey,
-		wireguard.DriverName); err != nil {
+		liqoconst.DriverName); err != nil {
 		klog.Error(err)
 		return
 	}

--- a/internal/liqonet/tunnel-operator/tunnel-operator.go
+++ b/internal/liqonet/tunnel-operator/tunnel-operator.go
@@ -103,7 +103,7 @@ func NewTunnelController(podIP, namespace string, er record.EventRecorder, k8sCl
 	if err != nil {
 		return nil, err
 	}
-	link, err := netlink.LinkByName(tunnelwg.DeviceName)
+	link, err := netlink.LinkByName(liqoconst.DeviceName)
 	if err != nil {
 		return nil, err
 	}
@@ -118,7 +118,7 @@ func NewTunnelController(podIP, namespace string, er record.EventRecorder, k8sCl
 	// 1) set it up;
 	// 2) replace the wgctl.Client with a new client spawned in the new netns.
 	var configureWg = func(netnsNamespace ns.NetNS) error {
-		link, err = netlink.LinkByName(tunnelwg.DeviceName)
+		link, err = netlink.LinkByName(liqoconst.DeviceName)
 		if err != nil {
 			return err
 		}
@@ -126,7 +126,7 @@ func NewTunnelController(podIP, namespace string, er record.EventRecorder, k8sCl
 		if err != nil {
 			return fmt.Errorf("failed to set wireguard iface up in gateway netns: %w", err)
 		}
-		w := tc.drivers[tunnelwg.DriverName]
+		w := tc.drivers[liqoconst.DriverName]
 		wg := w.(*tunnelwg.Wireguard)
 		if err := wg.SetNewClient(); err != nil {
 			return fmt.Errorf("an error occurred while setting new client in tunnel driver")
@@ -412,7 +412,7 @@ func (tc *TunnelController) SetUpIPTablesHandler() error {
 func (tc *TunnelController) SetUpRouteManager() error {
 	// Todo make the gateway routing manager to support more than one vpn technology at the same time.
 	// Todo it should use the right tunnel based on the backend type set inside the tep.
-	grm, err := liqorouting.NewGatewayRoutingManager(unix.RT_TABLE_MAIN, tc.drivers[tunnelwg.DriverName].GetLink())
+	grm, err := liqorouting.NewGatewayRoutingManager(unix.RT_TABLE_MAIN, tc.drivers[liqoconst.DriverName].GetLink())
 	if err != nil {
 		return err
 	}

--- a/pkg/consts/clusterid.go
+++ b/pkg/consts/clusterid.go
@@ -23,12 +23,15 @@ const (
 	ClusterIDConfigMapKey = "CLUSTER_ID"
 	// ClusterNameConfigMapKey is the key of the configmap where the cluster-name is stored.
 	ClusterNameConfigMapKey = "CLUSTER_NAME"
+	// ClusterIDConfigMapNameLabelKey key of the configmap used to get it by label.
+	ClusterIDConfigMapNameLabelKey = "app.kubernetes.io/name"
+	// ClusterIDConfigMapNameLabelValue value of the name key of the configmap used to get it by label.
+	ClusterIDConfigMapNameLabelValue = "clusterid-configmap"
 )
 
 // ClusterIDConfigMapSelector returns the selector for the configmap where the cluster-id is stored.
 func ClusterIDConfigMapSelector() labels.Selector {
 	return labels.SelectorFromSet(labels.Set{
-		"app.kubernetes.io/component": "clusterid-configmap",
-		"app.kubernetes.io/name":      "clusterid-configmap",
+		ClusterIDConfigMapNameLabelKey: ClusterIDConfigMapNameLabelValue,
 	})
 }

--- a/pkg/consts/clusterid.go
+++ b/pkg/consts/clusterid.go
@@ -23,8 +23,6 @@ const (
 	ClusterIDConfigMapKey = "CLUSTER_ID"
 	// ClusterNameConfigMapKey is the key of the configmap where the cluster-name is stored.
 	ClusterNameConfigMapKey = "CLUSTER_NAME"
-	// ClusterIDConfigMapNameLabelKey key of the configmap used to get it by label.
-	ClusterIDConfigMapNameLabelKey = "app.kubernetes.io/name"
 	// ClusterIDConfigMapNameLabelValue value of the name key of the configmap used to get it by label.
 	ClusterIDConfigMapNameLabelValue = "clusterid-configmap"
 )
@@ -32,6 +30,6 @@ const (
 // ClusterIDConfigMapSelector returns the selector for the configmap where the cluster-id is stored.
 func ClusterIDConfigMapSelector() labels.Selector {
 	return labels.SelectorFromSet(labels.Set{
-		ClusterIDConfigMapNameLabelKey: ClusterIDConfigMapNameLabelValue,
+		K8sAppNameKey: ClusterIDConfigMapNameLabelValue,
 	})
 }

--- a/pkg/consts/labels.go
+++ b/pkg/consts/labels.go
@@ -1,0 +1,52 @@
+// Copyright 2019-2022 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package consts
+
+// These labels are  either set during the deployment of liqo using the helm chart
+// or during their creation by liqo components.
+// Any change to those labels on the helm chart has also to be reflected here.
+// ServiceLabelKey key of the label added to the Gateway service. Used to get the
+// service by label.
+
+const (
+	// K8sAppNameKey = key of the label used to denote a deployed application.
+	K8sAppNameKey = "app.kubernetes.io/name"
+
+	// GatewayServiceLabelKey key of the label used to get the service.
+	GatewayServiceLabelKey = "net.liqo.io/gateway"
+	// GatewayServiceLabelValue value of the label used to get the service.
+	GatewayServiceLabelValue = "true"
+
+	// AuthAppName label value that denotes the name of the liqo-auth deployment.
+	AuthAppName = "auth"
+
+	// NetworkManagerAppName label value that denotes the name of the liqo-network-manager deployment.
+	NetworkManagerAppName = "network-manager"
+
+	// APIServerProxyAppName label value that denotes the name of the liqo-api-server-proxy deployment.
+	APIServerProxyAppName = "api-server-proxy"
+	// NatMappingResourceLabelKey is the constant representing
+	// the key of the label assigned to all NatMapping resources.
+	NatMappingResourceLabelKey = "net.liqo.io/natmapping"
+	// NatMappingResourceLabelValue is the constant representing
+	// the value of the label assigned to all NatMapping resources.
+	NatMappingResourceLabelValue = "true"
+	// IpamStorageResourceLabelKey is the constant representing
+	// the key of the label assigned to all IpamStorage resources.
+	IpamStorageResourceLabelKey = "net.liqo.io/ipamstorage"
+	// IpamStorageResourceLabelValue is the constant representing
+	// the value of the label assigned to all IpamStorage resources.
+	IpamStorageResourceLabelValue = "true"
+)

--- a/pkg/consts/liqonet.go
+++ b/pkg/consts/liqonet.go
@@ -24,18 +24,6 @@ const (
 	// NatMappingKind is the constant representing
 	// the value of the Kind field of all NatMapping resources.
 	NatMappingKind = "NatMapping"
-	// NatMappingResourceLabelKey is the constant representing
-	// the key of the label assigned to all NatMapping resources.
-	NatMappingResourceLabelKey = "net.liqo.io/natmapping"
-	// NatMappingResourceLabelValue is the constant representing
-	// the value of the label assigned to all NatMapping resources.
-	NatMappingResourceLabelValue = "true"
-	// IpamStorageResourceLabelKey is the constant representing
-	// the key of the label assigned to all IpamStorage resources.
-	IpamStorageResourceLabelKey = "net.liqo.io/ipamstorage"
-	// IpamStorageResourceLabelValue is the constant representing
-	// the value of the label assigned to all IpamStorage resources.
-	IpamStorageResourceLabelValue = "true"
 	// RoutingTableID used to identify the custom routing table used
 	// to configure the routes on the k8s nodes by route operator.
 	RoutingTableID = 18952
@@ -105,4 +93,12 @@ const (
 	DefaultMTU = 1440
 	// GatewayListeningPort port used by the vpn tunnel.
 	GatewayListeningPort = 5871
+
+	// **** Liqo Gateway Service ****.
+
+	// GatewayServiceAnnotationKey used to annotate the Gateway service with the IP of the node where the
+	// active gateway is running.
+	GatewayServiceAnnotationKey = "net.liqo.io/gatewayNodeIP"
+	// NetworkConfigNamePrefix prefix used to generate the names of the networkconfigs.
+	NetworkConfigNamePrefix = "net-config-"
 )

--- a/pkg/consts/wireguard.go
+++ b/pkg/consts/wireguard.go
@@ -1,0 +1,28 @@
+// Copyright 2019-2022 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package consts
+
+const (
+	// PublicKey is the key of publicKey entry in back-end map and also for the secret containing the wireguard keys.
+	PublicKey = "publicKey"
+	// ListeningPort is the key of the listeningPort entry in the back-end map.
+	ListeningPort = "port"
+	// DeviceName name of wireguard tunnel created on the custom network namespace.
+	DeviceName = "liqo.tunnel"
+	// DriverName  name of the driver which is also used as the type of the backend in tunnelendpoint CRD.
+	DriverName = "wireguard"
+	// KeysLabel label for the secret that contains the public key.
+	KeysLabel = "net.liqo.io/key"
+)

--- a/pkg/identityManager/certificate.go
+++ b/pkg/identityManager/certificate.go
@@ -115,7 +115,7 @@ func (certManager *identityManager) StoreCertificate(remoteCluster discoveryv1al
 		secret.Data[apiServerCaSecretKey] = apiServerCa
 	}
 
-	secret.Data[apiServerURLSecretKey] = []byte(identityResponse.APIServerURL)
+	secret.Data[APIServerURLSecretKey] = []byte(identityResponse.APIServerURL)
 	if remoteProxyURL != "" {
 		secret.StringData[apiProxyURLSecretKey] = remoteProxyURL
 	}

--- a/pkg/identityManager/client.go
+++ b/pkg/identityManager/client.go
@@ -114,9 +114,9 @@ func buildConfigFromSecret(secret *v1.Secret, remoteCluster discoveryv1alpha1.Cl
 		caData = nil
 	}
 
-	host, ok := secret.Data[apiServerURLSecretKey]
+	host, ok := secret.Data[APIServerURLSecretKey]
 	if !ok {
-		klog.Errorf("key %v not found in secret %v/%v", apiServerURLSecretKey, secret.Namespace, secret.Name)
+		klog.Errorf("key %v not found in secret %v/%v", APIServerURLSecretKey, secret.Namespace, secret.Name)
 		err = kerrors.NewNotFound(schema.GroupResource{
 			Group:    "v1",
 			Resource: "secrets",

--- a/pkg/identityManager/const.go
+++ b/pkg/identityManager/const.go
@@ -30,10 +30,11 @@ const (
 	identitySecretRoot      = "liqo-identity"
 	remoteCertificateSecret = "liqo-remote-certificate"
 
-	privateKeySecretKey   = "private-key"
-	csrSecretKey          = "csr"
-	certificateSecretKey  = "certificate"
-	apiServerURLSecretKey = "apiServerUrl"
+	privateKeySecretKey  = "private-key"
+	csrSecretKey         = "csr"
+	certificateSecretKey = "certificate"
+	// APIServerURLSecretKey key used for the api server url inside the secret.
+	APIServerURLSecretKey = "apiServerUrl"
 	apiProxyURLSecretKey  = "proxyURL"
 	apiServerCaSecretKey  = "apiServerCa"
 	namespaceSecretKey    = "namespace"

--- a/pkg/identityManager/identityManager_test.go
+++ b/pkg/identityManager/identityManager_test.go
@@ -142,7 +142,7 @@ var _ = Describe("IdentityManager", func() {
 		apiServerCa, err := base64.StdEncoding.DecodeString(secretIdentityResponse.APIServerCA)
 		Expect(err).To(BeNil())
 		certificateSecretData[apiServerCaSecretKey] = string(apiServerCa)
-		certificateSecretData[apiServerURLSecretKey] = secretIdentityResponse.APIServerURL
+		certificateSecretData[APIServerURLSecretKey] = secretIdentityResponse.APIServerURL
 		certificateSecretData[apiProxyURLSecretKey] = apiProxyURL
 		certificateSecretData[namespaceSecretKey] = secretIdentityResponse.Namespace
 
@@ -174,7 +174,7 @@ var _ = Describe("IdentityManager", func() {
 		iamSecretData[awsRegionSecretKey] = iamIdentityResponse.AWSIdentityInfo.Region
 		iamSecretData[awsEKSClusterIDSecretKey] = iamIdentityResponse.AWSIdentityInfo.EKSClusterID
 		iamSecretData[awsIAMUserArnSecretKey] = iamIdentityResponse.AWSIdentityInfo.IAMUserArn
-		iamSecretData[apiServerURLSecretKey] = iamIdentityResponse.APIServerURL
+		iamSecretData[APIServerURLSecretKey] = iamIdentityResponse.APIServerURL
 		apiServerCa, err = base64.StdEncoding.DecodeString(iamIdentityResponse.APIServerCA)
 		Expect(err).To(BeNil())
 		iamSecretData[apiServerCaSecretKey] = string(apiServerCa)
@@ -442,7 +442,7 @@ var _ = Describe("IdentityManager", func() {
 		})
 
 		It("api server url has not been set", func() {
-			delete(secret.Data, apiServerURLSecretKey)
+			delete(secret.Data, APIServerURLSecretKey)
 			config, err := buildConfigFromSecret(secret, remoteCluster)
 			Expect(config).To(BeNil())
 			Expect(err).To(MatchError(notFoundError))
@@ -476,7 +476,7 @@ var _ = Describe("IdentityManager", func() {
 			Expect(err).To(BeNil())
 			Expect(config).NotTo(BeNil())
 			Expect(config.Proxy).NotTo(BeNil())
-			Expect(config.Host).To(Equal(certificateSecretData[apiServerURLSecretKey]))
+			Expect(config.Host).To(Equal(certificateSecretData[APIServerURLSecretKey]))
 			Expect(config.TLSClientConfig.CertData).To(Equal([]byte(certificateSecretData[certificateSecretKey])))
 			Expect(config.TLSClientConfig.CAData).To(Equal([]byte(certificateSecretData[apiServerCaSecretKey])))
 			Expect(config.TLSClientConfig.KeyData).To(Equal([]byte(certificateSecretData[privateKeySecretKey])))
@@ -506,7 +506,7 @@ var _ = Describe("IdentityManager", func() {
 		})
 
 		It("api server url has not been set", func() {
-			delete(secret.Data, apiServerURLSecretKey)
+			delete(secret.Data, APIServerURLSecretKey)
 			config, err := tokenManager.getConfig(secret, remoteCluster)
 			Expect(config).To(BeNil())
 			Expect(err).To(MatchError(notFoundError))
@@ -567,7 +567,7 @@ var _ = Describe("IdentityManager", func() {
 			Expect(err).To(BeNil())
 			Expect(config).NotTo(BeNil())
 			Expect(config.Proxy).NotTo(BeNil())
-			Expect(config.Host).To(Equal(iamSecretData[apiServerURLSecretKey]))
+			Expect(config.Host).To(Equal(iamSecretData[APIServerURLSecretKey]))
 			Expect(config.TLSClientConfig.CAData).To(Equal([]byte(iamSecretData[apiServerCaSecretKey])))
 		})
 

--- a/pkg/identityManager/tokenManager.go
+++ b/pkg/identityManager/tokenManager.go
@@ -102,7 +102,7 @@ func (tokMan *iamTokenManager) getConfig(secret *v1.Secret, remoteCluster discov
 		return nil, err
 	}
 
-	clusterEndpoint, err := getValue(secret, apiServerURLSecretKey, remoteCluster)
+	clusterEndpoint, err := getValue(secret, APIServerURLSecretKey, remoteCluster)
 	if err != nil {
 		klog.Error(err)
 		return nil, err

--- a/pkg/liqoctl/common/cluster.go
+++ b/pkg/liqoctl/common/cluster.go
@@ -1,0 +1,744 @@
+// Copyright 2019-2022 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"strconv"
+	"time"
+
+	"github.com/pterm/pterm"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	k8s "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
+	netv1alpha1 "github.com/liqotech/liqo/apis/net/v1alpha1"
+	sharingv1alpha1 "github.com/liqotech/liqo/apis/sharing/v1alpha1"
+	"github.com/liqotech/liqo/pkg/auth"
+	liqoconsts "github.com/liqotech/liqo/pkg/consts"
+	"github.com/liqotech/liqo/pkg/discovery"
+	"github.com/liqotech/liqo/pkg/liqonet/ipam"
+	tenantnamespace "github.com/liqotech/liqo/pkg/tenantNamespace"
+	"github.com/liqotech/liqo/pkg/utils/authenticationtoken"
+	foreigncluster "github.com/liqotech/liqo/pkg/utils/foreignCluster"
+	liqogetters "github.com/liqotech/liqo/pkg/utils/getters"
+	liqolabels "github.com/liqotech/liqo/pkg/utils/labels"
+)
+
+const (
+	// Cluster1Name name used in output messages for cluster passed as first argument.
+	Cluster1Name = "cluster1"
+	// Cluster1Color color used in output messages for cluster passed as first argument.
+	Cluster1Color = pterm.FgLightBlue
+	// Cluster2Name name used in output messages for cluster passed as second argument.
+	Cluster2Name = "cluster2"
+	// Cluster2Color color used in output messages for cluster passed as second argument.
+	Cluster2Color = pterm.FgLightMagenta
+
+	proxyName = "liqo-proxy"
+
+	authPort = "https"
+)
+
+var (
+	// Scheme used for the controller runtime clients.
+	Scheme *runtime.Scheme
+)
+
+func init() {
+	Scheme = runtime.NewScheme()
+	utilruntime.Must(sharingv1alpha1.AddToScheme(Scheme))
+	utilruntime.Must(discoveryv1alpha1.AddToScheme(Scheme))
+	utilruntime.Must(netv1alpha1.AddToScheme(Scheme))
+	utilruntime.Must(corev1.AddToScheme(Scheme))
+}
+
+// Cluster struct that models a k8s cluster for connect and disconnect commands.
+type Cluster struct {
+	locK8sClient       k8s.Interface
+	locCtrlRunClient   client.Client
+	remCtrlRunClient   client.Client
+	locTenantNamespace string
+	remTenantNamespace string
+	namespaceManager   tenantnamespace.Manager
+	namespace          string
+	name               string
+	clusterID          *discoveryv1alpha1.ClusterIdentity
+	netConfig          *liqogetters.NetworkConfig
+	wgConfig           *WireGuardConfig
+	printer            Printer
+	PortForwardOpts    *PortForwardOptions
+	proxyEP            *Endpoint
+	authEP             *Endpoint
+	authToken          string
+}
+
+// NewCluster returns a new cluster object. The cluster has to be initialized before being consumed.
+func NewCluster(localK8sClient k8s.Interface, localCtrlRunClient, remoteCtrlRunClient client.Client,
+	restConfig *rest.Config, namespace, name string, printerColor pterm.Color) *Cluster {
+	genericPrinter := pterm.PrefixPrinter{
+		Prefix: pterm.Prefix{},
+		Scope: pterm.Scope{
+			Text:  name,
+			Style: pterm.NewStyle(printerColor),
+		},
+		MessageStyle: pterm.NewStyle(pterm.FgDefault),
+	}
+
+	successPrinter := SuccessPrinter.WithScope(
+		pterm.Scope{
+			Text:  name,
+			Style: pterm.NewStyle(printerColor),
+		})
+
+	warningPrinter := WarningPrinter.WithScope(
+		pterm.Scope{
+			Text:  name,
+			Style: pterm.NewStyle(printerColor),
+		})
+
+	errorPrinter := ErrorPrinter.WithScope(
+		pterm.Scope{
+			Text:  name,
+			Style: pterm.NewStyle(printerColor),
+		})
+
+	printer := Printer{
+		Info: genericPrinter.WithPrefix(pterm.Prefix{
+			Text:  "[INFO]",
+			Style: pterm.NewStyle(pterm.FgCyan),
+		}),
+		Success: successPrinter,
+		Warning: warningPrinter,
+		Error:   errorPrinter,
+		Spinner: &pterm.SpinnerPrinter{
+			Sequence:            spinnerCharset,
+			Style:               pterm.NewStyle(printerColor),
+			Delay:               time.Millisecond * 100,
+			MessageStyle:        pterm.NewStyle(printerColor),
+			SuccessPrinter:      successPrinter,
+			FailPrinter:         errorPrinter,
+			WarningPrinter:      warningPrinter,
+			RemoveWhenDone:      false,
+			ShowTimer:           true,
+			TimerRoundingFactor: time.Second,
+			TimerStyle:          &pterm.ThemeDefault.TimerStyle,
+		},
+	}
+
+	pfo := &PortForwardOptions{
+		Namespace: namespace,
+		Selector:  &liqolabels.NetworkManagerPodLabelSelector,
+		Config:    restConfig,
+		Client:    localCtrlRunClient,
+		PortForwarder: &DefaultPortForwarder{
+			genericclioptions.NewTestIOStreamsDiscard(),
+		},
+		RemotePort:   liqoconsts.NetworkManagerIpamPort,
+		LocalPort:    0,
+		Ports:        nil,
+		StopChannel:  make(chan struct{}),
+		ReadyChannel: make(chan struct{}),
+	}
+
+	return &Cluster{
+		name:             name,
+		namespace:        namespace,
+		printer:          printer,
+		locK8sClient:     localK8sClient,
+		locCtrlRunClient: localCtrlRunClient,
+		remCtrlRunClient: remoteCtrlRunClient,
+		namespaceManager: tenantnamespace.NewTenantNamespaceManager(localK8sClient),
+		PortForwardOpts:  pfo,
+	}
+}
+
+// Init initializes the cluster struct.
+func (c *Cluster) Init(ctx context.Context) error {
+	// Get cluster identity.
+	s, _ := c.printer.Spinner.Start("retrieving cluster identity")
+	selector, err := metav1.LabelSelectorAsSelector(&liqolabels.ClusterIDConfigMapLabelSelector)
+	if err != nil {
+		s.Fail(fmt.Sprintf("an error occurred while retrieving cluster identity: %v", err))
+		return err
+	}
+	cm, err := liqogetters.GetConfigMapByLabel(ctx, c.locCtrlRunClient, c.namespace, selector)
+	if err != nil {
+		s.Fail(fmt.Sprintf("an error occurred while retrieving cluster identity: %v", err))
+		return err
+	}
+	clusterID, err := liqogetters.RetrieveClusterIDFromConfigMap(cm)
+	if err != nil {
+		s.Fail(fmt.Sprintf("an error occurred while retrieving cluster identity: %v", err))
+		return err
+	}
+	s.Success("cluster identity correctly retrieved")
+
+	// Get network configuration.
+	s, _ = c.printer.Spinner.Start("retrieving network configuration")
+	selector, err = metav1.LabelSelectorAsSelector(&liqolabels.IPAMStorageLabelSelector)
+	if err != nil {
+		s.Fail(fmt.Sprintf("an error occurred while retrieving network configuration: %v", err))
+		return err
+	}
+	ipamStore, err := liqogetters.GetIPAMStorageByLabel(ctx, c.locCtrlRunClient, "default", selector)
+	if err != nil {
+		s.Fail(fmt.Sprintf("an error occurred while retrieving network configuration: %v", err))
+		return err
+	}
+	netcfg, err := liqogetters.RetrieveNetworkConfiguration(ipamStore)
+	if err != nil {
+		s.Fail(fmt.Sprintf("an error occurred while retrieving network configuration: %v", err))
+		return err
+	}
+	s.Success("network configuration correctly retrieved")
+
+	// Get vpn configuration.
+	s, _ = c.printer.Spinner.Start("retrieving WireGuard configuration")
+	selector, err = metav1.LabelSelectorAsSelector(&liqolabels.GatewayServiceLabelSelector)
+	if err != nil {
+		s.Fail(fmt.Sprintf("an error occurred while retrieving WireGuard configuration: %v", err))
+		return err
+	}
+	svc, err := liqogetters.GetServiceByLabel(ctx, c.locCtrlRunClient, c.namespace, selector)
+	if err != nil {
+		s.Fail(fmt.Sprintf("an error occurred while retrieving WireGuard configuration: %v", err))
+		return err
+	}
+	ip, port, err := liqogetters.RetrieveWGEPFromService(svc, liqoconsts.GatewayServiceAnnotationKey, liqoconsts.DriverName)
+	if err != nil {
+		s.Fail(fmt.Sprintf("an error occurred while retrieving WireGuard configuration: %v", err))
+		return err
+	}
+	selector, err = metav1.LabelSelectorAsSelector(&liqolabels.WireGuardSecretLabelSelector)
+	if err != nil {
+		s.Fail(fmt.Sprintf("an error occurred while retrieving WireGuard configuration: %v", err))
+		return err
+	}
+	secret, err := liqogetters.GetSecretByLabel(ctx, c.locCtrlRunClient, c.namespace, selector)
+	if err != nil {
+		s.Fail(fmt.Sprintf("an error occurred while retrieving WireGuard configuration: %v", err))
+		return err
+	}
+	pubKey, err := liqogetters.RetrieveWGPubKeyFromSecret(secret, liqoconsts.PublicKey)
+	if err != nil {
+		s.Fail(fmt.Sprintf("an error occurred while retrieving WireGuard configuration: %v", err))
+		return err
+	}
+	s.Success("wireGuard configuration correctly retrieved")
+
+	// Get authentication token.
+	s, _ = c.printer.Spinner.Start("retrieving authentication token")
+	authToken, err := auth.GetToken(ctx, c.locCtrlRunClient, c.namespace)
+	if err != nil {
+		s.Fail(fmt.Sprintf("an error occurred while retrieving auth token: %v", err))
+		return err
+	}
+	s.Success("authentication token correctly retrieved")
+
+	// Get authentication endpoint.
+	s, _ = c.printer.Spinner.Start("retrieving authentication  endpoint")
+	selector, err = metav1.LabelSelectorAsSelector(&liqolabels.AuthServiceLabelSelector)
+	if err != nil {
+		s.Fail(fmt.Sprintf("an error occurred while retrieving authentication endpoint: %v", err))
+		return err
+	}
+	svc, err = liqogetters.GetServiceByLabel(ctx, c.locCtrlRunClient, c.namespace, selector)
+	if err != nil {
+		s.Fail(fmt.Sprintf("an error occurred while retrieving authentication endpoint: %v", err))
+		return err
+	}
+	ipAuth, portAuth, err := liqogetters.RetrieveAuthEndpointFromClusterIPService(svc, authPort)
+	if err != nil {
+		s.Fail(fmt.Sprintf("an error occurred while retrieving authentication endpoint: %v", err))
+		return err
+	}
+	s.Success("authentication endpoint correctly retrieved")
+
+	// Set configuration
+	c.clusterID = clusterID
+	c.netConfig = netcfg
+
+	c.wgConfig = &WireGuardConfig{
+		PubKey:       pubKey.String(),
+		EndpointIP:   ip,
+		EndpointPort: port,
+		BackEndType:  liqoconsts.DriverName,
+	}
+
+	c.authToken = authToken
+
+	c.authEP = &Endpoint{
+		ip:   ipAuth,
+		port: portAuth,
+	}
+
+	return nil
+}
+
+// GetClusterID returns the cluster identity.
+func (c *Cluster) GetClusterID() *discoveryv1alpha1.ClusterIdentity {
+	return c.clusterID
+}
+
+// GetLocTenantNS returns the tenant namespace created for the remote cluster.
+func (c *Cluster) GetLocTenantNS() string {
+	return c.locTenantNamespace
+}
+
+// SetRemTenantNS sets the tenant namespace of the local cluster created by the remote cluster.
+func (c *Cluster) SetRemTenantNS(remTenantNamespace string) {
+	c.remTenantNamespace = remTenantNamespace
+}
+
+// GetAuthToken returns the authentication token of the local cluster.
+func (c *Cluster) GetAuthToken() string {
+	return c.authToken
+}
+
+// GetAuthURL returns the authentication URL of the local cluster.
+func (c *Cluster) GetAuthURL() string {
+	return c.authEP.GetHTTPSURL()
+}
+
+// GetProxyURL returns the proxy URL of the local cluster.
+func (c *Cluster) GetProxyURL() string {
+	return c.proxyEP.GetHTTPURL()
+}
+
+// SetUpTenantNamespace creates the tenant namespace in the local custer for the given remote cluster.
+func (c *Cluster) SetUpTenantNamespace(ctx context.Context, remoteClusterID *discoveryv1alpha1.ClusterIdentity) error {
+	s, _ := c.printer.Spinner.Start(fmt.Sprintf("creating tenant namespace for remote cluster {%s}", remoteClusterID.ClusterName))
+	ns, err := c.namespaceManager.CreateNamespace(*remoteClusterID)
+	if err != nil {
+		s.Fail(fmt.Sprintf("an error occurred while creating tenant namespace for remote cluster {%s}: %v", remoteClusterID.ClusterName, err))
+		return err
+	}
+	s.Success(fmt.Sprintf("tenant namespace {%s} created for remote cluster {%s}", ns.Name, remoteClusterID.ClusterName))
+	c.locTenantNamespace = ns.Name
+	return nil
+}
+
+// ExchangeNetworkCfg creates the local networkconfigs resource for the remote cluster, replicates it
+// into the remote cluster, waits for the remote cluster to populate the status of the resource and then
+// sets the remote status in the local networkconfigs resource.
+func (c *Cluster) ExchangeNetworkCfg(ctx context.Context, remoteClusterID *discoveryv1alpha1.ClusterIdentity) error {
+	// Enforce the network configuration in the local cluster.
+	s, _ := c.printer.Spinner.Start("creating network configuration in local cluster")
+	if err := c.enforceNetworkCfg(ctx, remoteClusterID, true); err != nil {
+		s.Fail(fmt.Sprintf("an error occurred while creating network configuration in local cluster: %v", err))
+		return err
+	}
+	s.Success(fmt.Sprintf("network configuration created in local cluster {%s}", c.clusterID.ClusterName))
+
+	// Enforce the network configuration in the local cluster.
+	s, _ = c.printer.Spinner.Start(fmt.Sprintf("creating network configuration in remote cluster {%s}", remoteClusterID.ClusterName))
+	if err := c.enforceNetworkCfg(ctx, remoteClusterID, false); err != nil {
+		s.Fail(fmt.Sprintf("an error occurred while creating network configuration in remote cluster: %v", err))
+		return err
+	}
+	s.Success(fmt.Sprintf("network configuration created in remote cluster {%s}", remoteClusterID.ClusterName))
+
+	// Wait for the network configuration to be processed by the remote cluster.
+	s, _ = c.printer.Spinner.Start(fmt.Sprintf("waiting network configuration to be processed by remote cluster {%s}", remoteClusterID.ClusterName))
+	netcfg, err := c.waitForNetCfg(ctx, remoteClusterID, 60*time.Second)
+	if err != nil {
+		s.Fail(err)
+		return err
+	}
+	s.UpdateText(fmt.Sprintf("reflecting network configuration status from cluster {%s}", remoteClusterID.ClusterName))
+	if err := c.reflectNetworkCfgStatus(ctx, remoteClusterID, &netcfg.Status); err != nil {
+		s.Fail(err)
+		return err
+	}
+	s.Success(fmt.Sprintf("network configuration status correctly reflected from cluster {%s}", remoteClusterID.ClusterName))
+	return nil
+}
+
+// enforceNetworkCfg enforces the presence of the networkconfigs resource for a given remote cluster.
+func (c *Cluster) enforceNetworkCfg(ctx context.Context, remoteClusterID *discoveryv1alpha1.ClusterIdentity, local bool) error {
+	// Get the network config.
+	netcfg, err := c.getNetworkCfg(ctx, remoteClusterID, local)
+	if client.IgnoreNotFound(err) != nil {
+		return err
+	}
+
+	if err != nil {
+		return c.createNetworkCfg(ctx, remoteClusterID, local)
+	}
+
+	return c.updateNetworkCfgSpec(ctx, netcfg, remoteClusterID, local)
+}
+
+// getNetworkCfg retrieves the networkconfigs resource for a given remote cluster.
+func (c *Cluster) getNetworkCfg(ctx context.Context,
+	remoteClusterID *discoveryv1alpha1.ClusterIdentity, local bool) (*netv1alpha1.NetworkConfig, error) {
+	var cl client.Client
+	var selector labels.Selector
+	var err error
+	var ns string
+
+	if local {
+		cl = c.locCtrlRunClient
+		if selector, err = labelSelectorForReplicatedResource(remoteClusterID, local); err != nil {
+			return nil, err
+		}
+		ns = c.locTenantNamespace
+	} else {
+		cl = c.remCtrlRunClient
+		if selector, err = labelSelectorForReplicatedResource(c.clusterID, local); err != nil {
+			return nil, err
+		}
+		ns = c.remTenantNamespace
+	}
+
+	// Get the network config.
+	return liqogetters.GetNetworkConfigByLabel(ctx, cl, ns, selector)
+}
+
+// createNetworkCfg creates the networkconfigs resource for the given remote cluster.
+func (c *Cluster) createNetworkCfg(ctx context.Context, remoteClusterID *discoveryv1alpha1.ClusterIdentity, local bool) error {
+	netcfg := &netv1alpha1.NetworkConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      foreigncluster.UniqueName(remoteClusterID),
+			Namespace: c.locTenantNamespace,
+			Labels: map[string]string{
+				liqoconsts.ReplicationRequestedLabel:   strconv.FormatBool(true),
+				liqoconsts.ReplicationDestinationLabel: remoteClusterID.ClusterID,
+			},
+		},
+	}
+	c.populateNetworkCfg(netcfg, remoteClusterID, local)
+
+	if local {
+		return c.locCtrlRunClient.Create(ctx, netcfg)
+	}
+
+	return c.remCtrlRunClient.Create(ctx, netcfg)
+}
+
+// updateNetworkCfgSpec given the local networkconfigs resource the spec is reflected on the
+// remote instance.
+func (c *Cluster) updateNetworkCfgSpec(ctx context.Context, netcfg *netv1alpha1.NetworkConfig,
+	remoteClusterID *discoveryv1alpha1.ClusterIdentity, local bool) error {
+	original := netcfg.DeepCopy()
+
+	c.populateNetworkCfg(netcfg, remoteClusterID, local)
+
+	if reflect.DeepEqual(original, netcfg) {
+		return nil
+	}
+
+	if local {
+		return c.locCtrlRunClient.Update(ctx, netcfg)
+	}
+
+	return c.remCtrlRunClient.Update(ctx, netcfg)
+}
+
+// updateNetworkCfgStatus given the remote networkconfigs resource the status is reflected on the
+// local instance.
+func (c *Cluster) updateNetworkCfgStatus(ctx context.Context, netcfg *netv1alpha1.NetworkConfig,
+	newStatus *netv1alpha1.NetworkConfigStatus) error {
+	if reflect.DeepEqual(netcfg.Status, newStatus) {
+		return nil
+	}
+
+	netcfg.Status = *newStatus
+	return c.locCtrlRunClient.Status().Update(ctx, netcfg)
+}
+
+// reflectNetworkCfgStatus given the remote networkconfigs resource the status is reflected on the
+// local instance.
+func (c *Cluster) reflectNetworkCfgStatus(ctx context.Context, remoteClusterID *discoveryv1alpha1.ClusterIdentity,
+	status *netv1alpha1.NetworkConfigStatus) error {
+	// Get the local networkconfig
+	netcfg, err := c.getNetworkCfg(ctx, remoteClusterID, true)
+	if err != nil {
+		return nil
+	}
+
+	return c.updateNetworkCfgStatus(ctx, netcfg, status)
+}
+
+// waitForNetCfg wait until a remote networkconfigs resource is processed by the remote cluster or the timeout expires.
+func (c *Cluster) waitForNetCfg(ctx context.Context, remoteClusterID *discoveryv1alpha1.ClusterIdentity,
+	timeout time.Duration) (*netv1alpha1.NetworkConfig, error) {
+	deadLine := time.After(timeout)
+	for {
+		select {
+		case <-deadLine:
+			return nil, fmt.Errorf("timout (%.0fs) expired while waiting for cluster {%s} to process the networkconfig",
+				timeout.Seconds(), remoteClusterID.ClusterName)
+		default:
+			netcfg, err := c.getNetworkCfg(ctx, remoteClusterID, false)
+			if err != nil {
+				return nil, err
+			}
+			if netcfg.Status.Processed {
+				return netcfg, err
+			}
+			time.Sleep(2 * time.Second)
+		}
+	}
+}
+
+// populateNetworkCfg sets the fields of a given networkconfigs resource for a remote cluster. Flag is used to
+// denote if the resource is local or remote.
+func (c *Cluster) populateNetworkCfg(netcfg *netv1alpha1.NetworkConfig, remoteClusterID *discoveryv1alpha1.ClusterIdentity, local bool) {
+	clusterID := remoteClusterID.ClusterID
+
+	if netcfg.Labels == nil {
+		netcfg.Labels = map[string]string{}
+	}
+
+	netcfg.Labels[liqoconsts.ReplicationRequestedLabel] = strconv.FormatBool(true)
+	netcfg.Labels[liqoconsts.ReplicationDestinationLabel] = clusterID
+
+	if !local {
+		// setting the right namespace in the remote cluster
+		netcfg.Namespace = c.remTenantNamespace
+		// setting the replication label to false
+		netcfg.Labels[liqoconsts.ReplicationRequestedLabel] = strconv.FormatBool(false)
+		// setting replication status to true
+		netcfg.Labels[liqoconsts.ReplicationStatusLabel] = strconv.FormatBool(true)
+		// setting originID i.e clusterID of home cluster
+		netcfg.Labels[liqoconsts.ReplicationOriginLabel] = c.clusterID.ClusterID
+	}
+
+	netcfg.Spec.RemoteCluster = *remoteClusterID
+	netcfg.Spec.PodCIDR = c.netConfig.PodCIDR
+	netcfg.Spec.ExternalCIDR = c.netConfig.ExternalCIDR
+	netcfg.Spec.EndpointIP = c.wgConfig.EndpointIP
+	netcfg.Spec.BackendType = liqoconsts.DriverName
+
+	if netcfg.Spec.BackendConfig == nil {
+		netcfg.Spec.BackendConfig = map[string]string{}
+	}
+
+	netcfg.Spec.BackendConfig[liqoconsts.PublicKey] = c.wgConfig.PubKey
+	netcfg.Spec.BackendConfig[liqoconsts.ListeningPort] = c.wgConfig.EndpointPort
+}
+
+// labelSelectorForReplicatedResource returns the correct labels used to get a replicated resource.
+// Based on the local flag it returns labels for the local one or the remote one.
+func labelSelectorForReplicatedResource(clusterID *discoveryv1alpha1.ClusterIdentity, local bool) (labels.Selector, error) {
+	if local {
+		labelsSet := labels.Set{
+			liqoconsts.ReplicationDestinationLabel: clusterID.ClusterID,
+			liqoconsts.ReplicationRequestedLabel:   strconv.FormatBool(true),
+		}
+
+		return labels.ValidatedSelectorFromSet(labelsSet)
+	}
+	labelsSet := labels.Set{
+		liqoconsts.ReplicationOriginLabel: clusterID.ClusterID,
+		liqoconsts.ReplicationStatusLabel: strconv.FormatBool(true),
+	}
+
+	return labels.ValidatedSelectorFromSet(labelsSet)
+}
+
+// PortForwardIPAM starts the port forwarding for the IPAM service.
+func (c *Cluster) PortForwardIPAM(ctx context.Context) error {
+	s, _ := c.printer.Spinner.Start("port-forwarding IPAM service")
+
+	if err := c.PortForwardOpts.RunPortForward(ctx); err != nil {
+		s.Fail(fmt.Sprintf("an error occurred while port-forwarding IPAM service: %v", err))
+		return err
+	}
+	s.Success(fmt.Sprintf("IPAM service correctly port-forwarded {%s}", c.PortForwardOpts.Ports[0]))
+
+	return nil
+}
+
+// StopPortForwardIPAM stops the port forwarding for the IPAM service.
+func (c *Cluster) StopPortForwardIPAM() {
+	s, _ := c.printer.Spinner.Start("stopping IPAM service port-forward")
+	c.PortForwardOpts.StopPortForward()
+	s.Success(fmt.Sprintf("IPAM service port-forward correctly stopped {%s}", c.PortForwardOpts.Ports[0]))
+}
+
+// SetUpProxy configures the proxy deployment.
+func (c *Cluster) SetUpProxy(ctx context.Context) error {
+	s, _ := c.printer.Spinner.Start(fmt.Sprintf("configuring proxy pod {%s} and service in namespace {%s}", proxyName, c.namespace))
+
+	ep, err := createProxyDeployment(ctx, c.locK8sClient, proxyName, c.namespace)
+	if err != nil {
+		s.Fail(fmt.Sprintf("an error occurred while setting up proxy {%s} in namespace {%s}: %v", proxyName, c.namespace, err))
+		return err
+	}
+	s.Success(fmt.Sprintf("proxy {%s} correctly configured in namespace {%s}", proxyName, c.namespace))
+
+	c.proxyEP = ep
+
+	return nil
+}
+
+// MapProxyIPForCluster maps the ClusterIP address of the local proxy on the local external CIDR as seen by the remote cluster.
+func (c *Cluster) MapProxyIPForCluster(ctx context.Context, ipamClient ipam.IpamClient, remoteCluster *discoveryv1alpha1.ClusterIdentity) error {
+	clusterName := remoteCluster.ClusterName
+	ipToBeRemapped := c.proxyEP.GetIP()
+
+	s, _ := c.printer.Spinner.Start(fmt.Sprintf("mapping proxy ip {%s} for cluster {%s}", ipToBeRemapped, clusterName))
+
+	ip, err := mapServiceForCluster(ctx, ipamClient, ipToBeRemapped, remoteCluster)
+	if err != nil {
+		s.Fail(fmt.Sprintf("an error occurred while mapping proxy address {%s} for cluster {%s}: %v", ipToBeRemapped, clusterName, err))
+		return err
+	}
+
+	c.proxyEP.SetRemappedIP(ip)
+
+	s.Success(fmt.Sprintf("proxy address {%s} remapped to {%s} for remote cluster {%s}", ipToBeRemapped, ip, clusterName))
+
+	return nil
+}
+
+// MapAuthIPForCluster maps the ClusterIP address of the local auth service on the local external CIDR as seen by the remote cluster.
+func (c *Cluster) MapAuthIPForCluster(ctx context.Context, ipamClient ipam.IpamClient, remoteCluster *discoveryv1alpha1.ClusterIdentity) error {
+	clusterName := remoteCluster.ClusterName
+	ipToBeRemapped := c.authEP.GetIP()
+
+	s, _ := c.printer.Spinner.Start(fmt.Sprintf("mapping auth ip {%s} for cluster {%s}", ipToBeRemapped, clusterName))
+
+	ip, err := mapServiceForCluster(ctx, ipamClient, ipToBeRemapped, remoteCluster)
+	if err != nil {
+		s.Fail(fmt.Sprintf("an error occurred while mapping auth address {%s} for cluster {%s}: %v", ipToBeRemapped, clusterName, err))
+		return err
+	}
+
+	c.authEP.SetRemappedIP(ip)
+
+	s.Success(fmt.Sprintf("auth address {%s} remapped to {%s} for remote cluster {%s}", ipToBeRemapped, ip, clusterName))
+
+	return nil
+}
+
+// NewIPAMClient creates and returns a client to the IPAM service.
+func (c *Cluster) NewIPAMClient(ctx context.Context) (ipam.IpamClient, error) {
+	ipamTarget := fmt.Sprintf("%s:%d", "localhost", c.PortForwardOpts.LocalPort)
+
+	dialctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+
+	connection, err := grpc.DialContext(dialctx, ipamTarget, grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithBlock())
+	cancel()
+	if err != nil {
+		c.printer.Error.Printf("an error occurred while creating IPAM client: %v", err)
+		return nil, err
+	}
+
+	return ipam.NewIpamClient(connection), nil
+}
+
+// mapServiceForCluster maps a local ip address to be consumed by a given remote cluster.
+func mapServiceForCluster(ctx context.Context, ipamClient ipam.IpamClient, ipToBeRemapped string,
+	remoteCluster *discoveryv1alpha1.ClusterIdentity) (string, error) {
+	mapRequest := &ipam.MapRequest{
+		ClusterID: remoteCluster.ClusterID,
+		Ip:        ipToBeRemapped,
+	}
+
+	resp, err := ipamClient.MapEndpointIP(ctx, mapRequest)
+	if err != nil {
+		return "", err
+	}
+
+	return resp.Ip, nil
+}
+
+// EnforceForeignCluster enforces the presence of the foreignclusters instance for a given remote cluster.
+// The newly created foreigncluster has the following fields set to:
+// 	* ForeignAuthURL -> the remapped ip address for the local cluster of the auth service living in the remote cluster;
+//  * ForeignProxyURL -> the remapped ip address for the local cluster of the proxy service living in the remote cluster;
+//  * OutgoingPeeringEnabled -> Yes
+//  * NetworkingEnabled -> No, we do not want the networking to be handled by the peering process. Networking is
+// 						   handled manually by the licoctl connect/disconnect commands.
+func (c *Cluster) EnforceForeignCluster(ctx context.Context, remoteClusterID *discoveryv1alpha1.ClusterIdentity,
+	token, authURL, proxyURL string) error {
+	remID := remoteClusterID.ClusterID
+	remName := remoteClusterID.ClusterName
+	s, _ := c.printer.Spinner.Start(fmt.Sprintf("creating foreign cluster for the remote cluster {%s}", remName))
+	if c.clusterID.ClusterID == remoteClusterID.ClusterID {
+		msg := fmt.Sprintf("the clusterID {%s} of remote cluster {%s} is equal to the ID of the local cluster", remID, remName)
+		s.Fail(msg)
+		return fmt.Errorf(msg)
+	}
+
+	if err := authenticationtoken.StoreInSecret(ctx, c.locK8sClient, remID, token, c.namespace); err != nil {
+		msg := fmt.Sprintf("an error occurred while storing auth token for remote cluster {%s}: %v", remName, err)
+		s.Fail(msg)
+		return fmt.Errorf(msg)
+	}
+
+	// Get existing foreign cluster if it does exist
+	fc, err := foreigncluster.GetForeignClusterByID(ctx, c.locCtrlRunClient, remID)
+	if client.IgnoreNotFound(err) != nil {
+		s.Fail(fmt.Sprintf("an error occurred while getting foreign cluster for remote cluster {%s}: %v", remName, err))
+		return err
+	}
+
+	// Not nil only if the foreign cluster does not exist.
+	if err != nil {
+		fc = &discoveryv1alpha1.ForeignCluster{ObjectMeta: metav1.ObjectMeta{Name: remName,
+			Labels: map[string]string{discovery.ClusterIDLabel: remID}}}
+	}
+
+	if _, err = controllerutil.CreateOrPatch(ctx, c.locCtrlRunClient, fc, func() error {
+		fc.Spec.ForeignAuthURL = authURL
+		fc.Spec.ForeignProxyURL = proxyURL
+		fc.Spec.OutgoingPeeringEnabled = discoveryv1alpha1.PeeringEnabledYes
+		fc.Spec.NetworkingEnabled = discoveryv1alpha1.NetworkingEnabledNo
+		if fc.Spec.IncomingPeeringEnabled == "" {
+			fc.Spec.IncomingPeeringEnabled = discoveryv1alpha1.PeeringEnabledAuto
+		}
+		if fc.Spec.InsecureSkipTLSVerify == nil {
+			fc.Spec.InsecureSkipTLSVerify = pointer.BoolPtr(true)
+		}
+		return nil
+	}); err != nil {
+		s.Fail(fmt.Sprintf("an error occurred while creating/updating foreign cluster for remote cluster {%s}: %v", remName, err))
+		return err
+	}
+	s.Success(fmt.Sprintf("foreign cluster for remote cluster {%s} correctly configured", remName))
+	return nil
+}
+
+// WaitForAuth waits until the authentication has been established with the remote cluster or the timeout expires.
+func (c *Cluster) WaitForAuth(ctx context.Context, remoteClusterID *discoveryv1alpha1.ClusterIdentity, timeout time.Duration) error {
+	remName := remoteClusterID.ClusterName
+	s, _ := c.printer.Spinner.Start(fmt.Sprintf("waiting for event {%s} from the remote cluster {%s}", AuthEvent, remName))
+	err := WaitForEventOnForeignCluster(ctx, remoteClusterID, AuthEvent, AuthChecker, timeout, c.locCtrlRunClient)
+	if err != nil {
+		s.Fail(err.Error())
+		return err
+	}
+	s.Success(fmt.Sprintf("event {%s} successfully occurred for remote cluster {%s}", AuthEvent, remName))
+	return nil
+}

--- a/pkg/liqoctl/common/endpoint.go
+++ b/pkg/liqoctl/common/endpoint.go
@@ -1,0 +1,44 @@
+// Copyright 2019-2022 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import "fmt"
+
+// Endpoint maps a service that has to be accessed by a remote cluster.
+type Endpoint struct {
+	ip         string
+	port       string
+	remappedIP string
+}
+
+// GetIP returns the ip address that has on the cluster where the endpoint lives.
+func (ep *Endpoint) GetIP() string {
+	return ep.ip
+}
+
+// SetRemappedIP sets the ip address as seen by the remote cluster.
+func (ep *Endpoint) SetRemappedIP(ip string) {
+	ep.remappedIP = ip
+}
+
+// GetHTTPURL returns the http url for the endpoint.
+func (ep *Endpoint) GetHTTPURL() string {
+	return fmt.Sprintf("http://%s:%s", ep.remappedIP, ep.port)
+}
+
+// GetHTTPSURL return the https url for the endpoint.
+func (ep *Endpoint) GetHTTPSURL() string {
+	return fmt.Sprintf("https://%s:%s", ep.remappedIP, ep.port)
+}

--- a/pkg/liqoctl/common/foreignClusterEvents.go
+++ b/pkg/liqoctl/common/foreignClusterEvents.go
@@ -1,0 +1,74 @@
+// Copyright 2019-2022 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
+	foreigncluster "github.com/liqotech/liqo/pkg/utils/foreignCluster"
+)
+
+type fcEventType string
+type fcEventChecker func(fc *discoveryv1alpha1.ForeignCluster) bool
+
+const (
+	// UnpeeringEvent name of the unpeering event.
+	UnpeeringEvent fcEventType = "unpeer"
+	// AuthEvent name of the authentication event.
+	AuthEvent fcEventType = "authentication"
+)
+
+var (
+	// UnpeerChecker checks if the two clusters are unpeered.
+	UnpeerChecker fcEventChecker = func(fc *discoveryv1alpha1.ForeignCluster) bool {
+		return foreigncluster.IsIncomingPeeringNone(fc) && foreigncluster.IsOutgoingPeeringNone(fc)
+	}
+
+	// AuthChecker checks if the authentication has been completed.
+	AuthChecker fcEventChecker = foreigncluster.IsAuthenticated
+)
+
+// WaitForEventOnForeignCluster given the remote cluster identity if waits for the given event
+// to be verified on the associated foreigncluster.
+func WaitForEventOnForeignCluster(ctx context.Context, remoteClusterID *discoveryv1alpha1.ClusterIdentity,
+	event fcEventType, checker fcEventChecker, timeout time.Duration, cl client.Client) error {
+	deadLine := time.After(timeout)
+	remName := remoteClusterID.ClusterName
+	remID := remoteClusterID.ClusterID
+	for {
+		select {
+		case <-deadLine:
+			return fmt.Errorf("timout (%.0fs) expired while waiting for event {%s} from cluster {%s}",
+				timeout.Seconds(), event, remName)
+		default:
+			fc, err := foreigncluster.GetForeignClusterByID(ctx, cl, remID)
+			if err != nil && !k8serrors.IsNotFound(err) {
+				return err
+			} else if k8serrors.IsNotFound(err) {
+				return nil
+			}
+			if checker(fc) {
+				return nil
+			}
+			time.Sleep(2 * time.Second)
+		}
+	}
+}

--- a/pkg/liqoctl/common/output.go
+++ b/pkg/liqoctl/common/output.go
@@ -1,0 +1,60 @@
+// Copyright 2019-2022 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import "github.com/pterm/pterm"
+
+var (
+	spinnerCharset = []string{"⠈⠁", "⠈⠑", "⠈⠱", "⠈⡱", "⢀⡱", "⢄⡱", "⢄⡱", "⢆⡱",
+		"⢎⡱", "⢎⡰", "⢎⡠", "⢎⡀", "⢎⠁", "⠎⠁", "⠊⠁"}
+
+	// GenericPrinter used to print generic output.
+	GenericPrinter = pterm.PrefixPrinter{
+		Prefix: pterm.Prefix{},
+		Scope: pterm.Scope{
+			Text:  "cmd",
+			Style: pterm.NewStyle(pterm.FgGray),
+		},
+		MessageStyle: pterm.NewStyle(pterm.FgDefault),
+	}
+
+	// SuccessPrinter used to print success output.
+	SuccessPrinter = GenericPrinter.WithPrefix(pterm.Prefix{
+		Text:  "[SUCCESS]",
+		Style: pterm.NewStyle(pterm.FgGreen),
+	})
+
+	// WarningPrinter used to print warning output.
+	WarningPrinter = GenericPrinter.WithPrefix(pterm.Prefix{
+		Text:  "[WARNING]",
+		Style: pterm.NewStyle(pterm.FgYellow),
+	})
+
+	// ErrorPrinter used to print error output.
+	ErrorPrinter = GenericPrinter.WithPrefix(pterm.Prefix{
+		Text:  "[ERROR]",
+		Style: pterm.NewStyle(pterm.FgRed),
+	})
+)
+
+// Printer manages all kinds of outputs.
+type Printer struct {
+	Info        *pterm.PrefixPrinter
+	Success     *pterm.PrefixPrinter
+	Warning     *pterm.PrefixPrinter
+	Error       *pterm.PrefixPrinter
+	Spinner     *pterm.SpinnerPrinter
+	InfoMessage string
+}

--- a/pkg/liqoctl/common/portForward.go
+++ b/pkg/liqoctl/common/portForward.go
@@ -1,0 +1,136 @@
+// Copyright 2019-2022 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	k8s "k8s.io/client-go/kubernetes"
+	restclient "k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/portforward"
+	"k8s.io/client-go/transport/spdy"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/liqotech/liqo/pkg/utils/getters"
+	liqolabels "github.com/liqotech/liqo/pkg/utils/labels"
+)
+
+// PortForwardOptions contains all the options in order to port-forward a pod's port.
+type PortForwardOptions struct {
+	Namespace     string
+	Selector      *metav1.LabelSelector
+	Config        *restclient.Config
+	Client        client.Client
+	PortForwarder PortForwarder
+	RemotePort    int
+	LocalPort     int
+	Ports         []string
+	StopChannel   chan struct{}
+	ReadyChannel  chan struct{}
+}
+
+// PortForwarder interface that a port forwarder needs to implement.
+type PortForwarder interface {
+	ForwardPorts(method string, podURL *url.URL, opts *PortForwardOptions) error
+}
+
+// DefaultPortForwarder default forwarder implementation used to forward ports.
+type DefaultPortForwarder struct {
+	genericclioptions.IOStreams
+}
+
+// ForwardPorts forwards the ports given in the options for the given pod url.
+func (f *DefaultPortForwarder) ForwardPorts(method string, podURL *url.URL, opt *PortForwardOptions) error {
+	errChan := make(chan error, 1)
+
+	transport, upgrader, err := spdy.RoundTripperFor(opt.Config)
+	if err != nil {
+		return err
+	}
+	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: transport}, method, podURL)
+
+	pf, err := portforward.New(dialer, opt.Ports, opt.StopChannel, opt.ReadyChannel, f.Out, f.ErrOut)
+	if err != nil {
+		return fmt.Errorf("unable to port forward into pod %s: %w", podURL.String(), err)
+	}
+
+	go func() {
+		errChan <- pf.ForwardPorts()
+	}()
+
+	select {
+	case err = <-errChan:
+		if err != nil {
+			return fmt.Errorf("an error occurred while port forwarding into pod %s: %w", podURL.String(), err)
+		}
+	case <-opt.ReadyChannel:
+		break
+	}
+
+	return nil
+}
+
+// RunPortForward starts the forwarding.
+func (o *PortForwardOptions) RunPortForward(ctx context.Context) error {
+	var err error
+	// Get the local port used to forward the pod's port.
+	o.LocalPort, err = getFreePort()
+	if err != nil {
+		return fmt.Errorf("unable to get a local port: %w", err)
+	}
+
+	podURL, err := o.getPodURL(ctx)
+	if err != nil {
+		return err
+	}
+
+	o.Ports = []string{fmt.Sprintf("%d:%d", o.LocalPort, o.RemotePort)}
+
+	return o.PortForwarder.ForwardPorts(http.MethodPost, podURL, o)
+}
+
+// StopPortForward stops the forwarding.
+func (o *PortForwardOptions) StopPortForward() {
+	o.StopChannel <- struct{}{}
+}
+
+func (o *PortForwardOptions) getPodURL(ctx context.Context) (*url.URL, error) {
+	lSelector, err := metav1.LabelSelectorAsSelector(&liqolabels.NetworkManagerPodLabelSelector)
+	if err != nil {
+		return nil, fmt.Errorf("an error occurred while retrieving network manager pod: %w", err)
+	}
+
+	fSelector := fields.OneTermEqualSelector("status.phase", string(v1.PodRunning))
+
+	pod, err := getters.GetPodByLabel(ctx, o.Client, o.Namespace, lSelector, fSelector)
+	if err != nil {
+		return nil, fmt.Errorf("an error occurred while retrieving network manager pod: %w", err)
+	}
+
+	// Dirty trick used to build the URL.
+	cl, err := k8s.NewForConfig(o.Config)
+	if err != nil {
+		return nil, fmt.Errorf("an error occurred while retrieving network manager pod: %w", err)
+	}
+
+	return cl.CoreV1().RESTClient().Post().Resource("pods").Namespace(pod.Namespace).Name(pod.Name).SubResource("portforward").URL(), nil
+}

--- a/pkg/liqoctl/common/proxyDeployment.go
+++ b/pkg/liqoctl/common/proxyDeployment.go
@@ -1,0 +1,203 @@
+// Copyright 2019-2022 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"context"
+	"strconv"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	k8s "k8s.io/client-go/kubernetes"
+
+	liqoconst "github.com/liqotech/liqo/pkg/consts"
+)
+
+const (
+	proxyImage = "envoyproxy/envoy:v1.21.0"
+)
+
+var (
+	proxyConfig = `
+admin:
+  address:
+    socket_address:
+      protocol: TCP
+      address: 0.0.0.0
+      port_value: 9901
+
+static_resources:
+  listeners:
+  - name: listener_http
+    address:
+      socket_address:
+        protocol: TCP
+        address: 0.0.0.0
+        port_value: 8118
+    access_log:
+      name: envoy.access_loggers.file
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+        path: /dev/stdout
+    filter_chains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          stat_prefix: ingress_http
+          route_config:
+            name: local_route
+            virtual_hosts:
+            - name: local_service
+              domains:
+              - "*"
+              routes:
+              - match:
+                  connect_matcher:
+                    {}
+                route:
+                  cluster: api_server
+                  upgrade_configs:
+                  - upgrade_type: CONNECT
+                    connect_config:
+                      {}
+          http_filters:
+          - name: envoy.filters.http.router
+  clusters:
+  - name: api_server
+    connect_timeout: 0.25s
+    type: STRICT_DNS
+    respect_dns_ttl: true
+    dns_lookup_family: V4_ONLY
+    dns_refresh_rate: 300s
+    lb_policy: ROUND_ROBIN
+    load_assignment:
+      cluster_name: api_server
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+               address: kubernetes.default
+               port_value: 443`
+)
+
+func createProxyDeployment(ctx context.Context, cl k8s.Interface, name, ns string) (*Endpoint, error) {
+	commonObjMeta := metav1.ObjectMeta{
+		Name:      name,
+		Namespace: ns,
+		Labels: map[string]string{
+			liqoconst.K8sAppNameKey: liqoconst.APIServerProxyAppName,
+		},
+	}
+
+	proxyConfigMap := &corev1.ConfigMap{
+		ObjectMeta: commonObjMeta,
+		Data: map[string]string{
+			"config": proxyConfig,
+		},
+	}
+
+	proxyService := &corev1.Service{
+		ObjectMeta: commonObjMeta,
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{{
+				Name:        "http",
+				Protocol:    "TCP",
+				AppProtocol: nil,
+				Port:        8118,
+				TargetPort: intstr.IntOrString{
+					Type:   intstr.Int,
+					IntVal: 8118,
+					StrVal: "8118",
+				},
+			}},
+			Selector: map[string]string{
+				liqoconst.K8sAppNameKey: liqoconst.APIServerProxyAppName,
+			},
+		},
+	}
+
+	deployment := &appsv1.Deployment{
+		ObjectMeta: commonObjMeta,
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					liqoconst.K8sAppNameKey: liqoconst.APIServerProxyAppName,
+				},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: commonObjMeta.Labels,
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "envoy",
+							Image: proxyImage,
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "config-volume",
+									MountPath: "/etc/envoy/envoy.yaml",
+									SubPath:   "config",
+								},
+							},
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "config-volume",
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: proxyName,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	_, err := cl.AppsV1().Deployments(ns).Create(ctx, deployment, metav1.CreateOptions{})
+	if err != nil && !k8serrors.IsAlreadyExists(err) {
+		return nil, err
+	}
+
+	_, err = cl.CoreV1().ConfigMaps(ns).Create(ctx, proxyConfigMap, metav1.CreateOptions{})
+	if err != nil && !k8serrors.IsAlreadyExists(err) {
+		return nil, err
+	}
+
+	svc, err := cl.CoreV1().Services(ns).Create(ctx, proxyService, metav1.CreateOptions{})
+	if err != nil && !k8serrors.IsAlreadyExists(err) {
+		return nil, err
+	}
+	if k8serrors.IsAlreadyExists(err) {
+		svc, err = cl.CoreV1().Services(ns).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &Endpoint{
+		ip:   svc.Spec.ClusterIP,
+		port: strconv.FormatInt(int64(svc.Spec.Ports[0].Port), 10),
+	}, err
+}

--- a/pkg/liqoctl/common/utils.go
+++ b/pkg/liqoctl/common/utils.go
@@ -16,6 +16,7 @@ package common
 
 import (
 	"fmt"
+	"net"
 	"strings"
 
 	"k8s.io/client-go/rest"
@@ -24,6 +25,14 @@ import (
 
 	"github.com/liqotech/liqo/pkg/utils/restcfg"
 )
+
+// WireGuardConfig holds the WireGuard configuration.
+type WireGuardConfig struct {
+	PubKey       string
+	EndpointIP   string
+	EndpointPort string
+	BackEndType  string
+}
 
 // GetLiqoctlRestConf gets a valid REST config and set a default value for the RateLimiters.
 func GetLiqoctlRestConf() (*rest.Config, error) {
@@ -47,4 +56,20 @@ func ExtractValueFromArgumentList(key string, argumentList []string) (string, er
 		}
 	}
 	return "", fmt.Errorf("argument not found")
+}
+
+// getFreePort get a free port on the system by listening in a socket,
+// checking the bound port number and then closing the socket.
+func getFreePort() (int, error) {
+	addr, err := net.ResolveTCPAddr("tcp", "localhost:0")
+	if err != nil {
+		return 0, err
+	}
+
+	l, err := net.ListenTCP("tcp", addr)
+	if err != nil {
+		return 0, err
+	}
+	defer l.Close()
+	return l.Addr().(*net.TCPAddr).Port, nil
 }

--- a/pkg/liqoctl/connect/doc.go
+++ b/pkg/liqoctl/connect/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2019-2022 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package connect contains the logic that handles the connect command in liqoctl
+package connect

--- a/pkg/liqoctl/connect/handler.go
+++ b/pkg/liqoctl/connect/handler.go
@@ -1,0 +1,191 @@
+// Copyright 2019-2022 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connect
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	k8s "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/liqotech/liqo/pkg/liqoctl/common"
+)
+
+// Args flags of the connect command.
+type Args struct {
+	Cluster1Namespace  string
+	Cluster2Namespace  string
+	Cluster1Kubeconfig string
+	Cluster2Kubeconfig string
+}
+
+// Handler implements the logic of the connect command.
+func (a *Args) Handler(ctx context.Context) error {
+	// Check that the kubeconfigs are different.
+	if a.Cluster1Kubeconfig == a.Cluster2Kubeconfig {
+		common.ErrorPrinter.Printf("kubeconfig1 and kubeconfig2 has to be different, current value: %s", a.Cluster2Kubeconfig)
+		return fmt.Errorf("kubeconfig1 and kubeconfig2 has to be different, current value: %s", a.Cluster2Kubeconfig)
+	}
+	// Create restconfigs and clients for cluster 1.
+	cl1RestCfg, err := clientcmd.BuildConfigFromFlags("", a.Cluster1Kubeconfig)
+	if err != nil {
+		common.ErrorPrinter.Printf("unable to create rest config from kubeconfig {%s}: %s", a.Cluster1Kubeconfig, err.Error())
+		return err
+	}
+	cl1K8sClient, err := k8s.NewForConfig(cl1RestCfg)
+	if err != nil {
+		common.ErrorPrinter.Printf("unable to create client set from kubeconfig {%s}: %s", a.Cluster1Kubeconfig, err.Error())
+		return err
+	}
+	cl1CRClient, err := client.New(cl1RestCfg, client.Options{
+		Scheme: common.Scheme,
+	})
+	if err != nil {
+		common.ErrorPrinter.Printf("unable to create controller runtime client from kubeconfig {%s}: %s",
+			a.Cluster1Kubeconfig, err.Error())
+		return err
+	}
+
+	// Create restconfigs and clients for cluster 2.
+	cl2RestCfg, err := clientcmd.BuildConfigFromFlags("", a.Cluster2Kubeconfig)
+	if err != nil {
+		common.ErrorPrinter.Printf("unable to create rest config from kubeconfig {%s}: %s", a.Cluster2Kubeconfig, err.Error())
+		return err
+	}
+	cl2K8sClient, err := k8s.NewForConfig(cl2RestCfg)
+	if err != nil {
+		common.ErrorPrinter.Printf("unable to create client set from kubeconfig {%s}: %s", a.Cluster2Kubeconfig, err.Error())
+		return err
+	}
+	cl2CRClient, err := client.New(cl2RestCfg, client.Options{
+		Scheme: common.Scheme,
+	})
+	if err != nil {
+		common.ErrorPrinter.Printf("unable to create controller runtime client from kubeconfig {%s}: %s",
+			a.Cluster2Kubeconfig, err.Error())
+		return err
+	}
+
+	// Create and initialize cluster 1.
+	cluster1 := common.NewCluster(cl1K8sClient, cl1CRClient, cl2CRClient, cl1RestCfg, a.Cluster1Namespace, common.Cluster1Name, common.Cluster1Color)
+	if err := cluster1.Init(ctx); err != nil {
+		return err
+	}
+
+	// Create and initialize cluster 2.
+	cluster2 := common.NewCluster(cl2K8sClient, cl2CRClient, cl1CRClient, cl2RestCfg, a.Cluster2Namespace, common.Cluster2Name, common.Cluster2Color)
+	if err := cluster2.Init(ctx); err != nil {
+		return err
+	}
+
+	// SetUp tenant namespace for cluster 2 in cluster 1.
+	if err := cluster1.SetUpTenantNamespace(ctx, cluster2.GetClusterID()); err != nil {
+		return err
+	}
+	cluster2.SetRemTenantNS(cluster1.GetLocTenantNS())
+
+	// SetUp tenant namespace for cluster  in cluster 2.
+	if err := cluster2.SetUpTenantNamespace(ctx, cluster1.GetClusterID()); err != nil {
+		return err
+	}
+	cluster1.SetRemTenantNS(cluster2.GetLocTenantNS())
+
+	// Configure network configuration for cluster 1.
+	if err := cluster1.ExchangeNetworkCfg(ctx, cluster2.GetClusterID()); err != nil {
+		return err
+	}
+
+	// Configure network configuration for cluster 2.
+	if err := cluster2.ExchangeNetworkCfg(ctx, cluster1.GetClusterID()); err != nil {
+		return err
+	}
+
+	// Port-forwarding ipam service for cluster 1.
+	if err := cluster1.PortForwardIPAM(ctx); err != nil {
+		return err
+	}
+	defer cluster1.StopPortForwardIPAM()
+
+	// Port-forwarding ipam service for cluster 2.
+	if err := cluster2.PortForwardIPAM(ctx); err != nil {
+		return err
+	}
+	defer cluster2.StopPortForwardIPAM()
+
+	// Setting up proxy pod for cluster 1.
+	if err := cluster1.SetUpProxy(ctx); err != nil {
+		return err
+	}
+
+	// Setting up proxy pod for cluster 2.
+	if err := cluster2.SetUpProxy(ctx); err != nil {
+		return err
+	}
+
+	// Creating IPAM client for cluster 1.
+	ipamClient1, err := cluster1.NewIPAMClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Creating IPAM client for cluster 2.
+	ipamClient2, err := cluster2.NewIPAMClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Mapping proxy's ip in cluster1 for cluster2.
+	if err := cluster1.MapProxyIPForCluster(ctx, ipamClient1, cluster2.GetClusterID()); err != nil {
+		return err
+	}
+
+	// Mapping proxy's ip in cluster2 for cluster2
+	if err := cluster2.MapProxyIPForCluster(ctx, ipamClient2, cluster1.GetClusterID()); err != nil {
+		return err
+	}
+
+	// Mapping auth's ip  in cluster1 for cluster2.
+	if err := cluster1.MapAuthIPForCluster(ctx, ipamClient1, cluster2.GetClusterID()); err != nil {
+		return err
+	}
+
+	// Mapping auth's ip in cluster2 for cluster1
+	if err := cluster2.MapAuthIPForCluster(ctx, ipamClient2, cluster1.GetClusterID()); err != nil {
+		return err
+	}
+
+	// Creating foreign cluster in cluster1 for cluster 2.
+	if err := cluster1.EnforceForeignCluster(ctx, cluster2.GetClusterID(), cluster2.GetAuthToken(),
+		cluster2.GetAuthURL(), cluster2.GetProxyURL()); err != nil {
+		return err
+	}
+
+	// Creating foreign cluster in cluster2 for cluster 1.
+	if err := cluster2.EnforceForeignCluster(ctx, cluster1.GetClusterID(), cluster1.GetAuthToken(),
+		cluster1.GetAuthURL(), cluster1.GetProxyURL()); err != nil {
+		return err
+	}
+
+	// Waiting for authentication to complete in cluster 1.
+	if err := cluster1.WaitForAuth(ctx, cluster2.GetClusterID(), 120*time.Second); err != nil {
+		return err
+	}
+
+	// Waiting for authentication to complete in cluster 2.
+	return cluster2.WaitForAuth(ctx, cluster1.GetClusterID(), 120*time.Second)
+}

--- a/pkg/liqonet/ipam/ipamStorage.go
+++ b/pkg/liqonet/ipam/ipamStorage.go
@@ -103,7 +103,7 @@ func NewIPAMStorage(dynClient dynamic.Interface) (*IPAMStorage, error) {
 		klog.Infof("Resource %s of type %s successfully created", ipam.GetName(), netv1alpha1.GroupVersion)
 	} else {
 		ipamStorage.storage = ipam
-		klog.Infof("Resource %s of type %s has been found", ipam.GetName(), netv1alpha1.IpamGroupResource)
+		klog.Infof("Resource %s of type %s has been found", ipam.GetName(), netv1alpha1.IpamGroupVersionResource)
 	}
 	klog.Infof("Ipam storage successfully configured")
 	return ipamStorage, nil
@@ -267,7 +267,7 @@ func (ipamStorage *IPAMStorage) updateConfig(updateType string, data interface{}
 	b.Write(jsonData)
 	b.WriteString("}]")
 
-	unstr, err := ipamStorage.dynClient.Resource(netv1alpha1.IpamGroupResource).Patch(context.Background(),
+	unstr, err := ipamStorage.dynClient.Resource(netv1alpha1.IpamGroupVersionResource).Patch(context.Background(),
 		ipamStorage.getConfigName(), types.JSONPatchType, b.Bytes(), metav1.PatchOptions{})
 	if err != nil {
 		klog.Error("Failed to patch the IPAM resource: %v", err)
@@ -333,7 +333,7 @@ func (ipamStorage *IPAMStorage) getConfigName() string {
 
 func (ipamStorage *IPAMStorage) retrieveConfig() (*netv1alpha1.IpamStorage, error) {
 	list, err := ipamStorage.dynClient.
-		Resource(netv1alpha1.IpamGroupResource).
+		Resource(netv1alpha1.IpamGroupVersionResource).
 		List(context.Background(), metav1.ListOptions{
 			LabelSelector: fmt.Sprintf("%s=%s", consts.IpamStorageResourceLabelKey, consts.IpamStorageResourceLabelValue),
 		})
@@ -344,9 +344,9 @@ func (ipamStorage *IPAMStorage) retrieveConfig() (*netv1alpha1.IpamStorage, erro
 
 	if len(list.Items) != 1 {
 		if len(list.Items) != 0 {
-			return nil, fmt.Errorf("multiple resources of type %s found", netv1alpha1.IpamGroupResource)
+			return nil, fmt.Errorf("multiple resources of type %s found", netv1alpha1.IpamGroupVersionResource)
 		}
-		return nil, errors.NewNotFound(netv1alpha1.IpamGroupResource.GroupResource(), "")
+		return nil, errors.NewNotFound(netv1alpha1.IpamGroupVersionResource.GroupResource(), "")
 	}
 
 	var storage netv1alpha1.IpamStorage
@@ -379,7 +379,7 @@ func (ipamStorage *IPAMStorage) createConfig() (*netv1alpha1.IpamStorage, error)
 	unstr, err := runtime.DefaultUnstructuredConverter.ToUnstructured(ipam)
 	utilruntime.Must(err)
 
-	created, err := ipamStorage.dynClient.Resource(netv1alpha1.IpamGroupResource).
+	created, err := ipamStorage.dynClient.Resource(netv1alpha1.IpamGroupVersionResource).
 		Create(context.Background(), &unstructured.Unstructured{Object: unstr}, metav1.CreateOptions{})
 	if err != nil {
 		klog.Errorf("cannot create ipam resource: %s", err.Error())

--- a/pkg/liqonet/ipam/ipam_test.go
+++ b/pkg/liqonet/ipam/ipam_test.go
@@ -1759,7 +1759,7 @@ func getNatMappingResourcePerCluster(clusterID string) (*liqonetapi.NatMapping, 
 
 func getIpamStorageResource() (*liqonetapi.IpamStorage, error) {
 	ipamConfig := &liqonetapi.IpamStorage{}
-	list, err := dynClient.Resource(liqonetapi.IpamGroupResource).List(
+	list, err := dynClient.Resource(liqonetapi.IpamGroupVersionResource).List(
 		context.Background(),
 		v1.ListOptions{
 			LabelSelector: fmt.Sprintf("%s=%s",
@@ -1771,7 +1771,7 @@ func getIpamStorageResource() (*liqonetapi.IpamStorage, error) {
 		return nil, err
 	}
 	if len(list.Items) == 0 {
-		return nil, k8serrors.NewNotFound(liqonetapi.IpamGroupResource.GroupResource(), "")
+		return nil, k8serrors.NewNotFound(liqonetapi.IpamGroupVersionResource.GroupResource(), "")
 	}
 	err = runtime.DefaultUnstructuredConverter.FromUnstructured(list.Items[0].Object, ipamConfig)
 	if err != nil {
@@ -1801,7 +1801,7 @@ func updateIpamStorageResource(ipamStorage *liqonetapi.IpamStorage) error {
 	if err != nil {
 		return err
 	}
-	_, err = dynClient.Resource(liqonetapi.IpamGroupResource).Update(
+	_, err = dynClient.Resource(liqonetapi.IpamGroupVersionResource).Update(
 		context.Background(),
 		&unstructured.Unstructured{Object: unstructuredResource},
 		v1.UpdateOptions{},

--- a/pkg/liqonet/natmappinginflater/natMappingInflater.go
+++ b/pkg/liqonet/natmappinginflater/natMappingInflater.go
@@ -481,7 +481,7 @@ func (inflater *NatMappingInflater) ipamConsistencyCheck() error {
 func (inflater *NatMappingInflater) getIPAMConfig() (*netv1alpha1.IpamStorage, error) {
 	res := &netv1alpha1.IpamStorage{}
 	list, err := inflater.dynClient.
-		Resource(netv1alpha1.IpamGroupResource).
+		Resource(netv1alpha1.IpamGroupVersionResource).
 		List(context.Background(), metav1.ListOptions{
 			LabelSelector: fmt.Sprintf("%s=%s", consts.IpamStorageResourceLabelKey, consts.IpamStorageResourceLabelValue),
 		})
@@ -491,9 +491,9 @@ func (inflater *NatMappingInflater) getIPAMConfig() (*netv1alpha1.IpamStorage, e
 	}
 	if len(list.Items) != 1 {
 		if len(list.Items) != 0 {
-			return nil, fmt.Errorf("multiple resources of type %s found", netv1alpha1.IpamGroupResource)
+			return nil, fmt.Errorf("multiple resources of type %s found", netv1alpha1.IpamGroupVersionResource)
 		}
-		return nil, k8sErr.NewNotFound(netv1alpha1.IpamGroupResource.GroupResource(), "")
+		return nil, k8sErr.NewNotFound(netv1alpha1.IpamGroupVersionResource.GroupResource(), "")
 	}
 	err = runtime.DefaultUnstructuredConverter.FromUnstructured(list.Items[0].Object, res)
 	if err != nil {

--- a/pkg/liqonet/natmappinginflater/natMappingInflater_test.go
+++ b/pkg/liqonet/natmappinginflater/natMappingInflater_test.go
@@ -552,7 +552,7 @@ func createIpamStorageResource(ipam *netv1alpha1.IpamStorage) error {
 		return err
 	}
 	_, err = inflater.dynClient.
-		Resource(netv1alpha1.IpamGroupResource).
+		Resource(netv1alpha1.IpamGroupVersionResource).
 		Create(context.Background(), &unstructured.Unstructured{Object: unstructuredIpam}, metav1.CreateOptions{})
 	if err != nil {
 		klog.Errorf("cannot create ipam resource: %s", err.Error())

--- a/pkg/liqonet/netns/veth.go
+++ b/pkg/liqonet/netns/veth.go
@@ -30,7 +30,7 @@ import (
 	liqoconst "github.com/liqotech/liqo/pkg/consts"
 	liqoneterrors "github.com/liqotech/liqo/pkg/liqonet/errors"
 	liqorouting "github.com/liqotech/liqo/pkg/liqonet/routing"
-	liqoutils "github.com/liqotech/liqo/pkg/liqonet/utils"
+	"github.com/liqotech/liqo/pkg/liqonet/utils/links"
 )
 
 // CreateVethPair it will create veth pair in hostNetns and move one of them in gatewayNetns.
@@ -45,7 +45,7 @@ func CreateVethPair(hostVethName, gatewayVethName string, hostNetns, gatewayNetn
 	}
 	// Check if in hostNetns, aka host netns, exists an interface named as hostVethName.
 	// If it exists than we remove it.
-	if err := liqoutils.DeleteIFaceByName(hostVethName); err != nil {
+	if err := links.DeleteIFaceByName(hostVethName); err != nil {
 		return hostVeth, gatewayVeth, fmt.Errorf("an error occurred while deleting interface {%s} in host network: %w",
 			hostVethName, err)
 	}

--- a/pkg/liqonet/tunnel/driver.go
+++ b/pkg/liqonet/tunnel/driver.go
@@ -33,7 +33,7 @@ func AddDriver(name string, driverCreate DriverCreateFunc) {
 	if Drivers[name] != nil {
 		klog.Fatalf("Multiple tunnel drivers attempting to register with name %q", name)
 	}
-	klog.Infof("driver for %s VPN successfully registered", name)
+	klog.V(5).Infof("driver for %s VPN successfully registered", name)
 	Drivers[name] = driverCreate
 }
 

--- a/pkg/liqonet/tunnel/wireguard/driver_test.go
+++ b/pkg/liqonet/tunnel/wireguard/driver_test.go
@@ -43,13 +43,13 @@ var _ = Describe("Driver", func() {
 		JustBeforeEach(func() {
 			tep = &netv1alpha1.TunnelEndpoint{
 				Spec: netv1alpha1.TunnelEndpointSpec{
-					BackendConfig: map[string]string{ListeningPort: ""},
+					BackendConfig: map[string]string{liqoconst.ListeningPort: ""},
 				},
 			}
 		})
 		Context("out of range port", func() {
 			It("port < than min acceptable value", func() {
-				tep.Spec.BackendConfig[ListeningPort] = outOfRangeMin
+				tep.Spec.BackendConfig[liqoconst.ListeningPort] = outOfRangeMin
 				port, err := getTunnelPortFromTep(tep)
 				Expect(port).To(BeNumerically("==", 0))
 				Expect(err).To(MatchError(fmt.Sprintf("port {%s} should be greater than {%d} and minor than {%d}",
@@ -57,7 +57,7 @@ var _ = Describe("Driver", func() {
 			})
 
 			It("port > than max acceptable value", func() {
-				tep.Spec.BackendConfig[ListeningPort] = outOfRangeMax
+				tep.Spec.BackendConfig[liqoconst.ListeningPort] = outOfRangeMax
 				port, err := getTunnelPortFromTep(tep)
 				Expect(port).To(BeNumerically("==", 0))
 				Expect(err).To(MatchError(fmt.Sprintf("port {%s} should be greater than {%d} and minor than {%d}",
@@ -65,7 +65,7 @@ var _ = Describe("Driver", func() {
 			})
 
 			It("port is not a valid number", func() {
-				tep.Spec.BackendConfig[ListeningPort] = notANumber
+				tep.Spec.BackendConfig[liqoconst.ListeningPort] = notANumber
 				port, err := getTunnelPortFromTep(tep)
 				Expect(port).To(BeNumerically("==", 0))
 				Expect(errors.Unwrap(err)).To(MatchError(&strconv.NumError{
@@ -76,16 +76,16 @@ var _ = Describe("Driver", func() {
 			})
 
 			It("port not set at all", func() {
-				delete(tep.Spec.BackendConfig, ListeningPort)
+				delete(tep.Spec.BackendConfig, liqoconst.ListeningPort)
 				port, err := getTunnelPortFromTep(tep)
 				Expect(port).To(BeNumerically("==", 0))
-				Expect(err).To(MatchError(fmt.Sprintf("port not found in BackendConfig map using key {%s}", ListeningPort)))
+				Expect(err).To(MatchError(fmt.Sprintf("port not found in BackendConfig map using key {%s}", liqoconst.ListeningPort)))
 			})
 		})
 
 		Context("in range port", func() {
 			It("port within range", func() {
-				tep.Spec.BackendConfig[ListeningPort] = intoTheRange
+				tep.Spec.BackendConfig[liqoconst.ListeningPort] = intoTheRange
 				expectedPort, err := strconv.ParseInt(intoTheRange, 10, 32)
 				Expect(err).To(BeNil())
 				port, err := getTunnelPortFromTep(tep)
@@ -155,7 +155,7 @@ var _ = Describe("Driver", func() {
 				tep = &netv1alpha1.TunnelEndpoint{
 					Spec: netv1alpha1.TunnelEndpointSpec{
 						EndpointIP:    "",
-						BackendConfig: map[string]string{ListeningPort: ""},
+						BackendConfig: map[string]string{liqoconst.ListeningPort: ""},
 					},
 				}
 			})
@@ -163,7 +163,7 @@ var _ = Describe("Driver", func() {
 			Context("valid parameters", func() {
 				It("valid port and address", func() {
 					tep.Spec.EndpointIP = ipv4Dns
-					tep.Spec.BackendConfig[ListeningPort] = intoTheRange
+					tep.Spec.BackendConfig[liqoconst.ListeningPort] = intoTheRange
 					udpAddr, err := getEndpoint(tep, addressResolverMock)
 					Expect(udpAddr).NotTo(BeNil())
 					Expect(udpAddr.IP.String()).Should(ContainSubstring(ipv4Literal))
@@ -174,7 +174,7 @@ var _ = Describe("Driver", func() {
 			Context("invalid parameters", func() {
 				It("invalid port and valid address", func() {
 					tep.Spec.EndpointIP = ipv4Dns
-					tep.Spec.BackendConfig[ListeningPort] = outOfRangeMax
+					tep.Spec.BackendConfig[liqoconst.ListeningPort] = outOfRangeMax
 					udpAddr, err := getEndpoint(tep, addressResolverMock)
 					Expect(udpAddr).To(BeNil())
 					Expect(err).To(HaveOccurred())
@@ -182,7 +182,7 @@ var _ = Describe("Driver", func() {
 
 				It("invalid address and valid port", func() {
 					tep.Spec.EndpointIP = "notExisting"
-					tep.Spec.BackendConfig[ListeningPort] = intoTheRange
+					tep.Spec.BackendConfig[liqoconst.ListeningPort] = intoTheRange
 					udpAddr, err := getEndpoint(tep, addressResolverMock)
 					Expect(udpAddr).To(BeNil())
 					Expect(err).To(HaveOccurred())
@@ -190,7 +190,7 @@ var _ = Describe("Driver", func() {
 
 				It("invalid port and invalid address", func() {
 					tep.Spec.EndpointIP = invalidAddress
-					tep.Spec.BackendConfig[ListeningPort] = outOfRangeMin
+					tep.Spec.BackendConfig[liqoconst.ListeningPort] = outOfRangeMin
 					udpAddr, err := getEndpoint(tep, addressResolverMock)
 					Expect(udpAddr).To(BeNil())
 					Expect(err).To(HaveOccurred())

--- a/pkg/liqonet/utils/links/doc.go
+++ b/pkg/liqonet/utils/links/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2019-2022 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package links contains utils functions to interact with link in linux systems.
+package links

--- a/pkg/liqonet/utils/links/links.go
+++ b/pkg/liqonet/utils/links/links.go
@@ -1,0 +1,43 @@
+// Copyright 2019-2022 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package links
+
+import (
+	"errors"
+
+	"github.com/vishvananda/netlink"
+	"k8s.io/klog/v2"
+)
+
+// DeleteIFaceByName deletes the interface that has the given name.
+func DeleteIFaceByName(ifaceName string) error {
+	existingIface, err := netlink.LinkByName(ifaceName)
+	if err != nil {
+		if errors.As(err, &netlink.LinkNotFoundError{}) {
+			return nil
+		}
+		klog.Errorf("an error occurred while getting network interface {%s}: %v", ifaceName, err)
+		return err
+	}
+	// Remove the existing network interface.
+	if err = netlink.LinkDel(existingIface); err != nil && errors.As(err, &netlink.LinkNotFoundError{}) {
+		if errors.As(err, &netlink.LinkNotFoundError{}) {
+			return nil
+		}
+		klog.Errorf("an error occurred while deleting network interface {%s}: %v", existingIface.Attrs().Name, err)
+		return err
+	}
+	return nil
+}

--- a/pkg/liqonet/utils/links/links_suite_test.go
+++ b/pkg/liqonet/utils/links/links_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright 2019-2022 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package links_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestLinks(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Links Suite")
+}

--- a/pkg/liqonet/utils/links/links_test.go
+++ b/pkg/liqonet/utils/links/links_test.go
@@ -1,0 +1,50 @@
+// Copyright 2019-2022 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package links_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/vishvananda/netlink"
+
+	"github.com/liqotech/liqo/pkg/liqonet/utils/links"
+)
+
+var _ = Describe("Links", func() {
+	var interfaceName = "dummy-link"
+	Describe("testing DeleteIfaceByName function", func() {
+		Context("when network interface exists", func() {
+			BeforeEach(func() {
+				// Create dummy link.
+				err := netlink.LinkAdd(&netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: interfaceName}})
+				Expect(err).ShouldNot(HaveOccurred())
+			})
+
+			It("should return nil", func() {
+				err := links.DeleteIFaceByName(interfaceName)
+				Expect(err).Should(BeNil())
+				_, err = netlink.LinkByName(interfaceName)
+				Expect(err).Should(MatchError("Link not found"))
+			})
+		})
+
+		Context("when network interface does not exist", func() {
+			It("should return nil", func() {
+				err := links.DeleteIFaceByName("not-existing")
+				Expect(err).Should(BeNil())
+			})
+		})
+	})
+})

--- a/pkg/liqonet/utils/utils.go
+++ b/pkg/liqonet/utils/utils.go
@@ -22,10 +22,8 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/vishvananda/netlink"
 	"inet.af/netaddr"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	netv1alpha1 "github.com/liqotech/liqo/apis/net/v1alpha1"
@@ -301,27 +299,6 @@ func GetLabelValueFromObj(obj client.Object, labelKey string) string {
 		return ""
 	}
 	return obj.GetLabels()[labelKey]
-}
-
-// DeleteIFaceByName deletes the interface that has the given name.
-func DeleteIFaceByName(ifaceName string) error {
-	existingIface, err := netlink.LinkByName(ifaceName)
-	if err != nil {
-		if errors.As(err, &netlink.LinkNotFoundError{}) {
-			return nil
-		}
-		klog.Errorf("an error occurred while getting network interface {%s}: %v", ifaceName, err)
-		return err
-	}
-	// Remove the existing network interface.
-	if err = netlink.LinkDel(existingIface); err != nil && errors.As(err, &netlink.LinkNotFoundError{}) {
-		if errors.As(err, &netlink.LinkNotFoundError{}) {
-			return nil
-		}
-		klog.Errorf("an error occurred while deleting network interface {%s}: %v", existingIface.Attrs().Name, err)
-		return err
-	}
-	return nil
 }
 
 // SplitNetwork returns the two halves that make up a given network.

--- a/pkg/liqonet/utils/utils_test.go
+++ b/pkg/liqonet/utils/utils_test.go
@@ -259,4 +259,5 @@ var _ = Describe("Liqonet", func() {
 			})
 		})
 	})
+
 })

--- a/pkg/liqonet/utils/utils_test.go
+++ b/pkg/liqonet/utils/utils_test.go
@@ -20,7 +20,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
-	"github.com/vishvananda/netlink"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -34,7 +33,6 @@ const (
 	labelValue        = "LabelValue"
 	annotationKey     = "net.liqo.io/AnnotationKey"
 	annotationValue   = "AnnotationValue"
-	interfaceName     = "dummy-link"
 )
 
 var (
@@ -235,29 +233,4 @@ var _ = Describe("Liqonet", func() {
 			})
 		})
 	})
-
-	Describe("testing DeleteIfaceByName function", func() {
-		Context("when network interface exists", func() {
-			BeforeEach(func() {
-				// Create dummy link.
-				err := netlink.LinkAdd(&netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: interfaceName}})
-				Expect(err).ShouldNot(HaveOccurred())
-			})
-
-			It("should return nil", func() {
-				err := utils.DeleteIFaceByName(interfaceName)
-				Expect(err).Should(BeNil())
-				_, err = netlink.LinkByName(interfaceName)
-				Expect(err).Should(MatchError("Link not found"))
-			})
-		})
-
-		Context("when network interface does not exist", func() {
-			It("should return nil", func() {
-				err := utils.DeleteIFaceByName("not-existing")
-				Expect(err).Should(BeNil())
-			})
-		})
-	})
-
 })

--- a/pkg/tenantNamespace/namespaceManager.go
+++ b/pkg/tenantNamespace/namespaceManager.go
@@ -80,7 +80,7 @@ func (nm *tenantNamespaceManager) CreateNamespace(cluster discoveryv1alpha1.Clus
 	// exit with an error, and retry during the next iteration.
 	ns = &v1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: getNameForNamespace(cluster),
+			Name: GetNameForNamespace(cluster),
 			Labels: map[string]string{
 				discovery.ClusterIDLabel:       cluster.ClusterID,
 				discovery.TenantNamespaceLabel: "true",
@@ -110,7 +110,7 @@ func (nm *tenantNamespaceManager) GetNamespace(cluster discoveryv1alpha1.Cluster
 	}
 
 	if nItems := len(namespaces); nItems == 0 {
-		err = kerrors.NewNotFound(v1.Resource("Namespace"), getNameForNamespace(cluster))
+		err = kerrors.NewNotFound(v1.Resource("Namespace"), GetNameForNamespace(cluster))
 		// do not log it always, since it is also used in the preliminary stage of the create method
 		klog.V(4).Info(err)
 		return nil, err
@@ -122,6 +122,7 @@ func (nm *tenantNamespaceManager) GetNamespace(cluster discoveryv1alpha1.Cluster
 	return namespaces[0].DeepCopy(), nil
 }
 
-func getNameForNamespace(cluster discoveryv1alpha1.ClusterIdentity) string {
+// GetNameForNamespace given a cluster identity it returns the name of the tenant namespace for the cluster.
+func GetNameForNamespace(cluster discoveryv1alpha1.ClusterIdentity) string {
 	return fmt.Sprintf("liqo-tenant-%s", foreignclusterutils.UniqueName(&cluster))
 }

--- a/pkg/utils/foreignCluster/peeringStatus.go
+++ b/pkg/utils/foreignCluster/peeringStatus.go
@@ -48,3 +48,15 @@ func IsOutgoingEnabled(foreignCluster *discoveryv1alpha1.ForeignCluster) bool {
 	curPhase := peeringconditionsutils.GetStatus(foreignCluster, discoveryv1alpha1.OutgoingPeeringCondition)
 	return curPhase != discoveryv1alpha1.PeeringConditionStatusNone && curPhase != ""
 }
+
+// IsIncomingPeeringNone checks if the incoming peering is set to none.
+func IsIncomingPeeringNone(foreignCluster *discoveryv1alpha1.ForeignCluster) bool {
+	curPhase := peeringconditionsutils.GetStatus(foreignCluster, discoveryv1alpha1.IncomingPeeringCondition)
+	return curPhase == discoveryv1alpha1.PeeringConditionStatusNone
+}
+
+// IsOutgoingPeeringNone checks if the outgoing peering is set to none.
+func IsOutgoingPeeringNone(foreignCluster *discoveryv1alpha1.ForeignCluster) bool {
+	curPhase := peeringconditionsutils.GetStatus(foreignCluster, discoveryv1alpha1.OutgoingPeeringCondition)
+	return curPhase == discoveryv1alpha1.PeeringConditionStatusNone
+}

--- a/pkg/utils/getters/dataGetters.go
+++ b/pkg/utils/getters/dataGetters.go
@@ -1,0 +1,225 @@
+// Copyright 2019-2022 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package getters
+
+import (
+	"fmt"
+	"strconv"
+
+	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+
+	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
+	netv1alpha1 "github.com/liqotech/liqo/apis/net/v1alpha1"
+	liqoconsts "github.com/liqotech/liqo/pkg/consts"
+)
+
+// NetworkConfig holds the liqo network configuration.
+type NetworkConfig struct {
+	PodCIDR         string
+	ExternalCIDR    string
+	ServiceCIDR     string
+	ReservedSubnets []string
+}
+
+// RetrieveClusterIDFromConfigMap retrieves ClusterIdentity from a given configmap.
+func RetrieveClusterIDFromConfigMap(cm *corev1.ConfigMap) (*discoveryv1alpha1.ClusterIdentity, error) {
+	id, found := cm.Data[liqoconsts.ClusterIDConfigMapKey]
+	if !found {
+		return nil, fmt.Errorf("unable to get cluster ID: field {%s} not found in configmap {%s/%s}",
+			liqoconsts.ClusterIDConfigMapKey, cm.Namespace, cm.Name)
+	}
+
+	name, found := cm.Data[liqoconsts.ClusterNameConfigMapKey]
+	if !found {
+		return nil, fmt.Errorf("unable to get cluster name: field {%s} not found in configmap {%s/%s}",
+			liqoconsts.ClusterNameConfigMapKey, cm.Namespace, cm.Name)
+	}
+
+	return &discoveryv1alpha1.ClusterIdentity{
+		ClusterID:   id,
+		ClusterName: name,
+	}, nil
+}
+
+// RetrieveAuthEndpointFromClusterIPService the auth endpoint from a ClusterIP service;
+// If the service is of type different from ClusterIP it will be treated as it.
+func RetrieveAuthEndpointFromClusterIPService(svc *corev1.Service, portName string) (endpointIP, endpointPort string, err error) {
+	if svc.Spec.Type == corev1.ServiceTypeNodePort || svc.Spec.Type == corev1.ServiceTypeLoadBalancer {
+		svc.Spec.Type = corev1.ServiceTypeClusterIP
+	}
+	// Retrieve the endpoint ip
+	if endpointIP, err = retrieveIPFromService(svc); err != nil {
+		return endpointIP, endpointPort, err
+	}
+
+	// Retrieve the endpoint port
+	if endpointPort, err = retrievePortFromService(svc, portName, svc.Spec.Type); err != nil {
+		endpointIP, endpointPort = "", ""
+	}
+
+	return endpointIP, endpointPort, err
+}
+
+// RetrieveWGEPFromNodePort retrieves the WireGuard endpoint from a NodePort service.
+func RetrieveWGEPFromNodePort(svc *corev1.Service, annotationKey, portName string) (endpointIP, endpointPort string, err error) {
+	// Check if the node's IP where the gatewayPod is running has been set
+	endpointIP, found := svc.GetAnnotations()[annotationKey]
+	if !found {
+		err = fmt.Errorf("the node IP where the gateway pod is running has not yet been set as an annotation for service %q", klog.KObj(svc))
+		return endpointIP, endpointPort, err
+	}
+
+	// Retrieve the endpoint port
+	if endpointPort, err = retrievePortFromService(svc, portName, corev1.ServiceTypeNodePort); err != nil {
+		endpointIP, endpointPort = "", ""
+	}
+
+	return endpointIP, endpointPort, err
+}
+
+// RetrieveWGEPFromLoadBalancer retrieves the WireGuard endpoint from a LoadBalancer service.
+func RetrieveWGEPFromLoadBalancer(svc *corev1.Service, portName string) (endpointIP, endpointPort string, err error) {
+	// Retrieve the endpoint ip.
+	if endpointIP, err = retrieveIPFromService(svc); err != nil {
+		return endpointIP, endpointPort, err
+	}
+
+	// Retrieve the endpoint port.
+	if endpointPort, err = retrievePortFromService(svc, portName, corev1.ServiceTypeLoadBalancer); err != nil {
+		endpointIP, endpointPort = "", ""
+	}
+
+	return endpointIP, endpointPort, err
+}
+
+// RetrieveWGEPFromService retrieves the WireGuard endpoint from a generic service.
+func RetrieveWGEPFromService(svc *corev1.Service, annotationKey, portName string) (endpointIP, endpointPort string, err error) {
+	switch svc.Spec.Type {
+	case corev1.ServiceTypeNodePort:
+		return RetrieveWGEPFromNodePort(svc, annotationKey, portName)
+
+	case corev1.ServiceTypeLoadBalancer:
+		return RetrieveWGEPFromLoadBalancer(svc, portName)
+
+	default:
+		return endpointIP, endpointPort, fmt.Errorf("service {%s/%s} is of type {%s}, only types of {%s} and {%s} are accepted",
+			svc.Namespace, svc.Name, svc.Spec.Type, corev1.ServiceTypeLoadBalancer, corev1.ServiceTypeNodePort)
+	}
+}
+
+// RetrieveWGPubKeyFromSecret retrieves the WireGuard public key from a given secret if present.
+func RetrieveWGPubKeyFromSecret(secret *corev1.Secret, keyName string) (pubKey wgtypes.Key, err error) {
+	// Extract the public key from the secret
+	pubKeyByte, found := secret.Data[keyName]
+	if !found {
+		err = fmt.Errorf("no data with key %s found in secret %q", keyName, klog.KObj(secret))
+		return pubKey, err
+	}
+	pubKey, err = wgtypes.ParseKey(string(pubKeyByte))
+	if err != nil {
+		err = fmt.Errorf("secret %q: invalid public key: %w", klog.KObj(secret), err)
+		return pubKey, err
+	}
+
+	return pubKey, nil
+}
+
+func retrieveIPFromService(svc *corev1.Service) (string, error) {
+	switch svc.Spec.Type {
+	case corev1.ServiceTypeClusterIP:
+		if svc.Spec.ClusterIP != "" {
+			return svc.Spec.ClusterIP, nil
+		}
+		return "", fmt.Errorf("the clusterIP address for service {%s/%s} of type {%s} has not been set",
+			svc.Namespace, svc.Name, svc.Spec.Type)
+	case corev1.ServiceTypeLoadBalancer:
+		var endpointIP string
+		errorMsg := fmt.Sprintf("the ingress address for service {%s/%s} of type {%s} has not been set",
+			svc.Namespace, svc.Name, svc.Spec.Type)
+		// Check if the ingress IP has been set.
+		if len(svc.Status.LoadBalancer.Ingress) == 0 {
+			return "", fmt.Errorf(errorMsg)
+		}
+		// Retrieve the endpoint address
+		if svc.Status.LoadBalancer.Ingress[0].IP != "" {
+			endpointIP = svc.Status.LoadBalancer.Ingress[0].IP
+		} else if svc.Status.LoadBalancer.Ingress[0].Hostname != "" {
+			endpointIP = svc.Status.LoadBalancer.Ingress[0].Hostname
+		}
+		if endpointIP != "" {
+			return endpointIP, nil
+		}
+		return "", fmt.Errorf(errorMsg)
+	default:
+		return "", fmt.Errorf("service {%s/%s} is of type {%s}, only types of {%s} and {%s} are accepted",
+			svc.Namespace, svc.Name, svc.Spec.Type, corev1.ServiceTypeLoadBalancer, corev1.ServiceTypeClusterIP)
+	}
+}
+
+func retrievePortFromService(svc *corev1.Service, portName string, portType corev1.ServiceType) (string, error) {
+	switch portType {
+	case corev1.ServiceTypeClusterIP, corev1.ServiceTypeLoadBalancer:
+		for _, port := range svc.Spec.Ports {
+			if port.Name == portName {
+				if port.Port == 0 {
+					return "", fmt.Errorf("the clusterIP port for service {%s/%s} of type {%s} has not been set",
+						svc.Namespace, svc.Name, svc.Spec.Type)
+				}
+				return strconv.FormatInt(int64(port.Port), 10), nil
+			}
+		}
+	case corev1.ServiceTypeNodePort:
+		for _, port := range svc.Spec.Ports {
+			if port.Name == portName {
+				if port.NodePort == 0 {
+					return "", fmt.Errorf("the clusterIP port for service {%s/%s} of type {%s} has not been set",
+						svc.Namespace, svc.Name, svc.Spec.Type)
+				}
+				return strconv.FormatInt(int64(port.NodePort), 10), nil
+			}
+		}
+	default:
+		return "", fmt.Errorf("service {%s/%s} is of type {%s}, only types of {%s}, {%s} and {%s} are accepted",
+			svc.Namespace, svc.Name, svc.Spec.Type, corev1.ServiceTypeClusterIP, corev1.ServiceTypeLoadBalancer, corev1.ServiceTypeNodePort)
+	}
+
+	return "", fmt.Errorf("port {%s} not found in service {%s/%s} of type {%s}",
+		portName, svc.Namespace, svc.Name, svc.Spec.Type)
+}
+
+// RetrieveNetworkConfiguration returns the podCIDR, serviceCIDR, reservedSubnets and the externalCIDR
+// as saved in the ipams.net.liqo.io custom resource instance.
+func RetrieveNetworkConfiguration(ipamS *netv1alpha1.IpamStorage) (*NetworkConfig, error) {
+	if ipamS.Spec.PodCIDR == "" {
+		return nil, fmt.Errorf("unable to get network configuration: podCIDR is not set in resource %q", klog.KObj(ipamS))
+	}
+
+	if ipamS.Spec.ServiceCIDR == "" {
+		return nil, fmt.Errorf("unable to get network configuration: serviceCIDR is not set in resource %q", klog.KObj(ipamS))
+	}
+
+	if ipamS.Spec.ExternalCIDR == "" {
+		return nil, fmt.Errorf("unable to get network configuration: externalCIDR is not set %q", klog.KObj(ipamS))
+	}
+
+	return &NetworkConfig{
+		PodCIDR:         ipamS.Spec.PodCIDR,
+		ServiceCIDR:     ipamS.Spec.ServiceCIDR,
+		ExternalCIDR:    ipamS.Spec.ExternalCIDR,
+		ReservedSubnets: ipamS.Spec.ReservedSubnets,
+	}, nil
+}

--- a/pkg/utils/getters/dataGetters_test.go
+++ b/pkg/utils/getters/dataGetters_test.go
@@ -25,7 +25,6 @@ import (
 	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
 	netv1alpha1 "github.com/liqotech/liqo/apis/net/v1alpha1"
 	liqoconst "github.com/liqotech/liqo/pkg/consts"
-	"github.com/liqotech/liqo/pkg/liqonet/tunnel/wireguard"
 	"github.com/liqotech/liqo/pkg/utils/getters"
 )
 
@@ -201,29 +200,29 @@ var _ = Describe("DataGetters", func() {
 
 		BeforeEach(func() {
 			secret = &corev1.Secret{
-				Data: map[string][]byte{wireguard.PublicKey: []byte(correctKey)},
+				Data: map[string][]byte{liqoconst.PublicKey: []byte(correctKey)},
 			}
 		})
 
 		Context("when key with given name does not exist", func() {
 			It("should return nil", func() {
-				delete(secret.Data, wireguard.PublicKey)
-				_, err := getters.RetrieveWGPubKeyFromSecret(secret, wireguard.PublicKey)
+				delete(secret.Data, liqoconst.PublicKey)
+				_, err := getters.RetrieveWGPubKeyFromSecret(secret, liqoconst.PublicKey)
 				Expect(err).NotTo(Succeed())
 			})
 		})
 
 		Context("when key is wrong format", func() {
 			It("should return err", func() {
-				secret.Data[wireguard.PublicKey] = []byte(wrongKey)
-				_, err := getters.RetrieveWGPubKeyFromSecret(secret, wireguard.PublicKey)
+				secret.Data[liqoconst.PublicKey] = []byte(wrongKey)
+				_, err := getters.RetrieveWGPubKeyFromSecret(secret, liqoconst.PublicKey)
 				Expect(err).NotTo(Succeed())
 			})
 		})
 
 		Context("when key exists", func() {
 			It("should return nil", func() {
-				key, err := getters.RetrieveWGPubKeyFromSecret(secret, wireguard.PublicKey)
+				key, err := getters.RetrieveWGPubKeyFromSecret(secret, liqoconst.PublicKey)
 				Expect(err).To(Succeed())
 				Expect(key.String()).To(Equal(correctKey))
 			})

--- a/pkg/utils/getters/dataGetters_test.go
+++ b/pkg/utils/getters/dataGetters_test.go
@@ -1,0 +1,354 @@
+// Copyright 2019-2022 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package getters_test
+
+import (
+	"strconv"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
+	netv1alpha1 "github.com/liqotech/liqo/apis/net/v1alpha1"
+	liqoconst "github.com/liqotech/liqo/pkg/consts"
+	"github.com/liqotech/liqo/pkg/liqonet/tunnel/wireguard"
+	"github.com/liqotech/liqo/pkg/utils/getters"
+)
+
+var _ = Describe("DataGetters", func() {
+	var (
+		clusterIP  = "10.1.1.1"
+		nodeIPAddr = "192.168.0.162"
+		port       = corev1.ServicePort{
+			Name:     "wireguard",
+			Protocol: corev1.ProtocolUDP,
+			Port:     5871,
+			NodePort: 32444,
+		}
+		loadBalancerIP   = "10.0.0.1"
+		loadBalancerHost = "testingWGEndpoint"
+
+		svcTemplate = &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					liqoconst.GatewayServiceLabelKey: liqoconst.GatewayServiceLabelValue,
+				},
+				Annotations: map[string]string{
+					liqoconst.GatewayServiceAnnotationKey: nodeIPAddr,
+				},
+			},
+			Spec: corev1.ServiceSpec{
+				Ports:     []corev1.ServicePort{port},
+				Type:      corev1.ServiceTypeClusterIP,
+				ClusterIP: clusterIP,
+			},
+			Status: corev1.ServiceStatus{
+				LoadBalancer: corev1.LoadBalancerStatus{
+					Ingress: []corev1.LoadBalancerIngress{
+						{
+							IP:       loadBalancerIP,
+							Hostname: loadBalancerHost,
+						},
+					},
+				},
+			},
+		}
+	)
+
+	Describe("endpoints getters", func() {
+		var (
+			epIP, epPort string
+			err          error
+			service      *corev1.Service
+		)
+
+		BeforeEach(func() {
+			service = svcTemplate.DeepCopy()
+		})
+
+		checksOnFailure := func() {
+			It("should return error", func() { Expect(err).Should(HaveOccurred()) })
+			It("should return empty ip address", func() { Expect(epIP).Should(BeEmpty()) })
+			It("should return empty port", func() { Expect(epPort).Should(BeEmpty()) })
+		}
+
+		Context("retrieval of WireGuard endpoint from service object", func() {
+			JustBeforeEach(func() {
+				epIP, epPort, err = getters.RetrieveWGEPFromService(service, liqoconst.GatewayServiceAnnotationKey, port.Name)
+			})
+
+			Context("service is of type NodePort", func() {
+				BeforeEach(func() { service.Spec.Type = corev1.ServiceTypeNodePort })
+
+				Context("when ip of the node has not been added as annotation to the service", func() {
+					BeforeEach(func() { delete(service.Annotations, liqoconst.GatewayServiceAnnotationKey) })
+					checksOnFailure()
+				})
+
+				Context("when port with given name does not exist", func() {
+					BeforeEach(func() { service.Spec.Ports = nil })
+					checksOnFailure()
+				})
+
+				Context("when node port has not been set", func() {
+					BeforeEach(func() { service.Spec.Ports[0].NodePort = 0 })
+					checksOnFailure()
+				})
+
+				Context("when service is ready", func() {
+					It("should return nil", func() { Expect(err).ShouldNot(HaveOccurred()) })
+					It("should return correct ip address", func() { Expect(epIP).To(Equal(nodeIPAddr)) })
+					It("should return correct port number", func() { Expect(epPort).To(Equal(strconv.FormatInt(int64(port.NodePort), 10))) })
+				})
+			})
+
+			Context("service is of type LoadBalancer", func() {
+				BeforeEach(func() { service.Spec.Type = corev1.ServiceTypeLoadBalancer })
+				Context("when the LoadBalancer IP has not been set", func() {
+					BeforeEach(func() { service.Status.LoadBalancer.Ingress = nil })
+					checksOnFailure()
+				})
+
+				Context("when port with given name does not exist", func() {
+					BeforeEach(func() { service.Spec.Ports = nil })
+					checksOnFailure()
+				})
+
+				Context("when neither ip address nor host has been set", func() {
+					BeforeEach(func() {
+						service.Status.LoadBalancer.Ingress[0].Hostname = ""
+						service.Status.LoadBalancer.Ingress[0].IP = ""
+					})
+					checksOnFailure()
+				})
+
+				Context("when only the ip address has been set", func() {
+					BeforeEach(func() { service.Status.LoadBalancer.Ingress[0].Hostname = "" })
+					It("should return nil", func() { Expect(err).ShouldNot(HaveOccurred()) })
+					It("should return correct ip address", func() { Expect(epIP).Should(Equal(loadBalancerIP)) })
+					It("should return correct port number", func() { Expect(epPort).To(Equal(strconv.FormatInt(int64(port.Port), 10))) })
+				})
+
+				Context("when only the hostname has been set", func() {
+					BeforeEach(func() { service.Status.LoadBalancer.Ingress[0].IP = "" })
+					It("should return nil", func() { Expect(err).ShouldNot(HaveOccurred()) })
+					It("should return correct ip address", func() { Expect(epIP).Should(Equal(loadBalancerHost)) })
+					It("should return correct port number", func() { Expect(epPort).To(Equal(strconv.FormatInt(int64(port.Port), 10))) })
+				})
+			})
+
+			Context("service is neither of type NodePort nor LoadBalancer", func() {
+				checksOnFailure()
+			})
+		})
+
+		Context("retrieval of Authentication endpoint from service object", func() {
+			JustBeforeEach(func() {
+				epIP, epPort, err = getters.RetrieveAuthEndpointFromClusterIPService(service, port.Name)
+			})
+
+			Context("service is of type ClusterIP", func() {
+				Context("when port with given name does not exist", func() {
+					BeforeEach(func() { service.Spec.Ports = nil })
+					checksOnFailure()
+				})
+
+				Context("when the ip address has not been set", func() {
+					BeforeEach(func() { service.Spec.ClusterIP = "" })
+					checksOnFailure()
+				})
+
+				Context("when the port number has not been set", func() {
+					BeforeEach(func() { service.Spec.Ports[0].Port = 0 })
+					checksOnFailure()
+				})
+
+				Context("when service is ready", func() {
+					It("should return nil", func() { Expect(err).ShouldNot(HaveOccurred()) })
+					It("should return correct ip address", func() { Expect(epIP).To(Equal(clusterIP)) })
+					It("should return correct port number", func() { Expect(epPort).To(Equal(strconv.FormatInt(int64(port.Port), 10))) })
+				})
+			})
+
+			Context("service is not of correct type", func() {
+				BeforeEach(func() { service.Spec.Type = "" })
+				checksOnFailure()
+			})
+		})
+
+	})
+
+	Describe("testing retrieval of WireGuard public Key from secret object", func() {
+		var (
+			secret     *corev1.Secret
+			correctKey = "cHVibGljLWtleS1vZi10aGUtY29ycmVjdC1sZW5ndGg="
+			wrongKey   = "incorrect key"
+		)
+
+		BeforeEach(func() {
+			secret = &corev1.Secret{
+				Data: map[string][]byte{wireguard.PublicKey: []byte(correctKey)},
+			}
+		})
+
+		Context("when key with given name does not exist", func() {
+			It("should return nil", func() {
+				delete(secret.Data, wireguard.PublicKey)
+				_, err := getters.RetrieveWGPubKeyFromSecret(secret, wireguard.PublicKey)
+				Expect(err).NotTo(Succeed())
+			})
+		})
+
+		Context("when key is wrong format", func() {
+			It("should return err", func() {
+				secret.Data[wireguard.PublicKey] = []byte(wrongKey)
+				_, err := getters.RetrieveWGPubKeyFromSecret(secret, wireguard.PublicKey)
+				Expect(err).NotTo(Succeed())
+			})
+		})
+
+		Context("when key exists", func() {
+			It("should return nil", func() {
+				key, err := getters.RetrieveWGPubKeyFromSecret(secret, wireguard.PublicKey)
+				Expect(err).To(Succeed())
+				Expect(key.String()).To(Equal(correctKey))
+			})
+		})
+	})
+
+	Describe("retrieval of clusterID from configmap", func() {
+		var (
+			clusterIdentity *discoveryv1alpha1.ClusterIdentity
+			err             error
+			cm              *corev1.ConfigMap
+		)
+
+		BeforeEach(func() {
+			cm = &corev1.ConfigMap{
+				Data: map[string]string{
+					liqoconst.ClusterIDConfigMapKey:   "113b9ab3-7ed8-4e00-9d81-0481b111a80d",
+					liqoconst.ClusterNameConfigMapKey: "cold-cherry",
+				},
+			}
+		})
+
+		JustBeforeEach(func() {
+			clusterIdentity, err = getters.RetrieveClusterIDFromConfigMap(cm)
+		})
+
+		Context("when cluster id is not set", func() {
+			BeforeEach(func() {
+				delete(cm.Data, liqoconst.ClusterIDConfigMapKey)
+
+			})
+
+			It("should fail", func() {
+				Expect(clusterIdentity).Should(BeNil())
+				Expect(err).Should(HaveOccurred())
+			})
+		})
+
+		Context("when cluster name is not set", func() {
+			BeforeEach(func() {
+				delete(cm.Data, liqoconst.ClusterNameConfigMapKey)
+
+			})
+
+			It("should fail", func() {
+				Expect(clusterIdentity).Should(BeNil())
+				Expect(err).Should(HaveOccurred())
+			})
+		})
+
+		Context("when cluster identity is set", func() {
+			It("should fail", func() {
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(clusterIdentity.ClusterName).Should(Equal(cm.Data[liqoconst.ClusterNameConfigMapKey]))
+				Expect(clusterIdentity.ClusterID).Should(Equal(cm.Data[liqoconst.ClusterIDConfigMapKey]))
+			})
+		})
+
+	})
+
+	Describe("retrieval of network configuration from ipamstorage", func() {
+		var (
+			ipamStorage  *netv1alpha1.IpamStorage
+			resNets      = []string{"10.1.0.0/16", "192.168.0.0/16"}
+			podCIDR      = "10.200.0.0/16"
+			serviceCIDR  = "10.150.2.0/24"
+			externalCIDR = "10.201.0.0/16"
+			netConfig    *getters.NetworkConfig
+			err          error
+		)
+
+		checkOnError := func() {
+			Expect(netConfig).To(BeNil())
+			Expect(err).To(HaveOccurred())
+		}
+
+		BeforeEach(func() {
+			ipamStorage = &netv1alpha1.IpamStorage{
+				Spec: netv1alpha1.IpamSpec{
+					ReservedSubnets: resNets,
+					ExternalCIDR:    externalCIDR,
+					PodCIDR:         podCIDR,
+					ServiceCIDR:     serviceCIDR,
+				},
+			}
+		})
+
+		JustBeforeEach(func() {
+			netConfig, err = getters.RetrieveNetworkConfiguration(ipamStorage)
+		})
+
+		Context("when podCIDR has not been set", func() {
+			BeforeEach(func() {
+				ipamStorage.Spec.PodCIDR = ""
+			})
+
+			It("should return error", checkOnError)
+		})
+
+		Context("when externalCIDR has not been set", func() {
+			BeforeEach(func() {
+				ipamStorage.Spec.ExternalCIDR = ""
+			})
+
+			It("should return error", checkOnError)
+		})
+
+		Context("when serviceCIDR has not been set", func() {
+			BeforeEach(func() {
+				ipamStorage.Spec.ServiceCIDR = ""
+			})
+
+			It("should return error", checkOnError)
+		})
+
+		Context("when all fields has been set", func() {
+			It("should return configuration and nil", func() {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(netConfig).NotTo(BeNil())
+				Expect(netConfig.ServiceCIDR).To(Equal(serviceCIDR))
+				Expect(netConfig.ExternalCIDR).To(Equal(externalCIDR))
+				Expect(netConfig.PodCIDR).To(Equal(podCIDR))
+				Expect(netConfig.ReservedSubnets).To(Equal(resNets))
+			})
+		})
+
+	})
+})

--- a/pkg/utils/getters/doc.go
+++ b/pkg/utils/getters/doc.go
@@ -1,0 +1,17 @@
+// Copyright 2019-2022 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package getters contains utility functions to get k8s resources and at the same time to extract
+// data from the same resources.
+package getters

--- a/pkg/utils/getters/getters_suite_test.go
+++ b/pkg/utils/getters/getters_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright 2019-2022 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package getters_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestGetters(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Getters Suite")
+}

--- a/pkg/utils/getters/k8sGetters.go
+++ b/pkg/utils/getters/k8sGetters.go
@@ -1,0 +1,148 @@
+// Copyright 2019-2022 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package getters provides functions to get k8s resources and liqo custom resources.
+package getters
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	netv1alpha1 "github.com/liqotech/liqo/apis/net/v1alpha1"
+)
+
+// GetIPAMStorageByLabel it returns a IPAMStorage instance that matches the given label selector.
+func GetIPAMStorageByLabel(ctx context.Context, cl client.Client, ns string, lSelector labels.Selector) (*netv1alpha1.IpamStorage, error) {
+	list := new(netv1alpha1.IpamStorageList)
+	if err := cl.List(ctx, list, &client.ListOptions{LabelSelector: lSelector}, client.InNamespace(ns)); err != nil {
+		return nil, err
+	}
+
+	switch len(list.Items) {
+	case 0:
+		return nil, kerrors.NewNotFound(netv1alpha1.IpamGroupResource, netv1alpha1.ResourceIpamStorages)
+	case 1:
+		return &list.Items[0], nil
+	default:
+		return nil, fmt.Errorf("multiple resources of type {%s} found for label selector {%s} in namespace {%s},"+
+			" when only one was expected", netv1alpha1.IpamGroupResource.String(), lSelector.String(), ns)
+	}
+}
+
+// GetNetworkConfigByLabel it returns a networkconfigs instance that matches the given label selector.
+func GetNetworkConfigByLabel(ctx context.Context, cl client.Client, ns string, lSelector labels.Selector) (*netv1alpha1.NetworkConfig, error) {
+	list := new(netv1alpha1.NetworkConfigList)
+	if err := cl.List(ctx, list, &client.ListOptions{LabelSelector: lSelector}, client.InNamespace(ns)); err != nil {
+		return nil, err
+	}
+
+	switch len(list.Items) {
+	case 0:
+		return nil, kerrors.NewNotFound(netv1alpha1.NetworkConfigGroupResource, netv1alpha1.ResourceNetworkConfigs)
+	case 1:
+		return &list.Items[0], nil
+	default:
+		return nil, fmt.Errorf("multiple resources of type {%s} found for label selector {%s} in namespace {%s},"+
+			" when only one was expected", netv1alpha1.NetworkConfigGroupResource.String(), lSelector.String(), ns)
+	}
+}
+
+// GetServiceByLabel it returns a service instance that matches the given label selector.
+func GetServiceByLabel(ctx context.Context, cl client.Client, ns string, lSelector labels.Selector) (*corev1.Service, error) {
+	list := new(corev1.ServiceList)
+	if err := cl.List(ctx, list, &client.ListOptions{LabelSelector: lSelector}, client.InNamespace(ns)); err != nil {
+		return nil, err
+	}
+	svcRN := string(corev1.ResourceServices)
+	svcGR := corev1.Resource(svcRN)
+
+	switch len(list.Items) {
+	case 0:
+		return nil, kerrors.NewNotFound(svcGR, svcRN)
+	case 1:
+		return &list.Items[0], nil
+	default:
+		return nil, fmt.Errorf("multiple resources of type {%s} found for label selector {%s} in namespace {%s},"+
+			" when only one was expected", svcGR.String(), lSelector.String(), ns)
+	}
+}
+
+// GetSecretByLabel it returns a secret instance that matches the given label selector.
+func GetSecretByLabel(ctx context.Context, cl client.Client, ns string, lSelector labels.Selector) (*corev1.Secret, error) {
+	list := new(corev1.SecretList)
+	if err := cl.List(ctx, list, &client.ListOptions{LabelSelector: lSelector}, client.InNamespace(ns)); err != nil {
+		return nil, err
+	}
+	scrRN := string(corev1.ResourceSecrets)
+	scrGR := corev1.Resource(scrRN)
+
+	switch len(list.Items) {
+	case 0:
+		return nil, kerrors.NewNotFound(scrGR, scrRN)
+	case 1:
+		return &list.Items[0], nil
+	default:
+		return nil, fmt.Errorf("multiple resources of type {%s} found for label selector {%s} in namespace {%s},"+
+			" when only one was expected", scrGR.String(), lSelector.String(), ns)
+	}
+}
+
+// GetConfigMapByLabel it returns a configmap instance that matches the given label selector.
+func GetConfigMapByLabel(ctx context.Context, cl client.Client, ns string, lSelector labels.Selector) (*corev1.ConfigMap, error) {
+	list := new(corev1.ConfigMapList)
+	if err := cl.List(ctx, list, &client.ListOptions{LabelSelector: lSelector}, client.InNamespace(ns)); err != nil {
+		return nil, err
+	}
+	cmRN := string(corev1.ResourceConfigMaps)
+	cmGR := corev1.Resource(cmRN)
+
+	switch len(list.Items) {
+	case 0:
+		return nil, kerrors.NewNotFound(cmGR, cmRN)
+	case 1:
+		return &list.Items[0], nil
+	default:
+		return nil, fmt.Errorf("multiple resources of type {%s} found for label selector {%s} in namespace {%s},"+
+			" when only one was expected", cmGR.String(), lSelector.String(), ns)
+	}
+}
+
+// GetPodByLabel it returns a pod instance that matches the given label and field selector.
+func GetPodByLabel(ctx context.Context, cl client.Client, ns string, lSelector labels.Selector, fSelector fields.Selector) (*corev1.Pod, error) {
+	list := new(corev1.PodList)
+	if err := cl.List(ctx, list, &client.ListOptions{
+		LabelSelector: lSelector,
+		FieldSelector: fSelector,
+	}, client.InNamespace(ns)); err != nil {
+		return nil, err
+	}
+	podRN := string(corev1.ResourcePods)
+	podGR := corev1.Resource(podRN)
+
+	switch len(list.Items) {
+	case 0:
+		return nil, kerrors.NewNotFound(podGR, podRN)
+	case 1:
+		return &list.Items[0], nil
+	default:
+		return nil, fmt.Errorf("multiple resources of type {%s} found for label selector {%s} in namespace {%s},"+
+			" when only one was expected", podGR.String(), lSelector.String(), ns)
+	}
+}

--- a/pkg/utils/labels/labelSelectors.go
+++ b/pkg/utils/labels/labelSelectors.go
@@ -1,0 +1,91 @@
+// Copyright 2019-2022 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package labels label selectors used throughout the liqo code in order to get
+// k8s resources.
+package labels
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	liqoconst "github.com/liqotech/liqo/pkg/consts"
+)
+
+var (
+	// IPAMStorageLabelSelector selector used to get the ipam storage instance.
+	IPAMStorageLabelSelector = metav1.LabelSelector{
+		MatchExpressions: []metav1.LabelSelectorRequirement{
+			{
+				Key:      liqoconst.IpamStorageResourceLabelKey,
+				Operator: metav1.LabelSelectorOpIn,
+				Values:   []string{liqoconst.IpamStorageResourceLabelValue},
+			},
+		},
+	}
+
+	// GatewayServiceLabelSelector selector used to get the gateway service.
+	GatewayServiceLabelSelector = metav1.LabelSelector{
+		MatchExpressions: []metav1.LabelSelectorRequirement{
+			{
+				Key:      liqoconst.GatewayServiceLabelKey,
+				Operator: metav1.LabelSelectorOpIn,
+				Values:   []string{liqoconst.GatewayServiceLabelValue},
+			},
+		},
+	}
+
+	// WireGuardSecretLabelSelector selector used to get the WireGuard secret.
+	WireGuardSecretLabelSelector = metav1.LabelSelector{
+		MatchExpressions: []metav1.LabelSelectorRequirement{
+			{
+				Key:      liqoconst.KeysLabel,
+				Operator: metav1.LabelSelectorOpIn,
+				Values:   []string{liqoconst.DriverName},
+			},
+		},
+	}
+
+	// ClusterIDConfigMapLabelSelector selector used to get the cluster id configmap.
+	ClusterIDConfigMapLabelSelector = metav1.LabelSelector{
+		MatchExpressions: []metav1.LabelSelectorRequirement{
+			{
+				Key:      liqoconst.ClusterIDConfigMapNameLabelKey,
+				Operator: metav1.LabelSelectorOpIn,
+				Values:   []string{liqoconst.ClusterIDConfigMapNameLabelValue},
+			},
+		},
+	}
+
+	// NetworkManagerPodLabelSelector selector used to get the Network Manager Pod.
+	NetworkManagerPodLabelSelector = metav1.LabelSelector{
+		MatchExpressions: []metav1.LabelSelectorRequirement{
+			{
+				Key:      liqoconst.K8sAppNameKey,
+				Operator: metav1.LabelSelectorOpIn,
+				Values:   []string{liqoconst.NetworkManagerAppName},
+			},
+		},
+	}
+
+	// AuthServiceLabelSelector selector used to get the auth service.
+	AuthServiceLabelSelector = metav1.LabelSelector{
+		MatchExpressions: []metav1.LabelSelectorRequirement{
+			{
+				Key:      liqoconst.K8sAppNameKey,
+				Operator: metav1.LabelSelectorOpIn,
+				Values:   []string{liqoconst.AuthAppName},
+			},
+		},
+	}
+)

--- a/pkg/utils/labels/labelSelectors.go
+++ b/pkg/utils/labels/labelSelectors.go
@@ -60,7 +60,7 @@ var (
 	ClusterIDConfigMapLabelSelector = metav1.LabelSelector{
 		MatchExpressions: []metav1.LabelSelectorRequirement{
 			{
-				Key:      liqoconst.ClusterIDConfigMapNameLabelKey,
+				Key:      liqoconst.K8sAppNameKey,
 				Operator: metav1.LabelSelectorOpIn,
 				Values:   []string{liqoconst.ClusterIDConfigMapNameLabelValue},
 			},


### PR DESCRIPTION
# Description

`liqoctl connect` is used to peer two k8s clusters that does not expose the **api-server** and the **liqo authentication endpoint** to the world. The connect command setups the liqo networking and then configures a proxy on both clusters to expose the local api-servers. The proxy and authentication services are accessed by liqo components through a local services that points to the remote proxy and auth service.

For more info check #1107 


Fixes #(issue)

# How Has This Been Tested?

- [x] Unit tests for liqo code
- [x] Manual tests for liqoctl connect command
