### PR TITLE
Virtual kubelet: introduce support for service account reflection

### DIFF
--- a/pkg/virtualKubelet/forge/configmaps_test.go
+++ b/pkg/virtualKubelet/forge/configmaps_test.go
@@ -79,5 +79,13 @@ var _ = Describe("ConfigMaps Forging", func() {
 			Expect(output.Immutable).NotTo(BeNil())
 			Expect(output.Immutable).To(PointTo(BeTrue()))
 		})
+
+		When("it is the root CA configmap", func() {
+			BeforeEach(func() { input.SetName(forge.RootCAConfigMapName) })
+
+			It("should append a suffix to the name", func() {
+				Expect(output.Name).To(PointTo(HaveSuffix(".local")))
+			})
+		})
 	})
 })

--- a/pkg/virtualKubelet/forge/secrets_test.go
+++ b/pkg/virtualKubelet/forge/secrets_test.go
@@ -71,12 +71,28 @@ var _ = Describe("Secrets Forging", func() {
 		})
 
 		It("should correctly set the type", func() {
-			Expect(*output.Type).To(Equal(corev1.SecretTypeBasicAuth))
+			Expect(output.Type).To(PointTo(Equal(corev1.SecretTypeBasicAuth)))
 		})
 
 		It("should correctly set the immutable field", func() {
 			Expect(output.Immutable).NotTo(BeNil())
 			Expect(output.Immutable).To(PointTo(BeTrue()))
+		})
+
+		When("it is of type ServiceAccountToken", func() {
+			BeforeEach(func() {
+				input.Type = corev1.SecretTypeServiceAccountToken
+				input.Annotations[corev1.ServiceAccountNameKey] = "service-account"
+			})
+
+			It("should change the type to Opaque", func() {
+				Expect(output.Type).To(PointTo(Equal(corev1.SecretTypeOpaque)))
+			})
+
+			It("should add a label with the ServiceAccount name", func() {
+				Expect(output.Labels).To(HaveLen(4)) // Ensure existing labels are not removed
+				Expect(output.Labels).To(HaveKeyWithValue(corev1.ServiceAccountNameKey, "service-account"))
+			})
 		})
 	})
 })

