### PR TITLE
Liqoctl: Improve Uninstall Command

### DIFF
--- a/pkg/consts/storage.go
+++ b/pkg/consts/storage.go
@@ -25,4 +25,7 @@ const (
 	VirtualPvcNamespaceLabel = "storage.liqo.io/virtual-pvc-namespace"
 	// VirtualPvcNameLabel is the label used to mark the name of a virtual PVC.
 	VirtualPvcNameLabel = "storage.liqo.io/virtual-pvc-name"
+
+	// StorageNamespaceLabel is the label used to mark the liqo storage namespace.
+	StorageNamespaceLabel = "liqo.io/storage-provisioner"
 )

--- a/pkg/liqo-controller-manager/storageprovisioner/storageprovisioner.go
+++ b/pkg/liqo-controller-manager/storageprovisioner/storageprovisioner.go
@@ -22,6 +22,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/sig-storage-lib-external-provisioner/v7/controller"
 
+	"github.com/liqotech/liqo/pkg/consts"
 	liqoerrors "github.com/liqotech/liqo/pkg/utils/errors"
 )
 
@@ -43,6 +44,9 @@ func NewLiqoLocalStorageProvisioner(ctx context.Context, cl client.Client,
 	err := cl.Create(ctx, &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: storageNamespace,
+			Labels: map[string]string{
+				consts.StorageNamespaceLabel: "true",
+			},
 		},
 	})
 	if liqoerrors.IgnoreAlreadyExists(err) != nil {

--- a/pkg/liqoctl/uninstall/handler.go
+++ b/pkg/liqoctl/uninstall/handler.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"helm.sh/helm/v3/pkg/storage/driver"
+	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -32,6 +33,8 @@ import (
 	offv1alpha1 "github.com/liqotech/liqo/apis/offloading/v1alpha1"
 	sharingv1alpha1 "github.com/liqotech/liqo/apis/sharing/v1alpha1"
 	virtualKubeletv1alpha1 "github.com/liqotech/liqo/apis/virtualkubelet/v1alpha1"
+	"github.com/liqotech/liqo/pkg/consts"
+	"github.com/liqotech/liqo/pkg/discovery"
 	"github.com/liqotech/liqo/pkg/liqoctl/factory"
 	"github.com/liqotech/liqo/pkg/liqoctl/install"
 )
@@ -53,8 +56,14 @@ type Options struct {
 
 // Run implements the uninstall command.
 func (o *Options) Run(ctx context.Context) error {
-	s := o.Printer.StartSpinner("Uninstalling Liqo")
+	s := o.Printer.StartSpinner("Running pre-uninstall checks")
+	if err := o.preUninstall(ctx); err != nil {
+		s.Fail(fmt.Sprintf("Pre-uninstall checks failed: %v", err))
+		return err
+	}
+	s.Success("Pre-uninstall checks passed")
 
+	s = o.Printer.StartSpinner("Uninstalling Liqo")
 	err := o.HelmClient().UninstallReleaseByName(install.LiqoReleaseName)
 	if err != nil && !errors.Is(err, driver.ErrReleaseNotFound) {
 		s.Fail("Error uninstalling Liqo: ", err)
@@ -70,6 +79,13 @@ func (o *Options) Run(ctx context.Context) error {
 			return err
 		}
 		s.Success("Liqo CRDs purged")
+
+		s = o.Printer.StartSpinner("Deleting Liqo namespaces")
+		if err = o.deleteLiqoNamespaces(ctx); err != nil {
+			s.Fail("Error deleting namespaces: ", err)
+			return err
+		}
+		s.Success("Liqo namespaces deleted")
 	}
 
 	return nil
@@ -98,6 +114,50 @@ func (o *Options) purge(ctx context.Context) error {
 			if client.IgnoreNotFound(err) != nil {
 				return err
 			}
+		}
+	}
+
+	return nil
+}
+
+func (o *Options) deleteLiqoNamespaces(ctx context.Context) error {
+	var nsList corev1.NamespaceList
+
+	// delete tenant namespaces
+	// we list them all and then delete them one by one to avoid the error
+	// "the server does not allow this method on the requested resource"
+	if err := o.CRClient.List(ctx, &nsList, client.MatchingLabels{
+		discovery.TenantNamespaceLabel: "true",
+	}); err != nil {
+		return err
+	}
+	for i := range nsList.Items {
+		ns := &nsList.Items[i]
+		if err := o.CRClient.Delete(ctx, ns); client.IgnoreNotFound(err) != nil {
+			return err
+		}
+	}
+
+	// delete liqo namespace
+	ns := corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: o.LiqoNamespace,
+		},
+	}
+	if err := o.CRClient.Delete(ctx, &ns); client.IgnoreNotFound(err) != nil {
+		return err
+	}
+
+	// delete liqo storage namespace
+	if err := o.CRClient.List(ctx, &nsList, client.MatchingLabels{
+		consts.StorageNamespaceLabel: "true",
+	}); err != nil {
+		return err
+	}
+	for i := range nsList.Items {
+		ns := &nsList.Items[i]
+		if err := o.CRClient.Delete(ctx, ns); client.IgnoreNotFound(err) != nil {
+			return err
 		}
 	}
 

