### PR TITLE
liqoctl disconnect 

### DIFF
--- a/cmd/liqoctl/cmd/disconnect.go
+++ b/cmd/liqoctl/cmd/disconnect.go
@@ -1,0 +1,43 @@
+// Copyright 2019-2022 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+	"golang.org/x/net/context"
+
+	"github.com/liqotech/liqo/pkg/liqoctl/disconnect"
+)
+
+func newDisconnectCommand(ctx context.Context) *cobra.Command {
+	var params = disconnect.Args{}
+
+	cmd := &cobra.Command{
+		Use:           "disconnect",
+		Short:         "Disconnects two clusters previously connected using a vpn tunnel",
+		Long:          `Disconnects two clusters previously connected using a vpn tunnel`,
+		SilenceErrors: true,
+		SilenceUsage:  true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return params.Handler(ctx)
+		},
+	}
+	cmd.Flags().StringVarP(&params.Cluster1Namespace, "namespace1", "", "liqo", "Namespace Liqo is running in cluster 1")
+	cmd.Flags().StringVarP(&params.Cluster2Namespace, "namespace2", "", "liqo", "Namespace Liqo is running in cluster 2")
+	cmd.Flags().StringVarP(&params.Cluster1Kubeconfig, "config1", "", "", "Kubeconfig of cluster 1")
+	cmd.Flags().StringVarP(&params.Cluster2Kubeconfig, "config2", "", "", "Kubeconfig of cluster 2")
+
+	return cmd
+}

--- a/cmd/liqoctl/cmd/root.go
+++ b/cmd/liqoctl/cmd/root.go
@@ -58,6 +58,7 @@ func NewRootCommand(ctx context.Context) *cobra.Command {
 	rootCmd.AddCommand(newStatusCommand(ctx))
 	rootCmd.AddCommand(newOffloadCommand(ctx))
 	rootCmd.AddCommand(newConnectCommand(ctx))
+	rootCmd.AddCommand(newDisconnectCommand(ctx))
 	rootCmd.AddCommand(newMoveCommand(ctx))
 	return rootCmd
 }

--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/vishvananda/netlink v1.1.1-0.20210330154013-f5de75959ad5
 	github.com/vishvananda/netns v0.0.0-20210104183010-2eb08e3e575f
 	golang.org/x/mod v0.5.1
+	golang.org/x/net v0.0.0-20220107192237-5cfca573fb4d
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e
 	golang.zx2c4.com/wireguard/wgctrl v0.0.0-20200609130330-bd2cb7843e1b
