### PR TITLE
Liqoctl: Upgrade CRDs on Chart Upgrade

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -58,6 +58,7 @@ require (
 	sigs.k8s.io/aws-iam-authenticator v0.5.7
 	sigs.k8s.io/controller-runtime v0.11.2
 	sigs.k8s.io/sig-storage-lib-external-provisioner/v7 v7.0.1
+	sigs.k8s.io/yaml v1.3.0
 )
 
 require (
@@ -232,7 +233,6 @@ require (
 	sigs.k8s.io/kustomize/api v0.11.4 // indirect
 	sigs.k8s.io/kustomize/kyaml v0.13.6 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.1 // indirect
-	sigs.k8s.io/yaml v1.3.0 // indirect
 )
 
 replace github.com/grandcat/zeroconf => github.com/liqotech/zeroconf v1.0.1-0.20201020081245-6384f3f21ffb


### PR DESCRIPTION
# Description

This pr adds the feature in the `liqoctl install` command to upgrade the Liqo CRDs when Liqo is upgraded.

# How Has This Been Tested?

- [x] locally
