### PR TITLE
liqoctl uninstall: add uninstallation check

### DIFF
--- a/cmd/liqoctl/cmd/peer.go
+++ b/cmd/liqoctl/cmd/peer.go
@@ -170,6 +170,7 @@ func newPeerInBandCommand(ctx context.Context, peerOptions *peer.Options) *cobra
 		Aliases: []string{"ib"},
 		Short:   "Enable an in-band peering towards a remote cluster",
 		Long:    WithTemplate(liqoctlPeerIBLongHelp),
+		Args:    cobra.NoArgs,
 
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			twoClustersPersistentPreRun(cmd, local, remote, factory.WithScopedPrinter)

--- a/cmd/liqoctl/cmd/uninstall.go
+++ b/cmd/liqoctl/cmd/uninstall.go
@@ -47,6 +47,7 @@ func newUninstallCommand(ctx context.Context, f *factory.Factory) *cobra.Command
 		Use:   "uninstall",
 		Short: "Uninstall Liqo from the selected cluster",
 		Long:  WithTemplate(liqoctlUninstallLongHelp),
+		Args:  cobra.NoArgs,
 
 		Run: func(cmd *cobra.Command, args []string) {
 			output.ExitOnErr(options.Run(ctx))

--- a/cmd/liqoctl/cmd/unpeer.go
+++ b/cmd/liqoctl/cmd/unpeer.go
@@ -139,6 +139,7 @@ func newUnpeerInBandCommand(ctx context.Context, unpeerOptions *unpeeroob.Option
 		Aliases: []string{"ib"},
 		Short:   "Disable an in-band peering towards a remote cluster",
 		Long:    WithTemplate(liqoctlUnpeerIBLongHelp),
+		Args:    cobra.NoArgs,
 
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			twoClustersPersistentPreRun(cmd, local, remote, factory.WithScopedPrinter)


### PR DESCRIPTION
# Description

This PR enriches the `liqoctl uninstall` command with an additional check, to prevent purging from being performed in case the release was not found, but cluster wide resources are still present (thus possibly leaving leftover resources behind). This might happen if the incorrect namespace is selected, or Liqo had been installed with alternative solutions.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Manually, on Kind

