### PR TITLE
Virtual kubelet: allow to disable API server support for offloaded pods

### DIFF
--- a/cmd/virtual-kubelet/root/flag.go
+++ b/cmd/virtual-kubelet/root/flag.go
@@ -47,7 +47,7 @@ func InstallFlags(flags *pflag.FlagSet, o *Opts) {
 	flags.UintVar(&o.IngressWorkers, "ingress-reflection-workers", o.IngressWorkers, "The number of ingress reflection workers")
 	flags.UintVar(&o.ConfigMapWorkers, "configmap-reflection-workers", o.ConfigMapWorkers, "The number of configmap reflection workers")
 	flags.UintVar(&o.SecretWorkers, "secret-reflection-workers", o.SecretWorkers, "The number of secret reflection workers")
-	flags.UintVar(&o.PersistenVolumeClaimWorkers, "persistentvolumeclaim-reflection-workers", o.PersistenVolumeClaimWorkers,
+	flags.UintVar(&o.PersistentVolumeClaimWorkers, "persistentvolumeclaim-reflection-workers", o.PersistentVolumeClaimWorkers,
 		"The number of persistentvolumeclaim reflection workers")
 
 	flags.DurationVar(&o.NodeLeaseDuration, "node-lease-duration", o.NodeLeaseDuration, "The duration of the node leases")
@@ -59,6 +59,8 @@ func InstallFlags(flags *pflag.FlagSet, o *Opts) {
 	flags.Var(&o.NodeExtraAnnotations, "node-extra-annotations", "Extra annotations to add to the Virtual Node")
 	flags.Var(&o.NodeExtraLabels, "node-extra-labels", "Extra labels to add to the Virtual Node")
 
+	flags.BoolVar(&o.EnableAPIServerSupport, "enable-apiserver-support", false,
+		"Enable offloaded pods to interact back with the local Kubernetes API server")
 	flags.BoolVar(&o.EnableStorage, "enable-storage", false, "Enable the Liqo storage reflection")
 	flags.StringVar(&o.VirtualStorageClassName, "virtual-storage-class-name", "liqo", "Name of the virtual storage class")
 	flags.StringVar(&o.RemoteRealStorageClassName, "remote-real-storage-class-name", "", "Name of the real storage class to use for the actual volumes")

--- a/cmd/virtual-kubelet/root/opts.go
+++ b/cmd/virtual-kubelet/root/opts.go
@@ -65,13 +65,13 @@ type Opts struct {
 	EnableProfiling bool
 
 	// Number of workers to use to handle pod notifications and resource reflection
-	PodWorkers                  uint
-	ServiceWorkers              uint
-	EndpointSliceWorkers        uint
-	IngressWorkers              uint
-	ConfigMapWorkers            uint
-	SecretWorkers               uint
-	PersistenVolumeClaimWorkers uint
+	PodWorkers                   uint
+	ServiceWorkers               uint
+	EndpointSliceWorkers         uint
+	IngressWorkers               uint
+	ConfigMapWorkers             uint
+	SecretWorkers                uint
+	PersistentVolumeClaimWorkers uint
 
 	NodeLeaseDuration time.Duration
 	NodePingInterval  time.Duration
@@ -80,6 +80,7 @@ type Opts struct {
 	NodeExtraAnnotations argsutils.StringMap
 	NodeExtraLabels      argsutils.StringMap
 
+	EnableAPIServerSupport     bool
 	EnableStorage              bool
 	VirtualStorageClassName    string
 	RemoteRealStorageClassName string
@@ -99,13 +100,13 @@ func NewOpts() *Opts {
 		MetricsAddress:  DefaultMetricsAddress,
 		EnableProfiling: false,
 
-		PodWorkers:                  DefaultPodWorkers,
-		ServiceWorkers:              DefaultServiceWorkers,
-		EndpointSliceWorkers:        DefaultEndpointSliceWorkers,
-		IngressWorkers:              DefaultIngressWorkers,
-		ConfigMapWorkers:            DefaultConfigMapWorkers,
-		SecretWorkers:               DefaultSecretWorkers,
-		PersistenVolumeClaimWorkers: DefaultPersistenVolumeClaimWorkers,
+		PodWorkers:                   DefaultPodWorkers,
+		ServiceWorkers:               DefaultServiceWorkers,
+		EndpointSliceWorkers:         DefaultEndpointSliceWorkers,
+		IngressWorkers:               DefaultIngressWorkers,
+		ConfigMapWorkers:             DefaultConfigMapWorkers,
+		SecretWorkers:                DefaultSecretWorkers,
+		PersistentVolumeClaimWorkers: DefaultPersistenVolumeClaimWorkers,
 
 		NodeLeaseDuration: node.DefaultLeaseDuration * time.Second,
 		NodePingInterval:  node.DefaultPingInterval,

--- a/cmd/virtual-kubelet/root/root.go
+++ b/cmd/virtual-kubelet/root/root.go
@@ -103,8 +103,9 @@ func runRootCommand(ctx context.Context, c *Opts) error {
 		IngressWorkers:              c.IngressWorkers,
 		ConfigMapWorkers:            c.ConfigMapWorkers,
 		SecretWorkers:               c.SecretWorkers,
-		PersistenVolumeClaimWorkers: c.PersistenVolumeClaimWorkers,
+		PersistenVolumeClaimWorkers: c.PersistentVolumeClaimWorkers,
 
+		EnableAPIServerSupport:     c.EnableAPIServerSupport,
 		EnableStorage:              c.EnableStorage,
 		VirtualStorageClassName:    c.VirtualStorageClassName,
 		RemoteRealStorageClassName: c.RemoteRealStorageClassName,

--- a/deployments/liqo/templates/liqo-controller-manager-deployment.yaml
+++ b/deployments/liqo/templates/liqo-controller-manager-deployment.yaml
@@ -2,6 +2,14 @@
 {{- $ctrlManagerConfig := (merge (dict "name" "controller-manager" "module" "controller-manager") .) -}}
 {{- $webhookConfig := (merge (dict "name" "webhook" "module" "webhook") .) -}}
 
+{{- /* Enable the API support only in for Kubernetes versions < 1.24 (due to lack of support for third party tokens), if not overridden by the user */ -}}
+{{- $vkargs := .Values.virtualKubelet.extra.args }}
+{{- if semverCompare "< 1.24.0" .Capabilities.KubeVersion.Version }}
+{{- if not (or (has "--enable-apiserver-support" $vkargs ) (has "--enable-apiserver-support=true" $vkargs ) (has "--enable-apiserver-support=false" $vkargs )) }}
+{{- $vkargs = append $vkargs "--enable-apiserver-support=true" }}
+{{- end }}
+{{- end }}
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -78,8 +86,8 @@ spec:
           {{- $d := dict "commandName" "--kubelet-extra-labels" "dictionary" .Values.virtualKubelet.extra.labels }}
           {{- include "liqo.concatenateMap" $d | nindent 10 }}
           {{- end }}
-          {{- if .Values.virtualKubelet.extra.args }}
-          {{- $d := dict "commandName" "--kubelet-extra-args" "list" .Values.virtualKubelet.extra.args }}
+          {{- if ge (len $vkargs) 1 }}
+          {{- $d := dict "commandName" "--kubelet-extra-args" "list" $vkargs }}
           {{- include "liqo.concatenateList" $d | nindent 10 }}
           {{- end }}
           {{- if .Values.virtualKubelet.virtualNode.extra.annotations }}

--- a/docs/usage/reflection.md
+++ b/docs/usage/reflection.md
@@ -100,4 +100,5 @@ In this respect, Liqo features also the propagation of Secrets holding **Service
 
 ```{warning}
 Currently, Liqo supports only the propagation of *ServiceAccount* tokens contained in the respective *Secret* object (i.e., *first party tokens*), and not of those to be retrieved from the *TokenRequest* API (i.e., *third party tokens*).
+Due to this limitation, service account reflection is currently *disabled* by default in Kubernetes v1.24+, as ServiceAccounts do not longer automatically generate the corresponding Secret.
 ```

--- a/pkg/virtualKubelet/forge/events.go
+++ b/pkg/virtualKubelet/forge/events.go
@@ -75,3 +75,8 @@ func EventReflectionDisabledMsg(namespace string) string {
 func EventReflectionDisabledErrorMsg(namespace string, err error) string {
 	return fmt.Sprintf("Reflection to cluster %q disabled for namespace %q: error updating status: %v", RemoteCluster.ClusterName, namespace, err)
 }
+
+// EventSAReflectionDisabledMsg returns the message for the event when service account reflection is disabled.
+func EventSAReflectionDisabledMsg() string {
+	return fmt.Sprintf("Reflection to cluster %q disabled for secrets holding service account tokens", RemoteCluster.ClusterName)
+}

--- a/pkg/virtualKubelet/reflection/workload/pod_test.go
+++ b/pkg/virtualKubelet/reflection/workload/pod_test.go
@@ -42,7 +42,7 @@ import (
 var _ = Describe("Pod Reflection Tests", func() {
 	Describe("the NewPodReflector function", func() {
 		It("should not return a nil reflector", func() {
-			reflector := workload.NewPodReflector(nil, nil, nil, 0)
+			reflector := workload.NewPodReflector(nil, nil, nil, false, 0)
 			Expect(reflector).ToNot(BeNil())
 			Expect(reflector.Reflector).ToNot(BeNil())
 		})
@@ -59,7 +59,7 @@ var _ = Describe("Pod Reflection Tests", func() {
 		BeforeEach(func() {
 			ipam := fakeipam.NewIPAMClient("192.168.200.0/24", "192.168.201.0/24", true)
 			metricsFactory := func(string) metricsv1beta1.PodMetricsInterface { return nil }
-			reflector := workload.NewPodReflector(nil, metricsFactory, ipam, 0)
+			reflector := workload.NewPodReflector(nil, metricsFactory, ipam, false, 0)
 			kubernetesServiceIPGetter = reflector.KubernetesServiceIPGetter()
 		})
 
@@ -106,7 +106,7 @@ var _ = Describe("Pod Reflection Tests", func() {
 			client = fake.NewSimpleClientset(&local)
 			factory := informers.NewSharedInformerFactory(client, 10*time.Hour)
 
-			reflector = workload.NewPodReflector(nil, nil, nil, 0)
+			reflector = workload.NewPodReflector(nil, nil, nil, false, 0)
 
 			opts := options.New(client, factory.Core().V1().Pods()).
 				WithHandlerFactory(FakeEventHandler).

--- a/pkg/virtualKubelet/reflection/workload/podns.go
+++ b/pkg/virtualKubelet/reflection/workload/podns.go
@@ -84,6 +84,7 @@ type NamespacedPodReflector struct {
 	remoteMetrics    metricsv1beta1.PodMetricsInterface
 
 	ipamclient                ipam.IpamClient
+	enableAPIServerSupport    bool
 	kubernetesServiceIPGetter func(context.Context) (string, error)
 	pods                      sync.Map /* implicit signature: map[string]*PodInfo */
 }
@@ -290,7 +291,7 @@ func (npr *NamespacedPodReflector) ForgeShadowPod(ctx context.Context, local *co
 	}
 
 	// Forge the target shadowpod object.
-	target := forge.RemoteShadowPod(local, shadow, npr.RemoteNamespace(), saSecretRetriever, ipGetter)
+	target := forge.RemoteShadowPod(local, shadow, npr.RemoteNamespace(), npr.enableAPIServerSupport, saSecretRetriever, ipGetter)
 
 	// Check whether an error occurred during secret name retrieval.
 	if saerr != nil {

--- a/pkg/virtualKubelet/reflection/workload/podns_test.go
+++ b/pkg/virtualKubelet/reflection/workload/podns_test.go
@@ -73,7 +73,7 @@ var _ = Describe("Namespaced Pod Reflection Tests", func() {
 
 			broadcaster := record.NewBroadcaster()
 			metricsFactory := func(string) metricsv1beta1.PodMetricsInterface { return nil }
-			rfl := workload.NewPodReflector(nil, metricsFactory, ipam, 0)
+			rfl := workload.NewPodReflector(nil, metricsFactory, ipam, true, 0)
 			rfl.Start(ctx, options.New(client, factory.Core().V1().Pods()).WithEventBroadcaster(broadcaster))
 			reflector = rfl.NewNamespaced(options.NewNamespaced().
 				WithLocal(LocalNamespace, client, factory).WithLiqoLocal(liqoClient, liqoFactory).


### PR DESCRIPTION
# Description

This PR enables the possibility to disable the API server support for offloaded pods through an appropriate flag. Specifically, this is necessary for kubernetes 1.24+ clusters, since the creation of the secrets associated with service accounts has been disables, and the Liqo virtual kubelet does not currently support third party tokens. By default, this feature is automatically enabled through Helm for all clusters with k8s version <1.24, although it can be manually overridden adding the appropriate flag. 

Fixes #(issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Existing + new tests
- [x] Manual tests, both with k8s 1.23 and 1.24 clusters. 
