### PR TITLE
Test action: send coverage on merge only

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -129,3 +129,4 @@ jobs:
       uses: shogo82148/actions-goveralls@v1.4.5
       with:
         path-to-profile: coverage.txt
+      if: github.event_name == 'push'


### PR DESCRIPTION
# Description

This PR modifies the test pipeline to ensure the test coverage is updated on merges into master only, to prevent bounces due to PRs. Indeed, given that tests are triggered by a slash command, all PRs are also apparently perceived as if they were pushes to the the master branch. 
