### PR TITLE
PVC reflection: add missing filter annotation

### DIFF
--- a/pkg/liqo-controller-manager/storageprovisioner/remoteprovisioner.go
+++ b/pkg/liqo-controller-manager/storageprovisioner/remoteprovisioner.go
@@ -135,6 +135,7 @@ var controllerAnnotations = []string{
 	"pv.kubernetes.io/bind-completed",
 	"pv.kubernetes.io/bound-by-controller",
 	"volume.beta.kubernetes.io/storage-provisioner",
+	"volume.kubernetes.io/storage-provisioner",
 	"volume.kubernetes.io/selected-node",
 	corev1.BetaStorageClassAnnotation,
 }


### PR DESCRIPTION
# Description

This PR adds a missing filter annotation to be applied during PVC reflection, which caused remote provisioning to fail.