### PR TITLE
liqoctl: wait for peering completion for the in-band case

### DIFF
--- a/pkg/liqoctl/inbound/cluster.go
+++ b/pkg/liqoctl/inbound/cluster.go
@@ -68,9 +68,7 @@ type WireGuardConfig struct {
 type Cluster struct {
 	local  *factory.Factory
 	remote *factory.Factory
-
-	localWaiter  *wait.Waiter
-	remoteWaiter *wait.Waiter
+	Waiter *wait.Waiter
 
 	locTenantNamespace string
 	remTenantNamespace string
@@ -104,8 +102,7 @@ func NewCluster(local, remote *factory.Factory) *Cluster {
 	return &Cluster{
 		local:            local,
 		remote:           remote,
-		localWaiter:      wait.NewWaiterFromFactory(local),
-		remoteWaiter:     wait.NewWaiterFromFactory(remote),
+		Waiter:           wait.NewWaiterFromFactory(local),
 		namespaceManager: tenantnamespace.NewManager(local.KubeClient),
 		PortForwardOpts:  pfo,
 	}
@@ -847,20 +844,4 @@ func (c *Cluster) DisablePeering(ctx context.Context, remoteClusterID *discovery
 	s.Success(fmt.Sprintf("peering correctly disabled for remote cluster %q", remName))
 
 	return nil
-}
-
-// WaitForUnpeering waits until the status on the foreiglcusters resource states that the in/outgoing peering has been successfully
-// set to None or the timeout expires.
-func (c *Cluster) WaitForUnpeering(ctx context.Context, remoteClusterID *discoveryv1alpha1.ClusterIdentity) error {
-	return c.localWaiter.ForUnpeering(ctx, remoteClusterID)
-}
-
-// WaitForAuth waits until the authentication has been established with the remote cluster or the timeout expires.
-func (c *Cluster) WaitForAuth(ctx context.Context, remoteClusterID *discoveryv1alpha1.ClusterIdentity) error {
-	return c.localWaiter.ForAuth(ctx, remoteClusterID)
-}
-
-// WaitForNetwork waits until the networking has been established with the remote cluster or the timeout expires.
-func (c *Cluster) WaitForNetwork(ctx context.Context, remoteClusterID *discoveryv1alpha1.ClusterIdentity) error {
-	return c.localWaiter.ForAuth(ctx, remoteClusterID)
 }

--- a/pkg/liqoctl/peerib/handler.go
+++ b/pkg/liqoctl/peerib/handler.go
@@ -127,30 +127,54 @@ func (o *Options) Run(ctx context.Context) error {
 	}
 
 	// Waiting for VPN connection to be established in cluster 1.
-	if err := cluster1.WaitForNetwork(ctx, cluster2.GetClusterID()); err != nil {
+	if err := cluster1.Waiter.ForNetwork(ctx, cluster2.GetClusterID()); err != nil {
 		return err
 	}
 
 	// Waiting for VPN connection to be established in cluster 2.
-	if err := cluster2.WaitForNetwork(ctx, cluster1.GetClusterID()); err != nil {
+	if err := cluster2.Waiter.ForNetwork(ctx, cluster1.GetClusterID()); err != nil {
 		return err
 	}
 
 	// Waiting for VPN connection to be established in cluster 1.
-	if err := cluster1.WaitForNetwork(ctx, cluster2.GetClusterID()); err != nil {
+	if err := cluster1.Waiter.ForNetwork(ctx, cluster2.GetClusterID()); err != nil {
 		return err
 	}
 
 	// Waiting for VPN connection to be established in cluster 2.
-	if err := cluster2.WaitForNetwork(ctx, cluster1.GetClusterID()); err != nil {
+	if err := cluster2.Waiter.ForNetwork(ctx, cluster1.GetClusterID()); err != nil {
 		return err
 	}
 
 	// Waiting for authentication to complete in cluster 1.
-	if err := cluster1.WaitForAuth(ctx, cluster2.GetClusterID()); err != nil {
+	if err := cluster1.Waiter.ForAuth(ctx, cluster2.GetClusterID()); err != nil {
 		return err
 	}
 
 	// Waiting for authentication to complete in cluster 2.
-	return cluster2.WaitForAuth(ctx, cluster1.GetClusterID())
+	if err := cluster2.Waiter.ForAuth(ctx, cluster1.GetClusterID()); err != nil {
+		return err
+	}
+
+	// Waiting for outgoing peering to complete in cluster 1.
+	if err := cluster1.Waiter.ForOutgoingPeering(ctx, cluster2.GetClusterID()); err != nil {
+		return err
+	}
+
+	// Waiting for virtual node to be created in cluster 1.
+	if err := cluster1.Waiter.ForNode(ctx, cluster2.GetClusterID()); err != nil {
+		return err
+	}
+
+	if !o.Bidirectional {
+		return nil
+	}
+
+	// Waiting for outgoing peering to complete in cluster 2.
+	if err := cluster2.Waiter.ForOutgoingPeering(ctx, cluster1.GetClusterID()); err != nil {
+		return err
+	}
+
+	// Waiting for virtual node to be created in cluster 2.
+	return cluster2.Waiter.ForNode(ctx, cluster1.GetClusterID())
 }

--- a/pkg/liqoctl/unpeerib/handler.go
+++ b/pkg/liqoctl/unpeerib/handler.go
@@ -61,12 +61,12 @@ func (o *Options) Run(ctx context.Context) error {
 	}
 
 	// Wait to unpeer in cluster 1.
-	if err := cluster1.WaitForUnpeering(ctx, cluster2.GetClusterID()); err != nil {
+	if err := cluster1.Waiter.ForUnpeering(ctx, cluster2.GetClusterID()); err != nil {
 		return err
 	}
 
 	// Disable peering in cluster 2.
-	if err := cluster2.WaitForUnpeering(ctx, cluster1.GetClusterID()); err != nil {
+	if err := cluster2.Waiter.ForUnpeering(ctx, cluster1.GetClusterID()); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
# Description

This PR extends the liqoctl peer in-band command, to additionally wait for the outgoing peering to complete, and the virtual node to be created before terminating, in order to provide better feedback to the users. This also reflects the current behavior of the peer out-of-band command.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Manually, on kind
