### PR TITLE
Add Liqoctl Install Generic Provider

### DIFF
--- a/cmd/liqoctl/cmd/install.go
+++ b/cmd/liqoctl/cmd/install.go
@@ -22,6 +22,7 @@ import (
 	"github.com/spf13/cobra"
 
 	liqoconst "github.com/liqotech/liqo/pkg/consts"
+	"github.com/liqotech/liqo/pkg/liqoctl/install"
 	"github.com/liqotech/liqo/pkg/liqoctl/install/provider"
 	installutils "github.com/liqotech/liqo/pkg/liqoctl/install/utils"
 )
@@ -29,9 +30,13 @@ import (
 // newInstallCommand generates a new Command representing `liqoctl install`.
 func newInstallCommand(ctx context.Context) *cobra.Command {
 	var installCmd = &cobra.Command{
-		Use:   installutils.LiqoctlInstallCommand,
-		Short: installutils.LiqoctlInstallShortHelp,
-		Long:  installutils.LiqoctlInstallLongHelp,
+		Use:          installutils.LiqoctlInstallCommand,
+		Short:        installutils.LiqoctlInstallShortHelp,
+		Long:         installutils.LiqoctlInstallLongHelp,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return install.HandleInstallCommand(ctx, cmd, os.Args[0], provider.GenericProviderName)
+		},
 	}
 
 	installCmd.PersistentFlags().IntP("timeout", "t", 600, "Configure the timeout for the installation process in seconds")
@@ -62,6 +67,8 @@ func newInstallCommand(ctx context.Context) *cobra.Command {
 	installCmd.PersistentFlags().Bool("enable-ha", false, "Enable the gateway component support active/passive high availability.")
 	installCmd.PersistentFlags().Int("mtu", 0, "mtu is the maximum transmission unit for interfaces managed by Liqo")
 	installCmd.PersistentFlags().Int("vpn-listening-port", liqoconst.GatewayListeningPort, "vpn-listening-port is the port used by the vpn tunnel")
+
+	provider.GenerateFlags(installCmd)
 
 	for _, providerName := range provider.Providers {
 		cmd, err := getCommand(ctx, providerName)

--- a/cmd/liqoctl/cmd/providers.go
+++ b/cmd/liqoctl/cmd/providers.go
@@ -47,11 +47,10 @@ var providerInitFunc = map[string]func(*cobra.Command){
 
 func getCommand(ctx context.Context, provider string) (*cobra.Command, error) {
 	cmd := &cobra.Command{
-		Use:           provider,
-		Short:         fmt.Sprintf(installShortHelp, provider),
-		Long:          fmt.Sprintf(installLongHelp, provider),
-		SilenceUsage:  true,
-		SilenceErrors: true,
+		Use:          provider,
+		Short:        fmt.Sprintf(installShortHelp, provider),
+		Long:         fmt.Sprintf(installLongHelp, provider),
+		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return install.HandleInstallCommand(ctx, cmd, os.Args[0], provider)
 		},

--- a/pkg/liqoctl/common/utils.go
+++ b/pkg/liqoctl/common/utils.go
@@ -58,6 +58,15 @@ func ExtractValueFromArgumentList(key string, argumentList []string) (string, er
 	return "", fmt.Errorf("argument not found")
 }
 
+// ExtractValuesFromArgumentListOrDefault extracts the argument value from an argument list or returns a default value.
+func ExtractValuesFromArgumentListOrDefault(key string, argumentList []string, defaultValue string) string {
+	value, err := ExtractValueFromArgumentList(key, argumentList)
+	if err != nil {
+		return defaultValue
+	}
+	return value
+}
+
 // getFreePort get a free port on the system by listening in a socket,
 // checking the bound port number and then closing the socket.
 func getFreePort() (int, error) {

--- a/pkg/liqoctl/install/aks/aks_test.go
+++ b/pkg/liqoctl/install/aks/aks_test.go
@@ -94,9 +94,9 @@ var _ = Describe("Extract elements from AKS", func() {
 
 		Expect(p.parseClusterOutput(ctx, clusterOutput)).To(Succeed())
 
-		Expect(p.endpoint).To(Equal(endpoint))
-		Expect(p.serviceCIDR).To(Equal(serviceCIDR))
-		Expect(p.podCIDR).To(Equal(podCIDR))
+		Expect(p.APIServer).To(Equal(endpoint))
+		Expect(p.ServiceCIDR).To(Equal(serviceCIDR))
+		Expect(p.PodCIDR).To(Equal(podCIDR))
 		Expect(len(p.ReservedSubnets)).To(BeNumerically("==", 1))
 		Expect(p.ReservedSubnets).To(ContainElement(defaultAksNodeCIDR))
 		Expect(p.ClusterLabels).ToNot(BeEmpty())

--- a/pkg/liqoctl/install/eks/cluster.go
+++ b/pkg/liqoctl/install/eks/cluster.go
@@ -66,13 +66,13 @@ func (k *eksProvider) parseClusterOutput(describeClusterResult *eks.DescribeClus
 		err := fmt.Errorf("the EKS cluster %v in region %v does not have a valid endpoint", k.eksClusterName, k.region)
 		return "", err
 	}
-	k.endpoint = *describeClusterResult.Cluster.Endpoint
+	k.APIServer = *describeClusterResult.Cluster.Endpoint
 
 	if describeClusterResult.Cluster.KubernetesNetworkConfig.ServiceIpv4Cidr == nil {
 		err := fmt.Errorf("the EKS cluster %v in region %v does not have a valid service CIDR", k.eksClusterName, k.region)
 		return "", err
 	}
-	k.serviceCIDR = *describeClusterResult.Cluster.KubernetesNetworkConfig.ServiceIpv4Cidr
+	k.ServiceCIDR = *describeClusterResult.Cluster.KubernetesNetworkConfig.ServiceIpv4Cidr
 
 	if describeClusterResult.Cluster.ResourcesVpcConfig.VpcId == nil {
 		err := fmt.Errorf("the EKS cluster %v in region %v does not have a valid VPC ID", k.eksClusterName, k.region)
@@ -96,7 +96,7 @@ func (k *eksProvider) parseVpcOutput(vpcID string, describeVpcResult *ec2.Descri
 		err := fmt.Errorf("multiple VPC found with id %v", vpcID)
 		return err
 	}
-	k.podCIDR = *vpcs[0].CidrBlock
+	k.PodCIDR = *vpcs[0].CidrBlock
 
 	return nil
 }

--- a/pkg/liqoctl/install/eks/eks_test.go
+++ b/pkg/liqoctl/install/eks/eks_test.go
@@ -94,8 +94,8 @@ var _ = Describe("Extract elements from EKS", func() {
 		Expect(err).To(Succeed())
 		Expect(resVpcID).To(Equal(vpcID))
 
-		Expect(p.endpoint).To(Equal(endpoint))
-		Expect(p.serviceCIDR).To(Equal(serviceCIDR))
+		Expect(p.APIServer).To(Equal(endpoint))
+		Expect(p.ServiceCIDR).To(Equal(serviceCIDR))
 		Expect(p.ClusterLabels).ToNot(BeEmpty())
 		Expect(p.ClusterLabels[consts.ProviderClusterLabel]).To(Equal(providerPrefix))
 		Expect(p.ClusterLabels[consts.TopologyRegionClusterLabel]).To(Equal(region))
@@ -110,7 +110,7 @@ var _ = Describe("Extract elements from EKS", func() {
 
 		Expect(p.parseVpcOutput("id", vpcOutput)).To(Succeed())
 
-		Expect(p.podCIDR).To(Equal(podCIDR))
+		Expect(p.PodCIDR).To(Equal(podCIDR))
 
 	})
 

--- a/pkg/liqoctl/install/eks/provider.go
+++ b/pkg/liqoctl/install/eks/provider.go
@@ -47,10 +47,6 @@ type eksProvider struct {
 	region         string
 	eksClusterName string
 
-	endpoint    string
-	serviceCIDR string
-	podCIDR     string
-
 	iamLiqoUser iamLiqoUser
 }
 
@@ -146,7 +142,7 @@ func (k *eksProvider) ExtractChartParameters(ctx context.Context, config *rest.C
 	}
 
 	if !commonArgs.DisableEndpointCheck {
-		if valid, err := installutils.CheckEndpoint(k.endpoint, config); err != nil {
+		if valid, err := installutils.CheckEndpoint(k.APIServer, config); err != nil {
 			return err
 		} else if !valid {
 			return fmt.Errorf("the retrieved cluster information and the cluster selected in the kubeconfig do not match")
@@ -170,12 +166,12 @@ func (k *eksProvider) UpdateChartValues(values map[string]interface{}) {
 		},
 	}
 	values["apiServer"] = map[string]interface{}{
-		"address": k.endpoint,
+		"address": k.APIServer,
 	}
 	values["networkManager"] = map[string]interface{}{
 		"config": map[string]interface{}{
-			"serviceCIDR":     k.serviceCIDR,
-			"podCIDR":         k.podCIDR,
+			"serviceCIDR":     k.ServiceCIDR,
+			"podCIDR":         k.PodCIDR,
 			"reservedSubnets": installutils.GetInterfaceSlice(k.ReservedSubnets),
 		},
 	}

--- a/pkg/liqoctl/install/gke/gke_test.go
+++ b/pkg/liqoctl/install/gke/gke_test.go
@@ -82,9 +82,9 @@ var _ = Describe("Extract elements from GKE", func() {
 
 		p.parseClusterOutput(clusterOutput)
 
-		Expect(p.endpoint).To(Equal(endpoint))
-		Expect(p.serviceCIDR).To(Equal(serviceCIDR))
-		Expect(p.podCIDR).To(Equal(podCIDR))
+		Expect(p.APIServer).To(Equal(endpoint))
+		Expect(p.ServiceCIDR).To(Equal(serviceCIDR))
+		Expect(p.PodCIDR).To(Equal(podCIDR))
 
 		Expect(p.ClusterLabels).ToNot(BeEmpty())
 		Expect(p.ClusterLabels[consts.ProviderClusterLabel]).To(Equal(providerPrefix))

--- a/pkg/liqoctl/install/k3s/provider.go
+++ b/pkg/liqoctl/install/k3s/provider.go
@@ -16,21 +16,14 @@ package k3s
 
 import (
 	"context"
-	"fmt"
-	"net"
-	"net/url"
 
 	"github.com/spf13/cobra"
-	flag "github.com/spf13/pflag"
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
+	"github.com/spf13/pflag"
 	"k8s.io/client-go/rest"
 
 	"github.com/liqotech/liqo/pkg/consts"
 	"github.com/liqotech/liqo/pkg/liqoctl/install/provider"
 	installutils "github.com/liqotech/liqo/pkg/liqoctl/install/utils"
-	logsutils "github.com/liqotech/liqo/pkg/utils/logs"
 )
 
 const (
@@ -44,22 +37,8 @@ const (
 	apiServerFlag   = "api-server"
 )
 
-var (
-	localhostValues = []string{
-		"localhost",
-		"127.0.0.1",
-	}
-)
-
 type k3sProvider struct {
 	provider.GenericProvider
-
-	k8sClient kubernetes.Interface
-	config    *rest.Config
-
-	apiServer   string
-	serviceCIDR string
-	podCIDR     string
 }
 
 // NewProvider initializes a new K3S provider struct.
@@ -74,65 +53,20 @@ func NewProvider() provider.InstallProviderInterface {
 }
 
 // ValidateCommandArguments validates specific arguments passed to the install command.
-func (k *k3sProvider) ValidateCommandArguments(flags *flag.FlagSet) (err error) {
-	k.podCIDR, err = flags.GetString(podCidrFlag)
-	if err != nil {
-		return err
-	}
-	logsutils.Infof("K3S PodCIDR: %v", k.podCIDR)
-
-	k.serviceCIDR, err = flags.GetString(serviceCidrFlag)
-	if err != nil {
-		return err
-	}
-	logsutils.Infof("K3S ServiceCIDR: %v", k.serviceCIDR)
-
-	k.apiServer, err = flags.GetString(apiServerFlag)
-	if err != nil {
-		return err
-	}
-	if k.apiServer != "" {
-		logsutils.Infof("K3S API Server: %v", k.apiServer)
-	}
-
-	return nil
+func (k *k3sProvider) ValidateCommandArguments(flags *pflag.FlagSet) (err error) {
+	return k.ValidateCommandArguments(flags)
 }
 
 // ExtractChartParameters fetches the parameters used to customize the Liqo installation on a specific cluster of a
 // given provider.
-func (k *k3sProvider) ExtractChartParameters(ctx context.Context, config *rest.Config, _ *provider.CommonArguments) error {
-	k8sClient, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		fmt.Printf("Unable to create client: %s", err)
-		return err
-	}
-
-	k.k8sClient = k8sClient
-	k.config = config
-
-	if k.apiServer == "" {
-		k.apiServer = config.Host
-	}
-
-	if err = k.validateAPIServer(); err != nil {
-		return err
-	}
-
-	if err = k.validatePodCIDR(ctx); err != nil {
-		return err
-	}
-
-	if err = k.validateServiceCIDR(ctx); err != nil {
-		return err
-	}
-
-	return nil
+func (k *k3sProvider) ExtractChartParameters(ctx context.Context, config *rest.Config, args *provider.CommonArguments) error {
+	return k.ExtractChartParameters(ctx, config, args)
 }
 
 // UpdateChartValues patches the values map with the values required for the selected cluster.
 func (k *k3sProvider) UpdateChartValues(values map[string]interface{}) {
 	values["apiServer"] = map[string]interface{}{
-		"address": k.apiServer,
+		"address": k.APIServer,
 	}
 	values["auth"] = map[string]interface{}{
 		"service": map[string]interface{}{
@@ -141,8 +75,8 @@ func (k *k3sProvider) UpdateChartValues(values map[string]interface{}) {
 	}
 	values["networkManager"] = map[string]interface{}{
 		"config": map[string]interface{}{
-			"serviceCIDR":     k.serviceCIDR,
-			"podCIDR":         k.podCIDR,
+			"serviceCIDR":     k.ServiceCIDR,
+			"podCIDR":         k.PodCIDR,
 			"reservedSubnets": installutils.GetInterfaceSlice(k.ReservedSubnets),
 		},
 	}
@@ -166,74 +100,4 @@ func GenerateFlags(command *cobra.Command) {
 	flags.String(podCidrFlag, defaultPodCIDR, "The Pod CIDR for your cluster (optional)")
 	flags.String(serviceCidrFlag, defaultServiceCIDR, "The Service CIDR for your cluster (optional)")
 	flags.String(apiServerFlag, "", "Your cluster API Server URL (optional)")
-}
-
-// validateServiceCIDR validates that the services in the target cluster matches the provided service CIDR.
-// This is necessary since k3s does not provide us an API to retrieve the service CIDR of the cluster. We can
-// only check if the provided one fits the services IPs.
-func (k *k3sProvider) validateServiceCIDR(ctx context.Context) error {
-	svcList, err := k.k8sClient.CoreV1().Services(v1.NamespaceAll).List(ctx, metav1.ListOptions{})
-	if err != nil {
-		return err
-	}
-
-	_, svcNet, err := net.ParseCIDR(k.serviceCIDR)
-	if err != nil {
-		return err
-	}
-
-	for i := range svcList.Items {
-		svc := &svcList.Items[i]
-		clusterIP := svc.Spec.ClusterIP
-		if clusterIP != "None" && clusterIP != "" && !svcNet.Contains(net.ParseIP(clusterIP)) {
-			return fmt.Errorf(
-				"it seems that the specified service CIDR (%v) is not correct as it does not match the services in your cluster", k.serviceCIDR)
-		}
-	}
-
-	return nil
-}
-
-// validatePodCIDR validates that the pods in the target cluster matches the provided pod CIDR.
-// This is necessary since k3s does not provide us an API to retrieve the pod CIDR of the cluster. We can
-// only check if the provided one fits the pods IPs (excluding the HostNetwork Pods and the offloaded ones).
-func (k *k3sProvider) validatePodCIDR(ctx context.Context) error {
-	podList, err := k.k8sClient.CoreV1().Pods(v1.NamespaceAll).List(ctx, metav1.ListOptions{
-		LabelSelector: fmt.Sprintf("!%v", consts.LocalPodLabelKey),
-	})
-	if err != nil {
-		return err
-	}
-
-	_, podNet, err := net.ParseCIDR(k.podCIDR)
-	if err != nil {
-		return err
-	}
-
-	for i := range podList.Items {
-		pod := &podList.Items[i]
-		podIP := pod.Status.PodIP
-		if podIP != "" && !pod.Spec.HostNetwork && !podNet.Contains(net.ParseIP(podIP)) {
-			return fmt.Errorf(
-				"it seems that the specified pod CIDR (%v) is not correct as it does not match the pods in your cluster", k.podCIDR)
-		}
-	}
-
-	return nil
-}
-
-func (k *k3sProvider) validateAPIServer() error {
-	apiServerURL, err := url.Parse(k.apiServer)
-	if err != nil {
-		return err
-	}
-
-	hostname := apiServerURL.Hostname()
-	for i := range localhostValues {
-		if hostname == localhostValues[i] {
-			return fmt.Errorf("cannot use localhost (%v) as API Server address, set an external address in your kubeconfig", hostname)
-		}
-	}
-
-	return nil
 }

--- a/pkg/liqoctl/install/kind/provider.go
+++ b/pkg/liqoctl/install/kind/provider.go
@@ -52,8 +52,8 @@ func (k *Kind) UpdateChartValues(values map[string]interface{}) {
 	}
 	values["networkManager"] = map[string]interface{}{
 		"config": map[string]interface{}{
-			"serviceCIDR":     k.ServiceCIDR,
-			"podCIDR":         k.PodCIDR,
+			"serviceCIDR":     k.Kubeadm.ServiceCIDR,
+			"podCIDR":         k.Kubeadm.PodCIDR,
 			"reservedSubnets": installutils.GetInterfaceSlice(k.ReservedSubnets),
 		},
 	}

--- a/pkg/liqoctl/install/kubeadm/types.go
+++ b/pkg/liqoctl/install/kubeadm/types.go
@@ -26,6 +26,9 @@ const (
 	serviceCIDRParameterFilter = `--service-cluster-ip-range`
 	podCIDRParameterFilter     = `--cluster-cidr`
 	kubeSystemNamespaceName    = "kube-system"
+
+	defaultPodCIDR     = "172.16.0.0/16"
+	defaultServiceCIDR = "10.96.0.0/12"
 )
 
 var kubeControllerManagerLabels = map[string]string{"component": "kube-controller-manager", "tier": "control-plane"}

--- a/pkg/liqoctl/install/kubeadm/types.go
+++ b/pkg/liqoctl/install/kubeadm/types.go
@@ -34,9 +34,6 @@ var kubeControllerManagerLabels = map[string]string{"component": "kube-controlle
 // those values.
 type Kubeadm struct {
 	provider.GenericProvider
-	APIServer   string
-	Config      *rest.Config
-	PodCIDR     string
-	ServiceCIDR string
-	K8sClient   kubernetes.Interface
+	Config    *rest.Config
+	K8sClient kubernetes.Interface
 }

--- a/pkg/liqoctl/install/kubeadm/utils.go
+++ b/pkg/liqoctl/install/kubeadm/utils.go
@@ -41,16 +41,11 @@ func retrieveClusterParameters(ctx context.Context, client kubernetes.Interface)
 	}
 
 	command := kubeControllerSpec.Items[0].Spec.Containers[0].Command
-	podCIDR, err = common.ExtractValueFromArgumentList(podCIDRParameterFilter, command)
+	podCIDR = common.ExtractValuesFromArgumentListOrDefault(podCIDRParameterFilter, command, defaultPodCIDR)
 	logsutils.Infof("Extracted podCIDR: %s\n", podCIDR)
-	if err != nil {
-		return "", "", err
-	}
-	serviceCIDR, err = common.ExtractValueFromArgumentList(serviceCIDRParameterFilter, command)
+
+	serviceCIDR = common.ExtractValuesFromArgumentListOrDefault(serviceCIDRParameterFilter, command, defaultServiceCIDR)
 	logsutils.Infof("Extracted serviceCIDR: %s\n", serviceCIDR)
-	if err != nil {
-		return "", "", err
-	}
 
 	return podCIDR, serviceCIDR, nil
 }

--- a/pkg/liqoctl/install/openshift/openshift_test.go
+++ b/pkg/liqoctl/install/openshift/openshift_test.go
@@ -72,8 +72,8 @@ var _ = Describe("Extract elements from OpenShift", func() {
 
 		Expect(p.parseNetworkConfig(networkConfig)).To(Succeed())
 
-		Expect(p.podCIDR).To(Equal(podCidr))
-		Expect(p.serviceCIDR).To(Equal(serviceCidr))
+		Expect(p.PodCIDR).To(Equal(podCidr))
+		Expect(p.ServiceCIDR).To(Equal(serviceCidr))
 	})
 
 })

--- a/pkg/liqoctl/install/provider/args.go
+++ b/pkg/liqoctl/install/provider/args.go
@@ -29,13 +29,14 @@ import (
 )
 
 var providersDefaultMTU = map[string]float64{
-	"kubeadm":   1440,
-	"kind":      1440,
-	"k3s":       1440,
-	"eks":       1440,
-	"gke":       1400,
-	"aks":       1360,
-	"openshift": 1440,
+	GenericProviderName: 1360, // generic provider default MTU
+	"kubeadm":           1440,
+	"kind":              1440,
+	"k3s":               1440,
+	"eks":               1440,
+	"gke":               1400,
+	"aks":               1360,
+	"openshift":         1440,
 }
 
 // CommonArguments encapsulates all the arguments common across install providers.

--- a/pkg/liqoctl/install/provider/generic.go
+++ b/pkg/liqoctl/install/provider/generic.go
@@ -15,21 +15,47 @@
 package provider
 
 import (
+	"context"
 	"fmt"
 	"math/rand"
+	"net"
+	"net/url"
 	"strings"
 
 	"github.com/goombaio/namegenerator"
+	"github.com/spf13/cobra"
 	flag "github.com/spf13/pflag"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 
 	"github.com/liqotech/liqo/pkg/consts"
 	installutils "github.com/liqotech/liqo/pkg/liqoctl/install/utils"
 	argsutils "github.com/liqotech/liqo/pkg/utils/args"
+	logsutils "github.com/liqotech/liqo/pkg/utils/logs"
 )
 
 // Providers list of providers supported by liqoctl.
 var Providers = []string{"kubeadm", "kind", "k3s", "eks", "gke", "aks", "openshift"}
+
+// GenericProviderName is the name of the generic provider.
+const GenericProviderName = ""
+
+var (
+	localhostValues = []string{
+		"localhost",
+		"127.0.0.1",
+	}
+)
+
+const (
+	podCidrFlag     = "pod-cidr"
+	serviceCidrFlag = "service-cidr"
+	apiServerFlag   = "api-server"
+)
 
 // GenericProvider includes the fields and the logic required by every install provider.
 type GenericProvider struct {
@@ -38,6 +64,17 @@ type GenericProvider struct {
 	GenerateClusterName bool
 	ClusterName         string
 	LanDiscovery        *bool
+
+	PodCIDR     string
+	ServiceCIDR string
+	APIServer   string
+	K8sClient   kubernetes.Interface
+	Config      *rest.Config
+}
+
+// NewProvider initializes a new generic provider.
+func NewProvider() InstallProviderInterface {
+	return &GenericProvider{}
 }
 
 // PreValidateGenericCommandArguments validates the flags required by every install provider
@@ -121,6 +158,163 @@ func (p *GenericProvider) PostValidateGenericCommandArguments(oldClusterName str
 	if len(errs) != 0 {
 		p.ClusterName = ""
 		return fmt.Errorf("the cluster name may only contain lowercase letters, numbers and hyphens, and must not be no longer than 63 characters")
+	}
+
+	return nil
+}
+
+// ValidateCommandArguments validates specific arguments passed to the install command.
+func (p *GenericProvider) ValidateCommandArguments(flags *flag.FlagSet) (err error) {
+	p.PodCIDR, err = flags.GetString(podCidrFlag)
+	if err != nil {
+		return err
+	}
+	logsutils.Infof("PodCIDR: %v", p.PodCIDR)
+
+	p.ServiceCIDR, err = flags.GetString(serviceCidrFlag)
+	if err != nil {
+		return err
+	}
+	logsutils.Infof("ServiceCIDR: %v", p.ServiceCIDR)
+
+	p.APIServer, err = flags.GetString(apiServerFlag)
+	if err != nil {
+		return err
+	}
+	if p.APIServer != "" {
+		logsutils.Infof("API Server: %v", p.APIServer)
+	}
+
+	return nil
+}
+
+// ExtractChartParameters fetches the parameters used to customize the Liqo installation on a specific cluster of a
+// given provider.
+func (p *GenericProvider) ExtractChartParameters(ctx context.Context, config *rest.Config, _ *CommonArguments) error {
+	k8sClient, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		fmt.Printf("Unable to create client: %s", err)
+		return err
+	}
+
+	p.K8sClient = k8sClient
+	p.Config = config
+
+	if p.APIServer == "" {
+		p.APIServer = config.Host
+	}
+
+	if err = ValidateAPIServer(p.APIServer); err != nil {
+		return err
+	}
+
+	if err = ValidatePodCIDR(ctx, p.K8sClient, p.PodCIDR); err != nil {
+		return err
+	}
+
+	return ValidateServiceCIDR(ctx, p.K8sClient, p.ServiceCIDR)
+}
+
+// UpdateChartValues patches the values map with the values required for the selected cluster.
+func (p *GenericProvider) UpdateChartValues(values map[string]interface{}) {
+	values["apiServer"] = map[string]interface{}{
+		"address": p.APIServer,
+	}
+	values["networkManager"] = map[string]interface{}{
+		"config": map[string]interface{}{
+			"serviceCIDR":     p.ServiceCIDR,
+			"podCIDR":         p.PodCIDR,
+			"reservedSubnets": installutils.GetInterfaceSlice(p.ReservedSubnets),
+		},
+	}
+	values["discovery"] = map[string]interface{}{
+		"config": map[string]interface{}{
+			"clusterLabels": installutils.GetInterfaceMap(p.ClusterLabels),
+			"clusterName":   p.ClusterName,
+		},
+	}
+}
+
+// GenerateFlags generates the set of specific subpath and flags are accepted for a specific provider.
+func GenerateFlags(command *cobra.Command) {
+	flags := command.Flags()
+
+	flags.String(podCidrFlag, "", "The Pod CIDR for your cluster")
+	flags.String(serviceCidrFlag, "", "The Service CIDR for your cluster")
+	flags.String(apiServerFlag, "", "Your cluster API Server URL")
+
+	utilruntime.Must(command.MarkFlagRequired(podCidrFlag))
+	utilruntime.Must(command.MarkFlagRequired(serviceCidrFlag))
+	utilruntime.Must(command.MarkFlagRequired(apiServerFlag))
+}
+
+// ValidateServiceCIDR validates that the services in the target cluster matches the provided service CIDR.
+// This is necessary for some distributions (for example k3s) do not provide us an API to retrieve
+// the service CIDR of the cluster. We can only check if the provided one fits the services IPs.
+func ValidateServiceCIDR(ctx context.Context, k8sClient kubernetes.Interface, serviceCIDR string) error {
+	svcList, err := k8sClient.CoreV1().Services(v1.NamespaceAll).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	_, svcNet, err := net.ParseCIDR(serviceCIDR)
+	if err != nil {
+		return err
+	}
+
+	for i := range svcList.Items {
+		svc := &svcList.Items[i]
+		clusterIP := svc.Spec.ClusterIP
+		if clusterIP != "None" && clusterIP != "" && !svcNet.Contains(net.ParseIP(clusterIP)) {
+			return fmt.Errorf(
+				"it seems that the specified service CIDR (%v) is not correct as it does not match the services in your cluster", serviceCIDR)
+		}
+	}
+
+	return nil
+}
+
+// ValidatePodCIDR validates that the pods in the target cluster matches the provided pod CIDR.
+// This is necessary for some distributions (for example k3s) do not provide us an API to retrieve
+// the pod CIDR of the cluster. We can only check if the provided one fits the pods IPs
+// (excluding the HostNetwork Pods and the offloaded ones).
+func ValidatePodCIDR(ctx context.Context, k8sClient kubernetes.Interface, podCIDR string) error {
+	podList, err := k8sClient.CoreV1().Pods(v1.NamespaceAll).List(ctx, metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("!%v", consts.LocalPodLabelKey),
+	})
+	if err != nil {
+		return err
+	}
+
+	_, podNet, err := net.ParseCIDR(podCIDR)
+	if err != nil {
+		return err
+	}
+
+	for i := range podList.Items {
+		pod := &podList.Items[i]
+		podIP := pod.Status.PodIP
+		if podIP != "" && !pod.Spec.HostNetwork && !podNet.Contains(net.ParseIP(podIP)) {
+			return fmt.Errorf(
+				"it seems that the specified pod CIDR (%v) is not correct as it does not match the pods in your cluster", podCIDR)
+		}
+	}
+
+	return nil
+}
+
+// ValidateAPIServer validates that the API server URL.
+func ValidateAPIServer(apiServer string) error {
+	apiServerURL, err := url.Parse(apiServer)
+	if err != nil {
+		return err
+	}
+
+	hostname := apiServerURL.Hostname()
+	for i := range localhostValues {
+		if hostname == localhostValues[i] {
+			return fmt.Errorf("cannot use localhost (%v) as API Server address, set an external address in your kubeconfig", hostname)
+		}
 	}
 
 	return nil

--- a/pkg/liqoctl/install/utils.go
+++ b/pkg/liqoctl/install/utils.go
@@ -39,6 +39,8 @@ import (
 
 func getProviderInstance(providerType string) provider.InstallProviderInterface {
 	switch providerType {
+	case provider.GenericProviderName:
+		return provider.NewProvider()
 	case "kubeadm":
 		return kubeadm.NewProvider()
 	case "kind":


### PR DESCRIPTION
# Description

This pr adds a generic install provider for `liqoctl install`. It also includes some other small fixes for the install command.

Fixes #1094 #1019

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] installing manually on kind
- [x] generating a `values.yaml` file to be then installed with helm
