### PR TITLE
Virtual kubelet: filter service account secrets during pod translation

### DIFF
--- a/pkg/virtualKubelet/forge/pods_test.go
+++ b/pkg/virtualKubelet/forge/pods_test.go
@@ -219,13 +219,15 @@ var _ = Describe("Pod forging", func() {
 				{Name: "first", VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{}}},
 				{Name: "second", VolumeSource: corev1.VolumeSource{Projected: &corev1.ProjectedVolumeSource{}}},
 				{Name: "third", VolumeSource: corev1.VolumeSource{PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{}}},
+				{Name: "forth", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: "secret"}}},
 			}
 			excluded = []corev1.Volume{
 				{Name: "kube-api-access-projected", VolumeSource: corev1.VolumeSource{Projected: &corev1.ProjectedVolumeSource{}}},
+				{Name: "service-account", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: "sa-token-1234"}}},
 			}
 		})
 
-		JustBeforeEach(func() { output = forge.RemoteVolumes(append(included, excluded...)) })
+		JustBeforeEach(func() { output = forge.RemoteVolumes(append(included, excluded...), "sa") })
 		It("should propagate all volume types, except the one referring to the service account", func() { Expect(output).To(ConsistOf(included)) })
 	})
 


### PR DESCRIPTION
# Description

This PR fixes a regression introduced in #1157, which removed the filtering of volumes referring to secrets of service accounts during pod translation, causing problems with the default service account and old versions of Kubernetes.  

Fixes #(issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Existing
- [x] Manually (on kind, with Kubernetes 1.19) 
