### PR TITLE
Liqoctl status: client refactor

### DIFF
--- a/apis/net/v1alpha1/tunnel_endpoint_types.go
+++ b/apis/net/v1alpha1/tunnel_endpoint_types.go
@@ -21,6 +21,9 @@ import (
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
+// ResourceTunnelEndpoints the name of the tunnelendpoint resources.
+var ResourceTunnelEndpoints = "tunnelendpoints"
+
 // TunnelEndpointSpec defines the desired state of TunnelEndpoint.
 type TunnelEndpointSpec struct {
 	// The ID of the remote cluster.

--- a/cmd/liqoctl/cmd/status.go
+++ b/cmd/liqoctl/cmd/status.go
@@ -35,9 +35,10 @@ func newStatusCommand(ctx context.Context) *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVarP(&params.Namespace, status.Namespace, "n", "liqo", "Namespace Liqo is running in")
-	params.ClusterNameFilter = cmd.Flags().StringSliceP("cluster-name", "N", []string{},
+	cmd.Flags().BoolVarP(&params.ShowOnlyLocal, status.ShowOnlyLocal, "l", false, "Shows only local cluster information")
+	params.ClusterNameFilter = cmd.Flags().StringSliceP(status.ClusterNameFilter, "N", []string{},
 		"show info about clusters specified by name, you can specify more than one cluster separating names with ',' character")
-	params.ClusterIDFilter = cmd.Flags().StringSliceP("cluster-id", "I", []string{},
+	params.ClusterIDFilter = cmd.Flags().StringSliceP(status.ClusterIDFilter, "I", []string{},
 		"show info about clusters specified by ID, you can specify more than one cluster separating IDs with ',' character")
 	return cmd
 }

--- a/cmd/liqoctl/cmd/status.go
+++ b/cmd/liqoctl/cmd/status.go
@@ -35,5 +35,9 @@ func newStatusCommand(ctx context.Context) *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVarP(&params.Namespace, status.Namespace, "n", "liqo", "Namespace Liqo is running in")
+	params.ClusterNameFilter = cmd.Flags().StringSliceP("cluster-name", "N", []string{},
+		"show info about clusters specified by name, you can specify more than one cluster separating names with ',' character")
+	params.ClusterIDFilter = cmd.Flags().StringSliceP("cluster-id", "I", []string{},
+		"show info about clusters specified by ID, you can specify more than one cluster separating IDs with ',' character")
 	return cmd
 }

--- a/cmd/liqoctl/main.go
+++ b/cmd/liqoctl/main.go
@@ -25,6 +25,7 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
 	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
+	netv1alpha1 "github.com/liqotech/liqo/apis/net/v1alpha1"
 	offloadingv1alpha1 "github.com/liqotech/liqo/apis/offloading/v1alpha1"
 	liqocmd "github.com/liqotech/liqo/cmd/liqoctl/cmd"
 )
@@ -36,6 +37,7 @@ const (
 func init() {
 	_ = discoveryv1alpha1.AddToScheme(scheme.Scheme)
 	_ = offloadingv1alpha1.AddToScheme(scheme.Scheme)
+	_ = netv1alpha1.AddToScheme(scheme.Scheme)
 }
 
 func main() {

--- a/liqo-cluster-config.yaml
+++ b/liqo-cluster-config.yaml
@@ -1,0 +1,8 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+networking:
+  serviceSubnet: "10.90.0.0/12"
+  podSubnet: "10.200.0.0/16"
+nodes:
+  - role: control-plane
+    image: kindest/node:v1.21.1

--- a/pkg/consts/labels.go
+++ b/pkg/consts/labels.go
@@ -35,6 +35,9 @@ const (
 	// NetworkManagerAppName label value that denotes the name of the liqo-network-manager deployment.
 	NetworkManagerAppName = "network-manager"
 
+	// ControllerManagerAppName label value that denotes the name of the liqo-controller-manager deployment.
+	ControllerManagerAppName = "controller-manager"
+
 	// APIServerProxyAppName label value that denotes the name of the liqo-api-server-proxy deployment.
 	APIServerProxyAppName = "proxy"
 	// NatMappingResourceLabelKey is the constant representing

--- a/pkg/liqoctl/common/liqohelm.go
+++ b/pkg/liqoctl/common/liqohelm.go
@@ -1,0 +1,65 @@
+// Copyright 2019-2022 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"log"
+	"os"
+
+	"helm.sh/helm/v3/pkg/action"
+	"helm.sh/helm/v3/pkg/cli"
+
+	installutils "github.com/liqotech/liqo/pkg/liqoctl/install/utils"
+)
+
+// LiqoHelmClient is a wrapper around the Helm client.
+type LiqoHelmClient struct {
+	release   string
+	getValues func() (map[string]interface{}, error)
+}
+
+// NewLiqoHelmClient creates a new instance of LiqoHelmClient.
+func NewLiqoHelmClient() (*LiqoHelmClient, error) {
+	lhc := &LiqoHelmClient{release: installutils.LiqoReleaseName}
+	settings := cli.New()
+	clientConfig := &action.Configuration{}
+	helmdriver := os.Getenv("HELM_DRIVER")
+	err := clientConfig.Init(settings.RESTClientGetter(), installutils.LiqoNamespace, helmdriver, log.Printf)
+	if err != nil {
+		return nil, err
+	}
+	lhc.getValues = func() (map[string]interface{}, error) { return action.NewGetValues(clientConfig).Run(lhc.release) }
+	return lhc, nil
+}
+
+// GetClusterLabels returns a map of cluster labels.
+func (lhc *LiqoHelmClient) GetClusterLabels() (map[string]string, error) {
+	values, err := lhc.getValues()
+	if err != nil {
+		return nil, err
+	}
+
+	result, err := ExtractValuesFromNestedMaps(values, "discovery", "config", "clusterLabels")
+	if err != nil {
+		return nil, err
+	}
+
+	clusterLabels := make(map[string]string)
+	tmp := result.(map[string]interface{})
+	for k, v := range tmp {
+		clusterLabels[k] = v.(string)
+	}
+	return clusterLabels, nil
+}

--- a/pkg/liqoctl/common/liqohelm_test.go
+++ b/pkg/liqoctl/common/liqohelm_test.go
@@ -1,0 +1,55 @@
+// Copyright 2019-2022 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("LiqoHelm", func() {
+	var (
+		lhc                         *LiqoHelmClient
+		expectedRelease             = "liqo"
+		expectedClusterLabels       = map[string]interface{}{"label1": "value1", "label2": "value2", "label3": "value3"}
+		expectedClusterLabelsString = map[string]string{"label1": "value1", "label2": "value2", "label3": "value3"}
+		clusterLabels               map[string]string
+	)
+	Context("Creating a new LiqoHelmClient", func() {
+		BeforeEach(func() {
+			lhc = &LiqoHelmClient{
+				release: expectedRelease,
+				getValues: func() (map[string]interface{}, error) {
+					return map[string]interface{}{
+						"discovery": map[string]interface{}{
+							"config": map[string]interface{}{
+								"clusterLabels": expectedClusterLabels,
+							},
+						},
+					}, nil
+				},
+			}
+		})
+		JustBeforeEach(func() {
+			clusterLabels, _ = lhc.GetClusterLabels()
+		})
+		It("should contain a valid release", func() {
+			Expect(expectedRelease).To(Equal(lhc.release))
+		})
+		It("should return cluster labels", func() {
+			Expect(expectedClusterLabelsString).To(Equal(clusterLabels))
+		})
+	})
+})

--- a/pkg/liqoctl/install/install_test.go
+++ b/pkg/liqoctl/install/install_test.go
@@ -15,7 +15,6 @@
 package install
 
 import (
-	"fmt"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
@@ -23,42 +22,10 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/spf13/cobra"
 
+	"github.com/liqotech/liqo/pkg/liqoctl/common"
 	installutils "github.com/liqotech/liqo/pkg/liqoctl/install/utils"
 	argsutils "github.com/liqotech/liqo/pkg/utils/args"
 )
-
-// This recursive function takes a map and a list of keys and visits a tree of nested maps
-// using the keys in the order provided. At each iteration, if the number of non-visited keys
-// is 1, the function returns the value associated to the last key, else if it is greater
-// than 1, the function expects the value to be a map and a new recursive iteration happens.
-// In case the key is not found, an empty string is returned.
-// In case no keys are provided, an error is returned.
-// Example:
-// 		m := map[string]interface{}{
-//			"first": map[string]interface{}{
-// 				"second": map[string]interface{}{
-// 					"third": "value",
-// 				},
-// 			},
-// 		}
-// 		ValueFor(m, "first", "second", "third") // returns "value", nil
-// 		ValueFor(m, "first", "second") // returns map[string]interface{}{ "third": "value" }, nil
-// 		ValueFor(m, "first", "third") // returns "", nil
-// 		ValueFor(m) // returns nil, "At least one key is required"
-func ValueFor(m map[string]interface{}, keys ...string) (val interface{}, err error) {
-	var ok bool
-	if len(keys) == 0 {
-		return nil, fmt.Errorf("At least one key is required")
-	} else if val, ok = m[keys[0]]; !ok {
-		return "", nil
-	} else if len(keys) == 1 {
-		return val, nil
-	} else if m, ok = val.(map[string]interface{}); !ok {
-		return nil, fmt.Errorf("The value for key %s is not map (expected to be a map)", keys[0])
-	} else {
-		return ValueFor(m, keys[1:]...)
-	}
-}
 
 func TestInstallCommand(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -143,13 +110,13 @@ var _ = Describe("Test the install command works as expected", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// Test values over expected ones
-			Expect(ValueFor(values, "discovery", "config", "clusterLabels", "liqo.io/provider")).To(Equal(tc.providerValue))
-			Expect(ValueFor(values, "discovery", "config", "clusterName")).To(Equal(tc.clusterNameValue))
-			Expect(ValueFor(values, "discovery", "config", "clusterLabels", "topology.liqo.io/region")).To(Equal(tc.regionValue))
-			Expect(ValueFor(values, "discovery", "config", "clusterLabels", "liqo.io/my-label")).To(Equal(tc.customLabelValue))
-			Expect(ValueFor(values, "discovery", "config", "enableAdvertisement")).To(Equal(tc.enableAdvertisementValue))
-			Expect(ValueFor(values, "discovery", "config", "enableDiscovery")).To(Equal(tc.enableDiscoveryValue))
-			Expect(ValueFor(values, "networkManager", "config", "reservedSubnets")).To(Equal(tc.reservedSubnetsValue))
+			Expect(common.ExtractValuesFromNestedMaps(values, "discovery", "config", "clusterLabels", "liqo.io/provider")).To(Equal(tc.providerValue))
+			Expect(common.ExtractValuesFromNestedMaps(values, "discovery", "config", "clusterName")).To(Equal(tc.clusterNameValue))
+			Expect(common.ExtractValuesFromNestedMaps(values, "discovery", "config", "clusterLabels", "topology.liqo.io/region")).To(Equal(tc.regionValue))
+			Expect(common.ExtractValuesFromNestedMaps(values, "discovery", "config", "clusterLabels", "liqo.io/my-label")).To(Equal(tc.customLabelValue))
+			Expect(common.ExtractValuesFromNestedMaps(values, "discovery", "config", "enableAdvertisement")).To(Equal(tc.enableAdvertisementValue))
+			Expect(common.ExtractValuesFromNestedMaps(values, "discovery", "config", "enableDiscovery")).To(Equal(tc.enableDiscoveryValue))
+			Expect(common.ExtractValuesFromNestedMaps(values, "networkManager", "config", "reservedSubnets")).To(Equal(tc.reservedSubnetsValue))
 		},
 		Entry("Install Kind cluster with default parameters", testCase{
 			"kind",

--- a/pkg/liqoctl/status/common.go
+++ b/pkg/liqoctl/status/common.go
@@ -25,8 +25,14 @@ func newTabWriter(checkerName string) (*tabwriter.Writer, *bytes.Buffer) {
 	var buf bytes.Buffer
 	w := tabwriter.NewWriter(&buf, 0, 0, 4, ' ', 0)
 
-	separator := strings.Repeat("-", len(checkerName))
-	fmt.Fprintf(w, "%s\n", checkerName)
-	fmt.Fprintf(w, "%s\n", separator)
+	if len(checkerName) > 0 {
+		separator := newSeparator(checkerName)
+		fmt.Fprintf(w, "%s%s%s\n", bpurple, checkerName, reset)
+		fmt.Fprintf(w, "%s\n", separator)
+	}
 	return w, &buf
+}
+
+func newSeparator(checkerName string) string {
+	return strings.Repeat("-", len(checkerName))
 }

--- a/pkg/liqoctl/status/consts.go
+++ b/pkg/liqoctl/status/consts.go
@@ -36,8 +36,12 @@ $ liqoctl status --namespace ns-where-Liqo-is-running
 	redCross  = "\u274c"
 	checkMark = "\u2714"
 
-	red    = "\033[31m"
-	yellow = "\033[33m"
-	green  = "\033[32m"
-	reset  = "\033[0m"
+	reset = "\033[0m"
+
+	red     = "\033[0;31m"
+	green   = "\033[0;32m"
+	yellow  = "\033[0;33m"
+	byellow = "\033[1;33m"
+	bpurple = "\033[1;35m"
+	bcyan   = "\033[1;36m"
 )

--- a/pkg/liqoctl/status/consts.go
+++ b/pkg/liqoctl/status/consts.go
@@ -33,6 +33,15 @@ $ liqoctl status --namespace ns-where-Liqo-is-running
 	// Namespace contains the name of namespace flag.
 	Namespace = "namespace"
 
+	// ClusterNameFilter contains the name of the cluster name filter flag.
+	ClusterNameFilter = "cluster-name"
+
+	// ClusterIDFilter contains the name of the cluster ID filter flag.
+	ClusterIDFilter = "cluster-id"
+
+	// ShowOnlyLocal contains the name of the show only local flag.
+	ShowOnlyLocal = "show-only-local"
+
 	redCross  = "\u274c"
 	checkMark = "\u2714"
 

--- a/pkg/liqoctl/status/handler.go
+++ b/pkg/liqoctl/status/handler.go
@@ -18,13 +18,17 @@ import (
 	"context"
 
 	k8s "k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/liqotech/liqo/pkg/liqoctl/common"
 )
 
 // Args flags of the status command.
 type Args struct {
-	Namespace string
+	Namespace         string
+	ClusterNameFilter *[]string
+	ClusterIDFilter   *[]string
+	CheckerSelector   *[]string
 }
 
 // Handler implements the logic of the status command.
@@ -39,7 +43,12 @@ func (a *Args) Handler(ctx context.Context) error {
 		return err
 	}
 
-	collector := newK8sStatusCollector(clientSet, *a)
+	clientCRT, err := client.New(restConfig, client.Options{})
+	if err != nil {
+		return err
+	}
+
+	collector := newK8sStatusCollector(ctx, clientSet, clientCRT, *a)
 
 	return collector.collectStatus(ctx)
 }

--- a/pkg/liqoctl/status/handler.go
+++ b/pkg/liqoctl/status/handler.go
@@ -25,6 +25,7 @@ import (
 
 // Args flags of the status command.
 type Args struct {
+	ShowOnlyLocal     bool
 	Namespace         string
 	ClusterNameFilter *[]string
 	ClusterIDFilter   *[]string

--- a/pkg/liqoctl/status/handler.go
+++ b/pkg/liqoctl/status/handler.go
@@ -17,7 +17,6 @@ package status
 import (
 	"context"
 
-	k8s "k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/liqotech/liqo/pkg/liqoctl/common"
@@ -39,17 +38,12 @@ func (a *Args) Handler(ctx context.Context) error {
 		return err
 	}
 
-	clientSet, err := k8s.NewForConfig(restConfig)
+	client, err := client.New(restConfig, client.Options{})
 	if err != nil {
 		return err
 	}
 
-	clientCRT, err := client.New(restConfig, client.Options{})
-	if err != nil {
-		return err
-	}
-
-	collector := newK8sStatusCollector(ctx, clientSet, clientCRT, *a)
+	collector := newK8sStatusCollector(ctx, client, *a)
 
 	return collector.collectStatus(ctx)
 }

--- a/pkg/liqoctl/status/info.go
+++ b/pkg/liqoctl/status/info.go
@@ -1,0 +1,134 @@
+// Copyright 2019-2022 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package status
+
+import (
+	"fmt"
+	"strings"
+)
+
+// InfoData implements the InfoInterface interface.
+// holds information about a field using a key/value pair.
+type InfoData struct {
+	key   string
+	value []string
+}
+
+// StringIndented return the  String() output but with indentation.
+func (id *InfoData) StringIndented(indent int) string {
+	indentation := strings.Repeat("\t", indent+1)
+	if len(id.value) == 1 {
+		return fmt.Sprintf("%s: %s%s%s", id.key, byellow, id.value[0], reset)
+	}
+	msg := fmt.Sprintf("%s:", id.key)
+	for _, v := range id.value {
+		msg += fmt.Sprintf("\n%s- %s%s%s", indentation, byellow, v, reset)
+	}
+	return msg
+}
+
+// StringNoColor return the  String() output but without colors.
+func (id *InfoData) StringNoColor() string {
+	return fmt.Sprintf("%s: %s", id.key, id.value)
+}
+
+// InfoNode is a node used to link objects implementing InfoInterface in a tree data-structure.
+type InfoNode struct {
+	title, detail string
+	nextNodes     []*InfoNode
+	data          []InfoData
+}
+
+func (in *InfoNode) String() string {
+	if in.detail != "" {
+		return fmt.Sprintf("%s%s%s %s[%s]%s", bpurple, in.title, reset, bcyan, in.detail, reset)
+	}
+	return fmt.Sprintf("%s%s%s", bpurple, in.title, reset)
+}
+
+// StringNoColor return the  String() output but without colors.
+func (in *InfoNode) StringNoColor() string {
+	if in.detail != "" {
+		return fmt.Sprintf("%s [%s]", in.title, in.detail)
+	}
+	return in.title
+}
+
+// newRootInfoNode init first InfoLayer inserting a InfoSection.
+func newRootInfoNode(sectionTitle string) InfoNode {
+	return InfoNode{
+		title: sectionTitle,
+	}
+}
+
+// deepPrintInfo print all InfoNode recursively.
+// It is a deepPrintInfoRecursive.
+func deepPrintInfo(in *InfoNode) string {
+	var msg string
+	deepPrintInfoRecursive(in, &msg, 0)
+	return msg
+}
+
+// deepPrintInfoRecursve print all InfoNode recursively.
+func deepPrintInfoRecursive(in *InfoNode, msg *string, nodeLevel int) {
+	indentation := strings.Repeat("\t", nodeLevel)
+
+	if nodeLevel > 0 {
+		*msg += fmt.Sprintf("%s%s\n", indentation, in.String())
+	} else {
+		*msg += fmt.Sprintf("%s\n%s\n", in.String(), newSeparator(in.StringNoColor()))
+	}
+
+	for i := range in.data {
+		*msg += fmt.Sprintf("\t%s%s\n", indentation, in.data[i].StringIndented(nodeLevel+1))
+	}
+	for i := range in.nextNodes {
+		deepPrintInfoRecursive(in.nextNodes[i], msg, nodeLevel+1)
+	}
+}
+
+// addDataToNode create a new InfoNode and add a new InfoData.
+func (in *InfoNode) addDataToNode(key, value string) {
+	in.data = append(in.data, InfoData{
+		key: key, value: []string{value},
+	})
+}
+
+//	addDataListToNode create a new InfoNode and add a new InfoData.
+func (in *InfoNode) addDataListToNode(key string, value []string) {
+	in.data = append(in.data, InfoData{
+		key: key, value: value,
+	})
+}
+
+// addSectionToNode create a new InfoNode and add a new InfoSection.
+func (in *InfoNode) addSectionToNode(sectionTitle, detail string) *InfoNode {
+	in.nextNodes = append(in.nextNodes, &InfoNode{
+		title:  sectionTitle,
+		detail: detail,
+		data:   []InfoData{},
+	})
+	return in.nextNodes[len(in.nextNodes)-1]
+}
+
+// findNodeByTitle returns the info node with the given title.
+func findNodeByTitle(infoNodes []*InfoNode, title string) *InfoNode {
+	for i := range infoNodes {
+		if infoNodes[i].title == title {
+			return infoNodes[i]
+		}
+	}
+	return nil
+}

--- a/pkg/liqoctl/status/info_test.go
+++ b/pkg/liqoctl/status/info_test.go
@@ -1,0 +1,132 @@
+// Copyright 2019-2022 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package status
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Info", func() {
+	var (
+		infoNode InfoNode
+	)
+	Context("Creating a new root InfoNode", func() {
+		JustBeforeEach(func() {
+			infoNode = newRootInfoNode("root")
+		})
+		It("should return a valid InfoNode", func() {
+			infoNodeTest := InfoNode{
+				title:     "root",
+				detail:    "",
+				nextNodes: nil,
+				data:      nil,
+			}
+			Expect(infoNode).To(Equal(infoNodeTest))
+		})
+	})
+	Context("Populating a root node with some sections", func() {
+		JustBeforeEach(func() {
+			infoNode = newRootInfoNode("root")
+			infoNode.addSectionToNode("section1", "detail1").
+				addSectionToNode("section1-1", "detail1-1")
+			infoNode.addSectionToNode("section2", "detail2").
+				addSectionToNode("section2-1", "detail2-1")
+		})
+		It("should return a valid InfoNode tree", func() {
+			Expect(infoNode.title).To(Equal("root"))
+			Expect(infoNode.nextNodes[0].title).To(Equal("section1"))
+			Expect(infoNode.nextNodes[0].detail).To(Equal("detail1"))
+			Expect(infoNode.nextNodes[0].nextNodes[0].title).To(Equal("section1-1"))
+			Expect(infoNode.nextNodes[0].nextNodes[0].detail).To(Equal("detail1-1"))
+			Expect(infoNode.nextNodes[1].title).To(Equal("section2"))
+			Expect(infoNode.nextNodes[1].detail).To(Equal("detail2"))
+			Expect(infoNode.nextNodes[1].nextNodes[0].title).To(Equal("section2-1"))
+			Expect(infoNode.nextNodes[1].nextNodes[0].detail).To(Equal("detail2-1"))
+		})
+	})
+	Context("Populating a root node with some data", func() {
+		JustBeforeEach(func() {
+			infoNode = newRootInfoNode("root")
+			infoNode.addDataToNode("key1", "value1")
+			infoNode.addDataToNode("key2", "value2")
+			infoNode.addDataToNode("key3", "value3")
+		})
+		It("should return a valid InfoNode tree", func() {
+			Expect(infoNode.title).To(Equal("root"))
+			Expect(infoNode.data[0].key).To(Equal("key1"))
+			Expect(infoNode.data[0].value[0]).To(Equal("value1"))
+			Expect(infoNode.data[1].key).To(Equal("key2"))
+			Expect(infoNode.data[1].value[0]).To(Equal("value2"))
+			Expect(infoNode.data[2].key).To(Equal("key3"))
+			Expect(infoNode.data[2].value[0]).To(Equal("value3"))
+		})
+	})
+	Context("Populating a root node with some data and sections", func() {
+		JustBeforeEach(func() {
+			infoNode = newRootInfoNode("root")
+			section1 := infoNode.addSectionToNode("section1", "detail1")
+			section2 := infoNode.addSectionToNode("section2", "detail2")
+			section3 := section2.addSectionToNode("section3", "detail3")
+			section1.addDataToNode("key1", "value1")
+			section1.addDataToNode("key2", "value2")
+			section1.addDataToNode("key3", "value3")
+			section3.addDataToNode("key1", "value1")
+			section3.addDataToNode("key2", "value2")
+			section3.addDataToNode("key3", "value3")
+		})
+		It("should return a valid InfoNode tree", func() {
+			Expect(infoNode.title).To(Equal("root"))
+			Expect(infoNode.nextNodes[0].title).To(Equal("section1"))
+			Expect(infoNode.nextNodes[1].title).To(Equal("section2"))
+			Expect(infoNode.nextNodes[1].nextNodes[0].title).To(Equal("section3"))
+
+			Expect(infoNode.nextNodes[0].data[0].value[0]).To(Equal("value1"))
+			Expect(infoNode.nextNodes[0].data[1].value[0]).To(Equal("value2"))
+			Expect(infoNode.nextNodes[0].data[2].value[0]).To(Equal("value3"))
+			Expect(infoNode.nextNodes[1].nextNodes[0].data[0].value[0]).To(Equal("value1"))
+			Expect(infoNode.nextNodes[1].nextNodes[0].data[1].value[0]).To(Equal("value2"))
+			Expect(infoNode.nextNodes[1].nextNodes[0].data[2].value[0]).To(Equal("value3"))
+		})
+	})
+	Context("Checking if a title is contained between the next nodes", func() {
+		var (
+			node1, node2, node3 *InfoNode
+		)
+		When("the title is contained", func() {
+			JustBeforeEach(func() {
+				infoNode = newRootInfoNode("root")
+				node1 = infoNode.addSectionToNode("section1", "detail1")
+				node2 = infoNode.addSectionToNode("section2", "detail2")
+				node3 = infoNode.addSectionToNode("section3", "detail3")
+			})
+			It("should return True", func() {
+				Expect(findNodeByTitle(infoNode.nextNodes, "section1")).To(Equal(node1))
+				Expect(findNodeByTitle(infoNode.nextNodes, "section2")).To(Equal(node2))
+				Expect(findNodeByTitle(infoNode.nextNodes, "section3")).To(Equal(node3))
+			})
+		})
+		When("the title is not contained", func() {
+
+			JustBeforeEach(func() {
+				infoNode = newRootInfoNode("root")
+				infoNode.addSectionToNode("section1", "detail1")
+			})
+			It("should return False", func() {
+				Expect(findNodeByTitle(infoNode.nextNodes, "section2")).To(BeNil())
+			})
+		})
+	})
+})

--- a/pkg/liqoctl/status/k8s.go
+++ b/pkg/liqoctl/status/k8s.go
@@ -40,7 +40,7 @@ func newK8sStatusCollector(ctx context.Context, client k8s.Interface, clientCRT 
 		newLocalInfoChecker(params.Namespace, clientCRT),
 	}
 	_, err := getters.GetForeignClustersByLabel(ctx, clientCRT, params.Namespace, labels.NewSelector())
-	if err == nil {
+	if err == nil && !params.ShowOnlyLocal {
 		checkers = append(checkers, newRemoteInfoChecker(params.Namespace, params.ClusterNameFilter, params.ClusterIDFilter, clientCRT))
 	}
 	return &k8sStatusCollector{

--- a/pkg/liqoctl/status/k8s.go
+++ b/pkg/liqoctl/status/k8s.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/labels"
-	k8s "k8s.io/client-go/kubernetes"
 	clientControllerRuntime "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/liqotech/liqo/pkg/utils/getters"
@@ -33,18 +32,18 @@ type k8sStatusCollector struct {
 }
 
 // newK8sStatusCollector returns a new k8sStatusCollector.
-func newK8sStatusCollector(ctx context.Context, client k8s.Interface, clientCRT clientControllerRuntime.Client, params Args) *k8sStatusCollector {
+func newK8sStatusCollector(ctx context.Context, client clientControllerRuntime.Client, params Args) *k8sStatusCollector {
 	checkers := []Checker{
 		newNamespaceChecker(params.Namespace, client),
 		newPodChecker(params.Namespace, liqoDeployments, liqoDaemonSets, client),
-		newLocalInfoChecker(params.Namespace, clientCRT),
+		newLocalInfoChecker(params.Namespace, client),
 	}
-	_, err := getters.GetForeignClustersByLabel(ctx, clientCRT, params.Namespace, labels.NewSelector())
+	_, err := getters.GetForeignClustersByLabel(ctx, client, params.Namespace, labels.NewSelector())
 	if err == nil && !params.ShowOnlyLocal {
-		checkers = append(checkers, newRemoteInfoChecker(params.Namespace, params.ClusterNameFilter, params.ClusterIDFilter, clientCRT))
+		checkers = append(checkers, newRemoteInfoChecker(params.Namespace, params.ClusterNameFilter, params.ClusterIDFilter, client))
 	}
 	return &k8sStatusCollector{
-		clientCRT: clientCRT,
+		clientCRT: client,
 		params:    params,
 		checkers:  checkers,
 	}

--- a/pkg/liqoctl/status/localinfo.go
+++ b/pkg/liqoctl/status/localinfo.go
@@ -1,0 +1,152 @@
+// Copyright 2019-2022 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package status
+
+import (
+	"context"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	controllerRuntimeClient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/liqotech/liqo/apis/discovery/v1alpha1"
+	"github.com/liqotech/liqo/pkg/liqoctl/common"
+	"github.com/liqotech/liqo/pkg/utils/getters"
+	liqolabels "github.com/liqotech/liqo/pkg/utils/labels"
+)
+
+// LocalInfoChecker implements the Check interface.
+// holds the Localinformation about the cluster.
+type LocalInfoChecker struct {
+	client            controllerRuntimeClient.Client
+	namespace         string
+	errors            bool
+	rootLocalInfoNode InfoNode
+	collectionErrors  []collectionError
+}
+
+// newPodChecker return a new pod checker.
+func newLocalInfoChecker(namespace string, client controllerRuntimeClient.Client) *LocalInfoChecker {
+	return &LocalInfoChecker{
+		client:            client,
+		namespace:         namespace,
+		errors:            false,
+		rootLocalInfoNode: newRootInfoNode("Local Cluster Informations"),
+	}
+}
+
+func getLocalClusterIdentity(ctx context.Context, client controllerRuntimeClient.Client, namespace string) (*v1alpha1.ClusterIdentity, error) {
+	selector, err := metav1.LabelSelectorAsSelector(&liqolabels.ClusterIDConfigMapLabelSelector)
+	if err != nil {
+		return nil, fmt.Errorf("unable to collect Selector from LabelSelector: %w", err)
+	}
+	configMap, err := getters.GetConfigMapByLabel(ctx, client, namespace, selector)
+	if err != nil {
+		return nil, fmt.Errorf("unable to collect ConfigMap using Selector: %w", err)
+	}
+	clusterIdentity, err := getters.RetrieveClusterIDFromConfigMap(configMap)
+	if err != nil {
+		return nil, fmt.Errorf("unable to collect ClusterIdentity using ConfigMap: %w", err)
+	}
+	return clusterIdentity, nil
+}
+
+func getLocalNetworkConfig(ctx context.Context, client controllerRuntimeClient.Client) (*getters.NetworkConfig, error) {
+	selector, err := metav1.LabelSelectorAsSelector(&liqolabels.IPAMStorageLabelSelector)
+	if err != nil {
+		return nil, fmt.Errorf("unable to collect Selector using LabelSelector: %w", err)
+	}
+	ipamStorage, err := getters.GetIPAMStorageByLabel(ctx, client, "default", selector)
+	if err != nil {
+		return nil, fmt.Errorf("unable to collect IPAMStorage map using Selector: %w", err)
+	}
+	networkConfig, err := getters.RetrieveNetworkConfiguration(ipamStorage)
+	if err != nil {
+		return nil, fmt.Errorf("unable to collect NetworkConfig map using IPAMStorage: %w", err)
+	}
+	return networkConfig, nil
+}
+
+// Collect implements the collect method of the Checker interface.
+// it collects the infos of the local cluster.
+func (lic *LocalInfoChecker) Collect(ctx context.Context) error {
+	clusterIdentity, err := getLocalClusterIdentity(ctx, lic.client, lic.namespace)
+	if err != nil {
+		lic.addCollectionError("ClusterIdentity", "", err)
+		lic.errors = true
+	}
+	lic.rootLocalInfoNode.addDataToNode("Cluster ID", clusterIdentity.ClusterID)
+	lic.rootLocalInfoNode.addDataToNode("Cluster Name", clusterIdentity.ClusterName)
+
+	clusterLabelsNode := lic.rootLocalInfoNode.addSectionToNode("Cluster Labels", "")
+	hc, err := common.NewLiqoHelmClient()
+	if err != nil {
+		lic.addCollectionError("ClusterIdentity", "Creating new LiqoHelmClient", err)
+		lic.errors = true
+	}
+	clusterLabels, err := hc.GetClusterLabels()
+	if err != nil {
+		lic.addCollectionError("Cluster Labels", "Getting cluster labels", err)
+		lic.errors = true
+	}
+	for k, v := range clusterLabels {
+		clusterLabelsNode.addDataToNode(k, v)
+	}
+
+	networkConfigNode := lic.rootLocalInfoNode.addSectionToNode("Network Configuration", "")
+	networkConfig, err := getLocalNetworkConfig(ctx, lic.client)
+	if err != nil {
+		lic.addCollectionError("Network Configuration", "", err)
+		lic.errors = true
+	}
+	networkConfigNode.addDataToNode("Pod CIDR", networkConfig.PodCIDR)
+	networkConfigNode.addDataToNode("External CIDR", networkConfig.ExternalCIDR)
+	networkConfigNode.addDataToNode("Service CIDR", networkConfig.ServiceCIDR)
+	if len(networkConfig.ReservedSubnets) != 0 {
+		networkConfigNode.addDataListToNode("Reserved Subnets", networkConfig.ReservedSubnets)
+	}
+
+	return nil
+}
+
+// Format implements the format method of the Checker interface.
+// it outputs the infos about the local cluster in a string ready to be
+// printed out.
+func (lic *LocalInfoChecker) Format() (string, error) {
+	w, buf := newTabWriter("")
+
+	fmt.Fprintf(w, "%s", deepPrintInfo(&lic.rootLocalInfoNode))
+
+	for _, err := range lic.collectionErrors {
+		fmt.Fprintf(w, "%s\t%s\t%s%s%s\n", err.appType, err.appName, red, err.err, reset)
+	}
+
+	if err := w.Flush(); err != nil {
+		return "", err
+	}
+
+	return buf.String(), nil
+}
+
+// HasSucceeded return true if no errors have been kept.
+func (lic *LocalInfoChecker) HasSucceeded() bool {
+	return !lic.errors
+}
+
+// addCollectionError adds a collection error. A collection error is an error that happens while
+// collecting the status of a Liqo component.
+func (lic *LocalInfoChecker) addCollectionError(localInfoType, localInfoName string, err error) {
+	lic.collectionErrors = append(lic.collectionErrors, newCollectionError(localInfoType, localInfoName, err))
+}

--- a/pkg/liqoctl/status/localinfo.go
+++ b/pkg/liqoctl/status/localinfo.go
@@ -87,8 +87,9 @@ func (lic *LocalInfoChecker) Collect(ctx context.Context) error {
 		lic.addCollectionError("ClusterIdentity", "", err)
 		lic.errors = true
 	}
-	lic.rootLocalInfoNode.addDataToNode("Cluster ID", clusterIdentity.ClusterID)
-	lic.rootLocalInfoNode.addDataToNode("Cluster Name", clusterIdentity.ClusterName)
+	clusterIdentityNode := lic.rootLocalInfoNode.addSectionToNode("Cluster Identity", "")
+	clusterIdentityNode.addDataToNode("Cluster ID", clusterIdentity.ClusterID)
+	clusterIdentityNode.addDataToNode("Cluster Name", clusterIdentity.ClusterName)
 
 	clusterLabelsNode := lic.rootLocalInfoNode.addSectionToNode("Cluster Labels", "")
 	hc, err := common.NewLiqoHelmClient()

--- a/pkg/liqoctl/status/localinfo_test.go
+++ b/pkg/liqoctl/status/localinfo_test.go
@@ -1,0 +1,133 @@
+// Copyright 2019-2022 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package status
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/liqotech/liqo/apis/discovery/v1alpha1"
+	netv1 "github.com/liqotech/liqo/apis/net/v1alpha1"
+	"github.com/liqotech/liqo/pkg/utils/getters"
+)
+
+var _ = Describe("LocalInfo", func() {
+	const (
+		clusterID    = "fake"
+		clusterName  = "fake"
+		namespace    = "liqo"
+		rootTitle    = "Local Cluster Informations"
+		serviceCIDR  = "10.80.0.0/12"
+		externalCIDR = "10.201.0.0/16"
+		podCIDR      = "10.200.0.0/16"
+	)
+
+	var (
+		reservedSubnets = []string{"10.202.0.0/16"}
+		clientBuilder   fake.ClientBuilder
+		rootNode        = newRootInfoNode(rootTitle)
+		lic             *LocalInfoChecker
+		ctx             = context.Background()
+		clusterIdentity *v1alpha1.ClusterIdentity
+		networkConfig   *getters.NetworkConfig
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		_ = netv1.AddToScheme(scheme.Scheme)
+		clientBuilder = *fake.NewClientBuilder().WithScheme(scheme.Scheme)
+	})
+
+	Context("Creating a new LocalInfoChecker", func() {
+		JustBeforeEach(func() {
+			lic = newLocalInfoChecker(namespace, clientBuilder.Build())
+		})
+		It("should return a valid LocalInfoChecker", func() {
+			licTest := &LocalInfoChecker{
+				client:            clientBuilder.Build(),
+				namespace:         namespace,
+				errors:            false,
+				collectionErrors:  nil,
+				rootLocalInfoNode: rootNode,
+			}
+			Expect(*lic).To(Equal(*licTest))
+		})
+	})
+	Context("Getting a local cluster identity", func() {
+		BeforeEach(func() {
+			clientBuilder.WithObjects(&v1.ConfigMap{
+				TypeMeta: metav1.TypeMeta{
+					Kind: "ConfigMap",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app.kubernetes.io/name": "clusterid-configmap",
+					},
+					Namespace: namespace,
+				},
+				Immutable: new(bool),
+				Data: map[string]string{
+					"CLUSTER_ID":   clusterID,
+					"CLUSTER_NAME": clusterName,
+				},
+				BinaryData: map[string][]byte{},
+			})
+		})
+		JustBeforeEach(func() {
+			clientBuilder.Build()
+			clusterIdentity, _ = getLocalClusterIdentity(ctx, clientBuilder.Build(), namespace)
+		})
+		It("should return a valid cluster identity", func() {
+			Expect(clusterIdentity.ClusterID).To(Equal(clusterID))
+			Expect(clusterIdentity.ClusterName).To(Equal(clusterName))
+		})
+	})
+	Context("Getting a network config", func() {
+		BeforeEach(func() {
+			clientBuilder.WithObjects(&netv1.IpamStorage{
+				TypeMeta: metav1.TypeMeta{
+					Kind: "IpamStorage",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"net.liqo.io/ipamstorage": "true",
+					},
+					Namespace: "default",
+				},
+				Spec: netv1.IpamSpec{
+					ReservedSubnets: reservedSubnets,
+					ExternalCIDR:    externalCIDR,
+					PodCIDR:         podCIDR,
+					ServiceCIDR:     serviceCIDR,
+				},
+			})
+		})
+		JustBeforeEach(func() {
+			networkConfig, _ = getLocalNetworkConfig(ctx, clientBuilder.Build())
+		})
+		It("should return a valid network config", func() {
+			Expect(networkConfig.ExternalCIDR).To(Equal(externalCIDR))
+			Expect(networkConfig.PodCIDR).To(Equal(podCIDR))
+			Expect(networkConfig.ReservedSubnets).To(Equal(reservedSubnets))
+			Expect(networkConfig.ServiceCIDR).To(Equal(serviceCIDR))
+		})
+	})
+})

--- a/pkg/liqoctl/status/namespace.go
+++ b/pkg/liqoctl/status/namespace.go
@@ -60,14 +60,12 @@ func (nc *namespaceChecker) Format() (string, error) {
 	w, buf := newTabWriter(nc.name)
 
 	if nc.succeeded {
-		fmt.Fprintf(w, "%s liqo control plane namespace %s[%s]%s exists\n", checkMark, green, nc.namespace, reset)
+		fmt.Fprintf(w, "%s%s%s liqo control plane namespace %s[%s]%s exists\n", green, checkMark, reset, green, nc.namespace, reset)
 	} else {
 		fmt.Fprintf(w, "%s liqo control plane namespace %s[%s]%s is not OK\n", redCross, red, nc.namespace, reset)
 		fmt.Fprintf(w, "Reason: %s\n", nc.failureReason)
 	}
 
-	// Add a new line ad the end of the message.
-	fmt.Fprintf(w, "\n")
 	if err := w.Flush(); err != nil {
 		return "", err
 	}

--- a/pkg/liqoctl/status/namespace_test.go
+++ b/pkg/liqoctl/status/namespace_test.go
@@ -99,7 +99,9 @@ var _ = Describe("Namespace", func() {
 					nsChecker.succeeded = true
 					msg, err := nsChecker.Format()
 					Expect(err).NotTo(HaveOccurred())
-					Expect(msg).To(ContainSubstring(fmt.Sprintf("%s liqo control plane namespace %s[%s]%s exists\n", checkMark, green, nsChecker.namespace, reset)))
+					Expect(msg).To(ContainSubstring(
+						fmt.Sprintf("%s%s%s liqo control plane namespace %s[%s]%s exists\n", green, checkMark, reset, green, nsChecker.namespace, reset),
+					))
 				})
 			})
 		})

