### PR TITLE
Liqoctl offload: fix selector

### DIFF
--- a/cmd/liqoctl/cmd/install.go
+++ b/cmd/liqoctl/cmd/install.go
@@ -121,7 +121,7 @@ func newInstallCommand(ctx context.Context, f *factory.Factory) *cobra.Command {
 	}
 
 	cmd.PersistentFlags().StringVar(&options.Version, "version", "",
-		"The version of Liqo to be installed, among releases and commit SHAs. Defaults to the latest stable release)")
+		"The version of Liqo to be installed, among releases and commit SHAs. Defaults to the latest stable release")
 	cmd.PersistentFlags().StringVar(&options.RepoURL, "repo-url", "https://github.com/liqotech/liqo.git",
 		"The URL of the git repository used to retrieve the Helm chart, if a non released version is specified")
 	cmd.PersistentFlags().StringVar(&options.ChartPath, "local-chart-path", "",

--- a/cmd/liqoctl/cmd/offload.go
+++ b/cmd/liqoctl/cmd/offload.go
@@ -18,7 +18,6 @@ import (
 	"context"
 
 	"github.com/spf13/cobra"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 
 	offloadingv1alpha1 "github.com/liqotech/liqo/apis/offloading/v1alpha1"
@@ -98,18 +97,12 @@ func newOffloadNamespaceCommand(ctx context.Context, f *factory.Factory) *cobra.
 		PreRun: func(cmd *cobra.Command, args []string) {
 			options.PodOffloadingStrategy = offloadingv1alpha1.PodOffloadingStrategyType(podOffloadingStrategy.Value)
 			options.NamespaceMappingStrategy = offloadingv1alpha1.NamespaceMappingStrategyType(namespaceMappingStrategy.Value)
-
-			// Parse the cluster selectors
-			for _, selector := range selectors {
-				s, err := metav1.ParseToLabelSelector(selector)
-				options.Printer.CheckErr(err)
-				options.ClusterSelector = append(options.ClusterSelector, s.MatchExpressions)
-			}
+			options.Printer.CheckErr(options.ParseClusterSelectors(selectors))
 		},
 
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			options.Namespace = args[0]
-			options.Printer.CheckErr(options.Run(ctx))
+			return options.Run(ctx)
 		},
 	}
 

--- a/pkg/liqoctl/offload/handler_test.go
+++ b/pkg/liqoctl/offload/handler_test.go
@@ -1,0 +1,62 @@
+// Copyright 2019-2022 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package offload_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/types"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/liqotech/liqo/pkg/liqoctl/offload"
+)
+
+var _ = Describe("Handler tests", func() {
+	type ClusterSelectorCase struct {
+		Selectors  []string
+		Expected   [][]metav1.LabelSelectorRequirement
+		ErrMatcher types.GomegaMatcher
+	}
+
+	DescribeTable("cluster selectors parsing",
+		func(c ClusterSelectorCase) {
+			var opts offload.Options
+			Expect(opts.ParseClusterSelectors(c.Selectors)).To(c.ErrMatcher)
+			Expect(opts.ClusterSelector).To(ContainElements(c.Expected))
+		},
+		Entry("equality selector", ClusterSelectorCase{
+			Selectors:  []string{"key=value"},
+			Expected:   [][]metav1.LabelSelectorRequirement{{{Key: "key", Operator: metav1.LabelSelectorOpIn, Values: []string{"value"}}}},
+			ErrMatcher: Not(HaveOccurred()),
+		}),
+		Entry("multiple selectors in logical AND", ClusterSelectorCase{
+			Selectors: []string{"key=value,!staging"},
+			Expected: [][]metav1.LabelSelectorRequirement{{
+				{Key: "staging", Operator: metav1.LabelSelectorOpDoesNotExist, Values: []string{}},
+				{Key: "key", Operator: metav1.LabelSelectorOpIn, Values: []string{"value"}},
+			}},
+			ErrMatcher: Not(HaveOccurred()),
+		}),
+		Entry("multiple selectors in logical OR", ClusterSelectorCase{
+			Selectors: []string{"key=value", "!staging"},
+			Expected: [][]metav1.LabelSelectorRequirement{
+				{{Key: "key", Operator: metav1.LabelSelectorOpIn, Values: []string{"value"}}},
+				{{Key: "staging", Operator: metav1.LabelSelectorOpDoesNotExist, Values: []string{}}},
+			},
+			ErrMatcher: Not(HaveOccurred()),
+		}),
+	)
+})

--- a/pkg/liqoctl/offload/offload_suite_test.go
+++ b/pkg/liqoctl/offload/offload_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright 2019-2022 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package offload_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestOffload(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Offload Suite")
+}


### PR DESCRIPTION
# Description

This PR fixes the liqoctl offload namespace command, ensuring the selector works also in case of 'key=value' filters.

Fixes #(issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Existing
- [x] Manually, on kind
