### PR TITLE
Fix Changelog Titles

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -5,20 +5,20 @@ changelog:
     authors:
     - dependabot[bot]
   categories:
-    - title: "### :boom: Breaking Change"
+    - title: ":boom: Breaking Change"
       labels:
       - kind/breaking
-    - title: "### :rocket: New Features"
+    - title: ":rocket: New Features"
       labels:
       - kind/feature
       - kind/epic
-    - title: "### :bug: Bug Fixes"
+    - title: ":bug: Bug Fixes"
       labels:
       - kind/bug
-    - title: "### :broom: Code Refactoring"
+    - title: ":broom: Code Refactoring"
       labels:
       - kind/cleanup
-    - title: "### :memo: Documentation"
+    - title: ":memo: Documentation"
       labels:
       - kind/docs
     - title: Other Changes


### PR DESCRIPTION
# Description

This pr fixes the changelog title since they are already set as headers by GitHub Actions