--- a/pkg/liqoctl/status/pods_test.go
+++ b/pkg/liqoctl/status/pods_test.go
@@ -228,7 +228,7 @@ var _ = Describe("Pods", func() {
 				deployments:      deployments,
 				daemonSets:       daemonSets,
 				namespace:        namespace,
-				name:             checkerName,
+				name:             podCheckerName,
 				podsState:        make(podStateMap, 2),
 				errors:           false,
 				collectionErrors: nil,
@@ -370,7 +370,7 @@ var _ = Describe("Pods", func() {
 				It("should state that the status is OK", func() {
 					msg, err := podC.Format()
 					Expect(err).NotTo(HaveOccurred())
-					Expect(msg).To(ContainSubstring(fmt.Sprintf("%s control plane pods are up and running\n", checkMark)))
+					Expect(msg).To(ContainSubstring(fmt.Sprintf("%s%s%s control plane pods are up and running\n", green, checkMark, reset)))
 				})
 			})
 		})

--- a/pkg/liqoctl/status/remoteinfo.go
+++ b/pkg/liqoctl/status/remoteinfo.go
@@ -1,0 +1,176 @@
+// Copyright 2019-2022 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package status
+
+import (
+	"context"
+	"fmt"
+
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	controllerRuntimeClient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/liqotech/liqo/pkg/utils/getters"
+)
+
+// RemoteInfoChecker implements the Check interface.
+// holds informations about remote clusters.
+type RemoteInfoChecker struct {
+	client             controllerRuntimeClient.Client
+	namespace          string
+	clusterNameFilter  *[]string
+	clusterIDFilter    *[]string
+	errors             bool
+	rootRemoteInfoNode InfoNode
+	collectionErrors   []collectionError
+}
+
+// newRemoteInfoChecker return a new remote info checker.
+func newRemoteInfoChecker(namespace string, clusterNameFilter, clusterIDFilter *[]string, client controllerRuntimeClient.Client) *RemoteInfoChecker {
+	return &RemoteInfoChecker{
+		client:             client,
+		namespace:          namespace,
+		clusterNameFilter:  clusterNameFilter,
+		clusterIDFilter:    clusterIDFilter,
+		errors:             false,
+		rootRemoteInfoNode: newRootInfoNode("Remote Clusters Information"),
+	}
+}
+
+// argsFilterCheck returns true if the given foreignClusterID or foreignClusterName are contained
+// in the respective filter list or if filter lists are void.
+func (ric *RemoteInfoChecker) argsFilterCheck(foreignClusterID, foreignClusterName string) bool {
+	return stringArrayContainsString(ric.clusterIDFilter, foreignClusterID) ||
+		stringArrayContainsString(ric.clusterNameFilter, foreignClusterName) ||
+		(len(*ric.clusterIDFilter) == 0 && len(*ric.clusterNameFilter) == 0)
+}
+
+// stringArrayContainsString returns true if the given string is contained in the given array.
+func stringArrayContainsString(a *[]string, s string) bool {
+	for _, v := range *a {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}
+
+// Collect implements the collect method of the Checker interface.
+// it collects the infos of the Remote cluster.
+func (ric *RemoteInfoChecker) Collect(ctx context.Context) error {
+	var localNetworkConfigNode, remoteNetworkConfigNode, selectedNode *InfoNode
+	var remoteNodeMsg string
+	localClusterIdentity, err := getLocalClusterIdentity(ctx, ric.client, ric.namespace)
+	localClusterName := localClusterIdentity.ClusterName
+	if err != nil {
+		ric.addCollectionError("LocalClusterName", "", err)
+		ric.errors = true
+	}
+
+	networkConfigs, err := getters.GetNetworkConfigsByLabel(ctx, ric.client, "", labels.NewSelector())
+	if err != nil {
+		ric.addCollectionError("NetworkConfigs", "unable to collect NetworkConfigs", err)
+		ric.errors = true
+	}
+
+	for i := range networkConfigs.Items {
+		foreignClusterName := networkConfigs.Items[i].OwnerReferences[0].Name
+		var foreignClusterID string
+		if networkConfigs.Items[i].Labels["liqo.io/originID"] != "" {
+			foreignClusterID = networkConfigs.Items[i].Labels["liqo.io/originID"]
+		} else {
+			foreignClusterID = networkConfigs.Items[i].Labels["liqo.io/remoteID"]
+		}
+
+		if ric.argsFilterCheck(foreignClusterID, foreignClusterName) {
+			clusterNode := findNodeByTitle(ric.rootRemoteInfoNode.nextNodes, foreignClusterName)
+			if clusterNode == nil {
+				clusterNode = ric.rootRemoteInfoNode.addSectionToNode(foreignClusterName, "")
+				localNetworkConfigNode = clusterNode.addSectionToNode("Local Network Configuration", "")
+				remoteNetworkConfigNode = clusterNode.addSectionToNode("Remote Network Configuration", "")
+			} else {
+				localNetworkConfigNode = clusterNode.nextNodes[0]
+				remoteNetworkConfigNode = clusterNode.nextNodes[1]
+			}
+
+			if networkConfigs.Items[i].Labels["liqo.io/replication"] == "true" {
+				selectedNode = localNetworkConfigNode
+				remoteNodeMsg = fmt.Sprintf("Status: how %s's CIDRs has been remapped by %s", localClusterName, foreignClusterName)
+			} else {
+				selectedNode = remoteNetworkConfigNode
+				remoteNodeMsg = fmt.Sprintf("Status: how %s remapped %s's CIDRs", localClusterName, foreignClusterName)
+			}
+
+			originalNode := selectedNode.addSectionToNode("Original Network Configuration", "Spec")
+			originalNode.addDataToNode("Pod CIDR", networkConfigs.Items[i].Spec.PodCIDR)
+			originalNode.addDataToNode("External CIDR", networkConfigs.Items[i].Spec.ExternalCIDR)
+			remoteNode := selectedNode.addSectionToNode("Remapped Network Configuration", remoteNodeMsg)
+			remoteNode.addDataToNode("Pod CIDR", networkConfigs.Items[i].Status.PodCIDRNAT)
+			remoteNode.addDataToNode("External CIDR", networkConfigs.Items[i].Status.ExternalCIDRNAT)
+
+			tunnelEnpointSelector, err := v1.LabelSelectorAsSelector(&v1.LabelSelector{
+				MatchExpressions: []v1.LabelSelectorRequirement{
+					{
+						Key:      "clusterID",
+						Operator: v1.LabelSelectorOpIn,
+						Values:   []string{networkConfigs.Items[i].Labels["liqo.io/remoteID"]},
+					},
+				},
+			})
+			if err != nil {
+				ric.addCollectionError("TunnelEndpoint", fmt.Sprintf("unable to create TunnelEnpoint Selector for %s", foreignClusterName), err)
+				ric.errors = true
+			}
+			tunnelEndpoint, err := getters.GetTunnelEndpointByLabel(ctx, ric.client, "", tunnelEnpointSelector)
+			if err == nil {
+				tunnelEndpointNode := clusterNode.addSectionToNode("Tunnel Endpoint", "")
+				tunnelEndpointNode.addDataToNode("Gateway IP", tunnelEndpoint.Status.GatewayIP)
+				tunnelEndpointNode.addDataToNode("Endpoint IP", tunnelEndpoint.Status.Connection.PeerConfiguration["endpointIP"])
+			}
+		}
+	}
+
+	return nil
+}
+
+// Format implements the format method of the Checker interface.
+// it outputs the infos about the Remote cluster in a string ready to be
+// printed out.
+func (ric *RemoteInfoChecker) Format() (string, error) {
+	w, buf := newTabWriter("")
+
+	fmt.Fprintf(w, "%s", deepPrintInfo(&ric.rootRemoteInfoNode))
+
+	for _, err := range ric.collectionErrors {
+		fmt.Fprintf(w, "%s\t%s\t%s%s%s\n", err.appType, err.appName, red, err.err, reset)
+	}
+
+	if err := w.Flush(); err != nil {
+		return "", err
+	}
+
+	return buf.String(), nil
+}
+
+// HasSucceeded return true if no errors have been kept.
+func (ric *RemoteInfoChecker) HasSucceeded() bool {
+	return !ric.errors
+}
+
+// addCollectionError adds a collection error. A collection error is an error that happens while
+// collecting the status of a Liqo component.
+func (ric *RemoteInfoChecker) addCollectionError(remoteInfoType, remoteInfoName string, err error) {
+	ric.collectionErrors = append(ric.collectionErrors, newCollectionError(remoteInfoType, remoteInfoName, err))
+}

--- a/pkg/liqoctl/status/remoteinfo_test.go
+++ b/pkg/liqoctl/status/remoteinfo_test.go
@@ -1,0 +1,272 @@
+// Copyright 2019-2022 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package status
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	netv1 "github.com/liqotech/liqo/apis/net/v1alpha1"
+)
+
+var _ = Describe("Remoteinfo", func() {
+	const (
+		rootTitle    = "Remote Clusters Information"
+		namespace    = "liqo"
+		clusterID1   = "e126183a-5445-404f-8802-fdd5ed64b4ec"
+		clusterName1 = "cluster1"
+		clusterID2   = "d945afca-3a15-45ef-a472-41f1803592d1"
+		clusterName2 = "cluster2"
+	)
+	var (
+		clientBuilder fake.ClientBuilder
+		rootNode      = newRootInfoNode(rootTitle)
+		ric           *RemoteInfoChecker
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		_ = netv1.AddToScheme(scheme.Scheme)
+		clientBuilder = *fake.NewClientBuilder().WithScheme(scheme.Scheme)
+	})
+
+	Context("Creating a new remoteInfoChecker", func() {
+		JustBeforeEach(func() {
+			ric = newRemoteInfoChecker(namespace, &[]string{}, &[]string{}, clientBuilder.Build())
+		})
+		It("should return a valid remoteInfoChecker", func() {
+			ricTest := &RemoteInfoChecker{
+				client:             clientBuilder.Build(),
+				namespace:          namespace,
+				clusterNameFilter:  &[]string{},
+				clusterIDFilter:    &[]string{},
+				errors:             false,
+				collectionErrors:   nil,
+				rootRemoteInfoNode: rootNode,
+			}
+			Expect(*ric).To(Equal(*ricTest))
+		})
+	})
+
+	Context("Checking if a cluster ID or a cluster name are included between filters", func() {
+		Context("Checking cluster ID", func() {
+			BeforeEach(func() {
+				ric.clusterIDFilter = &[]string{"cluster-id-1", "cluster-id-2"}
+			})
+			When("Cluster ID is included", func() {
+				It("should return true", func() {
+					Expect(ric.argsFilterCheck("cluster-id-1", "")).To(BeTrue())
+				})
+			})
+			When("Cluster ID is not included", func() {
+				It("should return false", func() {
+					Expect(ric.argsFilterCheck("cluster-id-3", "")).To(BeFalse())
+				})
+
+			})
+		})
+		Context("Checking cluster name", func() {
+			BeforeEach(func() {
+				ric.clusterNameFilter = &[]string{"cluster-name-1", "cluster-name-2"}
+			})
+			When("Cluster name is included", func() {
+				It("should return true", func() {
+					Expect(ric.argsFilterCheck("", "cluster-name-1")).To(BeTrue())
+				})
+			})
+			When("Cluster name is not included", func() {
+				It("should return false", func() {
+					Expect(ric.argsFilterCheck("", "cluster-name-3")).To(BeFalse())
+				})
+
+			})
+		})
+
+	})
+
+	Context("Getting Collect() result", func() {
+		var infoNode InfoNode
+		BeforeEach(func() {
+			clientBuilder.WithObjects(
+				&v1.ConfigMap{
+					TypeMeta: metav1.TypeMeta{
+						Kind: "ConfigMap",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							"app.kubernetes.io/name": "clusterid-configmap",
+						},
+						Namespace: namespace,
+					},
+					Immutable: new(bool),
+					Data: map[string]string{
+						"CLUSTER_ID":   clusterID1,
+						"CLUSTER_NAME": clusterName1,
+					},
+					BinaryData: map[string][]byte{},
+				},
+				&netv1.NetworkConfig{
+					TypeMeta: metav1.TypeMeta{
+						Kind: "NetworkConfig",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: clusterName1,
+						Labels: map[string]string{
+							"liqo.io/originID":    clusterID2,
+							"liqo.io/remoteID":    clusterID1,
+							"liqo.io/replication": "false",
+						},
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								Name: clusterName2,
+							},
+						},
+					},
+					Spec: netv1.NetworkConfigSpec{
+						PodCIDR:      "10.200.0.0/16",
+						ExternalCIDR: "10.201.0.0/16",
+					},
+					Status: netv1.NetworkConfigStatus{
+						PodCIDRNAT:      "10.202.0.0/16",
+						ExternalCIDRNAT: "10.203.0.0/16",
+					},
+				},
+				&netv1.NetworkConfig{
+					TypeMeta: metav1.TypeMeta{
+						Kind: "NetworkConfig",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: clusterName2,
+						Labels: map[string]string{
+							"liqo.io/remoteID":    clusterID2,
+							"liqo.io/replication": "true",
+						},
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								Name: clusterName2,
+							},
+						},
+					},
+					Spec: netv1.NetworkConfigSpec{
+						PodCIDR:      "10.200.0.0/16",
+						ExternalCIDR: "10.201.0.0/16",
+					},
+					Status: netv1.NetworkConfigStatus{
+						PodCIDRNAT:      "10.202.0.0/16",
+						ExternalCIDRNAT: "10.203.0.0/16",
+					},
+				},
+				&netv1.TunnelEndpoint{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							"clusterID": clusterID2,
+						},
+					},
+					Status: netv1.TunnelEndpointStatus{
+						GatewayIP: "172.18.0.2",
+						Connection: netv1.Connection{
+							PeerConfiguration: map[string]string{
+								"endpointIP": "172.18.0.3",
+							},
+						},
+					},
+				},
+			)
+			infoNode = InfoNode{}
+			infoNode.title = rootTitle
+			clusterSection := infoNode.addSectionToNode(clusterName2, "")
+			local := clusterSection.addSectionToNode("Local Network Configuration", "")
+			remote := clusterSection.addSectionToNode("Remote Network Configuration", "")
+			originalLocal := local.addSectionToNode("Original Network Configuration", "Spec")
+			remappedLocal := local.addSectionToNode(
+				"Remapped Network Configuration", fmt.Sprintf("Status: how %s's CIDRs has been remapped by %s", clusterName1, clusterName2),
+			)
+			originalRemote := remote.addSectionToNode("Original Network Configuration", "Spec")
+			remappedRemote := remote.addSectionToNode(
+				"Remapped Network Configuration", fmt.Sprintf("Status: how %s remapped %s's CIDRs", clusterName1, clusterName2),
+			)
+			originalLocal.addDataToNode("Pod CIDR", "10.200.0.0/16")
+			originalLocal.addDataToNode("External CIDR", "10.201.0.0/16")
+			remappedLocal.addDataToNode("Pod CIDR", "10.202.0.0/16")
+			remappedLocal.addDataToNode("External CIDR", "10.203.0.0/16")
+			originalRemote.addDataToNode("Pod CIDR", "10.200.0.0/16")
+			originalRemote.addDataToNode("External CIDR", "10.201.0.0/16")
+			remappedRemote.addDataToNode("Pod CIDR", "10.202.0.0/16")
+			remappedRemote.addDataToNode("External CIDR", "10.203.0.0/16")
+			tunnelEndpoint := clusterSection.addSectionToNode("Tunnel Endpoint", "")
+			tunnelEndpoint.addDataToNode("Gateway IP", "172.18.0.2")
+			tunnelEndpoint.addDataToNode("Endpoint IP", "172.18.0.3")
+		})
+
+		When("There aren't filters", func() {
+			JustBeforeEach(func() {
+				ric = newRemoteInfoChecker(namespace, &[]string{}, &[]string{}, clientBuilder.Build())
+			})
+			It("should return a valid tree", func() {
+				_ = ric.Collect(ctx)
+				Expect(ric.rootRemoteInfoNode).To(Equal(infoNode))
+			})
+		})
+		When("There is a filter on cluster ID", func() {
+			When("Filtered ID is contained in filtered ID list", func() {
+				JustBeforeEach(func() {
+					ric = newRemoteInfoChecker(namespace, &[]string{}, &[]string{clusterID2}, clientBuilder.Build())
+				})
+				It("should return a valid tree", func() {
+					_ = ric.Collect(ctx)
+					Expect(ric.rootRemoteInfoNode).To(Equal(infoNode))
+				})
+			})
+			When("Filtered ID is not contained in filtered ID list", func() {
+				JustBeforeEach(func() {
+					ric = newRemoteInfoChecker(namespace, &[]string{}, &[]string{"invalid filter"}, clientBuilder.Build())
+				})
+				It("should return a void tree", func() {
+					_ = ric.Collect(ctx)
+					Expect(ric.rootRemoteInfoNode.nextNodes).To(BeEmpty())
+				})
+			})
+
+		})
+		When("There is a filter on cluster name", func() {
+			When("Filtered name is contained in filtered name list", func() {
+				JustBeforeEach(func() {
+					ric = newRemoteInfoChecker(namespace, &[]string{clusterName2}, &[]string{}, clientBuilder.Build())
+				})
+				It("should return a valid tree", func() {
+					_ = ric.Collect(ctx)
+					Expect(ric.rootRemoteInfoNode).To(Equal(infoNode))
+				})
+			})
+			When("Filtered name is not contained in filtered name list", func() {
+				JustBeforeEach(func() {
+					ric = newRemoteInfoChecker(namespace, &[]string{"invalid filter"}, &[]string{}, clientBuilder.Build())
+				})
+				It("should return a void tree", func() {
+					_ = ric.Collect(ctx)
+					Expect(ric.rootRemoteInfoNode.nextNodes).To(BeEmpty())
+				})
+			})
+
+		})
+	})
+})

