### PR TITLE
global-ingress setup.sh: fail_on_error requires 2 string arguments

### DIFF
--- a/examples/global-ingress/setup.sh
+++ b/examples/global-ingress/setup.sh
@@ -40,7 +40,7 @@ helm repo update &> /dev/null
 
 info "Deploying bind server..."
 
-fail_on_error kubectl apply -f "$here/manifests/edge/" --kubeconfig="${KUBECONFIG_EDGE_DNS}" "Failed to deploy bind server"
+fail_on_error "kubectl apply -f $here/manifests/edge/ --kubeconfig=${KUBECONFIG_EDGE_DNS}" "Failed to deploy bind server"
 DNS_IP=$(kubectl get nodes --selector=node-role.kubernetes.io/master -o jsonpath='{$.items[*].status.addresses[?(@.type=="InternalIP")].address}' --kubeconfig="${KUBECONFIG_EDGE_DNS}")
 
 success_clear_line "Bind server has been deployed."


### PR DESCRIPTION
# Description
I am getting this when running the setup.sh with debug enabled:

```bash
INFO	Deploying bind server...
+ fail_on_error kubectl apply -f /Users/ab017z6/workspace/liqo/examples/global-ingress/manifests/edge/ --kubeconfig=/Users/ab017z6/.k3d/kubeconfig-edgedns.yaml 'Failed to deploy bind server'
+ local cmd=kubectl
+ local msg=apply
+ set +e
++ kubectl
+ output='kubectl controls the Kubernetes cluster manager.

 Find more information at: https://kubernetes.io/docs/reference/kubectl/overview/

Basic Commands (Beginner):
  create        Create a resource from a file or from stdin.
  expose        Take a replication controller, service, deployment or pod and expose it as a new Kubernetes Service
  run           Run a particular image on the cluster
  set           Set specific features on objects
...
```

My environment is Mac + zsh, but I think this will also happen on any Linux distro. The reason is the quotes and the way how `fail_on_error` [handles](https://github.com/liqotech/liqo/blob/v0.5.0/examples/common.sh#L230) the arguments.



# How Has This Been Tested?

by running the setup.sh script locally with `set -x` then, I can see this:

```bash
INFO	Deploying bind server...
+ fail_on_error 'kubectl apply -f /Users/ab017z6/workspace/liqo/examples/global-ingress/manifests/edge/ --kubeconfig=/Users/ab017z6/.k3d/kubeconfig-edgedns.yaml' 'Failed to deploy bind server'
+ local 'cmd=kubectl apply -f /Users/ab017z6/workspace/liqo/examples/global-ingress/manifests/edge/ --kubeconfig=/Users/ab017z6/.k3d/kubeconfig-edgedns.yaml'
+ local 'msg=Failed to deploy bind server'
```

(the argument was "parsed" correctly for the `fail_on_error` helper)

Signed-off-by: Jirka Kremser <jiri.kremser@gmail.com>
