### PR TITLE
Disable Specific Resource Reflection

### DIFF
--- a/cmd/virtual-kubelet/root/root.go
+++ b/cmd/virtual-kubelet/root/root.go
@@ -63,11 +63,6 @@ func runRootCommand(ctx context.Context, c *Opts) error {
 		return errors.New("cluster name is mandatory")
 	}
 
-	if c.PodWorkers == 0 || c.ServiceWorkers == 0 || c.IngressWorkers == 0 ||
-		c.EndpointSliceWorkers == 0 || c.ConfigMapWorkers == 0 || c.SecretWorkers == 0 {
-		return errors.New("reflection workers must be greater than 0")
-	}
-
 	localConfig, err := utils.GetRestConfig(c.HomeKubeconfig)
 	if err != nil {
 		return err


### PR DESCRIPTION
# Description

This pr makes it possible to disable the reflection/offloading of a specific resource kind by setting its worker number to 0.

# How Has This Been Tested?

- [x] locally