--- a/pkg/utils/getters/k8sGetters.go
+++ b/pkg/utils/getters/k8sGetters.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/liqotech/liqo/apis/discovery/v1alpha1"
 	netv1alpha1 "github.com/liqotech/liqo/apis/net/v1alpha1"
 )
 
@@ -46,7 +47,7 @@ func GetIPAMStorageByLabel(ctx context.Context, cl client.Client, ns string, lSe
 	}
 }
 
-// GetNetworkConfigByLabel it returns a networkconfigs instance that matches the given label selector.
+// GetNetworkConfigByLabel it returns a NetworkConfig instance that matches the given label selector.
 func GetNetworkConfigByLabel(ctx context.Context, cl client.Client, ns string, lSelector labels.Selector) (*netv1alpha1.NetworkConfig, error) {
 	list := new(netv1alpha1.NetworkConfigList)
 	if err := cl.List(ctx, list, &client.ListOptions{LabelSelector: lSelector}, client.InNamespace(ns)); err != nil {
@@ -62,6 +63,60 @@ func GetNetworkConfigByLabel(ctx context.Context, cl client.Client, ns string, l
 		return nil, fmt.Errorf("multiple resources of type {%s} found for label selector {%s} in namespace {%s},"+
 			" when only one was expected", netv1alpha1.NetworkConfigGroupResource.String(), lSelector.String(), ns)
 	}
+}
+
+// GetNetworkConfigsByLabel it returns a NetworkConfig list that matches the given label selector.
+func GetNetworkConfigsByLabel(ctx context.Context, cl client.Client, ns string, lSelector labels.Selector) (*netv1alpha1.NetworkConfigList, error) {
+	list := new(netv1alpha1.NetworkConfigList)
+	if err := cl.List(ctx, list, &client.ListOptions{LabelSelector: lSelector}, client.InNamespace(ns)); err != nil {
+		return nil, err
+	}
+	if len(list.Items) == 0 {
+		return nil, kerrors.NewNotFound(netv1alpha1.NetworkConfigGroupResource, netv1alpha1.ResourceNetworkConfigs)
+	}
+	return list, nil
+}
+
+// GetTunnelEndpointByLabel it returns a TunnelEndpoint instance that matches the given label selector.
+func GetTunnelEndpointByLabel(ctx context.Context, cl client.Client, ns string, lSelector labels.Selector) (*netv1alpha1.TunnelEndpoint, error) {
+	list := new(netv1alpha1.TunnelEndpointList)
+	if err := cl.List(ctx, list, &client.ListOptions{LabelSelector: lSelector}, client.InNamespace(ns)); err != nil {
+		return nil, err
+	}
+
+	switch len(list.Items) {
+	case 0:
+		return nil, kerrors.NewNotFound(netv1alpha1.TunnelEndpointGroupResource, netv1alpha1.ResourceTunnelEndpoints)
+	case 1:
+		return &list.Items[0], nil
+	default:
+		return nil, fmt.Errorf("multiple resources of type {%s} found for label selector {%s} in namespace {%s},"+
+			" when only one was expected", netv1alpha1.TunnelEndpointGroupResource.String(), lSelector.String(), ns)
+	}
+}
+
+// GetTunnelEndpointsByLabel it returns a TunnelEndpoint list that matches the given label selector.
+func GetTunnelEndpointsByLabel(ctx context.Context, cl client.Client, ns string, lSelector labels.Selector) (*netv1alpha1.TunnelEndpointList, error) {
+	list := new(netv1alpha1.TunnelEndpointList)
+	if err := cl.List(ctx, list, &client.ListOptions{LabelSelector: lSelector}, client.InNamespace(ns)); err != nil {
+		return nil, err
+	}
+	if len(list.Items) == 0 {
+		return nil, kerrors.NewNotFound(netv1alpha1.TunnelEndpointGroupResource, netv1alpha1.ResourceTunnelEndpoints)
+	}
+	return list, nil
+}
+
+// GetForeignClustersByLabel it returns a ForeignClusters list that matches the given label selector.
+func GetForeignClustersByLabel(ctx context.Context, cl client.Client, ns string, lSelector labels.Selector) (*v1alpha1.ForeignClusterList, error) {
+	list := new(v1alpha1.ForeignClusterList)
+	if err := cl.List(ctx, list, &client.ListOptions{LabelSelector: lSelector}, client.InNamespace(ns)); err != nil {
+		return nil, err
+	}
+	if len(list.Items) == 0 {
+		return nil, kerrors.NewNotFound(v1alpha1.ForeignClusterGroupResource, v1alpha1.ForeignClusterResource)
+	}
+	return list, nil
 }
 
 // GetServiceByLabel it returns a service instance that matches the given label selector.

--- a/pkg/utils/labels/labelSelectors.go
+++ b/pkg/utils/labels/labelSelectors.go
@@ -78,6 +78,17 @@ var (
 		},
 	}
 
+	// ControllerManagerPodLabelSelector selector used to get the Controller Manager Pod.
+	ControllerManagerPodLabelSelector = metav1.LabelSelector{
+		MatchExpressions: []metav1.LabelSelectorRequirement{
+			{
+				Key:      liqoconst.K8sAppNameKey,
+				Operator: metav1.LabelSelectorOpIn,
+				Values:   []string{liqoconst.ControllerManagerAppName},
+			},
+		},
+	}
+
 	// AuthServiceLabelSelector selector used to get the auth service.
 	AuthServiceLabelSelector = metav1.LabelSelector{
 		MatchExpressions: []metav1.LabelSelectorRequirement{


### PR DESCRIPTION
This PR replaces the old golang k8s client with the controller-runtime client in the liqoctl status code.
**This PR is based on #1168**

### ToDo

- [x] Package refactoring
- [ ] Test refactoring

