### PR TITLE
Helm chart: improve ci image suffix management

### DIFF
--- a/deployments/liqo/templates/_helpers.tpl
+++ b/deployments/liqo/templates/_helpers.tpl
@@ -44,10 +44,12 @@ Create version used to select the liqo version to be installed .
 {{- end }}
 
 {{/*
-Create version used to select the liqo version to be installed.
+The suffix added to the Liqo images, to identify CI builds.
 */}}
 {{- define "liqo.suffix" -}}
-{{- if or (eq .Values.tag "") (eq .Chart.AppVersion .Values.tag) }}
+{{/* https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string */}}
+{{- $semverregex := "^v(?P<major>0|[1-9]\\d*)\\.(?P<minor>0|[1-9]\\d*)\\.(?P<patch>0|[1-9]\\d*)(?:-(?P<prerelease>(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$" }}
+{{- if or (eq .Values.tag "") (mustRegexMatch $semverregex .Values.tag) }}
 {{- print "" }}
 {{- else }}
 {{- print "-ci" }}


### PR DESCRIPTION
# Description

This PR improves the management of the CI image suffix in the helm chart, to ensure that the correct image is selected in case a released version is specified, and the `appVersion` variable is not set. 

Fixes #(issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ x Manually, checking the outcome of helm template with different image versions.
