### PR TITLE
Add firewall rules for overlay network

### DIFF
--- a/cmd/liqonet/route-operator.go
+++ b/cmd/liqonet/route-operator.go
@@ -152,6 +152,10 @@ func runRouteOperator(commonFlags *liqonetCommonFlags, routeFlags *routeOperator
 		klog.Errorf("unable to setup controller: %s", err)
 		os.Exit(1)
 	}
+	if err = routeController.ConfigureFirewall(); err != nil {
+		klog.Errorf("unable to start go routine that configures firewall rules for the route controller: %v", err)
+		os.Exit(1)
+	}
 	overlayController, err := routeoperator.NewOverlayController(podIP.String(), vxlanDevice, mutex, nodeMap, overlayMgr.GetClient())
 	if err != nil {
 		klog.Errorf("an error occurred while creating overlay controller: %v", err)

--- a/internal/liqonet/route-operator/firewall.go
+++ b/internal/liqonet/route-operator/firewall.go
@@ -1,0 +1,72 @@
+// Copyright 2019-2022 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package routeoperator
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/coreos/go-iptables/iptables"
+)
+
+const (
+	filterTable = "filter"
+)
+
+// TODO: refactor the iptables package used by tunnel operator in order
+// to use it outside the tunnel operator.
+
+type firewallRule struct {
+	table string
+	chain string
+	rule  []string
+}
+
+func (fr *firewallRule) String() string {
+	ruleString := strings.Join(fr.rule, " ")
+	return strings.Join([]string{fr.table, fr.chain, ruleString}, " ")
+}
+
+// generateRules generates the firewall rules for the given overlay interface.
+func generateRules(ifaceName string) []firewallRule {
+	comment := fmt.Sprintf("LIQO accept traffic from/to overlay interface %s", ifaceName)
+	return []firewallRule{
+		{
+			table: filterTable,
+			chain: "INPUT",
+			rule:  []string{"-i", ifaceName, "-j", "ACCEPT", "-m", "comment", "--comment", comment},
+		},
+		{
+			table: filterTable,
+			chain: "FORWARD",
+			rule:  []string{"-i", ifaceName, "-j", "ACCEPT", "-m", "comment", "--comment", comment},
+		},
+		{
+			table: filterTable,
+			chain: "OUTPUT",
+			rule:  []string{"-o", ifaceName, "-j", "ACCEPT", "-m", "comment", "--comment", comment},
+		},
+	}
+}
+
+// addRule appends the rule if it does not exist.
+func addRule(ipt *iptables.IPTables, rule *firewallRule) error {
+	return ipt.AppendUnique(rule.table, rule.chain, rule.rule...)
+}
+
+// deleteRule removes the rule if it exists.
+func deleteRule(ipt *iptables.IPTables, rule *firewallRule) error {
+	return ipt.DeleteIfExists(rule.table, rule.chain, rule.rule...)
+}


### PR DESCRIPTION
# Description
In some environments with strict firewall configuration traffic toward remote clusters is dropped before being forwarded to the overlay interface. Now route operator adds three new rules in `filter table `in order to `ACCEPT` all the traffic going/coming to/from the liqo's overlay interface.


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Manually tested in environments with strict firewall configuration.
