### PR TITLE
Force Remote NodePort

### DIFF
--- a/pkg/consts/replication.go
+++ b/pkg/consts/replication.go
@@ -49,4 +49,8 @@ const (
 	// Ex. Local networkconfigs are owned by the component that creates them. If the resource is replicated in
 	// a remote cluster this label is removed by the CRDReplicator.
 	LocalResourceOwnership = "liqo.io/ownership"
+
+	// ForceRemoteNodePortAnnotationKey is the annotation key used to indicate that a service should be forced to
+	// use the same node port on both clusters.
+	ForceRemoteNodePortAnnotationKey = "liqo.io/force-remote-node-port"
 )

--- a/pkg/virtualKubelet/forge/services_test.go
+++ b/pkg/virtualKubelet/forge/services_test.go
@@ -98,7 +98,7 @@ var _ = Describe("Services Forging", func() {
 		}
 
 		DescribeTable("RemoteServiceSpec table", func(c remoteServiceTestcase) {
-			output := forge.RemoteServiceSpec(c.input.DeepCopy())
+			output := forge.RemoteServiceSpec(c.input.DeepCopy(), false)
 
 			By("should correctly replicate the core fields", func() {
 				Expect(output.Type).To(PointTo(c.expectedServiceType))
@@ -134,17 +134,19 @@ var _ = Describe("Services Forging", func() {
 
 	Describe("the RemoteServicePorts function", func() {
 		var (
-			input  corev1.ServicePort
-			output []*corev1apply.ServicePortApplyConfiguration
+			input               corev1.ServicePort
+			output              []*corev1apply.ServicePortApplyConfiguration
+			forceRemoteNodePort bool
 		)
 
 		BeforeEach(func() {
 			input = corev1.ServicePort{
 				Name: "HTTPS", Port: 443, TargetPort: intstr.FromInt(8443), Protocol: corev1.ProtocolTCP,
 			}
+			forceRemoteNodePort = false
 		})
 
-		JustBeforeEach(func() { output = forge.RemoteServicePorts([]corev1.ServicePort{input, input}) })
+		JustBeforeEach(func() { output = forge.RemoteServicePorts([]corev1.ServicePort{input, input}, forceRemoteNodePort) })
 
 		It("should return the correct number of ports", func() { Expect(output).To(HaveLen(2)) })
 		It("should correctly replicate the port fields", func() {
@@ -157,13 +159,23 @@ var _ = Describe("Services Forging", func() {
 		})
 
 		When("a node port is specified", func() {
-			BeforeEach(func() { input.NodePort = 33333 })
+			BeforeEach(func() {
+				input.NodePort = 33333
+			})
 			It("should be omitted", func() { Expect(output[0].NodePort).To(BeNil()) })
 		})
 
 		When("an app protocol is specified", func() {
 			BeforeEach(func() { input.AppProtocol = pointer.String("protocol") })
 			It("should be replicated", func() { Expect(output[0].AppProtocol).To(PointTo(Equal("protocol"))) })
+		})
+
+		When("force remote node port is specified", func() {
+			BeforeEach(func() {
+				input.NodePort = 33333
+				forceRemoteNodePort = true
+			})
+			It("should be replicated", func() { Expect(output[0].NodePort).To(PointTo(BeNumerically("==", 33333))) })
 		})
 	})
 })


### PR DESCRIPTION
# Description

This pr adds the possibility to force a remote service to use the same NodePort used in the local cluster by adding the `liqo.io/force-remote-node-port=true` annotation on that service.

NOTE: if the specified port is already taken in the remote cluster, the virtual kubelet will not be able to reflect the service to the remote cluster.

# How Has This Been Tested?

- [x] add unit test
- [x] locally
