### PR TITLE
liqoctl: fix regression in autocompletion

### DIFF
--- a/cmd/liqoctl/cmd/root.go
+++ b/cmd/liqoctl/cmd/root.go
@@ -73,7 +73,13 @@ func NewRootCommand(ctx context.Context) *cobra.Command {
 		// Initialize the factory with default parameters: thanks to lazy loading, this introduces no overhead,
 		// as well as no requirement for a valid kubeconfig if no subsequent API interaction is involved.
 		// The behavior can be customized in subcommands defining an appropriate PersistentPreRun function.
-		PersistentPreRun: func(cmd *cobra.Command, args []string) { singleClusterPersistentPreRun(cmd, f) },
+		// Yet, the initialization is skipped for the __complete command, as characterized by a peculiar behavior
+		// in terms of flags parsing (https://github.com/spf13/cobra/issues/1291#issuecomment-739056690).
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			if cmd != nil && cmd.Name() != cobra.ShellCompRequestCmd {
+				singleClusterPersistentPreRun(cmd, f)
+			}
+		},
 	}
 
 	// Since we cannot access internal klog configuration, we create a new flagset, let klog to install

--- a/pkg/liqoctl/completion/completion.go
+++ b/pkg/liqoctl/completion/completion.go
@@ -41,6 +41,10 @@ func common(ctx context.Context, f *factory.Factory, argsLimit int, retrieve ret
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
 
+		if err := f.Initialize(); err != nil {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+
 		values, err := retrieve(ctx, f)
 		if err != nil {
 			return nil, cobra.ShellCompDirectiveError


### PR DESCRIPTION
# Description

This PR fixes a regression introduced in #1285, which caused autocompletion of liqoctl parameters not to work correctly when referring to a remote cluster, or to namespaced resources. Indeed, in the former case the factory was not initialized at all, while in the latter the parameters where not configured correctly due to the peculiar behavior of the `__complete` command.

Fixes #(issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Manually checking the correct functioning of liqoctl autocompletion 
