### PR TITLE
Bump Golangci Version to 1.46.2

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,7 +23,7 @@ jobs:
         uses: golangci/golangci-lint-action@v3.1.0
         with:
           only-new-issues: true
-          version: v1.46.0
+          version: v1.46.2
           args: --timeout=600s
 
   gomodtidy:

--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ fmt: gci addlicense
 # Install golangci-lint if not available
 golangci-lint:
 ifeq (, $(shell which golangci-lint))
-	@go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.46.0
+	@go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.46.2
 GOLANGCILINT=$(GOBIN)/golangci-lint
 else
 GOLANGCILINT=$(shell which golangci-lint)


### PR DESCRIPTION
# Description

This pr bumps the golangci version to 1.46.2