@@ -206,7 +207,6 @@ require (
 	go4.org/intern v0.0.0-20210108033219-3eb7198706b2 // indirect
 	go4.org/unsafe/assume-no-moving-gc v0.0.0-20201222180813-1025295fd063 // indirect
 	golang.org/x/crypto v0.0.0-20211117183948-ae814b36b871 // indirect
-	golang.org/x/net v0.0.0-20220107192237-5cfca573fb4d // indirect
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8 // indirect
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
 	golang.org/x/text v0.3.7 // indirect

--- a/pkg/liqoctl/disconnect/doc.go
+++ b/pkg/liqoctl/disconnect/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2019-2022 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package disconnect contains the logic that handles the disconnect command in liqoctl
+package disconnect

--- a/pkg/liqoctl/disconnect/handler.go
+++ b/pkg/liqoctl/disconnect/handler.go
@@ -1,0 +1,177 @@
+// Copyright 2019-2022 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package disconnect
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	k8s "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/liqotech/liqo/pkg/liqoctl/common"
+)
+
+// Args flags of the disconnect command.
+type Args struct {
+	Cluster1Namespace  string
+	Cluster2Namespace  string
+	Cluster1Kubeconfig string
+	Cluster2Kubeconfig string
+}
+
+// Handler implements the logic of the disconnect command.
+func (a *Args) Handler(ctx context.Context) error {
+	// Check that the kubeconfigs are different.
+	if a.Cluster1Kubeconfig == a.Cluster2Kubeconfig {
+		common.ErrorPrinter.Printf("kubeconfig1 and kubeconfig2 has to be different, current value: %s", a.Cluster2Kubeconfig)
+		return fmt.Errorf("kubeconfig1 and kubeconfig2 has to be different, current value: %s", a.Cluster2Kubeconfig)
+	}
+	// Create restconfigs and clients for cluster 1.
+	cl1RestCfg, err := clientcmd.BuildConfigFromFlags("", a.Cluster1Kubeconfig)
+	if err != nil {
+		common.ErrorPrinter.Printf("unable to create rest config from kubeconfig {%s}: %s", a.Cluster1Kubeconfig, err.Error())
+		return err
+	}
+	cl1K8sClient, err := k8s.NewForConfig(cl1RestCfg)
+	if err != nil {
+		common.ErrorPrinter.Printf("unable to create client set from kubeconfig {%s}: %s", a.Cluster1Kubeconfig, err.Error())
+		return err
+	}
+	cl1CRClient, err := client.New(cl1RestCfg, client.Options{
+		Scheme: common.Scheme,
+	})
+	if err != nil {
+		common.ErrorPrinter.Printf("unable to create controller runtime client from kubeconfig {%s}: %s",
+			a.Cluster1Kubeconfig, err.Error())
+		return err
+	}
+
+	// Create restconfigs and clients for cluster 2.
+	cl2RestCfg, err := clientcmd.BuildConfigFromFlags("", a.Cluster2Kubeconfig)
+	if err != nil {
+		common.ErrorPrinter.Printf("unable to create rest config from kubeconfig {%s}: %s", a.Cluster2Kubeconfig, err.Error())
+		return err
+	}
+	cl2K8sClient, err := k8s.NewForConfig(cl2RestCfg)
+	if err != nil {
+		common.ErrorPrinter.Printf("unable to create client set from kubeconfig {%s}: %s", a.Cluster2Kubeconfig, err.Error())
+		return err
+	}
+	cl2CRClient, err := client.New(cl2RestCfg, client.Options{
+		Scheme: common.Scheme,
+	})
+	if err != nil {
+		common.ErrorPrinter.Printf("unable to create controller runtime client from kubeconfig {%s}: %s",
+			a.Cluster2Kubeconfig, err.Error())
+		return err
+	}
+
+	// Create and initialize cluster 1.
+	cluster1 := common.NewCluster(cl1K8sClient, cl1CRClient, cl2CRClient, cl1RestCfg, a.Cluster1Namespace, common.Cluster1Name, common.Cluster1Color)
+	if err := cluster1.Init(ctx); err != nil {
+		return err
+	}
+
+	// Create and initialize cluster 2.
+	cluster2 := common.NewCluster(cl2K8sClient, cl2CRClient, cl1CRClient, cl2RestCfg, a.Cluster2Namespace, common.Cluster2Name, common.Cluster2Color)
+	if err := cluster2.Init(ctx); err != nil {
+		return err
+	}
+
+	// Disable peering in cluster 1.
+	if err := cluster1.DisablePeering(ctx, cluster2.GetClusterID()); err != nil {
+		return err
+	}
+
+	// Disable peering in cluster 2.
+	if err := cluster2.DisablePeering(ctx, cluster1.GetClusterID()); err != nil {
+		return err
+	}
+
+	// Wait to unpeer in cluster 1.
+	if err := cluster1.WaitForUnpeering(ctx, cluster2.GetClusterID(), 60*time.Second); err != nil {
+		return err
+	}
+
+	// Disable peering in cluster 2.
+	if err := cluster2.WaitForUnpeering(ctx, cluster1.GetClusterID(), 60*time.Second); err != nil {
+		return err
+	}
+
+	// Delete foreigncluster of cluster2 in cluster1.
+	if err := cluster1.DeleteForeignCluster(ctx, cluster2.GetClusterID()); err != nil {
+		return err
+	}
+
+	// Delete foreigncluster of cluster1 in cluster2.
+	if err := cluster2.DeleteForeignCluster(ctx, cluster1.GetClusterID()); err != nil {
+		return err
+	}
+
+	// Clean up tenant namespace in cluster 1.
+	if err := cluster1.TearDownTenantNamespace(ctx, cluster2.GetClusterID(), 60*time.Second); err != nil {
+		return err
+	}
+
+	// Clean up tenant namespace in cluster 2.
+	if err := cluster2.TearDownTenantNamespace(ctx, cluster1.GetClusterID(), 60*time.Second); err != nil {
+		return err
+	}
+
+	// Port-forwarding ipam service for cluster 1.
+	if err := cluster1.PortForwardIPAM(ctx); err != nil {
+		return err
+	}
+	defer cluster1.StopPortForwardIPAM()
+
+	// Port-forwarding ipam service for cluster 2.
+	if err := cluster2.PortForwardIPAM(ctx); err != nil {
+		return err
+	}
+	defer cluster2.StopPortForwardIPAM()
+
+	// Creating IPAM client for cluster 1.
+	ipamClient1, err := cluster1.NewIPAMClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Creating IPAM client for cluster 2.
+	ipamClient2, err := cluster2.NewIPAMClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Unmapping proxy's ip in cluster1 for cluster2.
+	if err := cluster1.UnmapProxyIPForCluster(ctx, ipamClient1, cluster2.GetClusterID()); err != nil {
+		return err
+	}
+
+	// Unmapping proxy's ip in cluster2 for cluster2
+	if err := cluster2.UnmapProxyIPForCluster(ctx, ipamClient2, cluster1.GetClusterID()); err != nil {
+		return err
+	}
+
+	// Unmapping auth's ip  in cluster1 for cluster2.
+	if err := cluster1.UnmapAuthIPForCluster(ctx, ipamClient1, cluster2.GetClusterID()); err != nil {
+		return err
+	}
+
+	// Unapping auth's ip in cluster2 for cluster1
+	return cluster2.UnmapAuthIPForCluster(ctx, ipamClient2, cluster1.GetClusterID())
+}

--- a/pkg/utils/labels/labelSelectors.go
+++ b/pkg/utils/labels/labelSelectors.go
@@ -88,4 +88,15 @@ var (
 			},
 		},
 	}
+
+	// ProxyServiceLabelSelector selector used to get the gateway service.
+	ProxyServiceLabelSelector = metav1.LabelSelector{
+		MatchExpressions: []metav1.LabelSelectorRequirement{
+			{
+				Key:      liqoconst.K8sAppNameKey,
+				Operator: metav1.LabelSelectorOpIn,
+				Values:   []string{liqoconst.APIServerProxyAppName},
+			},
+		},
+	}
 )


### PR DESCRIPTION
# Description

`liqoctl disconnect `is used to unpeer two k8s clusters that were previously peered with the 'liqoctl connect' command.

For more info check #1132 



