### PR TITLE
Fix Wireguard Endpoint DNS Resolution

### DIFF
--- a/pkg/liqonet/tunnel/resolver/doc.go
+++ b/pkg/liqonet/tunnel/resolver/doc.go
@@ -12,30 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package wireguard
-
-import (
-	"fmt"
-	"net"
-)
-
-const (
-	ipv4Literal = "10.1.1.1"
-	ipv4Dns     = "ipv4.liqodns.resolver"
-)
-
-func addressResolverMock(address string) (*net.IPAddr, error) {
-	ipv4Addr := net.ParseIP(ipv4Literal)
-	ipv4Map := map[string]net.IP{
-		ipv4Literal: ipv4Addr,
-		ipv4Dns:     ipv4Addr,
-	}
-	val, found := ipv4Map[address]
-	if found {
-		return &net.IPAddr{
-			IP:   val,
-			Zone: "",
-		}, nil
-	}
-	return nil, fmt.Errorf("ip not found")
-}
+// Package resolver implements the resolver used to resolve hostnames to IP addresses.
+package resolver

--- a/pkg/liqonet/tunnel/resolver/resolver.go
+++ b/pkg/liqonet/tunnel/resolver/resolver.go
@@ -1,0 +1,87 @@
+// Copyright 2019-2022 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resolver
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"sync"
+)
+
+var (
+	resolverFunc = net.DefaultResolver.LookupIPAddr
+	resolveCache = sync.Map{}
+)
+
+// Resolve resolves the given hostname to an IP address.
+// It prefers IPv4 addresses if available, and falls back to IPv6 addresses if not.
+// If the hostname was already resolved and it is still valid, it returns the cached IP address.
+func Resolve(ctx context.Context, address string) (*net.IPAddr, error) {
+	if ip := net.ParseIP(address); ip != nil {
+		return &net.IPAddr{IP: ip}, nil
+	}
+
+	ipAddrs, err := resolverFunc(ctx, address)
+	if err != nil {
+		return nil, err
+	}
+
+	ipv4List := []*net.IPAddr{}
+	ipv6List := []*net.IPAddr{}
+
+	for i := range ipAddrs {
+		ip := ipAddrs[i]
+		if ipv4 := ip.IP.To4(); ipv4 != nil {
+			ipv4List = append(ipv4List, &ip)
+		}
+		if ipv6 := ip.IP.To16(); ipv6 != nil {
+			ipv6List = append(ipv6List, &ip)
+		}
+	}
+
+	if len(ipv4List) > 0 {
+		if ip := lookupCache(address, ipv4List); ip != nil {
+			return ip, nil
+		}
+		resolveCache.Store(address, ipv4List[0])
+		return ipv4List[0], nil
+	}
+	if len(ipv6List) > 0 {
+		if ip := lookupCache(address, ipv6List); ip != nil {
+			return ip, nil
+		}
+		resolveCache.Store(address, ipv6List[0])
+		return ipv6List[0], nil
+	}
+
+	return nil, fmt.Errorf("no IP addresses found for %q", address)
+}
+
+func lookupCache(hostname string, resolvedIPs []*net.IPAddr) *net.IPAddr {
+	v, found := resolveCache.Load(hostname)
+	if !found {
+		return nil
+	}
+	cachedIP := v.(*net.IPAddr)
+
+	for _, resIP := range resolvedIPs {
+		if resIP.IP.Equal(cachedIP.IP) {
+			return cachedIP
+		}
+	}
+
+	return nil
+}

--- a/pkg/liqonet/tunnel/resolver/resolver_suite_test.go
+++ b/pkg/liqonet/tunnel/resolver/resolver_suite_test.go
@@ -12,30 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package wireguard
+package resolver
 
 import (
-	"fmt"
-	"net"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 )
 
