### PR TITLE
liqoctl unpeer: fix description

### DIFF
--- a/cmd/liqoctl/cmd/unpeer.go
+++ b/cmd/liqoctl/cmd/unpeer.go
@@ -44,7 +44,7 @@ out-of-band or in-band, although in the latter case the VPN tunnel is not teared
 down (as the *unpeer in-band* instead would do).
 
 Examples:
-  $ {{ .Executable }} unpeer out-of-band eternal-donkey
+  $ {{ .Executable }} unpeer eternal-donkey
 `
 
 const liqoctlUnpeerOOBLongHelp = `Disable an out-of-band peering towards a remote cluster.


### PR DESCRIPTION
# Description

This PR removes a leftover word in the liqoctl unpeer description.