### PR TITLE
GitHub actions: add hold/unhold commands and do not run E2E on merge

### DIFF
--- a/.github/workflows/greeting.yml
+++ b/.github/workflows/greeting.yml
@@ -21,11 +21,12 @@ jobs:
             I am @adamjensenbot.
             You can interact with me issuing a **slash command** in the first line of a **comment**.
             Currently, I understand the following commands:
-            * `/rebase`:            Rebase this PR onto the master branch (You can add the option `test=true` to launch the tests 
+            * `/rebase`:            Rebase this PR onto the master branch (You can add the option `test=true` to launch the tests
               when the rebase operation is completed)
             * `/merge`:             Merge this PR into the master branch
-            * `/build`              Build Liqo components 
+            * `/build`              Build Liqo components
             * `/test`               Launch the E2E and Unit tests
+            * `/hold`, `/unhold`    Add/remove the hold label to prevent merging with /merge
 
             Make sure this PR appears in the **${{ github.event.repository.name }} changelog**, adding one of the following **labels**:
             * `kind/breaking`:      :boom: Breaking Change

--- a/.github/workflows/hold.yml
+++ b/.github/workflows/hold.yml
@@ -1,0 +1,47 @@
+name: Manage the hold label
+on:
+  repository_dispatch:
+    types:
+      - hold-command
+      - unhold-command
+
+jobs:
+  hold:
+    name: Add hold label
+    runs-on: ubuntu-latest
+    if: github.event.action == 'hold-command'
+
+    steps:
+      - name: Add the hold label to avoid merging
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          github_token: "${{ secrets.CI_TOKEN }}"
+          number: ${{ github.event.client_payload.github.payload.issue.number }}
+          labels: hold
+
+      - name: Report status as reaction
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          token: ${{ secrets.CI_TOKEN }}
+          comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
+          reactions: hooray
+
+  unhold:
+    name: Remove the hold label
+    runs-on: ubuntu-latest
+    if: github.event.action == 'unhold-command'
+
+    steps:
+      - name: Remove the hold label to allow merging
+        uses: actions-ecosystem/action-remove-labels@v1
+        with:
+          github_token: "${{ secrets.CI_TOKEN }}"
+          number: ${{ github.event.client_payload.github.payload.issue.number }}
+          labels: hold
+
+      - name: Report status as reaction
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          token: ${{ secrets.CI_TOKEN }}
+          comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
+          reactions: hooray

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -168,7 +168,7 @@ jobs:
   e2e-test-trigger:
     runs-on: ubuntu-latest
     needs: [build, configure, liqoctl]
-    if: github.event.client_payload.slash_command.command == 'test' || github.event_name == 'push'
+    if: github.event.client_payload.slash_command.command == 'test'
     steps:
 
        - name: Notify Event to E2E Tests

--- a/.github/workflows/slash-commands.yml
+++ b/.github/workflows/slash-commands.yml
@@ -34,4 +34,12 @@ jobs:
                 "command": "build",
                 "permission": "triage"
               }
+              {
+                "command": "hold",
+                "permission": "none"
+              },
+              {
+                "command": "unhold",
+                "permission": "none"
+              }
             ]


### PR DESCRIPTION
# Description

This PR introduces a pipeline to add/remove the hold label, which is copied over from the one initially written by @GabriFila for CrownLabs. Additionally, it modifies the integration pipeline to avoid executing the E2E tests upon merge into master, as already mandatory to merge the PR.
