### PR TITLE
Fix liqoctl-status

### DIFF
--- a/pkg/liqoctl/status/pods.go
+++ b/pkg/liqoctl/status/pods.go
@@ -36,9 +36,11 @@ var (
 		"liqo-controller-manager",
 		"liqo-network-manager",
 		"liqo-crd-replicator",
+		"liqo-metric-agent",
 		"liqo-webhook",
 		"liqo-gateway",
 		"liqo-auth",
+		"liqo-proxy",
 	}
 	liqoDaemonSets = []string{
 		"liqo-route",


### PR DESCRIPTION
# Description

`liqoctl status` command checks also the existence of the `liqo-metrics-agent` and `liqo-proxy` deployments.

Fixes #(issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Existing tests

