### PR TITLE
Bump golangci-lint version

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,11 +20,11 @@ jobs:
           go-version: 1.18
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3.1.0
+        uses: golangci/golangci-lint-action@v3.2.0
         with:
           only-new-issues: true
-          version: v1.46.2
-          args: --timeout=600s
+          version: v1.47.1
+          args: --timeout=900s
 
   gomodtidy:
     name: Enforce go.mod tidiness

--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ fmt: gci addlicense
 # Install golangci-lint if not available
 golangci-lint:
 ifeq (, $(shell which golangci-lint))
-	@go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.46.2
+	@go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.47.1
 GOLANGCILINT=$(GOBIN)/golangci-lint
 else
 GOLANGCILINT=$(shell which golangci-lint)


### PR DESCRIPTION
# Description

This PR bumps golangci-lint to the latest version, and increases the timeout to prevent seldom failures.