--- a/pkg/liqoctl/uninstall/preuninstall.go
+++ b/pkg/liqoctl/uninstall/preuninstall.go
@@ -1,0 +1,113 @@
+// Copyright 2019-2022 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package uninstall
+
+import (
+	"context"
+	"fmt"
+
+	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
+	offloadingv1alpha1 "github.com/liqotech/liqo/apis/offloading/v1alpha1"
+	"github.com/liqotech/liqo/pkg/utils/errors"
+	foreignclusterutils "github.com/liqotech/liqo/pkg/utils/foreignCluster"
+)
+
+type errorMap struct {
+	outgoingPeering []string
+	incomingPeering []string
+	networking      []string
+	offloading      []string
+}
+
+func newErrorMap() errorMap {
+	return errorMap{
+		outgoingPeering: []string{},
+		incomingPeering: []string{},
+		networking:      []string{},
+		offloading:      []string{},
+	}
+}
+
+func (em *errorMap) getError() error {
+	str := ""
+	hasErr := false
+	if len(em.outgoingPeering) > 0 {
+		str += "\ndisable outgoing peering for clusters:\n"
+		for _, fc := range em.outgoingPeering {
+			str += fmt.Sprintf("- %s\n", fc)
+		}
+		hasErr = true
+	}
+	if len(em.incomingPeering) > 0 {
+		str += "\ndisable incoming peering for clusters:\n"
+		for _, fc := range em.incomingPeering {
+			str += fmt.Sprintf("- %s\n", fc)
+		}
+		hasErr = true
+	}
+	if len(em.networking) > 0 {
+		str += "\ndisable networking for clusters:\n"
+		for _, fc := range em.networking {
+			str += fmt.Sprintf("- %s\n", fc)
+		}
+		hasErr = true
+	}
+	if len(em.offloading) > 0 {
+		str += "\ndisable offloading for namespaces:\n"
+		for _, fc := range em.offloading {
+			str += fmt.Sprintf("- %s\n", fc)
+		}
+		hasErr = true
+	}
+
+	if hasErr {
+		return fmt.Errorf("you should:\n%s", str)
+	}
+	return nil
+}
+
+func (o *Options) preUninstall(ctx context.Context) error {
+	var foreignClusterList discoveryv1alpha1.ForeignClusterList
+	if err := o.CRClient.List(ctx, &foreignClusterList); errors.IgnoreNoMatchError(err) != nil {
+		return err
+	}
+
+	errMap := newErrorMap()
+	for i := range foreignClusterList.Items {
+		fc := &foreignClusterList.Items[i]
+
+		if foreignclusterutils.IsOutgoingEnabled(fc) {
+			errMap.outgoingPeering = append(errMap.outgoingPeering, fc.Name)
+		}
+		if foreignclusterutils.IsIncomingEnabled(fc) {
+			errMap.incomingPeering = append(errMap.incomingPeering, fc.Name)
+		}
+		if foreignclusterutils.IsNetworkingEstablished(fc) {
+			errMap.networking = append(errMap.networking, fc.Name)
+		}
+	}
+
+	var namespaceOffloadings offloadingv1alpha1.NamespaceOffloadingList
+	if err := o.CRClient.List(ctx, &namespaceOffloadings); errors.IgnoreNoMatchError(err) != nil {
+		return err
+	}
+
+	for i := range namespaceOffloadings.Items {
+		offloading := &namespaceOffloadings.Items[i]
+		errMap.offloading = append(errMap.offloading, offloading.Namespace)
+	}
+
+	return errMap.getError()
+}

--- a/pkg/utils/errors/errors.go
+++ b/pkg/utils/errors/errors.go
@@ -18,6 +18,7 @@ import (
 	"flag"
 
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/klog/v2"
 )
 
@@ -60,5 +61,14 @@ func IgnoreAlreadyExists(err error) error {
 		return nil
 	}
 
+	return err
+}
+
+// IgnoreNoMatchError returns nil on NoMatch errors.
+// All other values that are not NoMatch errors or nil are returned unmodified.
+func IgnoreNoMatchError(err error) error {
+	if meta.IsNoMatchError(err) {
+		return nil
+	}
 	return err
 }

--- a/test/e2e/pipeline/installer/liqoctl/uninstall.sh
+++ b/test/e2e/pipeline/installer/liqoctl/uninstall.sh
@@ -47,6 +47,11 @@ source "${SCRIPT_DIR}/helm-utils.sh"
 
 download_helm
 
+# the unpeer command waits for the status in the local cluster, for the remote one
+# it may take a bit longer. Sleep for a second to make sure that the uninstall command
+# pre-checks will not fail
+sleep 1
+
 for i in $(seq 1 "${CLUSTER_NUMBER}");
 do
   export KUBECONFIG="${TMPDIR}/kubeconfigs/liqo_kubeconf_${i}"


### PR DESCRIPTION
# Description

This pr improves the `liqoctl uninstall` command.

It adds:

* pre-uninstall checks to make sure that no peering and/or offloading is enabled
* purging of the liqo namespaces if the `--purge` flag is set

# How Has This Been Tested?

- [x] locally
