### PR TITLE
Network config: fix incorrect log level

### DIFF
--- a/internal/liqonet/network-manager/netcfgcreator/networkconfig.go
+++ b/internal/liqonet/network-manager/netcfgcreator/networkconfig.go
@@ -229,6 +229,6 @@ func (ncc *NetworkConfigCreator) EnforceNetworkConfigAbsence(ctx context.Context
 		return err
 	}
 
-	klog.Errorf("Correctly ensured no NetworkConfigs associated with cluster %s are present", clusterIdentity)
+	klog.Infof("Correctly ensured no NetworkConfigs associated with cluster %s are present", clusterIdentity)
 	return nil
 }


### PR DESCRIPTION
# Description

This PR fixes an incorrect log instruction in the network config controller.