### PR TITLE
fix liqoctl disconnect race condition

### DIFF
--- a/pkg/liqoctl/disconnect/handler.go
+++ b/pkg/liqoctl/disconnect/handler.go
@@ -113,26 +113,6 @@ func (a *Args) Handler(ctx context.Context) error {
 		return err
 	}
 
-	// Delete foreigncluster of cluster2 in cluster1.
-	if err := cluster1.DeleteForeignCluster(ctx, cluster2.GetClusterID()); err != nil {
-		return err
-	}
-
-	// Delete foreigncluster of cluster1 in cluster2.
-	if err := cluster2.DeleteForeignCluster(ctx, cluster1.GetClusterID()); err != nil {
-		return err
-	}
-
-	// Clean up tenant namespace in cluster 1.
-	if err := cluster1.TearDownTenantNamespace(ctx, cluster2.GetClusterID(), 60*time.Second); err != nil {
-		return err
-	}
-
-	// Clean up tenant namespace in cluster 2.
-	if err := cluster2.TearDownTenantNamespace(ctx, cluster1.GetClusterID(), 60*time.Second); err != nil {
-		return err
-	}
-
 	// Port-forwarding ipam service for cluster 1.
 	if err := cluster1.PortForwardIPAM(ctx); err != nil {
 		return err
@@ -173,5 +153,24 @@ func (a *Args) Handler(ctx context.Context) error {
 	}
 
 	// Unapping auth's ip in cluster2 for cluster1
-	return cluster2.UnmapAuthIPForCluster(ctx, ipamClient2, cluster1.GetClusterID())
+	if err := cluster2.UnmapAuthIPForCluster(ctx, ipamClient2, cluster1.GetClusterID()); err != nil {
+		return err
+	}
+	// Delete foreigncluster of cluster2 in cluster1.
+	if err := cluster1.DeleteForeignCluster(ctx, cluster2.GetClusterID()); err != nil {
+		return err
+	}
+
+	// Delete foreigncluster of cluster1 in cluster2.
+	if err := cluster2.DeleteForeignCluster(ctx, cluster1.GetClusterID()); err != nil {
+		return err
+	}
+
+	// Clean up tenant namespace in cluster 1.
+	if err := cluster1.TearDownTenantNamespace(ctx, cluster2.GetClusterID(), 60*time.Second); err != nil {
+		return err
+	}
+
+	// Clean up tenant namespace in cluster 2.
+	return cluster2.TearDownTenantNamespace(ctx, cluster1.GetClusterID(), 60*time.Second)
 }


### PR DESCRIPTION
# Description

Fix race condition when disconnect two clusters using `liqoctl disconnect`. Removing the networking caused the `natmapping` resource to be deleted. When `unmapping` auth and proxy services an error like 
"_error occurred while unmapping proxy address {10.43.4.204} for cluster {dawn-butterfly}: rpc error: code = Unknown desc = cannot unmap the IP of endpoint 10.43.4.204: NatMapping for cluster 7efeb93b-2bf6-4a0a-ad0b-745848bba366 must be initialized first_" 
is returned.
