### PR TITLE
docs: Update instructions with new uninstall command 

### DIFF
--- a/docs/pages/gettingstarted/helloworld/install.md
+++ b/docs/pages/gettingstarted/helloworld/install.md
@@ -19,7 +19,7 @@ You can find more details about configuring `kubectl` in the [official documenta
 Now, you can install Liqo by launching:
 
 ```bash
-liqoctl install kind
+liqoctl install kind --generate-name
 ```
 
 This command will generate the adapt configuration for your Kind cluster.
@@ -30,7 +30,7 @@ Similarly, as done on the first cluster, you can deploy Liqo on the second clust
 
 ```
 export KUBECONFIG=./liqo_kubeconf_2
-liqoctl install kind
+liqoctl install kind --generate-name
 ```
 
 ## Enable cluster peering

--- a/docs/pages/gettingstarted/helloworld/uninstall.md
+++ b/docs/pages/gettingstarted/helloworld/uninstall.md
@@ -8,7 +8,7 @@ weight: 6
 This procedure uninstalls Liqo from your cluster.
 
 ```bash
-curl -sL https://raw.githubusercontent.com/liqotech/liqo/master/install.sh | bash -s -- --uninstall
+liqoctl uninstall
 ```
 
 _NOTE:_ all Liqo resources (i.e. CRDs) will not be automatically purged, so you will not lose your discovered clusters. If you want to delete these resources after uninstallation, invoke the same script with the `--purge` flag set.
@@ -18,7 +18,7 @@ _NOTE:_ all Liqo resources (i.e. CRDs) will not be automatically purged, so you 
 If you want all Liqo resources to be completely purged, add the `--purge` flag to the script invocation:
 
 ```bash
-curl -sL https://raw.githubusercontent.com/liqotech/liqo/master/install.sh | bash -s -- --uninstall --purge
+liqoctl uninstall --purge
 ```
 
 ### What happens to my deployed applications?

--- a/docs/pages/installation/install.md
+++ b/docs/pages/installation/install.md
@@ -319,13 +319,13 @@ Now, you can perform the proper Liqo installation on your cluster.
 {{< tabs groupId="provider" >}}
 {{% tab name="Kubernetes IN Docker (KIND)" %}}
 ```bash
-liqoctl install kind
+liqoctl install kind --generate-name
 ```
 {{% /tab %}}
 
 {{% tab name="K8s (Kubeadm)" %}}
 ```bash
-liqoctl install kubeadm
+liqoctl install kubeadm --generate-name
 ```
 {{% /tab %}}
 {{% tab name="EKS" %}}
@@ -339,26 +339,28 @@ liqoctl install eks --region=${EKS_CLUSTER_REGION} --eks-cluster-name=${EKS_CLUS
 ```bash
 liqoctl install aks --resource-group-name "${AKS_RESOURCE_GROUP}" \
          --resource-name "${AKS_RESOURCE_NAME}" \
-         --subscription-id "${AKS_SUBSCRIPTION_ID}"
+         --subscription-id "${AKS_SUBSCRIPTION_ID}" \
+         --generate-name
 ```
 {{% /tab %}}
 {{% tab name="GKE" %}}
 ```bash
 
 liqoctl install gke --project-id ${GKE_PROJECT_ID} \
-    --cluster-id ${GKE_CLUSTER_ID} \
-    --zone ${GKE_CLUSTER_ZONE} \
-    --credentials-path ${GKE_SERVICE_ACCOUNT_PATH}
+        --cluster-id ${GKE_CLUSTER_ID} \
+        --zone ${GKE_CLUSTER_ZONE} \
+        --credentials-path ${GKE_SERVICE_ACCOUNT_PATH} \
+        --generate-name
 ```
 {{% /tab %}}
 {{% tab name="K3s" %}}
 ```bash
-liqoctl install k3s
+liqoctl install k3s --generate-name
 ```
 {{% /tab %}}
 {{% tab name="OpenShift Container Platform (OCP)" %}}
 ```bash
-liqoctl install openshift
+liqoctl install openshift --generate-name
 ```
 {{% /tab %}}
 {{< /tabs >}}


### PR DESCRIPTION
# Description

Two related commits here, following the deprecation of `install.sh`

1. docs: Update instructions with new uninstall command

This commit removes the last remaining references to the script,
and now refers to the new `uninstall` command on the `liqoctl` binary.

This commit also adds `--generate-name` to all `liqoctl install`
examples, since the commands will fail without that or a given cluster
name.

-----------------------

2. chore: Remove install.sh refs from Makefile

The relevant make commands now build a new `liqoctl` bin  (gitignored)
and use the `install` and `uninstall` subcommands provided with that.

An e2e target has been updated to make the build command work for both
scenarios.

# How Has This Been Tested?

Manually running each affected make command
