### PR TITLE
Liqoctl install on AKS Fix and Documentation

### DIFF
--- a/docs/installation/install.md
+++ b/docs/installation/install.md
@@ -102,6 +102,12 @@ liqoctl install aks --resource-group-name "${AKS_RESOURCE_GROUP}" \
 
 By default, the cluster is assigned the same name as that specified through the `--resource-name` parameter.
 Alternatively, you can manually specify a different name with the `--cluster-name` *liqoctl* flag.
+
+```{admonition} Note
+If you are running an [AKS private cluster](https://docs.microsoft.com/en-us/azure/aks/private-clusters), you may need to set the `--disable-endpoint-check` *liqoctl* flag, since the API Server in your kubeconfig may be different from the one retrieved from the Azure APIs.
+
+Additionally, since your API Server is not accessible from the public Internet, you shall leverage the [in-band peering approach](FeaturesPeeringInBandControlPlane) towards the clusters not attached to the same Azure Virtual Network.
+```
 ````
 
 ````{tab} EKS

--- a/docs/usage/peer.md
+++ b/docs/usage/peer.md
@@ -22,7 +22,7 @@ Ensure you selected the correct target cluster before issuing *liqoctl* commands
 
 ## Out-of-band control plane
 
-Briefly, the procedure to establish an out-of-band control plane peering consists of a first step performed on the *provider*, to **retrieve the set of information** required (i.e., authentication endpoint and token, cluster ID, ...), followed by the creation of the necessary resources to **start the actual peering**.
+Briefly, the procedure to establish an [out-of-band control plane peering](FeaturesPeeringOutOfBandControlPlane) consists of a first step performed on the *provider*, to **retrieve the set of information** required (i.e., authentication endpoint and token, cluster ID, ...), followed by the creation of the necessary resources to **start the actual peering**.
 The remainder of the process, including identity retrieval, resource negotiation and network tunnel establishment is **performed automatically** by Liqo, through a mutual exchange of information and negotiation between the two clusters involved.
 
 ### Information retrieval
@@ -111,9 +111,11 @@ node representing the local cluster.
 Hence, the same command shall be executed on both clusters to completely tear down a bidirectional peering.
 ```
 
+(UsagePeerInBand)=
+
 ## In-band control plane
 
-Briefly, the procedure to establish an in-band control plane peering consists of a first step performed by *liqoctl*, which interacts alternatively with both clusters to **establish the cross-cluster VPN tunnel**, exchange the **authentication tokens** and configure the Liqo control plane traffic to flow inside the VPN.
+Briefly, the procedure to establish an [in-band control plane peering](FeaturesPeeringInBandControlPlane) consists of a first step performed by *liqoctl*, which interacts alternatively with both clusters to **establish the cross-cluster VPN tunnel**, exchange the **authentication tokens** and configure the Liqo control plane traffic to flow inside the VPN.
 The remainder of the process, including identity retrieval and resource negotiation, is **performed automatically** by Liqo, through a mutual exchange of information and negotiation between the two clusters involved.
 
 <!-- markdownlint-disable-next-line no-duplicate-heading -->

--- a/pkg/liqoctl/install/aks/provider.go
+++ b/pkg/liqoctl/install/aks/provider.go
@@ -148,9 +148,10 @@ func (o *Options) parseClusterOutput(ctx context.Context, cluster *containerserv
 		return fmt.Errorf("unknown AKS network plugin %v", cluster.NetworkProfile.NetworkPlugin)
 	}
 
-	if cluster.Fqdn != nil {
-		o.APIServer = *cluster.Fqdn
+	if cluster.Fqdn == nil {
+		return fmt.Errorf("failed to retrieve cluster APIServer FQDN, is the cluster running?")
 	}
+	o.APIServer = *cluster.Fqdn
 
 	if cluster.Location != nil {
 		o.ClusterLabels[consts.TopologyRegionClusterLabel] = *cluster.Location


### PR DESCRIPTION
# Description

This pr includes a small fix on liqo AKS installation (better error handling), and the documentation about the installation on Azure private clusters.

Fixes #1215 #1233 

# How Has This Been Tested?

- [x] on private AKS cluster, installing liqo from a VM with a network peering to the cluster virtual network
