### PR TITLE
Minor improvements to the documentation

### DIFF
--- a/docs/contributing/contributing.md
+++ b/docs/contributing/contributing.md
@@ -95,11 +95,16 @@ Some networking tests, however, require an isolated environment.
 To this end, you can leverage the dedicated *liqo-test* Docker image (the Dockerfile is available in *build/liqo-test*):
 
 ```bash
-# Run all unit tests
-docker run --rm -v $PATH_TO_LIQO:/go/src/github.com/liqotech/liqo liqo-test
+# Build the liqo-test Docker image
+make test-container
 
-# Run the tests for a specific package
-docker run --rm --entrypoint="" -v $PATH_TO_LIQO:/go/src/github.com/liqotech/liqo liqo-test go test $PACKAGE
+# Run all unit tests, and retrieve coverage
+make unit
+
+# Run the tests for a specific package.
+# Note, the package path must start with ./ to avoid the "package ... is not in GOROOT error".
+docker run --rm --entrypoint="" --mount type=bind,src=$(pwd),dst=/go/src/liqo \
+   --privileged=true --workdir /go/src/liqo liqo-test go test <package>
 ```
 
 #### Debugging unit tests
@@ -109,9 +114,8 @@ When executing the unit tests from the *liqo-test* container, it is possible to 
 1. Start the *liqo-test* container with an idle entry point, exposing a port of choice (e.g. 2345):
 
    ```bash
-   docker run --name=liqo-test -d -p 2345:2345 --entrypoint="" \
-      -v $PATH_TO_LIQO:/go/src/github.com/liqotech/liqo liqo-test tail -f /dev/null
-
+   docker run --name=liqo-test -d -p 2345:2345 --mount type=bind,src=$(pwd),dst=/go/src/liqo \
+      --privileged=true --workdir /go/src/liqo --entrypoint="" liqo-test tail -f /dev/null
    ```
 
 2. Open a shell inside the *liqo-test* container, and install Delve:

--- a/docs/features/peering.md
+++ b/docs/features/peering.md
@@ -6,7 +6,7 @@ In this case, we say that the consumer establishes an **outgoing peering** towar
 This configuration allows for maximum flexibility in asymmetric setups, while transparently supporting bidirectional peerings through their combination.
 Additionally, the same cluster can play the role of provider and consumer in multiple peerings.
 
-## Peering in a nutshell
+## Overview
 
 Overall, the establishment of a peering relationship between two clusters involves four main tasks:
 
@@ -22,7 +22,7 @@ Additional details are presented in the [network fabric section](/features/netwo
 
 (FeaturesPeeringApproaches)=
 
-## Peering approaches
+## Approaches
 
 Liqo supports two non-mutually exclusive peering approaches (i.e., the same cluster can leverage a different approach for different remote clusters), respectively referred to as **out-of-band control plane** and **in-band control plane**.
 The following sections briefly overview the differences among them, outlining the respective trade-offs.

--- a/docs/installation/install.md
+++ b/docs/installation/install.md
@@ -26,9 +26,15 @@ Ensure you selected the correct target cluster before issuing *liqoctl* commands
 **Supported CNIs**
 
 Liqo supports Kubernetes clusters using the following CNIs: [Flannel](https://github.com/coreos/flannel), [Calico](https://www.projectcalico.org/), [Canal](https://docs.projectcalico.org/getting-started/kubernetes/flannel/flannel), [Weave](https://github.com/weaveworks/weave).
+Additionally, partial support is provided for [Cilium](https://cilium.io/), although with the limitations listed below.
 
 ```{warning}
 If you are installing Liqo on a cluster using the **Calico** CNI, you MUST read the [dedicated configuration section](InstallationCalicoConfiguration) to avoid unwanted misconfigurations.
+```
+
+```{admonition} Liqo + Cilium limitations
+Currently, Liqo supports the Cilium CNI only when *kube-proxy* is enabled.
+Additionally, known limitations concern the impossibility of accessing the backends of *NodePort* and *LoadBalancer* services hosted on remote clusters, from a local cluster using Cilium as CNI.
 ```
 
 **Installation**


### PR DESCRIPTION
# Description

This PR introduces a few minor improvements to the documentation:
* Fix the commands to run the unit tests with the docker container
* Rename the section names in the peering page
* Add information concerning the support of Cilium in Liqo
