### PR TITLE
Update Golangci Lint to work with Go 1.18

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,10 +14,10 @@ jobs:
           repository: ${{github.event.pull_request.head.repo.full_name}}
           persist-credentials: false
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2.5.2
+        uses: golangci/golangci-lint-action@v3.1.0
         with:
           only-new-issues: true
-          version: v1.41.1
+          version: v1.45.2
           args: --timeout=600s
 
   gomodtidy:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -38,7 +38,12 @@ linters-settings:
             recommendations:
               - k8s.io/klog/v2
   gci:
-    local-prefixes: github.com/liqotech/liqo
+    sections:
+    - standard                          # Captures all standard packages if they do not match another section.
+    - newLine                           # Prints an empty line.
+    - default                           # Contains all imports that could not be matched to another section type.
+    - newLine                           # Prints an empty line.
+    - prefix(github.com/liqotech/liqo)  # Groups all imports with the specified Prefix.
   goconst:
     min-len: 2
     min-occurrences: 2

--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ fmt: gci addlicense
 # Install golangci-lint if not available
 golangci-lint:
 ifeq (, $(shell which golangci-lint))
-	@go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.43.0
+	@go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.45.2
 GOLANGCILINT=$(GOBIN)/golangci-lint
 else
 GOLANGCILINT=$(shell which golangci-lint)


### PR DESCRIPTION
# Description

This pr updates golangci lint to work with the new go 1.18 features

# How Has This Been Tested?

- [x] locally
