### PR TITLE
Foreign cluster print columns: shorten names

### DIFF
--- a/apis/discovery/v1alpha1/foreigncluster_types.go
+++ b/apis/discovery/v1alpha1/foreigncluster_types.go
@@ -193,10 +193,10 @@ type TenantNamespaceType struct {
 // ForeignCluster is the Schema for the foreignclusters API.
 // +kubebuilder:printcolumn:name="ClusterID",type=string,priority=1,JSONPath=`.spec.clusterIdentity.clusterID`
 // +kubebuilder:printcolumn:name="ClusterName",type=string,priority=1,JSONPath=`.spec.clusterIdentity.clusterName`
-// +kubebuilder:printcolumn:name="Outgoing peering phase",type=string,JSONPath=`.status.peeringConditions[?(@.type == 'OutgoingPeering')].status`
-// +kubebuilder:printcolumn:name="Incoming peering phase",type=string,JSONPath=`.status.peeringConditions[?(@.type == 'IncomingPeering')].status`
-// +kubebuilder:printcolumn:name="Networking status",type=string,JSONPath=`.status.peeringConditions[?(@.type == 'NetworkStatus')].status`
-// +kubebuilder:printcolumn:name="Authentication status",type=string,JSONPath=`.status.peeringConditions[?(@.type == 'AuthenticationStatus')].status`
+// +kubebuilder:printcolumn:name="Outgoing peering",type=string,JSONPath=`.status.peeringConditions[?(@.type == 'OutgoingPeering')].status`
+// +kubebuilder:printcolumn:name="Incoming peering",type=string,JSONPath=`.status.peeringConditions[?(@.type == 'IncomingPeering')].status`
+// +kubebuilder:printcolumn:name="Networking",type=string,JSONPath=`.status.peeringConditions[?(@.type == 'NetworkStatus')].status`
+// +kubebuilder:printcolumn:name="Authentication",type=string,JSONPath=`.status.peeringConditions[?(@.type == 'AuthenticationStatus')].status`
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 type ForeignCluster struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/deployments/liqo/crds/discovery.liqo.io_foreignclusters.yaml
+++ b/deployments/liqo/crds/discovery.liqo.io_foreignclusters.yaml
@@ -27,16 +27,16 @@ spec:
       priority: 1
       type: string
     - jsonPath: .status.peeringConditions[?(@.type == 'OutgoingPeering')].status
-      name: Outgoing peering phase
+      name: Outgoing peering
       type: string
     - jsonPath: .status.peeringConditions[?(@.type == 'IncomingPeering')].status
-      name: Incoming peering phase
+      name: Incoming peering
       type: string
     - jsonPath: .status.peeringConditions[?(@.type == 'NetworkStatus')].status
-      name: Networking status
+      name: Networking
       type: string
     - jsonPath: .status.peeringConditions[?(@.type == 'AuthenticationStatus')].status
-      name: Authentication status
+      name: Authentication
       type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age


### PR DESCRIPTION
# Description

This PR shortens the titles of the print columns of the ForeignCluster CRD, to make them better fit narrow terminals.