-const (
-	ipv4Literal = "10.1.1.1"
-	ipv4Dns     = "ipv4.liqodns.resolver"
-)
-
-func addressResolverMock(address string) (*net.IPAddr, error) {
-	ipv4Addr := net.ParseIP(ipv4Literal)
-	ipv4Map := map[string]net.IP{
-		ipv4Literal: ipv4Addr,
-		ipv4Dns:     ipv4Addr,
-	}
-	val, found := ipv4Map[address]
-	if found {
-		return &net.IPAddr{
-			IP:   val,
-			Zone: "",
-		}, nil
-	}
-	return nil, fmt.Errorf("ip not found")
+func TestResolver(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Resolver Suite")
 }

--- a/pkg/liqonet/tunnel/resolver/resolver_test.go
+++ b/pkg/liqonet/tunnel/resolver/resolver_test.go
@@ -1,0 +1,184 @@
+// Copyright 2019-2022 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resolver
+
+import (
+	"context"
+	"net"
+	"sync"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Resolver", func() {
+
+	var (
+		newSyncMap = func(m map[string]*net.IPAddr, sm *sync.Map) {
+			sm.Range(func(key, value interface{}) bool {
+				sm.Delete(key)
+				return true
+			})
+			for k, v := range m {
+				sm.Store(k, v)
+			}
+		}
+
+		newMap = func(sm *sync.Map) map[string]*net.IPAddr {
+			res := map[string]*net.IPAddr{}
+			sm.Range(func(k, v interface{}) bool {
+				res[k.(string)] = v.(*net.IPAddr)
+				return true
+			})
+			return res
+		}
+	)
+
+	var (
+		ctx context.Context
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+	})
+
+	type resolveTestcase struct {
+		name          string
+		resolver      func(ctx context.Context, host string) ([]net.IPAddr, error)
+		cache         map[string]*net.IPAddr
+		expectedIP    string
+		expectedCache OmegaMatcher
+	}
+
+	DescribeTable("Resolve",
+
+		func(c *resolveTestcase) {
+			newSyncMap(c.cache, &resolveCache)
+			resolverFunc = c.resolver
+			ip, err := Resolve(ctx, c.name)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ip.String()).To(Equal(c.expectedIP))
+			Expect(newMap(&resolveCache)).To(c.expectedCache)
+		},
+
+		Entry("should handle an IP name", &resolveTestcase{
+			name:          "1.2.3.4",
+			resolver:      nil,
+			cache:         map[string]*net.IPAddr{},
+			expectedIP:    "1.2.3.4",
+			expectedCache: BeEmpty(),
+		}),
+
+		Entry("should resolve IPv4 addresses", &resolveTestcase{
+			name: "example.com",
+			resolver: func(ctx context.Context, host string) ([]net.IPAddr, error) {
+				return []net.IPAddr{
+					{IP: net.IPv4(1, 2, 3, 4)},
+					{IP: net.IPv4(1, 2, 3, 5)},
+				}, nil
+			},
+			cache:         map[string]*net.IPAddr{},
+			expectedIP:    "1.2.3.4",
+			expectedCache: HaveKeyWithValue("example.com", &net.IPAddr{IP: net.IPv4(1, 2, 3, 4)}),
+		}),
+
+		Entry("should resolve IPv4 address with cache", &resolveTestcase{
+			name: "example.com",
+			resolver: func(ctx context.Context, host string) ([]net.IPAddr, error) {
+				return []net.IPAddr{
+					{IP: net.IPv4(1, 2, 3, 4)},
+					{IP: net.IPv4(1, 2, 3, 5)},
+				}, nil
+			},
+			cache: map[string]*net.IPAddr{
+				"example.com": {IP: net.IPv4(1, 2, 3, 5)},
+			},
+			expectedIP:    "1.2.3.5",
+			expectedCache: HaveKeyWithValue("example.com", &net.IPAddr{IP: net.IPv4(1, 2, 3, 5)}),
+		}),
+
+		Entry("should resolve IPv6 addresses", &resolveTestcase{
+			name: "example.com",
+			resolver: func(ctx context.Context, host string) ([]net.IPAddr, error) {
+				return []net.IPAddr{
+					{IP: net.ParseIP("2001:db8:a0b:12f0::1")},
+					{IP: net.ParseIP("2001:db8:a0b:12f0::2")},
+				}, nil
+			},
+			cache:         map[string]*net.IPAddr{},
+			expectedIP:    "2001:db8:a0b:12f0::1",
+			expectedCache: HaveKeyWithValue("example.com", &net.IPAddr{IP: net.ParseIP("2001:db8:a0b:12f0::1")}),
+		}),
+
+		Entry("should resolve IPv6 address with cache", &resolveTestcase{
+			name: "example.com",
+			resolver: func(ctx context.Context, host string) ([]net.IPAddr, error) {
+				return []net.IPAddr{
+					{IP: net.ParseIP("2001:db8:a0b:12f0::1")},
+					{IP: net.ParseIP("2001:db8:a0b:12f0::2")},
+				}, nil
+			},
+			cache: map[string]*net.IPAddr{
+				"example.com": {IP: net.ParseIP("2001:db8:a0b:12f0::2")},
+			},
+			expectedIP:    "2001:db8:a0b:12f0::2",
+			expectedCache: HaveKeyWithValue("example.com", &net.IPAddr{IP: net.ParseIP("2001:db8:a0b:12f0::2")}),
+		}),
+
+		Entry("should prefer IPv4 address", &resolveTestcase{
+			name: "example.com",
+			resolver: func(ctx context.Context, host string) ([]net.IPAddr, error) {
+				return []net.IPAddr{
+					{IP: net.ParseIP("2001:db8:a0b:12f0::1")},
+					{IP: net.IPv4(1, 2, 3, 4)},
+				}, nil
+			},
+			cache:         map[string]*net.IPAddr{},
+			expectedIP:    "1.2.3.4",
+			expectedCache: HaveKeyWithValue("example.com", &net.IPAddr{IP: net.IPv4(1, 2, 3, 4)}),
+		}),
+
+		Entry("should prefer IPv4 address with cache", &resolveTestcase{
+			name: "example.com",
+			resolver: func(ctx context.Context, host string) ([]net.IPAddr, error) {
+				return []net.IPAddr{
+					{IP: net.ParseIP("2001:db8:a0b:12f0::1")},
+					{IP: net.IPv4(1, 2, 3, 4)},
+				}, nil
+			},
+			cache: map[string]*net.IPAddr{
+				"example.com": {IP: net.ParseIP("2001:db8:a0b:12f0::1")},
+			},
+			expectedIP:    "1.2.3.4",
+			expectedCache: HaveKeyWithValue("example.com", &net.IPAddr{IP: net.IPv4(1, 2, 3, 4)}),
+		}),
+
+		Entry("should update cache if entry is no more valid", &resolveTestcase{
+			name: "example.com",
+			resolver: func(ctx context.Context, host string) ([]net.IPAddr, error) {
+				return []net.IPAddr{
+					{IP: net.IPv4(1, 2, 3, 5)},
+				}, nil
+			},
+			cache: map[string]*net.IPAddr{
+				"example.com": {IP: net.IPv4(1, 2, 3, 4)},
+			},
+			expectedIP:    "1.2.3.5",
+			expectedCache: HaveKeyWithValue("example.com", &net.IPAddr{IP: net.IPv4(1, 2, 3, 5)}),
+		}),
+	)
+
+})

