### PR TITLE
Liqoctl: Improve Validation Feedback

### DIFF
--- a/cmd/liqoctl/cmd/install.go
+++ b/cmd/liqoctl/cmd/install.go
@@ -147,6 +147,9 @@ func newInstallCommand(ctx context.Context, f *factory.Factory) *cobra.Command {
 	cmd.PersistentFlags().StringSliceVar(&options.OverrideValues, "set", []string{}, "Set additional values on the command line (key1=val1,key2=val2)")
 	cmd.PersistentFlags().BoolVar(&options.DisableAPIServerSanityChecks, "disable-api-server-sanity-check", false,
 		"Disable the sanity checks concerning the retrieved Kubernetes API server URL (default false)")
+	cmd.PersistentFlags().BoolVar(&options.SkipValidation, "skip-validation", false, "Skip the validation of the arguments "+
+		"(ClusterName, PodCIDR, ServiceCIDR). "+
+		"This is useful when you are sure of what you are doing and the amount of pods and services in your cluster is very large (default false)")
 
 	f.AddLiqoNamespaceFlag(cmd.PersistentFlags())
 

--- a/pkg/liqoctl/install/handler.go
+++ b/pkg/liqoctl/install/handler.go
@@ -87,6 +87,7 @@ type Options struct {
 
 	DisableAPIServerSanityChecks bool
 	DisableAPIServerDefaulting   bool
+	SkipValidation               bool
 }
 
 // Run implements the install command.
@@ -113,10 +114,12 @@ func (o *Options) Run(ctx context.Context, provider Provider) error {
 		return err
 	}
 
-	err = o.validate(ctx)
-	if err != nil {
-		s.Fail("Error retrieving configuration: ", output.PrettyErr(err))
-		return err
+	if !o.SkipValidation {
+		err = o.validate(ctx)
+		if err != nil {
+			s.Fail("Error retrieving configuration: ", output.PrettyErr(err))
+			return err
+		}
 	}
 
 	s.Success("Cluster configuration correctly retrieved")

--- a/pkg/liqoctl/install/validation.go
+++ b/pkg/liqoctl/install/validation.go
@@ -43,12 +43,16 @@ func (o *Options) validate(ctx context.Context) error {
 	o.Printer.Verbosef("Kubernetes API Server: %s\n", o.PodCIDR)
 
 	if err := o.validatePodCIDR(ctx); err != nil {
-		return fmt.Errorf("failed validating Pod CIDR %q: %w", o.PodCIDR, err)
+		return fmt.Errorf("failed validating Pod CIDR %q: %w. "+
+			"Try setting the correct Pod CIDR using the vanilla *liqoctl install* command, or installing Liqo with Helm",
+			o.PodCIDR, err)
 	}
 	o.Printer.Verbosef("Pod CIDR: %s\n", o.PodCIDR)
 
 	if err := o.validateServiceCIDR(ctx); err != nil {
-		return fmt.Errorf("failed validating Service CIDR %q: %w", o.ServiceCIDR, err)
+		return fmt.Errorf("failed validating Service CIDR %q: %w. "+
+			"Try setting the correct Service CIDR using the vanilla *liqoctl install* command, or installing Liqo with Helm",
+			o.ServiceCIDR, err)
 	}
 	o.Printer.Verbosef("Service CIDR: %s\n", o.ServiceCIDR)
 


### PR DESCRIPTION
# Description

This pr improves the liqoctl install parameters feedback to tell the user to use the generic provider or to install with helm when the pod/service CIDRs are not the ones expected by the provider. This can be useful when using different CNIs that the ones expected by cloud providers.

# How Has This Been Tested?

- [x] locally
