### PR TITLE
Support offloaded apps interacting with the local API server

### DIFF
--- a/pkg/virtualKubelet/forge/forge.go
+++ b/pkg/virtualKubelet/forge/forge.go
@@ -15,6 +15,7 @@
 package forge
 
 import (
+	"os"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -28,21 +29,33 @@ var (
 	LocalClusterID string
 	// RemoteClusterID -> the cluster ID associated with the remote cluster.
 	RemoteClusterID string
+
 	// LiqoNodeName -> the name of the node associated with the current virtual-kubelet.
 	LiqoNodeName string
 	// LiqoNodeIP -> the local IP of the node associated with the current virtual-kubelet.
 	LiqoNodeIP string
 	// StartTime -> the instant in time the forging logic has been started.
 	StartTime time.Time
+
+	// KubernetesServicePort -> the port of the kubernetes.default service.
+	KubernetesServicePort string
 )
 
 // Init initializes the forging logic.
 func Init(localClusterID, remoteClusterID, nodeName, nodeIP string) {
 	LocalClusterID = localClusterID
 	RemoteClusterID = remoteClusterID
+
 	LiqoNodeName = nodeName
 	LiqoNodeIP = nodeIP
 	StartTime = time.Now().Truncate(time.Second)
+
+	// The kubernetes service port is directly retrieved from the corresponding environment variable,
+	// since it is the one used locally. In case it is not found, it is defaulted to 443.
+	KubernetesServicePort = os.Getenv("KUBERNETES_SERVICE_PORT")
+	if KubernetesServicePort == "" {
+		KubernetesServicePort = "443"
+	}
 }
 
 // ApplyOptions returns the apply options configured for object reflection.

--- a/pkg/virtualKubelet/forge/secrets.go
+++ b/pkg/virtualKubelet/forge/secrets.go
@@ -19,9 +19,6 @@ import (
 	corev1apply "k8s.io/client-go/applyconfigurations/core/v1"
 )
 
-// DefaultServiceAccountName is the name of the default service account.
-const DefaultServiceAccountName = "default"
-
 // RemoteSecret forges the apply patch for the reflected secret, given the local one.
 func RemoteSecret(local *corev1.Secret, targetNamespace string) *corev1apply.SecretApplyConfiguration {
 	applyConfig := corev1apply.Secret(local.GetName(), targetNamespace).

--- a/pkg/virtualKubelet/reflection/workload/podns.go
+++ b/pkg/virtualKubelet/reflection/workload/podns.go
@@ -474,11 +474,6 @@ func (npr *NamespacedPodReflector) RetrieveServiceAccountSecretName(info *PodInf
 		return info.ServiceAccountSecret, nil
 	}
 
-	// The ServiceAccountName field in the pod specifications is optional, and empty means default.
-	if saName == "" {
-		saName = forge.DefaultServiceAccountName
-	}
-
 	saSecretRequirement, err := labels.NewRequirement(string(corev1.ServiceAccountNameKey), selection.Equals, []string{saName})
 	utilruntime.Must(err)
 

--- a/pkg/virtualKubelet/reflection/workload/podns_test.go
+++ b/pkg/virtualKubelet/reflection/workload/podns_test.go
@@ -461,23 +461,13 @@ var _ = Describe("Namespaced Pod Reflection Tests", func() {
 			})
 
 			When("a secret is associated with the given service account", func() {
-				ContextBody := func(serviceAccountName string) func() {
-					return func() {
-						BeforeEach(func() {
-							CreateServiceAccountSecret(client, RemoteNamespace, "secret-name", serviceAccountName)
-							if serviceAccountName == "default" {
-								input = ""
-							}
-						})
+				BeforeEach(func() {
+					CreateServiceAccountSecret(client, RemoteNamespace, "secret-name", "service-account")
+				})
 
-						It("should succeed", func() { Expect(err).ToNot(HaveOccurred()) })
-						It("should return the correct secret name", func() { Expect(output).To(BeIdenticalTo("secret-name")) })
-						It("should correctly update the pod cache", func() { Expect(podinfo.ServiceAccountSecret).To(BeIdenticalTo("secret-name")) })
-					}
-				}
-
-				Context("an explicit service account", ContextBody("service-account"))
-				Context("the default service account", ContextBody("default"))
+				It("should succeed", func() { Expect(err).ToNot(HaveOccurred()) })
+				It("should return the correct secret name", func() { Expect(output).To(BeIdenticalTo("secret-name")) })
+				It("should correctly update the pod cache", func() { Expect(podinfo.ServiceAccountSecret).To(BeIdenticalTo("secret-name")) })
 			})
 		})
 