--- a/pkg/liqonet/tunnel/wireguard/driver_test.go
+++ b/pkg/liqonet/tunnel/wireguard/driver_test.go
@@ -127,29 +127,6 @@ var _ = Describe("Driver", func() {
 			})
 		})
 
-		Context("protocol family ipv6", func() {
-			It("address is in literal format", func() {
-				tep.Spec.EndpointIP = ipv6Literal
-				addr, err := getTunnelAddressFromTep(tep, addressResolverMock)
-				Expect(addr.IP.String()).Should(ContainSubstring(ipv6Literal))
-				Expect(err).To(BeNil())
-			})
-
-			It("address is in dns format", func() {
-				tep.Spec.EndpointIP = ipv6Dns
-				addr, err := getTunnelAddressFromTep(tep, addressResolverMock)
-				Expect(addr.IP.String()).Should(ContainSubstring(ipv6Literal))
-				Expect(err).To(BeNil())
-			})
-
-			It("address could not be found", func() {
-				tep.Spec.EndpointIP = invalidAddress
-				addr, err := getTunnelAddressFromTep(tep, addressResolverMock)
-				Expect(addr).Should(BeNil())
-				Expect(err).To(HaveOccurred())
-			})
-		})
-
 		Describe("testing getEndpoint", func() {
 			JustBeforeEach(func() {
 				tep = &netv1alpha1.TunnelEndpoint{


### PR DESCRIPTION
# Description

This pr fixes the DNS resolver for the remote Wireguard endpoint.

If the endpoint is a DNS name, it caches the resolved IP (preferring IPv4 over IPv6) and returns it for the other resolutions. This prevents the Wireguard interface from periodically reconfiguring when multiple IPs were resolved in random order; causing connection issues.

# How Has This Been Tested?

- [x] on EKS + AKS peering (where EKS LB has 3 IPv4 addresses)
