### PR TITLE
Liqoctl: add client lazy loading, and improve error management

### DIFF
--- a/cmd/liqoctl/cmd/docs.go
+++ b/cmd/liqoctl/cmd/docs.go
@@ -32,8 +32,6 @@ func newDocsCommand(ctx context.Context) *cobra.Command {
 		Long:  WithTemplate("Generate {{ .Executable }} documentation"),
 		Args:  cobra.NoArgs,
 
-		PreRun: func(cmd *cobra.Command, args []string) { cmd.SilenceErrors = true },
-
 		Run: func(cmd *cobra.Command, args []string) {
 			options.Root = cmd.Root()
 			util.CheckErr(options.Run(ctx))

--- a/cmd/liqoctl/cmd/generate.go
+++ b/cmd/liqoctl/cmd/generate.go
@@ -18,11 +18,11 @@ import (
 	"context"
 
 	"github.com/spf13/cobra"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 
 	"github.com/liqotech/liqo/pkg/liqoctl/completion"
 	"github.com/liqotech/liqo/pkg/liqoctl/factory"
 	"github.com/liqotech/liqo/pkg/liqoctl/generate"
+	"github.com/liqotech/liqo/pkg/liqoctl/output"
 )
 
 const liqoctlGeneratePeerLongHelp = `Generate the command to execute on another cluster to peer with the local cluster.
@@ -60,14 +60,14 @@ func newGeneratePeerCommand(ctx context.Context, f *factory.Factory) *cobra.Comm
 		Long:  WithTemplate(liqoctlGeneratePeerLongHelp),
 		Args:  cobra.NoArgs,
 
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return options.Run(ctx)
+		Run: func(cmd *cobra.Command, args []string) {
+			output.ExitOnErr(options.Run(ctx))
 		},
 	}
 
 	cmd.Flags().BoolVar(&options.OnlyCommand, "only-command", false, "Print only the resulting peer command, for scripts usage (default false)")
 
 	f.AddLiqoNamespaceFlag(cmd.Flags())
-	utilruntime.Must(cmd.RegisterFlagCompletionFunc(factory.FlagNamespace, completion.Namespaces(ctx, f, completion.NoLimit)))
+	f.Printer.CheckErr(cmd.RegisterFlagCompletionFunc(factory.FlagNamespace, completion.Namespaces(ctx, f, completion.NoLimit)))
 	return cmd
 }

--- a/cmd/liqoctl/cmd/generate.go
+++ b/cmd/liqoctl/cmd/generate.go
@@ -60,15 +60,6 @@ func newGeneratePeerCommand(ctx context.Context, f *factory.Factory) *cobra.Comm
 		Long:  WithTemplate(liqoctlGeneratePeerLongHelp),
 		Args:  cobra.NoArgs,
 
-		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-			if options.OnlyCommand {
-				// Do not print the initialization messages in case the only-command flag is set.
-				singleClusterPersistentPreRun(cmd, f, factory.Silent)
-			} else {
-				singleClusterPersistentPreRun(cmd, f)
-			}
-		},
-
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return options.Run(ctx)
 		},

--- a/cmd/liqoctl/cmd/install.go
+++ b/cmd/liqoctl/cmd/install.go
@@ -31,6 +31,7 @@ import (
 	"github.com/liqotech/liqo/pkg/liqoctl/install/kind"
 	"github.com/liqotech/liqo/pkg/liqoctl/install/kubeadm"
 	"github.com/liqotech/liqo/pkg/liqoctl/install/openshift"
+	"github.com/liqotech/liqo/pkg/liqoctl/output"
 	"github.com/liqotech/liqo/pkg/utils/args"
 )
 
@@ -111,12 +112,8 @@ func newInstallCommand(ctx context.Context, f *factory.Factory) *cobra.Command {
 			options.ReservedSubnets = reservedSubnets.StringList.StringList
 		},
 
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return options.Run(ctx, base)
-		},
-
-		PersistentPostRun: func(cmd *cobra.Command, args []string) {
-			options.Printer.CheckErr(options.PostRun())
+		Run: func(cmd *cobra.Command, args []string) {
+			output.ExitOnErr(options.Run(ctx, base))
 		},
 	}
 
@@ -173,8 +170,8 @@ func newInstallProviderCommand(ctx context.Context, options *install.Options, cr
 		Long:  WithTemplate(fmt.Sprintf(liqoctlInstallProviderLongHelp, provider.Name(), provider.Name(), provider.Examples())),
 		Args:  cobra.NoArgs,
 
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return options.Run(ctx, provider)
+		Run: func(cmd *cobra.Command, args []string) {
+			output.ExitOnErr(options.Run(ctx, provider))
 		},
 	}
 

--- a/cmd/liqoctl/cmd/move.go
+++ b/cmd/liqoctl/cmd/move.go
@@ -18,11 +18,11 @@ import (
 	"context"
 
 	"github.com/spf13/cobra"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 
 	"github.com/liqotech/liqo/pkg/liqoctl/completion"
 	"github.com/liqotech/liqo/pkg/liqoctl/factory"
 	"github.com/liqotech/liqo/pkg/liqoctl/move"
+	"github.com/liqotech/liqo/pkg/liqoctl/output"
 	"github.com/liqotech/liqo/pkg/utils"
 )
 
@@ -71,20 +71,20 @@ func newMoveVolumeCommand(ctx context.Context, f *factory.Factory) *cobra.Comman
 		Args:              cobra.ExactArgs(1),
 		ValidArgsFunction: completion.PVCs(ctx, f, 1),
 
-		RunE: func(cmd *cobra.Command, args []string) error {
+		Run: func(cmd *cobra.Command, args []string) {
 			options.VolumeName = args[0]
-			return options.Run(ctx)
+			output.ExitOnErr(options.Run(ctx))
 		},
 	}
 
 	f.AddNamespaceFlag(cmd.Flags())
-	utilruntime.Must(cmd.RegisterFlagCompletionFunc(factory.FlagNamespace, completion.Namespaces(ctx, f, completion.NoLimit)))
+	f.Printer.CheckErr(cmd.RegisterFlagCompletionFunc(factory.FlagNamespace, completion.Namespaces(ctx, f, completion.NoLimit)))
 
 	cmd.Flags().StringVar(&options.TargetNode, "target-node", "",
 		"The target node (either physical or virtual) the PVC will be moved to")
 
-	utilruntime.Must(cmd.MarkFlagRequired("target-node"))
-	utilruntime.Must(cmd.RegisterFlagCompletionFunc("target-node", completion.Nodes(ctx, f, completion.NoLimit)))
+	f.Printer.CheckErr(cmd.MarkFlagRequired("target-node"))
+	f.Printer.CheckErr(cmd.RegisterFlagCompletionFunc("target-node", completion.Nodes(ctx, f, completion.NoLimit)))
 
 	return cmd
 }

--- a/cmd/liqoctl/cmd/move.go
+++ b/cmd/liqoctl/cmd/move.go
@@ -54,8 +54,6 @@ func newMoveCommand(ctx context.Context, f *factory.Factory) *cobra.Command {
 		Short: "Move an object to a different cluster",
 		Long:  "Move an object to a different cluster.",
 		Args:  cobra.NoArgs,
-
-		PersistentPreRun: func(cmd *cobra.Command, args []string) { singleClusterPersistentPreRun(cmd, f) },
 	}
 
 	cmd.AddCommand(newMoveVolumeCommand(ctx, f))

--- a/cmd/liqoctl/cmd/offload.go
+++ b/cmd/liqoctl/cmd/offload.go
@@ -63,8 +63,6 @@ func newOffloadCommand(ctx context.Context, f *factory.Factory) *cobra.Command {
 		Short: "Offload a resource to remote clusters",
 		Long:  "Offload a resource to remote clusters.",
 		Args:  cobra.NoArgs,
-
-		PersistentPreRun: func(cmd *cobra.Command, args []string) { singleClusterPersistentPreRun(cmd, f) },
 	}
 
 	cmd.AddCommand(newOffloadNamespaceCommand(ctx, f))

--- a/cmd/liqoctl/cmd/offload.go
+++ b/cmd/liqoctl/cmd/offload.go
@@ -19,12 +19,12 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 
 	offloadingv1alpha1 "github.com/liqotech/liqo/apis/offloading/v1alpha1"
 	"github.com/liqotech/liqo/pkg/liqoctl/completion"
 	"github.com/liqotech/liqo/pkg/liqoctl/factory"
 	"github.com/liqotech/liqo/pkg/liqoctl/offload"
+	"github.com/liqotech/liqo/pkg/liqoctl/output"
 	"github.com/liqotech/liqo/pkg/utils/args"
 )
 
@@ -99,9 +99,9 @@ func newOffloadNamespaceCommand(ctx context.Context, f *factory.Factory) *cobra.
 			options.Printer.CheckErr(options.ParseClusterSelectors(selectors))
 		},
 
-		RunE: func(cmd *cobra.Command, args []string) error {
+		Run: func(cmd *cobra.Command, args []string) {
 			options.Namespace = args[0]
-			return options.Run(ctx)
+			output.ExitOnErr(options.Run(ctx))
 		},
 	}
 
@@ -114,8 +114,8 @@ func newOffloadNamespaceCommand(ctx context.Context, f *factory.Factory) *cobra.
 	cmd.Flags().StringArrayVarP(&selectors, "selector", "l", []string{},
 		"The selector to filter the target clusters. Can be specified multiple times, defining alternative requirements (i.e., in logical OR)")
 
-	utilruntime.Must(cmd.RegisterFlagCompletionFunc("pod-offloading-strategy", completion.Enumeration(podOffloadingStrategy.Allowed)))
-	utilruntime.Must(cmd.RegisterFlagCompletionFunc("namespace-mapping-strategy", completion.Enumeration(namespaceMappingStrategy.Allowed)))
+	f.Printer.CheckErr(cmd.RegisterFlagCompletionFunc("pod-offloading-strategy", completion.Enumeration(podOffloadingStrategy.Allowed)))
+	f.Printer.CheckErr(cmd.RegisterFlagCompletionFunc("namespace-mapping-strategy", completion.Enumeration(namespaceMappingStrategy.Allowed)))
 
 	return cmd
 }

--- a/cmd/liqoctl/cmd/peer.go
+++ b/cmd/liqoctl/cmd/peer.go
@@ -114,8 +114,6 @@ func newPeerCommand(ctx context.Context, f *factory.Factory) *cobra.Command {
 		Args:              cobra.ExactArgs(1),
 		ValidArgsFunction: completion.ForeignClusters(ctx, f, 1),
 
-		PersistentPreRun: func(cmd *cobra.Command, args []string) { singleClusterPersistentPreRun(cmd, f) },
-
 		RunE: func(cmd *cobra.Command, args []string) error {
 			options.ClusterName = args[0]
 			return options.Run(ctx)

--- a/cmd/liqoctl/cmd/root.go
+++ b/cmd/liqoctl/cmd/root.go
@@ -28,6 +28,7 @@ import (
 	"github.com/spf13/cobra"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/klog/v2"
+	"k8s.io/kubectl/pkg/cmd/util"
 
 	"github.com/liqotech/liqo/pkg/liqoctl/factory"
 )
@@ -107,15 +108,12 @@ func NewRootCommand(ctx context.Context) *cobra.Command {
 func WithTemplate(str string) string {
 	tmpl := template.Must(template.New("liqoctl").Parse(str))
 	var buf bytes.Buffer
-	utilruntime.Must(tmpl.Execute(&buf, struct{ Executable string }{liqoctl}))
+	util.CheckErr(tmpl.Execute(&buf, struct{ Executable string }{liqoctl}))
 	return buf.String()
 }
 
 // singleClusterPersistentPreRun initializes the local factory.
 func singleClusterPersistentPreRun(cmd *cobra.Command, f *factory.Factory, opts ...factory.Options) {
-	// Errors are silenced here, to ensure those referring to incorrect flags are printed out.
-	cmd.SilenceErrors = true
-
 	// Populate the factory fields based on the configured parameters.
 	f.Printer.CheckErr(f.Initialize(opts...))
 }

--- a/cmd/liqoctl/cmd/root.go
+++ b/cmd/liqoctl/cmd/root.go
@@ -69,8 +69,10 @@ func NewRootCommand(ctx context.Context) *cobra.Command {
 		Args:         cobra.NoArgs,
 		SilenceUsage: true, // Do not show the usage message in case of errors.
 
-		// The factory is not initialized by a PersistentPreRun here, to avoid issues with the completion
-		// functions (that do not require the clients to be setup) and allow for better customization.
+		// Initialize the factory with default parameters: thanks to lazy loading, this introduces no overhead,
+		// as well as no requirement for a valid kubeconfig if no subsequent API interaction is involved.
+		// The behavior can be customized in subcommands defining an appropriate PersistentPreRun function.
+		PersistentPreRun: func(cmd *cobra.Command, args []string) { singleClusterPersistentPreRun(cmd, f) },
 	}
 
 	// Since we cannot access internal klog configuration, we create a new flagset, let klog to install

--- a/cmd/liqoctl/cmd/status.go
+++ b/cmd/liqoctl/cmd/status.go
@@ -18,10 +18,10 @@ import (
 	"context"
 
 	"github.com/spf13/cobra"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 
 	"github.com/liqotech/liqo/pkg/liqoctl/completion"
 	"github.com/liqotech/liqo/pkg/liqoctl/factory"
+	"github.com/liqotech/liqo/pkg/liqoctl/output"
 	"github.com/liqotech/liqo/pkg/liqoctl/status"
 )
 
@@ -45,12 +45,12 @@ func newStatusCommand(ctx context.Context, f *factory.Factory) *cobra.Command {
 		Long:  WithTemplate(liqoctlStatusLongHelp),
 		Args:  cobra.NoArgs,
 
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return options.Run(ctx)
+		Run: func(cmd *cobra.Command, args []string) {
+			output.ExitOnErr(options.Run(ctx))
 		},
 	}
 
 	f.AddLiqoNamespaceFlag(cmd.Flags())
-	utilruntime.Must(cmd.RegisterFlagCompletionFunc(factory.FlagNamespace, completion.Namespaces(ctx, f, completion.NoLimit)))
+	f.Printer.CheckErr(cmd.RegisterFlagCompletionFunc(factory.FlagNamespace, completion.Namespaces(ctx, f, completion.NoLimit)))
 	return cmd
 }

--- a/cmd/liqoctl/cmd/status.go
+++ b/cmd/liqoctl/cmd/status.go
@@ -45,8 +45,6 @@ func newStatusCommand(ctx context.Context, f *factory.Factory) *cobra.Command {
 		Long:  WithTemplate(liqoctlStatusLongHelp),
 		Args:  cobra.NoArgs,
 
-		PersistentPreRun: func(cmd *cobra.Command, args []string) { singleClusterPersistentPreRun(cmd, f) },
-
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return options.Run(ctx)
 		},

--- a/cmd/liqoctl/cmd/uninstall.go
+++ b/cmd/liqoctl/cmd/uninstall.go
@@ -18,10 +18,10 @@ import (
 	"context"
 
 	"github.com/spf13/cobra"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 
 	"github.com/liqotech/liqo/pkg/liqoctl/completion"
 	"github.com/liqotech/liqo/pkg/liqoctl/factory"
+	"github.com/liqotech/liqo/pkg/liqoctl/output"
 	"github.com/liqotech/liqo/pkg/liqoctl/uninstall"
 )
 
@@ -48,15 +48,15 @@ func newUninstallCommand(ctx context.Context, f *factory.Factory) *cobra.Command
 		Short: "Uninstall Liqo from the selected cluster",
 		Long:  WithTemplate(liqoctlUninstallLongHelp),
 
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return options.Run(ctx)
+		Run: func(cmd *cobra.Command, args []string) {
+			output.ExitOnErr(options.Run(ctx))
 		},
 	}
 
 	cmd.Flags().BoolVar(&options.Purge, "purge", false, "Whether to purge all Liqo CRDs from the cluster (default false)")
 
 	f.AddLiqoNamespaceFlag(cmd.Flags())
-	utilruntime.Must(cmd.RegisterFlagCompletionFunc(factory.FlagNamespace, completion.Namespaces(ctx, f, completion.NoLimit)))
+	f.Printer.CheckErr(cmd.RegisterFlagCompletionFunc(factory.FlagNamespace, completion.Namespaces(ctx, f, completion.NoLimit)))
 
 	return cmd
 }

--- a/cmd/liqoctl/cmd/uninstall.go
+++ b/cmd/liqoctl/cmd/uninstall.go
@@ -32,7 +32,7 @@ optionally removing all the associated CRDs (i.e., with the --purge flag).
 
 Warning: due to current limitations, the uninstallation process might hang in
 case peerings are still established, or namespaces are selected for offloading.
-It is suggested to unpeer all clusters and unoffload all namespaces in advance.
+It is necessary to unpeer all clusters and unoffload all namespaces in advance.
 
 Examples:
   $ {{ .Executable }} uninstall
@@ -47,8 +47,6 @@ func newUninstallCommand(ctx context.Context, f *factory.Factory) *cobra.Command
 		Use:   "uninstall",
 		Short: "Uninstall Liqo from the selected cluster",
 		Long:  WithTemplate(liqoctlUninstallLongHelp),
-
-		PersistentPreRun: func(cmd *cobra.Command, args []string) { singleClusterPersistentPreRun(cmd, f) },
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return options.Run(ctx)

--- a/cmd/liqoctl/cmd/unoffload.go
+++ b/cmd/liqoctl/cmd/unoffload.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/liqotech/liqo/pkg/liqoctl/completion"
 	"github.com/liqotech/liqo/pkg/liqoctl/factory"
+	"github.com/liqotech/liqo/pkg/liqoctl/output"
 	"github.com/liqotech/liqo/pkg/liqoctl/unoffload"
 )
 
@@ -58,9 +59,9 @@ func newUnoffloadNamespaceCommand(ctx context.Context, f *factory.Factory) *cobr
 		Args:              cobra.ExactArgs(1),
 		ValidArgsFunction: completion.OffloadedNamespaces(ctx, f, 1),
 
-		RunE: func(cmd *cobra.Command, args []string) error {
+		Run: func(cmd *cobra.Command, args []string) {
 			options.Namespace = args[0]
-			return options.Run(ctx)
+			output.ExitOnErr(options.Run(ctx))
 		},
 	}
 

--- a/cmd/liqoctl/cmd/unoffload.go
+++ b/cmd/liqoctl/cmd/unoffload.go
@@ -41,8 +41,6 @@ func newUnoffloadCommand(ctx context.Context, f *factory.Factory) *cobra.Command
 		Short: "Unoffload a resource from remote clusters",
 		Long:  "Unoffload a resource from remote clusters.",
 		Args:  cobra.NoArgs,
-
-		PersistentPreRun: func(cmd *cobra.Command, args []string) { singleClusterPersistentPreRun(cmd, f) },
 	}
 
 	cmd.AddCommand(newUnoffloadNamespaceCommand(ctx, f))

--- a/cmd/liqoctl/cmd/unpeer.go
+++ b/cmd/liqoctl/cmd/unpeer.go
@@ -97,7 +97,6 @@ func newUnpeerCommand(ctx context.Context, f *factory.Factory) *cobra.Command {
 		Args:              cobra.ExactArgs(1),
 		ValidArgsFunction: completion.ForeignClusters(ctx, f, 1),
 
-		PersistentPreRun: func(cmd *cobra.Command, args []string) { singleClusterPersistentPreRun(cmd, f) },
 		RunE: func(cmd *cobra.Command, args []string) error {
 			options.ClusterName = args[0]
 			return options.Run(ctx)

--- a/cmd/liqoctl/cmd/unpeer.go
+++ b/cmd/liqoctl/cmd/unpeer.go
@@ -19,10 +19,10 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 
 	"github.com/liqotech/liqo/pkg/liqoctl/completion"
 	"github.com/liqotech/liqo/pkg/liqoctl/factory"
+	"github.com/liqotech/liqo/pkg/liqoctl/output"
 	"github.com/liqotech/liqo/pkg/liqoctl/unpeerib"
 	"github.com/liqotech/liqo/pkg/liqoctl/unpeeroob"
 )
@@ -97,9 +97,9 @@ func newUnpeerCommand(ctx context.Context, f *factory.Factory) *cobra.Command {
 		Args:              cobra.ExactArgs(1),
 		ValidArgsFunction: completion.ForeignClusters(ctx, f, 1),
 
-		RunE: func(cmd *cobra.Command, args []string) error {
+		Run: func(cmd *cobra.Command, args []string) {
 			options.ClusterName = args[0]
-			return options.Run(ctx)
+			output.ExitOnErr(options.Run(ctx))
 		},
 	}
 
@@ -122,7 +122,7 @@ func newUnpeerOutOfBandCommand(ctx context.Context, options *unpeeroob.Options) 
 
 		Run: func(cmd *cobra.Command, args []string) {
 			options.ClusterName = args[0]
-			options.Printer.CheckErr(options.Run(ctx))
+			output.ExitOnErr(options.Run(ctx))
 		},
 	}
 
@@ -144,9 +144,9 @@ func newUnpeerInBandCommand(ctx context.Context, unpeerOptions *unpeeroob.Option
 			twoClustersPersistentPreRun(cmd, local, remote, factory.WithScopedPrinter)
 		},
 
-		RunE: func(cmd *cobra.Command, args []string) (err error) {
+		Run: func(cmd *cobra.Command, args []string) {
 			options.Timeout = unpeerOptions.Timeout
-			return options.Run(ctx)
+			output.ExitOnErr(options.Run(ctx))
 		},
 	}
 
@@ -154,8 +154,8 @@ func newUnpeerInBandCommand(ctx context.Context, unpeerOptions *unpeeroob.Option
 	remote.AddLiqoNamespaceFlag(cmd.Flags())
 	remote.AddFlags(cmd.Flags(), cmd.RegisterFlagCompletionFunc)
 
-	utilruntime.Must(cmd.RegisterFlagCompletionFunc("namespace", completion.Namespaces(ctx, options.LocalFactory, completion.NoLimit)))
-	utilruntime.Must(cmd.RegisterFlagCompletionFunc("remote-namespace", completion.Namespaces(ctx, options.RemoteFactory, completion.NoLimit)))
+	local.Printer.CheckErr(cmd.RegisterFlagCompletionFunc("namespace", completion.Namespaces(ctx, options.LocalFactory, completion.NoLimit)))
+	local.Printer.CheckErr(cmd.RegisterFlagCompletionFunc("remote-namespace", completion.Namespaces(ctx, options.RemoteFactory, completion.NoLimit)))
 
 	return cmd
 }

--- a/cmd/liqoctl/cmd/version.go
+++ b/cmd/liqoctl/cmd/version.go
@@ -42,15 +42,12 @@ func newVersionCommand(ctx context.Context, f *factory.Factory) *cobra.Command {
 		Long:  WithTemplate(liqoctlVersionLongHelp),
 		Args:  cobra.NoArgs,
 
-		// The factory is directly initialized by the command itself.
-		PreRun: func(cmd *cobra.Command, args []string) { cmd.SilenceErrors = true },
-
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return options.Run(ctx)
 		},
 	}
 
-	cmd.Flags().BoolVar(&options.ClientOnly, "client", false, "Sho client version only (no server required) (default false)")
+	cmd.Flags().BoolVar(&options.ClientOnly, "client", false, "Show client version only (no server required) (default false)")
 
 	f.AddLiqoNamespaceFlag(cmd.Flags())
 	utilruntime.Must(cmd.RegisterFlagCompletionFunc(factory.FlagNamespace, completion.Namespaces(ctx, f, completion.NoLimit)))

--- a/cmd/liqoctl/cmd/version.go
+++ b/cmd/liqoctl/cmd/version.go
@@ -18,10 +18,10 @@ import (
 	"context"
 
 	"github.com/spf13/cobra"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 
 	"github.com/liqotech/liqo/pkg/liqoctl/completion"
 	"github.com/liqotech/liqo/pkg/liqoctl/factory"
+	"github.com/liqotech/liqo/pkg/liqoctl/output"
 	"github.com/liqotech/liqo/pkg/liqoctl/version"
 )
 
@@ -42,15 +42,15 @@ func newVersionCommand(ctx context.Context, f *factory.Factory) *cobra.Command {
 		Long:  WithTemplate(liqoctlVersionLongHelp),
 		Args:  cobra.NoArgs,
 
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return options.Run(ctx)
+		Run: func(cmd *cobra.Command, args []string) {
+			output.ExitOnErr(options.Run(ctx))
 		},
 	}
 
 	cmd.Flags().BoolVar(&options.ClientOnly, "client", false, "Show client version only (no server required) (default false)")
 
 	f.AddLiqoNamespaceFlag(cmd.Flags())
-	utilruntime.Must(cmd.RegisterFlagCompletionFunc(factory.FlagNamespace, completion.Namespaces(ctx, f, completion.NoLimit)))
+	f.Printer.CheckErr(cmd.RegisterFlagCompletionFunc(factory.FlagNamespace, completion.Namespaces(ctx, f, completion.NoLimit)))
 
 	return cmd
 }

--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 	golang.org/x/mod v0.6.0-dev.0.20220106191415-9b9b3d81d5e3
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/sys v0.0.0-20220517195934-5e4e11fc645e
+	golang.org/x/text v0.3.7
 	golang.zx2c4.com/wireguard/wgctrl v0.0.0-20220330030906-9490840b0b01
 	gomodules.xyz/jsonpatch/v2 v2.2.0
 	google.golang.org/api v0.74.0
@@ -213,7 +214,6 @@ require (
 	golang.org/x/net v0.0.0-20220325170049-de3da57026de // indirect
 	golang.org/x/oauth2 v0.0.0-20220309155454-6242fa91716a // indirect
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
-	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20220224211638-0e9765cccd65 // indirect
 	golang.org/x/tools v0.1.10 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect

--- a/pkg/liqoctl/completion/completion.go
+++ b/pkg/liqoctl/completion/completion.go
@@ -41,10 +41,6 @@ func common(ctx context.Context, f *factory.Factory, argsLimit int, retrieve ret
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
 
-		if err := f.Initialize(factory.Silent); err != nil {
-			return nil, cobra.ShellCompDirectiveNoFileComp
-		}
-
 		values, err := retrieve(ctx, f)
 		if err != nil {
 			return nil, cobra.ShellCompDirectiveError

--- a/pkg/liqoctl/docs/handler.go
+++ b/pkg/liqoctl/docs/handler.go
@@ -24,6 +24,8 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 // Options encapsulates the arguments of the docs command.
@@ -44,7 +46,7 @@ func (o *Options) Run(ctx context.Context) error {
 			hdrFunc := func(filename string) string {
 				base := filepath.Base(filename)
 				name := strings.TrimSuffix(base, path.Ext(base))
-				title := strings.Title(strings.ReplaceAll(name, "_", " "))
+				title := cases.Title(language.English).String(strings.ReplaceAll(name, "_", " "))
 				return fmt.Sprintf("---\ntitle: %q\n---\n\n", title)
 			}
 

--- a/pkg/liqoctl/docs/handler.go
+++ b/pkg/liqoctl/docs/handler.go
@@ -55,6 +55,6 @@ func (o *Options) Run(ctx context.Context) error {
 		manHdr := &doc.GenManHeader{Title: "LIQOCTL", Section: "1"}
 		return doc.GenManTree(o.Root, manHdr, o.Destination)
 	default:
-		return errors.Errorf("unknown doc type %q. Try 'markdown' or 'man'", o.DocTypeString)
+		return errors.Errorf("unknown doc type %q. Try \"markdown\" or \"man\"", o.DocTypeString)
 	}
 }

--- a/pkg/liqoctl/factory/factory.go
+++ b/pkg/liqoctl/factory/factory.go
@@ -30,6 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/liqotech/liqo/pkg/consts"
+	"github.com/liqotech/liqo/pkg/liqoctl/output"
 	"github.com/liqotech/liqo/pkg/utils/restcfg"
 )
 
@@ -54,7 +55,7 @@ type Factory struct {
 	remote bool
 
 	// Printer is the object used to output messages in the appropriate format.
-	Printer *Printer
+	Printer *output.Printer
 	// Whether to add a scope to the printer (i.e., local/remote).
 	ScopedPrinter bool
 
@@ -183,9 +184,9 @@ func (f *Factory) Initialize(opts ...Options) (err error) {
 	}
 
 	if f.remote {
-		f.Printer = newRemotePrinter(o.scoped, verbose)
+		f.Printer = output.NewRemotePrinter(o.scoped, verbose)
 	} else {
-		f.Printer = newLocalPrinter(o.scoped, verbose)
+		f.Printer = output.NewLocalPrinter(o.scoped, verbose)
 	}
 
 	if f.Namespace == "" {

--- a/pkg/liqoctl/factory/output.go
+++ b/pkg/liqoctl/factory/output.go
@@ -84,7 +84,7 @@ func (p *Printer) CheckErr(err error, s ...*pterm.SpinnerPrinter) {
 			os.Exit(code)
 		})
 
-	// Print the error through the printer, if initialize.
+	// Print the error through the printer, if initialized.
 	case p != nil:
 		util.BehaviorOnFatal(func(msg string, code int) {
 			p.Error.Println(strings.TrimRight(msg, "\n"))

--- a/pkg/liqoctl/generate/handler.go
+++ b/pkg/liqoctl/generate/handler.go
@@ -22,6 +22,7 @@ import (
 	"github.com/liqotech/liqo/pkg/auth"
 	"github.com/liqotech/liqo/pkg/consts"
 	"github.com/liqotech/liqo/pkg/liqoctl/factory"
+	"github.com/liqotech/liqo/pkg/liqoctl/output"
 	"github.com/liqotech/liqo/pkg/liqoctl/peeroob"
 	"github.com/liqotech/liqo/pkg/liqoctl/util"
 	"github.com/liqotech/liqo/pkg/utils"
@@ -41,7 +42,7 @@ func (o *Options) Run(ctx context.Context) error {
 	if o.OnlyCommand {
 		command, err := o.generate(ctx)
 		if err != nil {
-			o.Printer.Error.Printf("Failed to retrieve peering information: %v\n", err)
+			o.Printer.Error.Printfln("Failed to retrieve peering information: %v", output.PrettyErr(err))
 			return err
 		}
 
@@ -52,7 +53,7 @@ func (o *Options) Run(ctx context.Context) error {
 	s := o.Printer.StartSpinner("Retrieving peering information")
 	command, err := o.generate(ctx)
 	if err != nil {
-		s.Fail("Failed to retrieve peering information: ", err)
+		s.Fail("Failed to retrieve peering information: ", output.PrettyErr(err))
 		return err
 	}
 	s.Success("Peering information correctly retrieved")

--- a/pkg/liqoctl/inbound/cluster.go
+++ b/pkg/liqoctl/inbound/cluster.go
@@ -41,6 +41,7 @@ import (
 	liqoconsts "github.com/liqotech/liqo/pkg/consts"
 	"github.com/liqotech/liqo/pkg/discovery"
 	"github.com/liqotech/liqo/pkg/liqoctl/factory"
+	"github.com/liqotech/liqo/pkg/liqoctl/output"
 	"github.com/liqotech/liqo/pkg/liqoctl/wait"
 	"github.com/liqotech/liqo/pkg/liqonet/ipam"
 	tenantnamespace "github.com/liqotech/liqo/pkg/tenantNamespace"
@@ -116,17 +117,17 @@ func (c *Cluster) Init(ctx context.Context) error {
 	s := c.local.Printer.StartSpinner("retrieving cluster identity")
 	selector, err := metav1.LabelSelectorAsSelector(&liqolabels.ClusterIDConfigMapLabelSelector)
 	if err != nil {
-		s.Fail(fmt.Sprintf("an error occurred while retrieving cluster identity: %v", err))
+		s.Fail(fmt.Sprintf("an error occurred while retrieving cluster identity: %v", output.PrettyErr(err)))
 		return err
 	}
 	cm, err := liqogetters.GetConfigMapByLabel(ctx, c.local.CRClient, c.local.LiqoNamespace, selector)
 	if err != nil {
-		s.Fail(fmt.Sprintf("an error occurred while retrieving cluster identity: %v", err))
+		s.Fail(fmt.Sprintf("an error occurred while retrieving cluster identity: %v", output.PrettyErr(err)))
 		return err
 	}
 	clusterID, err := liqogetters.RetrieveClusterIDFromConfigMap(cm)
 	if err != nil {
-		s.Fail(fmt.Sprintf("an error occurred while retrieving cluster identity: %v", err))
+		s.Fail(fmt.Sprintf("an error occurred while retrieving cluster identity: %v", output.PrettyErr(err)))
 		return err
 	}
 	s.Success("cluster identity correctly retrieved")
@@ -135,17 +136,17 @@ func (c *Cluster) Init(ctx context.Context) error {
 	s = c.local.Printer.StartSpinner("retrieving network configuration")
 	selector, err = metav1.LabelSelectorAsSelector(&liqolabels.IPAMStorageLabelSelector)
 	if err != nil {
-		s.Fail(fmt.Sprintf("an error occurred while retrieving network configuration: %v", err))
+		s.Fail(fmt.Sprintf("an error occurred while retrieving network configuration: %v", output.PrettyErr(err)))
 		return err
 	}
 	ipamStore, err := liqogetters.GetIPAMStorageByLabel(ctx, c.local.CRClient, "default", selector)
 	if err != nil {
-		s.Fail(fmt.Sprintf("an error occurred while retrieving network configuration: %v", err))
+		s.Fail(fmt.Sprintf("an error occurred while retrieving network configuration: %v", output.PrettyErr(err)))
 		return err
 	}
 	netcfg, err := liqogetters.RetrieveNetworkConfiguration(ipamStore)
 	if err != nil {
-		s.Fail(fmt.Sprintf("an error occurred while retrieving network configuration: %v", err))
+		s.Fail(fmt.Sprintf("an error occurred while retrieving network configuration: %v", output.PrettyErr(err)))
 		return err
 	}
 	s.Success("network configuration correctly retrieved")
@@ -154,17 +155,17 @@ func (c *Cluster) Init(ctx context.Context) error {
 	s = c.local.Printer.StartSpinner("retrieving WireGuard configuration")
 	selector, err = metav1.LabelSelectorAsSelector(&liqolabels.GatewayServiceLabelSelector)
 	if err != nil {
-		s.Fail(fmt.Sprintf("an error occurred while retrieving WireGuard configuration: %v", err))
+		s.Fail(fmt.Sprintf("an error occurred while retrieving WireGuard configuration: %v", output.PrettyErr(err)))
 		return err
 	}
 	svc, err := liqogetters.GetServiceByLabel(ctx, c.local.CRClient, c.local.LiqoNamespace, selector)
 	if err != nil {
-		s.Fail(fmt.Sprintf("an error occurred while retrieving WireGuard configuration: %v", err))
+		s.Fail(fmt.Sprintf("an error occurred while retrieving WireGuard configuration: %v", output.PrettyErr(err)))
 		return err
 	}
 	ip, port, err := liqogetters.RetrieveWGEPFromService(svc, liqoconsts.GatewayServiceAnnotationKey, liqoconsts.DriverName)
 	if err != nil {
-		s.Fail(fmt.Sprintf("an error occurred while retrieving WireGuard configuration: %v", err))
+		s.Fail(fmt.Sprintf("an error occurred while retrieving WireGuard configuration: %v", output.PrettyErr(err)))
 		return err
 	}
 	wgIP := net.ParseIP(ip)
@@ -174,17 +175,17 @@ func (c *Cluster) Init(ctx context.Context) error {
 	}
 	selector, err = metav1.LabelSelectorAsSelector(&liqolabels.WireGuardSecretLabelSelector)
 	if err != nil {
-		s.Fail(fmt.Sprintf("an error occurred while retrieving WireGuard configuration: %v", err))
+		s.Fail(fmt.Sprintf("an error occurred while retrieving WireGuard configuration: %v", output.PrettyErr(err)))
 		return err
 	}
 	secret, err := liqogetters.GetSecretByLabel(ctx, c.local.CRClient, c.local.LiqoNamespace, selector)
 	if err != nil {
-		s.Fail(fmt.Sprintf("an error occurred while retrieving WireGuard configuration: %v", err))
+		s.Fail(fmt.Sprintf("an error occurred while retrieving WireGuard configuration: %v", output.PrettyErr(err)))
 		return err
 	}
 	pubKey, err := liqogetters.RetrieveWGPubKeyFromSecret(secret, liqoconsts.PublicKey)
 	if err != nil {
-		s.Fail(fmt.Sprintf("an error occurred while retrieving WireGuard configuration: %v", err))
+		s.Fail(fmt.Sprintf("an error occurred while retrieving WireGuard configuration: %v", output.PrettyErr(err)))
 		return err
 	}
 	if wgIP.IsPrivate() {
@@ -197,7 +198,7 @@ func (c *Cluster) Init(ctx context.Context) error {
 	s = c.local.Printer.StartSpinner("retrieving authentication token")
 	authToken, err := auth.GetToken(ctx, c.local.CRClient, c.local.LiqoNamespace)
 	if err != nil {
-		s.Fail(fmt.Sprintf("an error occurred while retrieving auth token: %v", err))
+		s.Fail(fmt.Sprintf("an error occurred while retrieving auth token: %v", output.PrettyErr(err)))
 		return err
 	}
 	s.Success("authentication token correctly retrieved")
@@ -206,17 +207,17 @@ func (c *Cluster) Init(ctx context.Context) error {
 	s = c.local.Printer.StartSpinner("retrieving authentication  endpoint")
 	selector, err = metav1.LabelSelectorAsSelector(&liqolabels.AuthServiceLabelSelector)
 	if err != nil {
-		s.Fail(fmt.Sprintf("an error occurred while retrieving authentication endpoint: %v", err))
+		s.Fail(fmt.Sprintf("an error occurred while retrieving authentication endpoint: %v", output.PrettyErr(err)))
 		return err
 	}
 	svc, err = liqogetters.GetServiceByLabel(ctx, c.local.CRClient, c.local.LiqoNamespace, selector)
 	if err != nil {
-		s.Fail(fmt.Sprintf("an error occurred while retrieving authentication endpoint: %v", err))
+		s.Fail(fmt.Sprintf("an error occurred while retrieving authentication endpoint: %v", output.PrettyErr(err)))
 		return err
 	}
 	ipAuth, portAuth, err := liqogetters.RetrieveEndpointFromService(svc, corev1.ServiceTypeClusterIP, authPort)
 	if err != nil {
-		s.Fail(fmt.Sprintf("an error occurred while retrieving authentication endpoint: %v", err))
+		s.Fail(fmt.Sprintf("an error occurred while retrieving authentication endpoint: %v", output.PrettyErr(err)))
 		return err
 	}
 	s.Success("authentication endpoint correctly retrieved")
@@ -225,17 +226,17 @@ func (c *Cluster) Init(ctx context.Context) error {
 	s = c.local.Printer.StartSpinner("retrieving proxy endpoint")
 	selector, err = metav1.LabelSelectorAsSelector(&liqolabels.ProxyServiceLabelSelector)
 	if err != nil {
-		s.Fail(fmt.Sprintf("an error occurred while retrieving proxy endpoint: %v", err))
+		s.Fail(fmt.Sprintf("an error occurred while retrieving proxy endpoint: %v", output.PrettyErr(err)))
 		return err
 	}
 	svc, err = liqogetters.GetServiceByLabel(ctx, c.local.CRClient, c.local.LiqoNamespace, selector)
 	if err != nil {
-		s.Fail(fmt.Sprintf("an error occurred while retrieving proxy endpoint: %v", err))
+		s.Fail(fmt.Sprintf("an error occurred while retrieving proxy endpoint: %v", output.PrettyErr(err)))
 		return err
 	}
 	ipProxy, portProxy, err := liqogetters.RetrieveEndpointFromService(svc, corev1.ServiceTypeClusterIP, proxyPort)
 	if err != nil {
-		s.Fail(fmt.Sprintf("an error occurred while retrieving proxy endpoint: %v", err))
+		s.Fail(fmt.Sprintf("an error occurred while retrieving proxy endpoint: %v", output.PrettyErr(err)))
 		return err
 	}
 	s.Success("proxy endpoint correctly retrieved")
@@ -355,7 +356,7 @@ func (c *Cluster) ExchangeNetworkCfg(ctx context.Context, remoteClusterID *disco
 	// Enforce the network configuration in the local cluster.
 	s := c.local.Printer.StartSpinner("creating network configuration in local cluster")
 	if err := c.enforceNetworkCfg(ctx, remoteClusterID, true); err != nil {
-		s.Fail(fmt.Sprintf("an error occurred while creating network configuration in local cluster: %v", err))
+		s.Fail(fmt.Sprintf("an error occurred while creating network configuration in local cluster: %v", output.PrettyErr(err)))
 		return err
 	}
 	s.Success(fmt.Sprintf("network configuration created in local cluster %q", c.clusterID.ClusterName))
@@ -363,7 +364,7 @@ func (c *Cluster) ExchangeNetworkCfg(ctx context.Context, remoteClusterID *disco
 	// Enforce the network configuration in the local cluster.
 	s = c.local.Printer.StartSpinner(fmt.Sprintf("creating network configuration in remote cluster %q", remoteClusterID.ClusterName))
 	if err := c.enforceNetworkCfg(ctx, remoteClusterID, false); err != nil {
-		s.Fail(fmt.Sprintf("an error occurred while creating network configuration in remote cluster: %v", err))
+		s.Fail(fmt.Sprintf("an error occurred while creating network configuration in remote cluster: %v", output.PrettyErr(err)))
 		return err
 	}
 	s.Success(fmt.Sprintf("network configuration created in remote cluster %q", remoteClusterID.ClusterName))
@@ -573,7 +574,7 @@ func (c *Cluster) PortForwardIPAM(ctx context.Context) error {
 	s := c.local.Printer.StartSpinner("port-forwarding IPAM service")
 
 	if err := c.PortForwardOpts.RunPortForward(ctx); err != nil {
-		s.Fail(fmt.Sprintf("an error occurred while port-forwarding IPAM service: %v", err))
+		s.Fail(fmt.Sprintf("an error occurred while port-forwarding IPAM service: %v", output.PrettyErr(err)))
 		return err
 	}
 	s.Success(fmt.Sprintf("IPAM service correctly port-forwarded %q", c.PortForwardOpts.Ports[0]))
@@ -672,7 +673,7 @@ func (c *Cluster) NewIPAMClient(ctx context.Context) (ipam.IpamClient, error) {
 		grpc.WithBlock())
 	cancel()
 	if err != nil {
-		c.local.Printer.Error.Printf("an error occurred while creating IPAM client: %v", err)
+		c.local.Printer.Error.Printfln("an error occurred while creating IPAM client: %v", output.PrettyErr(err))
 		return nil, err
 	}
 

--- a/pkg/liqoctl/install/kubeadm/kubeadm_test.go
+++ b/pkg/liqoctl/install/kubeadm/kubeadm_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/liqotech/liqo/pkg/liqoctl/factory"
 	"github.com/liqotech/liqo/pkg/liqoctl/install"
+	"github.com/liqotech/liqo/pkg/liqoctl/output"
 )
 
 var (
@@ -79,7 +80,7 @@ var _ = Describe("Extract elements from apiServer", func() {
 	BeforeEach(func() {
 		options = Options{Options: &install.Options{Factory: &factory.Factory{
 			KubeClient: fake.NewSimpleClientset(p),
-			Printer:    factory.NewFakePrinter(GinkgoWriter),
+			Printer:    output.NewFakePrinter(GinkgoWriter),
 		}}}
 	})
 

--- a/pkg/liqoctl/offload/handler.go
+++ b/pkg/liqoctl/offload/handler.go
@@ -26,6 +26,7 @@ import (
 	offloadingv1alpha1 "github.com/liqotech/liqo/apis/offloading/v1alpha1"
 	"github.com/liqotech/liqo/pkg/consts"
 	"github.com/liqotech/liqo/pkg/liqoctl/factory"
+	"github.com/liqotech/liqo/pkg/liqoctl/output"
 	"github.com/liqotech/liqo/pkg/liqoctl/wait"
 )
 
@@ -80,7 +81,7 @@ func (o *Options) Run(ctx context.Context) error {
 		return nil
 	})
 	if err != nil {
-		s.Fail(fmt.Sprintf("Failed enabling namespace offloading: %v", err))
+		s.Fail(fmt.Sprintf("Failed enabling namespace offloading: %v", output.PrettyErr(err)))
 		return err
 	}
 	s.Success(fmt.Sprintf("Offloading of namespace %q correctly enabled", o.Namespace))

--- a/pkg/liqoctl/output/doc.go
+++ b/pkg/liqoctl/output/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2019-2022 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package output implements the logic to dealing with the commands output.
+package output

--- a/pkg/liqoctl/peeroob/handler.go
+++ b/pkg/liqoctl/peeroob/handler.go
@@ -25,6 +25,7 @@ import (
 
 	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
 	"github.com/liqotech/liqo/pkg/discovery"
+	"github.com/liqotech/liqo/pkg/liqoctl/output"
 	"github.com/liqotech/liqo/pkg/liqoctl/peer"
 	"github.com/liqotech/liqo/pkg/utils"
 	authenticationtokenutils "github.com/liqotech/liqo/pkg/utils/authenticationtoken"
@@ -49,13 +50,12 @@ func (o *Options) Run(ctx context.Context) error {
 
 	fc, err := o.peer(ctx)
 	if err != nil {
-		s.Fail(err.Error())
+		s.Fail("Failed peering clusters:", output.PrettyErr(err))
 		return err
 	}
 	s.Success("Peering enabled")
 
 	if err := o.Wait(ctx, &fc.Spec.ClusterIdentity); err != nil {
-		s.Fail(err.Error())
 		return err
 	}
 

--- a/pkg/liqoctl/uninstall/handler.go
+++ b/pkg/liqoctl/uninstall/handler.go
@@ -37,6 +37,7 @@ import (
 	"github.com/liqotech/liqo/pkg/discovery"
 	"github.com/liqotech/liqo/pkg/liqoctl/factory"
 	"github.com/liqotech/liqo/pkg/liqoctl/install"
+	"github.com/liqotech/liqo/pkg/liqoctl/output"
 )
 
 var liqoGroupVersions = []schema.GroupVersion{
@@ -58,7 +59,7 @@ type Options struct {
 func (o *Options) Run(ctx context.Context) error {
 	s := o.Printer.StartSpinner("Running pre-uninstall checks")
 	if err := o.preUninstall(ctx); err != nil {
-		s.Fail(fmt.Sprintf("Pre-uninstall checks failed: %v", err))
+		s.Fail("Pre-uninstall checks failed: ", output.PrettyErr(err))
 		return err
 	}
 	s.Success("Pre-uninstall checks passed")
@@ -66,7 +67,7 @@ func (o *Options) Run(ctx context.Context) error {
 	s = o.Printer.StartSpinner("Uninstalling Liqo")
 	err := o.HelmClient().UninstallReleaseByName(install.LiqoReleaseName)
 	if err != nil && !errors.Is(err, driver.ErrReleaseNotFound) {
-		s.Fail("Error uninstalling Liqo: ", err)
+		s.Fail("Error uninstalling Liqo: ", output.PrettyErr(err))
 		return err
 	}
 	s.Success("Liqo uninstalled")
@@ -75,14 +76,14 @@ func (o *Options) Run(ctx context.Context) error {
 		s = o.Printer.StartSpinner("Purging Liqo CRDs")
 
 		if err = o.purge(ctx); err != nil {
-			s.Fail("Error purging CRDs: ", err)
+			s.Fail("Error purging CRDs: ", output.PrettyErr(err))
 			return err
 		}
 		s.Success("Liqo CRDs purged")
 
 		s = o.Printer.StartSpinner("Deleting Liqo namespaces")
 		if err = o.deleteLiqoNamespaces(ctx); err != nil {
-			s.Fail("Error deleting namespaces: ", err)
+			s.Fail("Error deleting namespaces: ", output.PrettyErr(err))
 			return err
 		}
 		s.Success("Liqo namespaces deleted")

--- a/pkg/liqoctl/unpeeroob/handler.go
+++ b/pkg/liqoctl/unpeeroob/handler.go
@@ -22,6 +22,7 @@ import (
 
 	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
 	"github.com/liqotech/liqo/pkg/liqoctl/factory"
+	"github.com/liqotech/liqo/pkg/liqoctl/output"
 	"github.com/liqotech/liqo/pkg/liqoctl/wait"
 )
 
@@ -42,7 +43,7 @@ func (o *Options) Run(ctx context.Context) error {
 
 	fc, err := o.unpeer(ctx)
 	if err != nil {
-		s.Fail(err.Error())
+		s.Fail("Failed unpeering clusters: ", output.PrettyErr(err))
 		return err
 	}
 	s.Success("Peering disabled")

--- a/pkg/liqoctl/version/handler.go
+++ b/pkg/liqoctl/version/handler.go
@@ -24,14 +24,14 @@ import (
 
 var liqoctlVersion = "development"
 
-// Options encapsulates the arguments of the offload namespace command.
+// Options encapsulates the arguments of the version command.
 type Options struct {
 	*factory.Factory
 
 	ClientOnly bool
 }
 
-// Run implements the offload namespace command.
+// Run implements the version command.
 func (o *Options) Run(ctx context.Context) error {
 	fmt.Printf("Client version: %s\n", liqoctlVersion)
 
@@ -39,7 +39,6 @@ func (o *Options) Run(ctx context.Context) error {
 		return nil
 	}
 
-	o.Printer.CheckErr(o.Factory.Initialize(factory.Silent))
 	release, err := o.HelmClient().GetRelease(install.LiqoReleaseName)
 	if err != nil {
 		o.Printer.Error.Printf("Failed to retrieve release information from namespace %q: %v\n", o.LiqoNamespace, err)

--- a/pkg/liqoctl/version/handler.go
+++ b/pkg/liqoctl/version/handler.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/liqotech/liqo/pkg/liqoctl/factory"
 	"github.com/liqotech/liqo/pkg/liqoctl/install"
+	"github.com/liqotech/liqo/pkg/liqoctl/output"
 )
 
 var liqoctlVersion = "development"
@@ -41,12 +42,12 @@ func (o *Options) Run(ctx context.Context) error {
 
 	release, err := o.HelmClient().GetRelease(install.LiqoReleaseName)
 	if err != nil {
-		o.Printer.Error.Printf("Failed to retrieve release information from namespace %q: %v\n", o.LiqoNamespace, err)
+		o.Printer.Error.Printfln("Failed to retrieve release information from namespace %q: %v", o.LiqoNamespace, output.PrettyErr(err))
 		return err
 	}
 
 	if release.Chart == nil || release.Chart.Metadata == nil {
-		o.Printer.Error.Print("Invalid release information\n")
+		o.Printer.Error.Println("Invalid release information")
 		return err
 	}
 
@@ -55,7 +56,7 @@ func (o *Options) Run(ctx context.Context) error {
 		// Development version, fallback to the value specified as tag
 		tag, ok := release.Config["tag"]
 		if !ok {
-			o.Printer.Error.Print("Invalid release information\n")
+			o.Printer.Error.Println("Invalid release information")
 			return err
 		}
 		version = tag.(string)

--- a/pkg/liqoctl/wait/wait.go
+++ b/pkg/liqoctl/wait/wait.go
@@ -26,6 +26,7 @@ import (
 	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
 	offloadingv1alpha1 "github.com/liqotech/liqo/apis/offloading/v1alpha1"
 	"github.com/liqotech/liqo/pkg/liqoctl/factory"
+	"github.com/liqotech/liqo/pkg/liqoctl/output"
 	"github.com/liqotech/liqo/pkg/utils"
 	fcutils "github.com/liqotech/liqo/pkg/utils/foreignCluster"
 	getters "github.com/liqotech/liqo/pkg/utils/getters"
@@ -34,7 +35,7 @@ import (
 // Waiter is a struct that contains the necessary information to wait for resource events.
 type Waiter struct {
 	// Printer is the object used to output messages in the appropriate format.
-	Printer *factory.Printer
+	Printer *output.Printer
 	// crClient is the controller runtime client.
 	CRClient client.Client
 }
@@ -54,7 +55,7 @@ func (w *Waiter) ForUnpeering(ctx context.Context, remoteClusterID *discoveryv1a
 	s := w.Printer.StartSpinner(fmt.Sprintf("Unpeering from the remote cluster %q", remName))
 	err := fcutils.PollForEvent(ctx, w.CRClient, remoteClusterID, fcutils.IsUnpeered, 1*time.Second)
 	if client.IgnoreNotFound(err) != nil {
-		s.Fail(fmt.Sprintf("Failed unpeering from remote cluster %q: %s", remName, err.Error()))
+		s.Fail(fmt.Sprintf("Failed unpeering from remote cluster %q: %s", remName, output.PrettyErr(err)))
 		return err
 	}
 	s.Success(fmt.Sprintf("Successfully unpeered from remote cluster %q", remName))
@@ -68,7 +69,7 @@ func (w *Waiter) ForOutgoingUnpeering(ctx context.Context, remoteClusterID *disc
 	s := w.Printer.StartSpinner(fmt.Sprintf("Disabling outgoing peering to the remote cluster %q", remName))
 	err := fcutils.PollForEvent(ctx, w.CRClient, remoteClusterID, fcutils.IsOutgoingPeeringNone, 1*time.Second)
 	if client.IgnoreNotFound(err) != nil {
-		s.Fail(fmt.Sprintf("Failed disabling outgoing peering to the remote cluster %q: %s", remName, err.Error()))
+		s.Fail(fmt.Sprintf("Failed disabling outgoing peering to the remote cluster %q: %s", remName, output.PrettyErr(err)))
 		return err
 	}
 	s.Success(fmt.Sprintf("Successfully disabled outgoing peering to the remote cluster %q", remName))
@@ -81,7 +82,7 @@ func (w *Waiter) ForAuth(ctx context.Context, remoteClusterID *discoveryv1alpha1
 	s := w.Printer.StartSpinner(fmt.Sprintf("Waiting for authentication to the cluster %q", remName))
 	err := fcutils.PollForEvent(ctx, w.CRClient, remoteClusterID, fcutils.IsAuthenticated, 1*time.Second)
 	if err != nil {
-		s.Fail(fmt.Sprintf("Authentication to the remote cluster %q failed: %s", remName, err.Error()))
+		s.Fail(fmt.Sprintf("Authentication to the remote cluster %q failed: %s", remName, output.PrettyErr(err)))
 		return err
 	}
 	s.Success(fmt.Sprintf("Authenticated to cluster %q", remName))
@@ -94,7 +95,7 @@ func (w *Waiter) ForNetwork(ctx context.Context, remoteClusterID *discoveryv1alp
 	s := w.Printer.StartSpinner(fmt.Sprintf("Waiting for network to the remote cluster %q", remName))
 	err := fcutils.PollForEvent(ctx, w.CRClient, remoteClusterID, fcutils.IsNetworkingEstablished, 1*time.Second)
 	if err != nil {
-		s.Fail(fmt.Sprintf("Failed establishing networking to the remote cluster %q: %s", remName, err.Error()))
+		s.Fail(fmt.Sprintf("Failed establishing networking to the remote cluster %q: %s", remName, output.PrettyErr(err)))
 		return err
 	}
 	s.Success(fmt.Sprintf("Network established to the remote cluster %q", remName))
@@ -108,7 +109,7 @@ func (w *Waiter) ForOutgoingPeering(ctx context.Context, remoteClusterID *discov
 	s := w.Printer.StartSpinner(fmt.Sprintf("Activating outgoing peering to the remote cluster %q", remName))
 	err := fcutils.PollForEvent(ctx, w.CRClient, remoteClusterID, fcutils.IsOutgoingJoined, 1*time.Second)
 	if err != nil {
-		s.Fail(fmt.Sprintf("Failed activating outgoing peering to the remote cluster %q: %s", remName, err.Error()))
+		s.Fail(fmt.Sprintf("Failed activating outgoing peering to the remote cluster %q: %s", remName, output.PrettyErr(err)))
 		return err
 	}
 	s.Success(fmt.Sprintf("Outgoing peering activated to the remote cluster %q", remName))
@@ -129,7 +130,7 @@ func (w *Waiter) ForNode(ctx context.Context, remoteClusterID *discoveryv1alpha1
 		return utils.IsNodeReady(node), nil
 	})
 	if err != nil {
-		s.Fail(fmt.Sprintf("Failed waiting for node to be created for remote cluster %q: %s", remName, err.Error()))
+		s.Fail(fmt.Sprintf("Failed waiting for node to be created for remote cluster %q: %s", remName, output.PrettyErr(err)))
 		return err
 	}
 	s.Success(fmt.Sprintf("Node created for remote cluster %q", remName))
@@ -165,7 +166,7 @@ func (w *Waiter) ForOffloading(ctx context.Context, namespace string) error {
 		return ready || noClusterSelected, nil
 	})
 	if err != nil {
-		s.Fail(fmt.Sprintf("Failed waiting for offloading to complete: %s", err.Error()))
+		s.Fail(fmt.Sprintf("Failed waiting for offloading to complete: %s", output.PrettyErr(err)))
 		return err
 	}
 	if noClusterSelected {
@@ -185,7 +186,7 @@ func (w *Waiter) ForUnoffloading(ctx context.Context, namespace string) error {
 		return apierrors.IsNotFound(err), client.IgnoreNotFound(err)
 	})
 	if err != nil {
-		s.Fail(fmt.Sprintf("Failed waiting for unoffloading to complete: %s", err.Error()))
+		s.Fail(fmt.Sprintf("Failed waiting for unoffloading to complete: %s", output.PrettyErr(err)))
 		return err
 	}
 	s.Success("Unoffloading completed successfully")


### PR DESCRIPTION
# Description

This PR modifies the liqoctl logic to introduce lazy loading of the controller runtime client, to avoid requiring hacks (or introducing penalty) in case of commands not using it, as well as improving the overall performance thanks to a shared REST mapper.

Additionally, it improves the error management, adopting a more uniform style (leveraging the standard kubectl messages), and ensuring that the errors emitted by the cobra library are always printed out. 

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Manually, checking the correct functioning of the commands
- [x] Existing tests
