### PR TITLE
Liqoctl: Improve Peer and Unpeer Commands

### DIFF
--- a/pkg/liqo-controller-manager/resourceoffer-controller/resourceoffer_controller_methods.go
+++ b/pkg/liqo-controller-manager/resourceoffer-controller/resourceoffer_controller_methods.go
@@ -118,7 +118,7 @@ func (r *ResourceOfferReconciler) createVirtualKubeletDeployment(
 
 	// forge the virtual Kubelet
 	vkDeployment, err := forge.VirtualKubeletDeployment(
-		r.cluster, remoteClusterIdentity, namespace, r.liqoNamespace,
+		&r.cluster, &remoteClusterIdentity, namespace, r.liqoNamespace,
 		r.virtualKubeletOpts, resourceOffer)
 	if err != nil {
 		klog.Error(err)

--- a/pkg/liqoctl/peer/doc.go
+++ b/pkg/liqoctl/peer/doc.go
@@ -12,13 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package peeroob
-
-const (
-	// AuthURLFlagName contains the name of auth-url flag.
-	AuthURLFlagName = "auth-url"
-	// ClusterIDFlagName contains the name of cluster ID flag.
-	ClusterIDFlagName = "cluster-id"
-	// ClusterTokenFlagName contains the name for the token flag.
-	ClusterTokenFlagName = "auth-token"
-)
+// Package peer contains the logic to enable a peering towards a remote cluster.
+package peer

--- a/pkg/liqoctl/peer/handler.go
+++ b/pkg/liqoctl/peer/handler.go
@@ -1,0 +1,91 @@
+// Copyright 2019-2022 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package peer
+
+import (
+	"context"
+	"time"
+
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
+
+	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
+	"github.com/liqotech/liqo/pkg/liqoctl/factory"
+	"github.com/liqotech/liqo/pkg/liqoctl/wait"
+)
+
+// Options encapsulates the arguments of the peer command.
+type Options struct {
+	*factory.Factory
+
+	ClusterName string
+	Timeout     time.Duration
+}
+
+// Run implements the peer out-of-band command.
+func (o *Options) Run(ctx context.Context) error {
+	ctx, cancel := context.WithTimeout(ctx, o.Timeout)
+	defer cancel()
+
+	s := o.Printer.StartSpinner("Processing cluster peering")
+
+	remoteClusterID, err := o.peer(ctx)
+	if err != nil {
+		s.Fail(err.Error())
+		return err
+	}
+	s.Success("Peering enabled")
+
+	if err = o.Wait(ctx, remoteClusterID); err != nil {
+		return err
+	}
+
+	o.Printer.Success.Println("Peering successfully established")
+	return nil
+}
+
+func (o *Options) peer(ctx context.Context) (*discoveryv1alpha1.ClusterIdentity, error) {
+	var fc discoveryv1alpha1.ForeignCluster
+	if err := o.CRClient.Get(ctx, types.NamespacedName{
+		Name: o.ClusterName,
+	}, &fc); err != nil {
+		return nil, err
+	}
+
+	fc.Spec.OutgoingPeeringEnabled = discoveryv1alpha1.PeeringEnabledYes
+
+	return &fc.Spec.ClusterIdentity, retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		return o.CRClient.Update(ctx, &fc)
+	})
+}
+
+// Wait waits for the peering to the remote cluster to be fully enabled.
+func (o *Options) Wait(ctx context.Context, remoteClusterID *discoveryv1alpha1.ClusterIdentity) error {
+	waiter := wait.NewWaiterFromFactory(o.Factory)
+
+	if err := waiter.ForAuth(ctx, remoteClusterID); err != nil {
+		return err
+	}
+
+	if err := waiter.ForNetwork(ctx, remoteClusterID); err != nil {
+		return err
+	}
+
+	if err := waiter.ForOutgoingPeering(ctx, remoteClusterID); err != nil {
+		return err
+	}
+
+	return waiter.ForNode(ctx, remoteClusterID)
+}