--- a/pkg/virtualKubelet/reflection/configuration/configmap.go
+++ b/pkg/virtualKubelet/reflection/configuration/configmap.go
@@ -18,6 +18,8 @@ import (
 	"context"
 
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	corev1clients "k8s.io/client-go/kubernetes/typed/core/v1"
 	corev1listers "k8s.io/client-go/listers/core/v1"
@@ -34,8 +36,6 @@ import (
 const (
 	// ConfigMapReflectorName is the name associated with the ConfigMap reflector.
 	ConfigMapReflectorName = "ConfigMap"
-
-	rootCAConfigMapName = "kube-root-ca.crt"
 )
 
 // NamespacedConfigMapReflector manages the ConfigMap reflection.
@@ -52,6 +52,14 @@ func NewConfigMapReflector(workers uint) manager.Reflector {
 	return generic.NewReflector(ConfigMapReflectorName, NewNamespacedConfigMapReflector, generic.WithoutFallback(), workers)
 }
 
+// RemoteConfigMapNamespacedKeyer returns a keyer associated with the given namespace,
+// which accounts for the root CA configmap name remapping.
+func RemoteConfigMapNamespacedKeyer(namespace string) func(metadata metav1.Object) types.NamespacedName {
+	return func(metadata metav1.Object) types.NamespacedName {
+		return types.NamespacedName{Namespace: namespace, Name: forge.LocalConfigMapName(metadata.GetName())}
+	}
+}
+
 // NewNamespacedConfigMapReflector returns a function generating NamespacedConfigMapReflector instances.
 func NewNamespacedConfigMapReflector(opts *options.NamespacedOpts) manager.NamespacedReflector {
 	local := opts.LocalFactory.Core().V1().ConfigMaps()
@@ -60,7 +68,7 @@ func NewNamespacedConfigMapReflector(opts *options.NamespacedOpts) manager.Names
 	// Using opts.LocalNamespace for both event handlers so that the object will be put in the same workqueue
 	// no matter the cluster, hence it will be processed by the handle function in the same way.
 	local.Informer().AddEventHandler(opts.HandlerFactory(generic.NamespacedKeyer(opts.LocalNamespace)))
-	remote.Informer().AddEventHandler(opts.HandlerFactory(generic.NamespacedKeyer(opts.LocalNamespace)))
+	remote.Informer().AddEventHandler(opts.HandlerFactory(RemoteConfigMapNamespacedKeyer(opts.LocalNamespace)))
 
 	return &NamespacedConfigMapReflector{
 		NamespacedReflector:    generic.NewNamespacedReflector(opts),
@@ -70,6 +78,11 @@ func NewNamespacedConfigMapReflector(opts *options.NamespacedOpts) manager.Names
 	}
 }
 
+// RemoteRef returns the ObjectRef associated with the remote namespace.
+func (ncr *NamespacedConfigMapReflector) RemoteRef(name string) klog.ObjectRef {
+	return klog.KRef(ncr.RemoteNamespace(), forge.RemoteConfigMapName(name))
+}
+
 // Handle is responsible for reconciling the given object and ensuring it is correctly reflected.
 func (ncr *NamespacedConfigMapReflector) Handle(ctx context.Context, name string) error {
 	tracer := trace.FromContext(ctx)
@@ -77,16 +90,9 @@ func (ncr *NamespacedConfigMapReflector) Handle(ctx context.Context, name string
 	// Retrieve the local and remote objects (only not found errors can occur).
 	klog.V(4).Infof("Handling reflection of local ConfigMap %q (remote: %q)", ncr.LocalRef(name), ncr.RemoteRef(name))
 
-	// Abort the reflection of the root CA configmap. The "IsReflected" check performed below
-	// is not sufficient, since we might be faster than the remote controller-manager.
-	if name == rootCAConfigMapName {
-		klog.Infof("Skipping reflection of local root CA ConfigMap %q as already present remotely", ncr.LocalRef(name))
-		return nil
-	}
-
 	local, lerr := ncr.localConfigMaps.Get(name)
 	utilruntime.Must(client.IgnoreNotFound(lerr))
-	remote, rerr := ncr.remoteConfigMaps.Get(name)
+	remote, rerr := ncr.remoteConfigMaps.Get(forge.RemoteConfigMapName(name))
 	utilruntime.Must(client.IgnoreNotFound(rerr))
 	tracer.Step("Retrieved the local and remote objects")
 
@@ -101,7 +107,7 @@ func (ncr *NamespacedConfigMapReflector) Handle(ctx context.Context, name string
 		defer tracer.Step("Ensured the absence of the remote object")
 		if !kerrors.IsNotFound(rerr) {
 			klog.V(4).Infof("Deleting remote ConfigMap %q, since local %q does no longer exist", ncr.RemoteRef(name), ncr.LocalRef(name))
-			return ncr.DeleteRemote(ctx, ncr.remoteConfigMapsClient, ConfigMapReflectorName, name, remote.GetUID())
+			return ncr.DeleteRemote(ctx, ncr.remoteConfigMapsClient, ConfigMapReflectorName, remote.GetName(), remote.GetUID())
 		}
 
 		klog.V(4).Infof("Local ConfigMap %q and remote ConfigMap %q both vanished", ncr.LocalRef(name), ncr.RemoteRef(name))

--- a/pkg/virtualKubelet/reflection/configuration/configmap_test.go
+++ b/pkg/virtualKubelet/reflection/configuration/configmap_test.go
@@ -185,9 +185,9 @@ var _ = Describe("ConfigMap Reflection", func() {
 			})
 
 			It("should succeed", func() { Expect(err).ToNot(HaveOccurred()) })
-			It("the remote object should not be created", func() {
-				_, err = client.CoreV1().ConfigMaps(RemoteNamespace).Get(ctx, name, metav1.GetOptions{})
-				Expect(err).To(BeNotFound())
+			It("the remapped remote object should be created", func() {
+				_, err = client.CoreV1().ConfigMaps(RemoteNamespace).Get(ctx, forge.RemoteConfigMapName(name), metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
 			})
 		})
 	})

--- a/pkg/virtualKubelet/reflection/configuration/secret.go
+++ b/pkg/virtualKubelet/reflection/configuration/secret.go
@@ -17,7 +17,6 @@ package configuration
 import (
 	"context"
 
-	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	corev1clients "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -81,12 +80,6 @@ func (nsr *NamespacedSecretReflector) Handle(ctx context.Context, name string) e
 	remote, rerr := nsr.remoteSecrets.Get(name)
 	utilruntime.Must(client.IgnoreNotFound(rerr))
 	tracer.Step("Retrieved the local and remote objects")
-
-	// Abort the reflection if the local object is a secret of type "kubernetes.io/service-account-token".
-	if lerr == nil && local.Type == corev1.SecretTypeServiceAccountToken {
-		klog.Infof("Skipping reflection of local Secret %q because of type %s", nsr.LocalRef(name), corev1.SecretTypeServiceAccountToken)
-		return nil
-	}
 
 	// Abort the reflection if the remote object is not managed by us, as we do not want to mutate others' objects.
 	if rerr == nil && !forge.IsReflected(remote) {

--- a/pkg/virtualKubelet/reflection/configuration/secret_test.go
+++ b/pkg/virtualKubelet/reflection/configuration/secret_test.go
@@ -185,9 +185,9 @@ var _ = Describe("Secret Reflection", func() {
 			})
 
 			It("should succeed", func() { Expect(err).ToNot(HaveOccurred()) })
-			It("the remote object should not be created", func() {
-				_, err = client.CoreV1().Secrets(RemoteNamespace).Get(ctx, name, metav1.GetOptions{})
-				Expect(err).To(BeNotFound())
+			It("the remote object should be created, and be of type opaque", func() {
+				remote := GetSecret(RemoteNamespace)
+				Expect(remote.Type).To(Equal(corev1.SecretTypeOpaque))
 			})
 		})
 	})

--- a/pkg/virtualKubelet/reflection/workload/pod.go
+++ b/pkg/virtualKubelet/reflection/workload/pod.go
@@ -109,6 +109,7 @@ func (pr *PodReflector) NewNamespaced(opts *options.NamespacedOpts) manager.Name
 	remote.Informer().AddEventHandler(opts.HandlerFactory(generic.NamespacedKeyer(opts.LocalNamespace)))
 	remoteShadow := opts.RemoteLiqoFactory.Virtualkubelet().V1alpha1().ShadowPods()
 	remoteShadow.Informer().AddEventHandler(opts.HandlerFactory(generic.NamespacedKeyer(opts.LocalNamespace)))
+	remoteSecrets := opts.RemoteFactory.Core().V1().Secrets()
 
 	reflector := &NamespacedPodReflector{
 		NamespacedReflector: generic.NewNamespacedReflector(opts),
@@ -116,6 +117,7 @@ func (pr *PodReflector) NewNamespaced(opts *options.NamespacedOpts) manager.Name
 		localPods:        pr.localPods.Pods(opts.LocalNamespace),
 		remotePods:       remote.Lister().Pods(opts.RemoteNamespace),
 		remoteShadowPods: remoteShadow.Lister().ShadowPods(opts.RemoteNamespace),
+		remoteSecrets:    remoteSecrets.Lister().Secrets(opts.RemoteNamespace),
 
 		localPodsClient:        opts.LocalClient.CoreV1().Pods(opts.LocalNamespace),
 		remotePodsClient:       opts.RemoteClient.CoreV1().Pods(opts.RemoteNamespace),

--- a/pkg/virtualKubelet/reflection/workload/workload_suite_test.go
+++ b/pkg/virtualKubelet/reflection/workload/workload_suite_test.go
@@ -114,3 +114,11 @@ func UpdatePod(client kubernetes.Interface, pod *corev1.Pod) *corev1.Pod {
 	ExpectWithOffset(1, errpod).ToNot(HaveOccurred())
 	return pod
 }
+
+func CreateServiceAccountSecret(client kubernetes.Interface, namespace, name, saName string) *corev1.Secret {
+	secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+		Name: name, Namespace: namespace, Labels: map[string]string{corev1.ServiceAccountNameKey: saName}}}
+	secret, errsecret := client.CoreV1().Secrets(namespace).Create(ctx, secret, metav1.CreateOptions{})
+	ExpectWithOffset(1, errsecret).ToNot(HaveOccurred())
+	return secret
+}


### PR DESCRIPTION
# Description

This PR introduces the initial support for the reflection of the secrets regarding service account tokens, while adapting the corresponding pod volume definition to make it target the correct resources. Still, the transparent communication with the local API server is not yet supported, and it will be introduced in future PRs.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Unit testing (new + existing)
- [x] E2E testing
- [x] Manual testing (kind v1.19 and v1.23)
