### PR TITLE
Liqoctl: fix node name in add command

### DIFF
--- a/pkg/liqoctl/add/consts.go
+++ b/pkg/liqoctl/add/consts.go
@@ -52,7 +52,7 @@ kubectl get foreignclusters %s
 
 * Check if the virtual node is correctly created (this should take less than ~30s) 📦:
 
-kubectl get nodes liqo-%s
+kubectl get nodes %s
 
 * Ready to go! Let's deploy a simple cross-cluster application using Liqo 🚜:
 

--- a/test/e2e/pipeline/installer/liqoctl/peer.sh
+++ b/test/e2e/pipeline/installer/liqoctl/peer.sh
@@ -29,8 +29,7 @@ trap 'error "${BASH_SOURCE}" "${LINENO}"' ERR
 for i in $(seq 2 "${CLUSTER_NUMBER}");
 do
   export KUBECONFIG="${TMPDIR}/kubeconfigs/liqo_kubeconf_${i}"
-  # Add the cluster with a different name than the one it declares, so we can test that we use cluster names correctly
-  ADD_COMMAND=$(${LIQOCTL} generate-add-command --only-command | sed "s/add cluster liqo-${i}/add cluster foreign-${i}/g")
+  ADD_COMMAND=$(${LIQOCTL} generate-add-command --only-command)
 
   export KUBECONFIG="${TMPDIR}/kubeconfigs/liqo_kubeconf_1"
   eval "${ADD_COMMAND}"


### PR DESCRIPTION
# Description

This PR corrects the node name reported by the `liqoctl add cluster` command.

Ref #1212

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] Running the command locally and checking the output.