--- a/pkg/liqoctl/peerib/handler.go
+++ b/pkg/liqoctl/peerib/handler.go
@@ -28,10 +28,14 @@ type Options struct {
 	RemoteFactory *factory.Factory
 
 	Bidirectional bool
+	Timeout       time.Duration
 }
 
 // Run implements the peer in-band command.
 func (o *Options) Run(ctx context.Context) error {
+	ctx, cancel := context.WithTimeout(ctx, o.Timeout)
+	defer cancel()
+
 	// Create and initialize cluster 1.
 	cluster1 := inbound.NewCluster(o.LocalFactory, o.RemoteFactory)
 	if err := cluster1.Init(ctx); err != nil {
@@ -123,30 +127,30 @@ func (o *Options) Run(ctx context.Context) error {
 	}
 
 	// Waiting for VPN connection to be established in cluster 1.
-	if err := cluster1.WaitForNetwork(ctx, cluster2.GetClusterID(), 120*time.Second); err != nil {
+	if err := cluster1.WaitForNetwork(ctx, cluster2.GetClusterID()); err != nil {
 		return err
 	}
 
 	// Waiting for VPN connection to be established in cluster 2.
-	if err := cluster2.WaitForNetwork(ctx, cluster1.GetClusterID(), 120*time.Second); err != nil {
+	if err := cluster2.WaitForNetwork(ctx, cluster1.GetClusterID()); err != nil {
 		return err
 	}
 
 	// Waiting for VPN connection to be established in cluster 1.
-	if err := cluster1.WaitForNetwork(ctx, cluster2.GetClusterID(), 120*time.Second); err != nil {
+	if err := cluster1.WaitForNetwork(ctx, cluster2.GetClusterID()); err != nil {
 		return err
 	}
 
 	// Waiting for VPN connection to be established in cluster 2.
-	if err := cluster2.WaitForNetwork(ctx, cluster1.GetClusterID(), 120*time.Second); err != nil {
+	if err := cluster2.WaitForNetwork(ctx, cluster1.GetClusterID()); err != nil {
 		return err
 	}
 
 	// Waiting for authentication to complete in cluster 1.
-	if err := cluster1.WaitForAuth(ctx, cluster2.GetClusterID(), 120*time.Second); err != nil {
+	if err := cluster1.WaitForAuth(ctx, cluster2.GetClusterID()); err != nil {
 		return err
 	}
 
 	// Waiting for authentication to complete in cluster 2.
-	return cluster2.WaitForAuth(ctx, cluster1.GetClusterID(), 120*time.Second)
+	return cluster2.WaitForAuth(ctx, cluster1.GetClusterID())
 }

--- a/pkg/liqoctl/peeroob/handler_test.go
+++ b/pkg/liqoctl/peeroob/handler_test.go
@@ -28,6 +28,7 @@ import (
 
 	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
 	"github.com/liqotech/liqo/pkg/liqoctl/factory"
+	"github.com/liqotech/liqo/pkg/liqoctl/peer"
 	foreigncluster "github.com/liqotech/liqo/pkg/utils/foreignCluster"
 	"github.com/liqotech/liqo/pkg/utils/testutil"
 )
@@ -49,8 +50,10 @@ var _ = Describe("Test Peer Command", func() {
 	BeforeEach(func() {
 		ctx = context.Background()
 		options = &Options{
-			Factory:        &factory.Factory{LiqoNamespace: "liqo-non-standard"},
-			ClusterName:    "remote-cluster-name",
+			Options: &peer.Options{
+				Factory:     &factory.Factory{LiqoNamespace: "liqo-non-standard"},
+				ClusterName: "remote-cluster-name",
+			},
 			ClusterID:      "remote-cluster-id",
 			ClusterToken:   "remote-token",
 			ClusterAuthURL: "https://remote.auth",

--- a/pkg/liqoctl/unpeerib/handler.go
+++ b/pkg/liqoctl/unpeerib/handler.go
@@ -29,10 +29,15 @@ type Options struct {
 
 	LocalLiqoNamespace  string
 	RemoteLiqoNamespace string
+
+	Timeout time.Duration
 }
 
 // Run implements the unpeer in-band command.
 func (o *Options) Run(ctx context.Context) error {
+	ctx, cancel := context.WithTimeout(ctx, o.Timeout)
+	defer cancel()
+
 	// Create and initialize cluster 1.
 	cluster1 := inbound.NewCluster(o.LocalFactory, o.RemoteFactory)
 	if err := cluster1.Init(ctx); err != nil {
@@ -56,12 +61,12 @@ func (o *Options) Run(ctx context.Context) error {
 	}
 
 	// Wait to unpeer in cluster 1.
-	if err := cluster1.WaitForUnpeering(ctx, cluster2.GetClusterID(), 60*time.Second); err != nil {
+	if err := cluster1.WaitForUnpeering(ctx, cluster2.GetClusterID()); err != nil {
 		return err
 	}
 
 	// Disable peering in cluster 2.
-	if err := cluster2.WaitForUnpeering(ctx, cluster1.GetClusterID(), 60*time.Second); err != nil {
+	if err := cluster2.WaitForUnpeering(ctx, cluster1.GetClusterID()); err != nil {
 		return err
 	}
 
@@ -119,10 +124,10 @@ func (o *Options) Run(ctx context.Context) error {
 	}
 
 	// Clean up tenant namespace in cluster 1.
-	if err := cluster1.TearDownTenantNamespace(ctx, cluster2.GetClusterID(), 60*time.Second); err != nil {
+	if err := cluster1.TearDownTenantNamespace(ctx, cluster2.GetClusterID()); err != nil {
 		return err
 	}
 
 	// Clean up tenant namespace in cluster 2.
-	return cluster2.TearDownTenantNamespace(ctx, cluster1.GetClusterID(), 60*time.Second)
+	return cluster2.TearDownTenantNamespace(ctx, cluster1.GetClusterID())
 }

--- a/pkg/liqoctl/unpeeroob/handler_test.go
+++ b/pkg/liqoctl/unpeeroob/handler_test.go
@@ -67,7 +67,8 @@ var _ = Describe("Test Unpeer Command", func() {
 		DescribeTable("unpeering table",
 			func(c removeTestcase) {
 				options.ClusterName = c.clusterName
-				Expect(options.unpeer(ctx)).To(c.expectedError)
+				_, err := options.unpeer(ctx)
+				Expect(err).To(c.expectedError)
 
 				var fc discoveryv1alpha1.ForeignCluster
 				Expect(options.CRClient.Get(ctx, types.NamespacedName{Name: foreignClusterName}, &fc)).To(Succeed())

--- a/pkg/liqoctl/wait/doc.go
+++ b/pkg/liqoctl/wait/doc.go
@@ -12,13 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package peeroob
-
-const (
-	// AuthURLFlagName contains the name of auth-url flag.
-	AuthURLFlagName = "auth-url"
-	// ClusterIDFlagName contains the name of cluster ID flag.
-	ClusterIDFlagName = "cluster-id"
-	// ClusterTokenFlagName contains the name for the token flag.
-	ClusterTokenFlagName = "auth-token"
-)
+// Package wait contains the functions to wait for resource events.
+package wait

--- a/pkg/liqoctl/wait/wait.go
+++ b/pkg/liqoctl/wait/wait.go
@@ -1,0 +1,135 @@
+// Copyright 2019-2022 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wait
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
+	"github.com/liqotech/liqo/pkg/liqoctl/factory"
+	"github.com/liqotech/liqo/pkg/utils"
+	fcutils "github.com/liqotech/liqo/pkg/utils/foreignCluster"
+	getters "github.com/liqotech/liqo/pkg/utils/getters"
+)
+
+// Waiter is a struct that contains the necessary information to wait for resource events.
+type Waiter struct {
+	// Printer is the object used to output messages in the appropriate format.
+	Printer *factory.Printer
+	// crClient is the controller runtime client.
+	CRClient client.Client
+}
+
+// NewWaiterFromFactory creates a new Waiter object from the given factory.
+func NewWaiterFromFactory(f *factory.Factory) *Waiter {
+	return &Waiter{
+		Printer:  f.Printer,
+		CRClient: f.CRClient,
+	}
+}
+
+// ForUnpeering waits until the status on the foreiglcusters resource states that the in/outgoing peering has been successfully
+// set to None or the timeout expires.
+func (w *Waiter) ForUnpeering(ctx context.Context, remoteClusterID *discoveryv1alpha1.ClusterIdentity) error {
+	remName := remoteClusterID.ClusterName
+	s := w.Printer.StartSpinner(fmt.Sprintf("Unpeering from the remote cluster %q", remName))
+	err := fcutils.PollForEvent(ctx, w.CRClient, remoteClusterID, fcutils.IsUnpeered, 1*time.Second)
+	if client.IgnoreNotFound(err) != nil {
+		s.Fail(fmt.Sprintf("Failed unpeering from remote cluster %q: %s", remName, err.Error()))
+		return err
+	}
+	s.Success(fmt.Sprintf("Successfully unpeered from remote cluster %q", remName))
+	return nil
+}
+
+// ForOutgoingUnpeering waits until the status on the foreiglcusters resource states that the outgoing peering has been successfully
+// set to None or the timeout expires.
+func (w *Waiter) ForOutgoingUnpeering(ctx context.Context, remoteClusterID *discoveryv1alpha1.ClusterIdentity) error {
+	remName := remoteClusterID.ClusterName
+	s := w.Printer.StartSpinner(fmt.Sprintf("Disabling outgoing peering to the remote cluster %q", remName))
+	err := fcutils.PollForEvent(ctx, w.CRClient, remoteClusterID, fcutils.IsOutgoingPeeringNone, 1*time.Second)
+	if client.IgnoreNotFound(err) != nil {
+		s.Fail(fmt.Sprintf("Failed disabling outgoing peering to the remote cluster %q: %s", remName, err.Error()))
+		return err
+	}
+	s.Success(fmt.Sprintf("Successfully disabled outgoing peering to the remote cluster %q", remName))
+	return nil
+}
+
+// ForAuth waits until the authentication has been established with the remote cluster or the timeout expires.
+func (w *Waiter) ForAuth(ctx context.Context, remoteClusterID *discoveryv1alpha1.ClusterIdentity) error {
+	remName := remoteClusterID.ClusterName
+	s := w.Printer.StartSpinner(fmt.Sprintf("Waiting for authentication to the cluster %q", remName))
+	err := fcutils.PollForEvent(ctx, w.CRClient, remoteClusterID, fcutils.IsAuthenticated, 1*time.Second)
+	if err != nil {
+		s.Fail(fmt.Sprintf("Authentication to the remote cluster %q failed: %s", remName, err.Error()))
+		return err
+	}
+	s.Success(fmt.Sprintf("Authenticated to cluster %q", remName))
+	return nil
+}
+
+// ForNetwork waits until the networking has been established with the remote cluster or the timeout expires.
+func (w *Waiter) ForNetwork(ctx context.Context, remoteClusterID *discoveryv1alpha1.ClusterIdentity) error {
+	remName := remoteClusterID.ClusterName
+	s := w.Printer.StartSpinner(fmt.Sprintf("Waiting for network to the remote cluster %q", remName))
+	err := fcutils.PollForEvent(ctx, w.CRClient, remoteClusterID, fcutils.IsNetworkingEstablished, 1*time.Second)
+	if err != nil {
+		s.Fail(fmt.Sprintf("Failed establishing networking to the remote cluster %q: %s", remName, err.Error()))
+		return err
+	}
+	s.Success(fmt.Sprintf("Network established to the remote cluster %q", remName))
+	return nil
+}
+
+// ForOutgoingPeering waits until the status on the foreiglcusters resource states that the outgoing peering has been successfully
+// established or the timeout expires.
+func (w *Waiter) ForOutgoingPeering(ctx context.Context, remoteClusterID *discoveryv1alpha1.ClusterIdentity) error {
+	remName := remoteClusterID.ClusterName
+	s := w.Printer.StartSpinner(fmt.Sprintf("Activating outgoing peering to the remote cluster %q", remName))
+	err := fcutils.PollForEvent(ctx, w.CRClient, remoteClusterID, fcutils.IsOutgoingJoined, 1*time.Second)
+	if err != nil {
+		s.Fail(fmt.Sprintf("Failed activating outgoing peering to the remote cluster %q: %s", remName, err.Error()))
+		return err
+	}
+	s.Success(fmt.Sprintf("Outgoing peering activated to the remote cluster %q", remName))
+	return nil
+}
+
+// ForNode waits until the node has been added to the cluster or the timeout expires.
+func (w *Waiter) ForNode(ctx context.Context, remoteClusterID *discoveryv1alpha1.ClusterIdentity) error {
+	remName := remoteClusterID.ClusterName
+	s := w.Printer.StartSpinner(fmt.Sprintf("Waiting for node to be created for the remote cluster %q", remName))
+
+	err := wait.PollImmediateUntilWithContext(ctx, 1*time.Second, func(ctx context.Context) (done bool, err error) {
+		node, err := getters.GetNodeByClusterID(ctx, w.CRClient, remoteClusterID)
+		if err != nil {
+			return false, client.IgnoreNotFound(err)
+		}
+
+		return utils.IsNodeReady(node), nil
+	})
+	if err != nil {
+		s.Fail(fmt.Sprintf("Failed waiting for node to be created for remote cluster %q: %s", remName, err.Error()))
+		return err
+	}
+	s.Success(fmt.Sprintf("Node created for remote cluster %q", remName))
+	return nil
+}

--- a/pkg/virtualKubelet/const.go
+++ b/pkg/virtualKubelet/const.go
@@ -28,6 +28,6 @@ const (
 )
 
 // VirtualNodeName generates the virtual node name based on the cluster ID.
-func VirtualNodeName(cluster discoveryv1alpha1.ClusterIdentity) string {
+func VirtualNodeName(cluster *discoveryv1alpha1.ClusterIdentity) string {
 	return VirtualNodePrefix + cluster.ClusterName
 }

--- a/pkg/vkMachinery/forge/creation.go
+++ b/pkg/vkMachinery/forge/creation.go
@@ -29,7 +29,7 @@ import (
 )
 
 // VirtualKubeletDeployment forges the deployment for a virtual-kubelet.
-func VirtualKubeletDeployment(homeCluster, remoteCluster discoveryv1alpha1.ClusterIdentity, vkNamespace, liqoNamespace string,
+func VirtualKubeletDeployment(homeCluster, remoteCluster *discoveryv1alpha1.ClusterIdentity, vkNamespace, liqoNamespace string,
 	opts *VirtualKubeletOpts, resourceOffer *sharingv1alpha1.ResourceOffer) (*appsv1.Deployment, error) {
 	vkLabels := VirtualKubeletLabels(remoteCluster.ClusterID, opts)
 	annotations := opts.ExtraAnnotations

--- a/pkg/vkMachinery/forge/forge.go
+++ b/pkg/vkMachinery/forge/forge.go
@@ -109,7 +109,7 @@ func getDeafultStorageClass(storageClasses []sharingv1alpha1.StorageType) sharin
 }
 
 func forgeVKContainers(
-	vkImage string, homeCluster, remoteCluster discoveryv1alpha1.ClusterIdentity,
+	vkImage string, homeCluster, remoteCluster *discoveryv1alpha1.ClusterIdentity,
 	nodeName, vkNamespace, liqoNamespace string, opts *VirtualKubeletOpts,
 	resourceOffer *sharingv1alpha1.ResourceOffer) []v1.Container {
 	command := []string{
@@ -176,7 +176,7 @@ func forgeVKContainers(
 
 func forgeVKPodSpec(
 	vkNamespace, liqoNamespace string,
-	homeCluster, remoteCluster discoveryv1alpha1.ClusterIdentity, opts *VirtualKubeletOpts,
+	homeCluster, remoteCluster *discoveryv1alpha1.ClusterIdentity, opts *VirtualKubeletOpts,
 	resourceOffer *sharingv1alpha1.ResourceOffer) v1.PodSpec {
 	nodeName := virtualKubelet.VirtualNodeName(remoteCluster)
 	return v1.PodSpec{

--- a/test/e2e/testutils/net/pod.go
+++ b/test/e2e/testutils/net/pod.go
@@ -108,7 +108,7 @@ func forgeTesterPod(image, namespace string, opts *TesterOpts) *v1.Pod {
 	if opts.Offloaded {
 		NodeAffinityOperator = v1.NodeSelectorOpIn
 		nodeSelector = map[string]string{
-			"kubernetes.io/hostname": virtualKubelet.VirtualNodeName(opts.Cluster),
+			"kubernetes.io/hostname": virtualKubelet.VirtualNodeName(&opts.Cluster),
 		}
 	}
 


### PR DESCRIPTION
# Description

This pr improves the liqoctl peer and unpeer commands.
In particular, these commands are now waiting for completion. It is now possible to re-enable a peering without providing all the remote configurations again.

You can now type:

```bash
liqoctl peer <cluster-name>
```

instead of the generated peer command.

# How Has This Been Tested?

- [x] locally on KinD
