### PR TITLE
CRDs: add category to retrieve all liqo resources

### DIFF
--- a/apis/discovery/v1alpha1/foreigncluster_types.go
+++ b/apis/discovery/v1alpha1/foreigncluster_types.go
@@ -187,7 +187,7 @@ type TenantNamespaceType struct {
 }
 
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:resource:scope=Cluster,categories=liqo
 // +kubebuilder:subresource:status
 
 // ForeignCluster is the Schema for the foreignclusters API.

--- a/apis/discovery/v1alpha1/resourcerequest_types.go
+++ b/apis/discovery/v1alpha1/resourcerequest_types.go
@@ -54,6 +54,7 @@ type ResourceRequestStatus struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:resource:categories=liqo
 // +kubebuilder:subresource:status
 
 // ResourceRequest is the Schema for the ResourceRequests API.

--- a/apis/discovery/v1alpha1/searchdomain_types.go
+++ b/apis/discovery/v1alpha1/searchdomain_types.go
@@ -40,7 +40,7 @@ type SearchDomainStatus struct {
 }
 
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:resource:scope=Cluster,categories=liqo
 
 // SearchDomain is the Schema for the SearchDomains API.
 type SearchDomain struct {

--- a/apis/net/v1alpha1/ipamstorage_types.go
+++ b/apis/net/v1alpha1/ipamstorage_types.go
@@ -80,7 +80,7 @@ type IpamSpec struct {
 }
 
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:resource:scope=Cluster,categories=liqo
 
 // IpamStorage is the Schema for the ipams API.
 type IpamStorage struct {

--- a/apis/net/v1alpha1/natmapping_types.go
+++ b/apis/net/v1alpha1/natmapping_types.go
@@ -1,18 +1,16 @@
-/*
-Copyright 2021.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// Copyright 2019-2022 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package v1alpha1
 
@@ -51,7 +49,7 @@ type NatMappingStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
-//+kubebuilder:resource:scope=Cluster
+//+kubebuilder:resource:scope=Cluster,categories=liqo
 
 // NatMapping is the Schema for the natmappings API.
 type NatMapping struct {

--- a/apis/net/v1alpha1/networkconfig_types.go
+++ b/apis/net/v1alpha1/networkconfig_types.go
@@ -62,6 +62,7 @@ type NetworkConfigStatus struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:resource:categories=liqo
 // +kubebuilder:subresource:status
 
 // NetworkConfig is the Schema for the networkconfigs API.

--- a/apis/net/v1alpha1/tunnel_endpoint_types.go
+++ b/apis/net/v1alpha1/tunnel_endpoint_types.go
@@ -91,6 +91,7 @@ const (
 )
 
 // +kubebuilder:object:root=true
+// +kubebuilder:resource:categories=liqo
 // +kubebuilder:subresource:status
 
 // TunnelEndpoint is the Schema for the endpoints API.

--- a/apis/offloading/v1alpha1/namespaceoffloading_types.go
+++ b/apis/offloading/v1alpha1/namespaceoffloading_types.go
@@ -135,7 +135,7 @@ type NamespaceOffloadingStatus struct {
 }
 
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:shortName="nsof"
+// +kubebuilder:resource:shortName="nsof",categories=liqo
 // +kubebuilder:printcolumn:name="NamespaceMappingStrategy",type=string,JSONPath=`.spec.namespaceMappingStrategy`
 // +kubebuilder:printcolumn:name="PodOffloadingStrategy",type=string,JSONPath=`.spec.podOffloadingStrategy`
 // +kubebuilder:printcolumn:name="OffloadingPhase",type=string,JSONPath=`.status.offloadingPhase`

--- a/apis/sharing/v1alpha1/resourceoffer_types.go
+++ b/apis/sharing/v1alpha1/resourceoffer_types.go
@@ -88,7 +88,7 @@ type ResourceOfferStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:shortName="offer"
+// +kubebuilder:resource:shortName="offer",categories=liqo
 
 // ResourceOffer is the Schema for the resourceOffers API.
 // +kubebuilder:printcolumn:name="Status",type=string,JSONPath=`.status.phase`

--- a/apis/virtualkubelet/v1alpha1/namespacemap_types.go
+++ b/apis/virtualkubelet/v1alpha1/namespacemap_types.go
@@ -57,6 +57,7 @@ type NamespaceMapStatus struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:resource:categories=liqo
 // +kubebuilder:subresource:status
 // +genclient
 

--- a/deployments/liqo/crds/discovery.liqo.io_foreignclusters.yaml
+++ b/deployments/liqo/crds/discovery.liqo.io_foreignclusters.yaml
@@ -9,6 +9,8 @@ metadata:
 spec:
   group: discovery.liqo.io
   names:
+    categories:
+    - liqo
     kind: ForeignCluster
     listKind: ForeignClusterList
     plural: foreignclusters

--- a/deployments/liqo/crds/discovery.liqo.io_resourcerequests.yaml
+++ b/deployments/liqo/crds/discovery.liqo.io_resourcerequests.yaml
@@ -9,6 +9,8 @@ metadata:
 spec:
   group: discovery.liqo.io
   names:
+    categories:
+    - liqo
     kind: ResourceRequest
     listKind: ResourceRequestList
     plural: resourcerequests

--- a/deployments/liqo/crds/discovery.liqo.io_searchdomains.yaml
+++ b/deployments/liqo/crds/discovery.liqo.io_searchdomains.yaml
@@ -9,6 +9,8 @@ metadata:
 spec:
   group: discovery.liqo.io
   names:
+    categories:
+    - liqo
     kind: SearchDomain
     listKind: SearchDomainList
     plural: searchdomains

--- a/deployments/liqo/crds/net.liqo.io_ipamstorages.yaml
+++ b/deployments/liqo/crds/net.liqo.io_ipamstorages.yaml
@@ -9,6 +9,8 @@ metadata:
 spec:
   group: net.liqo.io
   names:
+    categories:
+    - liqo
     kind: IpamStorage
     listKind: IpamStorageList
     plural: ipamstorages

--- a/deployments/liqo/crds/net.liqo.io_natmappings.yaml
+++ b/deployments/liqo/crds/net.liqo.io_natmappings.yaml
@@ -9,6 +9,8 @@ metadata:
 spec:
   group: net.liqo.io
   names:
+    categories:
+    - liqo
     kind: NatMapping
     listKind: NatMappingList
     plural: natmappings

--- a/deployments/liqo/crds/net.liqo.io_networkconfigs.yaml
+++ b/deployments/liqo/crds/net.liqo.io_networkconfigs.yaml
@@ -9,6 +9,8 @@ metadata:
 spec:
   group: net.liqo.io
   names:
+    categories:
+    - liqo
     kind: NetworkConfig
     listKind: NetworkConfigList
     plural: networkconfigs

--- a/deployments/liqo/crds/net.liqo.io_tunnelendpoints.yaml
+++ b/deployments/liqo/crds/net.liqo.io_tunnelendpoints.yaml
@@ -9,6 +9,8 @@ metadata:
 spec:
   group: net.liqo.io
   names:
+    categories:
+    - liqo
     kind: TunnelEndpoint
     listKind: TunnelEndpointList
     plural: tunnelendpoints

--- a/deployments/liqo/crds/offloading.liqo.io_namespaceoffloadings.yaml
+++ b/deployments/liqo/crds/offloading.liqo.io_namespaceoffloadings.yaml
@@ -9,6 +9,8 @@ metadata:
 spec:
   group: offloading.liqo.io
   names:
+    categories:
+    - liqo
     kind: NamespaceOffloading
     listKind: NamespaceOffloadingList
     plural: namespaceoffloadings

--- a/deployments/liqo/crds/sharing.liqo.io_resourceoffers.yaml
+++ b/deployments/liqo/crds/sharing.liqo.io_resourceoffers.yaml
@@ -9,6 +9,8 @@ metadata:
 spec:
   group: sharing.liqo.io
   names:
+    categories:
+    - liqo
     kind: ResourceOffer
     listKind: ResourceOfferList
     plural: resourceoffers

--- a/deployments/liqo/crds/virtualkubelet.liqo.io_namespacemaps.yaml
+++ b/deployments/liqo/crds/virtualkubelet.liqo.io_namespacemaps.yaml
@@ -9,6 +9,8 @@ metadata:
 spec:
   group: virtualkubelet.liqo.io
   names:
+    categories:
+    - liqo
     kind: NamespaceMap
     listKind: NamespaceMapList
     plural: namespacemaps


### PR DESCRIPTION
# Description

This PR adds the `liqo` category to (almost) all liqo control-plane CRDs, to allow retrieving all the relevant resources with a single command (`kubectl get liqo -A`). The ShadowPods CRD is not included, given the possibly high cardinality (one per each offloaded pod),

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Manually checking the outcome of `kubectl get liqo -A`
