### PR TITLE
Docs: Download Liqoctl from Compressed Archives

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -224,8 +224,8 @@ jobs:
 
       - name: Create Archives
         run: |
-          cp liqoctl-${{ matrix.goos }}-${{ matrix.goarch }} kubectl-liqo
-          tar -czvf liqoctl-${{ matrix.goos }}-${{ matrix.goarch }}.tar.gz kubectl-liqo
+          cp liqoctl-${{ matrix.goos }}-${{ matrix.goarch }} liqoctl
+          tar -czvf liqoctl-${{ matrix.goos }}-${{ matrix.goarch }}.tar.gz liqoctl
 
       - name: Upload Liqoctl
         uses: actions/upload-artifact@v2

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -122,16 +122,16 @@ def generate_liqoctl_install(platform: str, arch: str) -> str:
 curl --fail -LSO \"{__get_download_url('liqoctl-windows-amd64')}\"\n\
 ```\n"
     elif platform == 'darwin':
-        file = __get_download_url(f"liqoctl-darwin-{arch}")
+        file = __get_download_url(f"liqoctl-darwin-{arch}.tar.gz")
         return f"```bash\n\
-curl --fail -LS --output liqoctl \"{file}\"\n\
+curl --fail -LS \"{file}\" | tar -xz\n\
 chmod +x liqoctl\n\
 sudo mv liqoctl /usr/local/bin/liqoctl\n\
 ```\n"
     elif platform == 'linux':
-        file = __get_download_url(f"liqoctl-linux-{arch}")
+        file = __get_download_url(f"liqoctl-linux-{arch}.tar.gz")
         return f"```bash\n\
-curl --fail -LS --output liqoctl \"{file}\"\n\
+curl --fail -LS \"{file}\" | tar -xz\n\
 sudo install -o root -g root -m 0755 liqoctl /usr/local/bin/liqoctl\n\
 ```\n"
 


### PR DESCRIPTION
# Description

This pr changes the name of the artifact in the tar archives from `kubectl-liqo` to `liqoctl` and makes it the default URL when downloading liqoctl for mac and linux.

# How Has This Been Tested?

- [x] locally
