### PR TITLE
Virtual kubelet: allow to disable remote API server readiness check

### DIFF
--- a/cmd/virtual-kubelet/root/flag.go
+++ b/cmd/virtual-kubelet/root/flag.go
@@ -51,7 +51,7 @@ func InstallFlags(flags *pflag.FlagSet, o *Opts) {
 
 	flags.DurationVar(&o.NodeLeaseDuration, "node-lease-duration", o.NodeLeaseDuration, "The duration of the node leases")
 	flags.DurationVar(&o.NodePingInterval, "node-ping-interval", o.NodePingInterval,
-		"The interval the reachability of the remote API server is verified to assess node readiness")
+		"The interval the reachability of the remote API server is verified to assess node readiness, 0 to disable")
 	flags.DurationVar(&o.NodePingTimeout, "node-ping-timeout", o.NodePingTimeout,
 		"The timeout of the remote API server reachability check")
 

--- a/cmd/virtual-kubelet/root/root.go
+++ b/cmd/virtual-kubelet/root/root.go
@@ -135,6 +135,7 @@ func runRootCommand(ctx context.Context, c *Opts) error {
 		ExtraAnnotations: c.NodeExtraAnnotations.StringMap,
 
 		InformerResyncPeriod: c.InformerResyncPeriod,
+		PingDisabled:         c.NodePingInterval == 0,
 	}
 
 	nodeProvider := nodeprovider.NewLiqoNodeProvider(&nodecfg)

--- a/pkg/virtualKubelet/liqoNodeProvider/nodeProvider.go
+++ b/pkg/virtualKubelet/liqoNodeProvider/nodeProvider.go
@@ -40,6 +40,7 @@ type LiqoNodeProvider struct {
 	foreignClusterID string
 	tenantNamespace  string
 	resyncPeriod     time.Duration
+	pingDisabled     bool
 
 	networkReady bool
 
@@ -49,6 +50,10 @@ type LiqoNodeProvider struct {
 
 // Ping checks if the the node is still active.
 func (p *LiqoNodeProvider) Ping(ctx context.Context) error {
+	if p.pingDisabled {
+		return nil
+	}
+
 	start := time.Now()
 	klog.V(4).Infof("Checking whether the remote API server is ready")
 

--- a/pkg/virtualKubelet/liqoNodeProvider/setup.go
+++ b/pkg/virtualKubelet/liqoNodeProvider/setup.go
@@ -56,6 +56,7 @@ type InitConfig struct {
 
 	PodProviderStopper   chan struct{}
 	InformerResyncPeriod time.Duration
+	PingDisabled         bool
 }
 
 // NewLiqoNodeProvider creates and returns a new LiqoNodeProvider.
@@ -71,6 +72,7 @@ func NewLiqoNodeProvider(cfg *InitConfig) *LiqoNodeProvider {
 
 		networkReady: false,
 		resyncPeriod: cfg.InformerResyncPeriod,
+		pingDisabled: cfg.PingDisabled,
 
 		nodeName:         cfg.NodeName,
 		foreignClusterID: cfg.RemoteClusterID,


### PR DESCRIPTION
# Description

This PR introduces the possibility to disable the remote API server ping check added in #1017 .

Fixes #(issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Manually, on kind