--- a/pkg/virtualKubelet/reflection/workload/workload_suite_test.go
+++ b/pkg/virtualKubelet/reflection/workload/workload_suite_test.go
@@ -16,6 +16,7 @@ package workload_test
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
@@ -61,10 +62,14 @@ var _ = BeforeSuite(func() {
 
 	testutil.LogsToGinkgoWriter()
 
+	Expect(os.Setenv("KUBERNETES_SERVICE_PORT", "8443")).To(Succeed())
 	forge.Init(LocalClusterID, RemoteClusterID, LiqoNodeName, LiqoNodeIP)
 })
 
-var _ = BeforeEach(func() { ctx, cancel = context.WithCancel(context.Background()) })
+var _ = BeforeEach(func() {
+	Expect(os.Setenv("KUBERNETES_SERVICE_HOST", "10.96.0.1")).To(Succeed())
+	ctx, cancel = context.WithCancel(context.Background())
+})
 var _ = AfterEach(func() { cancel() })
 
 var FakeEventHandler = func(options.Keyer) cache.ResourceEventHandler {

--- a/test/e2e/testutils/apiserver/create.go
+++ b/test/e2e/testutils/apiserver/create.go
@@ -1,0 +1,107 @@
+// Copyright 2019-2022 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apiserver
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	// JobName -> the name of the tester job.
+	JobName = "kubectl"
+
+	containerName      = "kubectl"
+	image              = "bitnami/kubectl"
+	serviceAccountName = "kubectl"
+	clusterRoleName    = "admin"
+)
+
+// CreateKubectlJob creates the offloaded kubectl job to perform a request on the remote API server.
+func CreateKubectlJob(ctx context.Context, cl client.Client, namespace string) error {
+	version := os.Getenv("K8S_VERSION")
+	if version == "" {
+		return errors.New("failed to retrieve kubernetes version from the K8S_VERSION environment variable")
+	}
+
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{Name: JobName, Namespace: namespace},
+		Spec: batchv1.JobSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:  containerName,
+						Image: fmt.Sprintf("%s:%s", image, strings.Replace(version, "v", "", 1)),
+						Args:  []string{"get", "pods", "-n", namespace, "--no-headers", "-o", "custom-columns=:.metadata.name"},
+					}},
+					ServiceAccountName: serviceAccountName,
+					RestartPolicy:      corev1.RestartPolicyNever,
+				},
+			},
+		},
+	}
+
+	return cl.Create(ctx, job)
+}
+
+// RetrieveJobLogs retrieves the logs from the offloaded kubectl pod.
+func RetrieveJobLogs(ctx context.Context, cl kubernetes.Interface, namespace string) (podName, retrieved string, err error) {
+	pods, err := cl.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil || len(pods.Items) != 1 {
+		return "", "", fmt.Errorf("failed to retrieve pods: %w", err)
+	}
+
+	logOpts := corev1.PodLogOptions{
+		Container: containerName,
+	}
+
+	stream, err := cl.CoreV1().Pods(namespace).GetLogs(pods.Items[0].GetName(), &logOpts).Stream(ctx)
+	if err != nil {
+		return "", "", fmt.Errorf("could not get stream from logs request: %w", err)
+	}
+
+	var buffer bytes.Buffer
+	if _, err := buffer.ReadFrom(stream); err != nil {
+		return "", "", fmt.Errorf("could not read from logs stream: %w", err)
+	}
+	return pods.Items[0].GetName(), buffer.String(), nil
+}
+
+// CreateServiceAccount creates the service account leveraged by the kubectl pod.
+func CreateServiceAccount(ctx context.Context, cl client.Client, namespace string) error {
+	sa := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: serviceAccountName, Namespace: namespace}}
+	return cl.Create(ctx, sa)
+}
+
+// CreateRoleBinding creates the role binding granting the appropriate permissions to the service account.
+func CreateRoleBinding(ctx context.Context, cl client.Client, namespace string) error {
+	rb := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: serviceAccountName, Namespace: namespace},
+		RoleRef:    rbacv1.RoleRef{Kind: "ClusterRole", Name: clusterRoleName, APIGroup: rbacv1.GroupName},
+		Subjects:   []rbacv1.Subject{{Kind: rbacv1.ServiceAccountKind, Name: serviceAccountName, Namespace: namespace}},
+	}
+	return cl.Create(ctx, rb)
+}

--- a/test/e2e/testutils/apiserver/doc.go
+++ b/test/e2e/testutils/apiserver/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2019-2022 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package apiserver implements the logic to perform the tests concerning the interaction with the local API server from an offloaded pod.
+package apiserver


### PR DESCRIPTION
# Description

This PR introduces the support to allow offloaded pods to interact with the local API server. This is enabled by the configuration of the appropriate container environment variables to modify the target API server, as well as the introduction of a custom host alias to associate the `kubernetes.default` hostname with the remapped IP allowing to reach the local API server. Such feature enables the support for offloaded operators, as well as for those applications (e.g., HA databases) that require to interact with the API server for synchronization purposes.

Ref #1185

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] Unit testing (new + existing)
- [X] E2E testing (new + existing)
- [X] Manual testing (kind v1.23), offloading both a real operator and a kubectl pod. 
