### PR TITLE
liqoctl peer in-band improvements

### DIFF
--- a/cmd/crd-replicator/main.go
+++ b/cmd/crd-replicator/main.go
@@ -71,7 +71,7 @@ func main() {
 	// Create a clientSet.
 	k8sClient := kubernetes.NewForConfigOrDie(cfg)
 
-	namespaceManager := tenantnamespace.NewTenantNamespaceManager(k8sClient)
+	namespaceManager := tenantnamespace.NewCachedManager(k8sClient)
 
 	dynClient := dynamic.NewForConfigOrDie(cfg)
 

--- a/cmd/liqo-controller-manager/main.go
+++ b/cmd/liqo-controller-manager/main.go
@@ -204,7 +204,7 @@ func main() {
 
 	clientset := kubernetes.NewForConfigOrDie(config)
 
-	namespaceManager := tenantnamespace.NewTenantNamespaceManager(clientset)
+	namespaceManager := tenantnamespace.NewCachedManager(clientset)
 	idManager := identitymanager.NewCertificateIdentityManager(clientset, clusterIdentity, namespaceManager)
 
 	// populate the lists of ClusterRoles to bind in the different peering states

--- a/cmd/virtual-kubelet/root/root.go
+++ b/cmd/virtual-kubelet/root/root.go
@@ -72,7 +72,7 @@ func runRootCommand(ctx context.Context, c *Opts) error {
 	localClient := kubernetes.NewForConfigOrDie(localConfig)
 
 	// Retrieve the remote restcfg
-	tenantNamespaceManager := tenantnamespace.NewTenantNamespaceManager(localClient)
+	tenantNamespaceManager := tenantnamespace.NewManager(localClient) // Do not use the cached version, as leveraged only once.
 	identityManager := identitymanager.NewCertificateIdentityReader(localClient, c.HomeCluster, tenantNamespaceManager)
 
 	remoteConfig, err := identityManager.GetConfig(c.ForeignCluster, c.TenantNamespace)

--- a/docs/usage/peer.md
+++ b/docs/usage/peer.md
@@ -22,7 +22,7 @@ Ensure you selected the correct target cluster before issuing *liqoctl* commands
 
 ## Out-of-band control plane
 
-Briefly, the procedure to establish an [out-of-band control plane peering](FeaturesPeeringOutOfBandControlPlane) consists of a first step performed on the *provider*, to **retrieve the set of information** required (i.e., authentication endpoint and token, cluster ID, ...), followed by the creation of the necessary resources to **start the actual peering**.
+Briefly, the procedure to establish an [out-of-band control plane peering](FeaturesPeeringOutOfBandControlPlane) consists of a first step performed on the *provider*, to **retrieve the set of information** required (i.e., authentication endpoint and token, cluster ID, ...), followed by the creation, on the *consumer*, of the necessary resources to **start the actual peering**.
 The remainder of the process, including identity retrieval, resource negotiation and network tunnel establishment is **performed automatically** by Liqo, through a mutual exchange of information and negotiation between the two clusters involved.
 
 ### Information retrieval
@@ -117,6 +117,10 @@ Hence, the same command shall be executed on both clusters to completely tear do
 
 Briefly, the procedure to establish an [in-band control plane peering](FeaturesPeeringInBandControlPlane) consists of a first step performed by *liqoctl*, which interacts alternatively with both clusters to **establish the cross-cluster VPN tunnel**, exchange the **authentication tokens** and configure the Liqo control plane traffic to flow inside the VPN.
 The remainder of the process, including identity retrieval and resource negotiation, is **performed automatically** by Liqo, through a mutual exchange of information and negotiation between the two clusters involved.
+
+```{admonition} Note
+The host used to issue the *liqoctl peer in-band* command must have **concurrent access to both clusters** (i.e., *consumer* and *provider*) while carrying out the in-band control plane peering process.
+```
 
 <!-- markdownlint-disable-next-line no-duplicate-heading -->
 ### Peering establishment

--- a/internal/auth-service/auth-service.go
+++ b/internal/auth-service/auth-service.go
@@ -94,7 +94,7 @@ func NewAuthServiceCtrl(config *rest.Config, namespace string,
 	informerFactory.Start(wait.NeverStop)
 	informerFactory.WaitForCacheSync(wait.NeverStop)
 
-	namespaceManager := tenantnamespace.NewTenantNamespaceManager(clientset)
+	namespaceManager := tenantnamespace.NewCachedManager(clientset)
 
 	var idProvider identitymanager.IdentityProvider
 	if awsConfig.IsEmpty() {

--- a/internal/auth-service/auth_test.go
+++ b/internal/auth-service/auth_test.go
@@ -104,7 +104,7 @@ var _ = Describe("Auth", func() {
 		informerFactory.Start(stopChan)
 		informerFactory.WaitForCacheSync(wait.NeverStop)
 
-		namespaceManager := tenantnamespace.NewTenantNamespaceManager(cluster.GetClient())
+		namespaceManager := tenantnamespace.NewManager(cluster.GetClient())
 		identityProvider := identitymanager.NewCertificateIdentityProvider(
 			context.Background(), cluster.GetClient(), clusterIdentity, namespaceManager)
 

--- a/internal/auth-service/identity.go
+++ b/internal/auth-service/identity.go
@@ -96,7 +96,7 @@ func (authService *Controller) handleIdentity(
 
 	remoteClusterIdentity := identityRequest.ClusterIdentity
 	klog.V(4).Infof("Creating Tenant Namespace for cluster %s", remoteClusterIdentity)
-	namespace, err := authService.namespaceManager.CreateNamespace(remoteClusterIdentity)
+	namespace, err := authService.namespaceManager.CreateNamespace(ctx, remoteClusterIdentity)
 	if err != nil {
 		klog.Error(err)
 		return nil, err
@@ -131,7 +131,7 @@ func (authService *Controller) handleIdentity(
 
 	// bind basic permission required to start the peering
 	if _, err = authService.namespaceManager.BindClusterRoles(
-		remoteClusterIdentity, authService.peeringPermission.Basic...); err != nil {
+		ctx, remoteClusterIdentity, authService.peeringPermission.Basic...); err != nil {
 		klog.Error(err)
 		return nil, err
 	}

--- a/pkg/identityManager/certificate.go
+++ b/pkg/identityManager/certificate.go
@@ -42,7 +42,7 @@ import (
 
 // CreateIdentity creates a new key and a new csr to be used as an identity to authenticate with a remote cluster.
 func (certManager *identityManager) CreateIdentity(remoteCluster discoveryv1alpha1.ClusterIdentity) (*v1.Secret, error) {
-	namespace, err := certManager.namespaceManager.GetNamespace(remoteCluster)
+	namespace, err := certManager.namespaceManager.GetNamespace(context.TODO(), remoteCluster)
 	if err != nil {
 		klog.Error(err)
 		return nil, err
@@ -129,7 +129,7 @@ func (certManager *identityManager) StoreCertificate(remoteCluster discoveryv1al
 
 // getSecret retrieves the identity secret given the clusterID.
 func (certManager *identityManager) getSecret(remoteCluster discoveryv1alpha1.ClusterIdentity) (*v1.Secret, error) {
-	namespace, err := certManager.namespaceManager.GetNamespace(remoteCluster)
+	namespace, err := certManager.namespaceManager.GetNamespace(context.TODO(), remoteCluster)
 	if err != nil {
 		klog.Error(err)
 		return nil, err

--- a/pkg/identityManager/certificateIdentityProvider.go
+++ b/pkg/identityManager/certificateIdentityProvider.go
@@ -161,7 +161,7 @@ func (identityProvider *certificateIdentityProvider) ApproveSigningRequest(clust
 // storeRemoteCertificate stores the issued certificate in a Secret in the TenantNamespace.
 func (identityProvider *certificateIdentityProvider) storeRemoteCertificate(cluster discoveryv1alpha1.ClusterIdentity,
 	signingRequest, certificate []byte) (*v1.Secret, error) {
-	namespace, err := identityProvider.namespaceManager.GetNamespace(cluster)
+	namespace, err := identityProvider.namespaceManager.GetNamespace(context.TODO(), cluster)
 	if err != nil {
 		klog.Error(err)
 		return nil, err

--- a/pkg/identityManager/identityManager_test.go
+++ b/pkg/identityManager/identityManager_test.go
@@ -111,17 +111,17 @@ var _ = Describe("IdentityManager", func() {
 		client = cluster.GetClient()
 		restConfig = cluster.GetCfg()
 
-		namespaceManager = tenantnamespace.NewTenantNamespaceManager(client)
+		namespaceManager = tenantnamespace.NewManager(client)
 		identityMan = NewCertificateIdentityManager(cluster.GetClient(), localCluster, namespaceManager)
 		identityProvider = NewCertificateIdentityProvider(ctx, cluster.GetClient(), localCluster, namespaceManager)
 
-		namespace, err = namespaceManager.CreateNamespace(remoteCluster)
+		namespace, err = namespaceManager.CreateNamespace(ctx, remoteCluster)
 		if err != nil {
 			By(err.Error())
 			os.Exit(1)
 		}
 		// Make sure the namespace has been cached for subsequent retrieval.
-		Eventually(func() (*v1.Namespace, error) { return namespaceManager.GetNamespace(remoteCluster) }).Should(Equal(namespace))
+		Eventually(func() (*v1.Namespace, error) { return namespaceManager.GetNamespace(ctx, remoteCluster) }).Should(Equal(namespace))
 
 		// Certificate Secret Section
 		apiServerConfig = apiserver.Config{Address: "127.0.0.1", TrustedCA: false}

--- a/pkg/liqo-controller-manager/foreign-cluster-operator/foreign-cluster-operator_test.go
+++ b/pkg/liqo-controller-manager/foreign-cluster-operator/foreign-cluster-operator_test.go
@@ -88,20 +88,20 @@ var _ = Describe("ForeignClusterOperator", func() {
 			ClusterName: "local-cluster-name",
 		}
 
-		namespaceManager := tenantnamespace.NewTenantNamespaceManager(cluster.GetClient())
+		namespaceManager := tenantnamespace.NewManager(cluster.GetClient())
 		identityManagerCtrl := identitymanager.NewCertificateIdentityManager(cluster.GetClient(), homeCluster, namespaceManager)
 
 		foreignCluster := discoveryv1alpha1.ClusterIdentity{
 			ClusterID:   "foreign-cluster-id",
 			ClusterName: "foreign-cluster-name",
 		}
-		tenantNamespace, err = namespaceManager.CreateNamespace(foreignCluster)
+		tenantNamespace, err = namespaceManager.CreateNamespace(ctx, foreignCluster)
 		if err != nil {
 			By(err.Error())
 			os.Exit(1)
 		}
 		// Make sure the namespace has been cached for subsequent retrieval.
-		Eventually(func() (*v1.Namespace, error) { return namespaceManager.GetNamespace(foreignCluster) }).Should(Equal(tenantNamespace))
+		Eventually(func() (*v1.Namespace, error) { return namespaceManager.GetNamespace(ctx, foreignCluster) }).Should(Equal(tenantNamespace))
 
 		controller = ForeignClusterReconciler{
 			Client:           mgr.GetClient(),
@@ -444,7 +444,7 @@ var _ = Describe("ForeignClusterOperator", func() {
 
 			var ns *v1.Namespace
 			Eventually(func() error {
-				ns, err = controller.NamespaceManager.GetNamespace(foreignCluster.Spec.ClusterIdentity)
+				ns, err = controller.NamespaceManager.GetNamespace(ctx, foreignCluster.Spec.ClusterIdentity)
 				return err
 			}).Should(Succeed())
 
@@ -903,7 +903,7 @@ var _ = Describe("ForeignClusterOperator", func() {
 				By("Delete RoleBindings")
 
 				// create all
-				_, err := controller.NamespaceManager.BindClusterRoles(c.fc.Spec.ClusterIdentity, &clusterRole1, &clusterRole2)
+				_, err := controller.NamespaceManager.BindClusterRoles(ctx, c.fc.Spec.ClusterIdentity, &clusterRole1, &clusterRole2)
 				Expect(err).To(Succeed())
 
 				Expect(controller.ensurePermission(ctx, &c.fc)).To(Succeed())

--- a/pkg/liqo-controller-manager/foreign-cluster-operator/permission.go
+++ b/pkg/liqo-controller-manager/foreign-cluster-operator/permission.go
@@ -30,52 +30,52 @@ func (r *ForeignClusterReconciler) ensurePermission(ctx context.Context, foreign
 	remoteCluster := foreignCluster.Spec.ClusterIdentity
 	peeringPhase := foreignclusterutils.GetPeeringPhase(foreignCluster)
 
-	if _, err = r.NamespaceManager.BindClusterRoles(remoteCluster, r.PeeringPermission.Basic...); err != nil {
+	if _, err = r.NamespaceManager.BindClusterRoles(ctx, remoteCluster, r.PeeringPermission.Basic...); err != nil {
 		klog.Error(err)
 		return err
 	}
 
 	switch peeringPhase {
 	case consts.PeeringPhaseNone, consts.PeeringPhaseAuthenticated:
-		if err = r.NamespaceManager.UnbindClusterRoles(remoteCluster,
+		if err = r.NamespaceManager.UnbindClusterRoles(ctx, remoteCluster,
 			clusterRolesToNames(r.PeeringPermission.Outgoing)...); err != nil {
 			klog.Error(err)
 			return err
 		}
-		if err = r.NamespaceManager.UnbindClusterRoles(remoteCluster,
+		if err = r.NamespaceManager.UnbindClusterRoles(ctx, remoteCluster,
 			clusterRolesToNames(r.PeeringPermission.Incoming)...); err != nil {
 			klog.Error(err)
 			return err
 		}
 	case consts.PeeringPhaseOutgoing:
-		if _, err = r.NamespaceManager.BindClusterRoles(remoteCluster,
+		if _, err = r.NamespaceManager.BindClusterRoles(ctx, remoteCluster,
 			r.PeeringPermission.Outgoing...); err != nil {
 			klog.Error(err)
 			return err
 		}
-		if err = r.NamespaceManager.UnbindClusterRoles(remoteCluster,
+		if err = r.NamespaceManager.UnbindClusterRoles(ctx, remoteCluster,
 			clusterRolesToNames(r.PeeringPermission.Incoming)...); err != nil {
 			klog.Error(err)
 			return err
 		}
 	case consts.PeeringPhaseIncoming:
-		if err = r.NamespaceManager.UnbindClusterRoles(remoteCluster,
+		if err = r.NamespaceManager.UnbindClusterRoles(ctx, remoteCluster,
 			clusterRolesToNames(r.PeeringPermission.Outgoing)...); err != nil {
 			klog.Error(err)
 			return err
 		}
-		if _, err = r.NamespaceManager.BindClusterRoles(remoteCluster,
+		if _, err = r.NamespaceManager.BindClusterRoles(ctx, remoteCluster,
 			r.PeeringPermission.Incoming...); err != nil {
 			klog.Error(err)
 			return err
 		}
 	case consts.PeeringPhaseBidirectional:
-		if _, err = r.NamespaceManager.BindClusterRoles(remoteCluster,
+		if _, err = r.NamespaceManager.BindClusterRoles(ctx, remoteCluster,
 			r.PeeringPermission.Outgoing...); err != nil {
 			klog.Error(err)
 			return err
 		}
-		if _, err = r.NamespaceManager.BindClusterRoles(remoteCluster,
+		if _, err = r.NamespaceManager.BindClusterRoles(ctx, remoteCluster,
 			r.PeeringPermission.Incoming...); err != nil {
 			klog.Error(err)
 			return err

--- a/pkg/liqo-controller-manager/foreign-cluster-operator/tenantNamespace.go
+++ b/pkg/liqo-controller-manager/foreign-cluster-operator/tenantNamespace.go
@@ -25,7 +25,7 @@ import (
 // ensureLocalTenantNamespace creates the LocalTenantNamespace for the given ForeignCluster, if it is not yet present.
 func (r *ForeignClusterReconciler) ensureLocalTenantNamespace(
 	ctx context.Context, foreignCluster *v1alpha1.ForeignCluster) error {
-	namespace, err := r.NamespaceManager.CreateNamespace(foreignCluster.Spec.ClusterIdentity)
+	namespace, err := r.NamespaceManager.CreateNamespace(ctx, foreignCluster.Spec.ClusterIdentity)
 	if err != nil {
 		klog.Error(err)
 		return err

--- a/pkg/liqoctl/inbound/cluster.go
+++ b/pkg/liqoctl/inbound/cluster.go
@@ -106,7 +106,7 @@ func NewCluster(local, remote *factory.Factory) *Cluster {
 		remote:           remote,
 		localWaiter:      wait.NewWaiterFromFactory(local),
 		remoteWaiter:     wait.NewWaiterFromFactory(remote),
-		namespaceManager: tenantnamespace.NewTenantNamespaceManager(local.KubeClient),
+		namespaceManager: tenantnamespace.NewManager(local.KubeClient),
 		PortForwardOpts:  pfo,
 	}
 }
@@ -300,7 +300,7 @@ func (c *Cluster) GetProxyURL() string {
 // SetUpTenantNamespace creates the tenant namespace in the local custer for the given remote cluster.
 func (c *Cluster) SetUpTenantNamespace(ctx context.Context, remoteClusterID *discoveryv1alpha1.ClusterIdentity) error {
 	s := c.local.Printer.StartSpinner(fmt.Sprintf("creating tenant namespace for remote cluster %q", remoteClusterID.ClusterName))
-	ns, err := c.namespaceManager.CreateNamespace(*remoteClusterID)
+	ns, err := c.namespaceManager.CreateNamespace(ctx, *remoteClusterID)
 	if err != nil {
 		s.Fail(fmt.Sprintf("an error occurred while creating tenant namespace for remote cluster %q: %v", remoteClusterID.ClusterName, err))
 		return err

--- a/pkg/liqoctl/output/output.go
+++ b/pkg/liqoctl/output/output.go
@@ -207,10 +207,10 @@ func NewRemotePrinter(scoped, verbose bool) *Printer {
 }
 
 func newPrinter(scope string, color pterm.Color, scoped, verbose bool) *Printer {
-	generic := pterm.PrefixPrinter{MessageStyle: pterm.NewStyle(pterm.FgDefault)}
+	generic := &pterm.PrefixPrinter{MessageStyle: pterm.NewStyle(pterm.FgDefault)}
 
 	if scoped {
-		generic.WithScope(pterm.Scope{Text: scope, Style: pterm.NewStyle(pterm.FgGray)})
+		generic = generic.WithScope(pterm.Scope{Text: scope, Style: pterm.NewStyle(pterm.FgGray)})
 	}
 
 	printer := &Printer{

--- a/pkg/tenantNamespace/interface.go
+++ b/pkg/tenantNamespace/interface.go
@@ -15,6 +15,8 @@
 package tenantnamespace
 
 import (
+	"context"
+
 	v1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 
@@ -24,8 +26,8 @@ import (
 // Manager provides the methods to handle the creation and
 // the management of tenant namespaces.
 type Manager interface {
-	CreateNamespace(cluster discoveryv1alpha1.ClusterIdentity) (*v1.Namespace, error)
-	GetNamespace(cluster discoveryv1alpha1.ClusterIdentity) (*v1.Namespace, error)
-	BindClusterRoles(cluster discoveryv1alpha1.ClusterIdentity, clusterRoles ...*rbacv1.ClusterRole) ([]*rbacv1.RoleBinding, error)
-	UnbindClusterRoles(cluster discoveryv1alpha1.ClusterIdentity, clusterRoles ...string) error
+	CreateNamespace(ctx context.Context, cluster discoveryv1alpha1.ClusterIdentity) (*v1.Namespace, error)
+	GetNamespace(ctx context.Context, cluster discoveryv1alpha1.ClusterIdentity) (*v1.Namespace, error)
+	BindClusterRoles(ctx context.Context, cluster discoveryv1alpha1.ClusterIdentity, clusterRoles ...*rbacv1.ClusterRole) ([]*rbacv1.RoleBinding, error)
+	UnbindClusterRoles(ctx context.Context, cluster discoveryv1alpha1.ClusterIdentity, clusterRoles ...string) error
 }


### PR DESCRIPTION
# Description

This PR introduces a set of improvements concerning the liqoctl peer in-band process. In particular
* Prevents the command from hanging in case of unreachable clusters/incorrect kubeconfigs. Specifically, the tenant namespace manager is slightly refactored to support both a cached (i.e., for controllers) and an uncached version (i.e., for interactive commands), while introducing at the same time the proper support for operation interruption through contexts.
* Fixes a regression which caused the cluster scope not to be printed, to explicit the target cluster of each operation.
* Introduces a note in the in-band peering documentation, to explicit the requirement for concurrent access to both clusters during the process.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Manually, on kind
- [x] Existing automated tests
