### PR TITLE
Examples: fix the k3d ApiServer Address Retrieval

### DIFF
--- a/examples/common.sh
+++ b/examples/common.sh
@@ -147,11 +147,13 @@ function install_liqo_k3d() {
     shift 4
     labels="$*"
 
+    api_server_address=$(kubectl get nodes --kubeconfig "$kubeconfig" --selector=node-role.kubernetes.io/master -o jsonpath='{$.items[*].status.addresses[?(@.type=="InternalIP")].address}')
+
     fail_on_error "liqoctl install k3s --cluster-name $cluster_name \
         --cluster-labels=$(join_by , "${labels[@]}") \
         --pod-cidr $pod_cidr \
         --service-cidr $service_cidr \
-        --api-server-url https://$(kubectl get nodes --kubeconfig "$kubeconfig" --selector=node-role.kubernetes.io/master -o jsonpath='{$.items[*].status.addresses[?(@.type=="InternalIP")].address}'):6443 \
+        --api-server-url https://$api_server_address:6443 \
         --kubeconfig $kubeconfig" "Failed to install liqo on cluster \"${cluster_name}\""
 
     success_clear_line "Liqo has been installed on cluster \"$cluster_name\"."


### PR DESCRIPTION
# Description

This pr splits the retrieval and the usage of the k3d APIServer address to have a better error handling

# How Has This Been Tested?

- [x] locally
