### PR TITLE
PVC reflection: add missing filter annotation and fix typo

### DIFF
--- a/pkg/liqo-controller-manager/storageprovisioner/remoteprovisioner.go
+++ b/pkg/liqo-controller-manager/storageprovisioner/remoteprovisioner.go
@@ -116,7 +116,7 @@ func remotePersistentVolumeClaimSpec(virtualPvc *corev1.PersistentVolumeClaim,
 			}
 			return corev1.PersistentVolumeFilesystem
 		}()).
-		WithResources(persistenVolumeClaimResources(virtualPvc.Spec.Resources))
+		WithResources(persistentVolumeClaimResources(virtualPvc.Spec.Resources))
 
 	if storageClass != "" {
 		res.WithStorageClassName(storageClass)
@@ -125,7 +125,7 @@ func remotePersistentVolumeClaimSpec(virtualPvc *corev1.PersistentVolumeClaim,
 	return res
 }
 
-func persistenVolumeClaimResources(resources corev1.ResourceRequirements) *v1apply.ResourceRequirementsApplyConfiguration {
+func persistentVolumeClaimResources(resources corev1.ResourceRequirements) *v1apply.ResourceRequirementsApplyConfiguration {
 	return v1apply.ResourceRequirements().
 		WithLimits(resources.Limits).
 		WithRequests(resources.Requests)
@@ -136,6 +136,7 @@ var controllerAnnotations = []string{
 	"pv.kubernetes.io/bound-by-controller",
 	"volume.beta.kubernetes.io/storage-provisioner",
 	"volume.kubernetes.io/selected-node",
+	corev1.BetaStorageClassAnnotation,
 }
 
 func filterAnnotations(annotations map[string]string) map[string]string {


### PR DESCRIPTION
# Description

This PR fixes a bug in the PVC reflection logic, adding the `volume.beta.kubernetes.io/storage-class` annotation to the filter list in order to prevent the propagation of the incorrect storage class name. In addition, it fixes a typo in a method name.

Fixes #(issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] Manually, on kind (v1.23)

