### PR TITLE
Virtual kubelet: enable skipping single object reflection

### DIFF
--- a/docs/usage/reflection.md
+++ b/docs/usage/reflection.md
@@ -9,6 +9,10 @@ Briefly, the set of supported resources includes (by category):
 * [**Storage**](UsageReflectionStorage): *PersistentVolumeClaims*, *PresistentVolumes*
 * [**Configuration**](UsageReflectionConfiguration): *ConfigMaps*, *Secrets*
 
+```{admonition} Note
+The reflection of a given object belonging to the *Exposition* or *Configuration* categories, and living in a namespace enabled for offloading, can be manually disabled adding the `liqo.io/skip-reflection` annotation to the object itself.
+```
+
 (UsageReflectionPods)=
 
 ## Pods offloading

--- a/pkg/consts/replication.go
+++ b/pkg/consts/replication.go
@@ -53,4 +53,7 @@ const (
 	// ForceRemoteNodePortAnnotationKey is the annotation key used to indicate that a service should be forced to
 	// use the same node port on both clusters.
 	ForceRemoteNodePortAnnotationKey = "liqo.io/force-remote-node-port"
+
+	// SkipReflectionAnnotationKey is the annotation key used to indicate that a given object should not be reflected into a remote cluster.
+	SkipReflectionAnnotationKey = "liqo.io/skip-reflection"
 )

--- a/pkg/virtualKubelet/forge/events.go
+++ b/pkg/virtualKubelet/forge/events.go
@@ -26,7 +26,7 @@ const (
 	// EventFailedDeletion -> the reason for the event when the deletion of an object fails.
 	EventFailedDeletion = "FailedDeletion"
 
-	// EventReflectionDisabled -> the reason for the event when reflection is disabled for the given namespace.
+	// EventReflectionDisabled -> the reason for the event when reflection is disabled for the given namespace/object.
 	EventReflectionDisabled = "ReflectionDisabled"
 )
 
@@ -74,6 +74,11 @@ func EventReflectionDisabledMsg(namespace string) string {
 // EventReflectionDisabledErrorMsg returns the message for the event when reflection is disabled for the given namespace, and an error occurs.
 func EventReflectionDisabledErrorMsg(namespace string, err error) string {
 	return fmt.Sprintf("Reflection to cluster %q disabled for namespace %q: error updating status: %v", RemoteCluster.ClusterName, namespace, err)
+}
+
+// EventObjectReflectionDisabledMsg returns the message for the event when reflection is disabled for a given resource.
+func EventObjectReflectionDisabledMsg() string {
+	return fmt.Sprintf("Reflection to cluster %q disabled for the current object", RemoteCluster.ClusterName)
 }
 
 // EventSAReflectionDisabledMsg returns the message for the event when service account reflection is disabled.

--- a/pkg/virtualKubelet/reflection/configuration/configmap.go
+++ b/pkg/virtualKubelet/reflection/configuration/configmap.go
@@ -105,6 +105,19 @@ func (ncr *NamespacedConfigMapReflector) Handle(ctx context.Context, name string
 		}
 		return nil
 	}
+
+	// Abort the reflection if the local object has the "skip-reflection" annotation.
+	if !kerrors.IsNotFound(lerr) && ncr.ShouldSkipReflection(local) {
+		klog.Infof("Skipping reflection of local ConfigMap %q as marked with the skip annotation", ncr.LocalRef(name))
+		ncr.Event(local, corev1.EventTypeNormal, forge.EventReflectionDisabled, forge.EventObjectReflectionDisabledMsg())
+		if kerrors.IsNotFound(rerr) { // The remote object does not already exist, hence no further action is required.
+			return nil
+		}
+
+		// Otherwise, let pretend the local object does not exist, so that the remote one gets deleted.
+		lerr = kerrors.NewNotFound(corev1.Resource("configmap"), local.GetName())
+	}
+
 	tracer.Step("Performed the sanity checks")
 
 	if kerrors.IsNotFound(lerr) {

--- a/pkg/virtualKubelet/reflection/configuration/configmap.go
+++ b/pkg/virtualKubelet/reflection/configuration/configmap.go
@@ -55,9 +55,9 @@ func NewConfigMapReflector(workers uint) manager.Reflector {
 
 // RemoteConfigMapNamespacedKeyer returns a keyer associated with the given namespace,
 // which accounts for the root CA configmap name remapping.
-func RemoteConfigMapNamespacedKeyer(namespace string) func(metadata metav1.Object) types.NamespacedName {
-	return func(metadata metav1.Object) types.NamespacedName {
-		return types.NamespacedName{Namespace: namespace, Name: forge.LocalConfigMapName(metadata.GetName())}
+func RemoteConfigMapNamespacedKeyer(namespace string) func(metadata metav1.Object) []types.NamespacedName {
+	return func(metadata metav1.Object) []types.NamespacedName {
+		return []types.NamespacedName{{Namespace: namespace, Name: forge.LocalConfigMapName(metadata.GetName())}}
 	}
 }
 

--- a/pkg/virtualKubelet/reflection/exposition/service.go
+++ b/pkg/virtualKubelet/reflection/exposition/service.go
@@ -98,6 +98,19 @@ func (nsr *NamespacedServiceReflector) Handle(ctx context.Context, name string) 
 		}
 		return nil
 	}
+
+	// Abort the reflection if the local object has the "skip-reflection" annotation.
+	if !kerrors.IsNotFound(lerr) && nsr.ShouldSkipReflection(local) {
+		klog.Infof("Skipping reflection of local Service %q as marked with the skip annotation", nsr.LocalRef(name))
+		nsr.Event(local, corev1.EventTypeNormal, forge.EventReflectionDisabled, forge.EventObjectReflectionDisabledMsg())
+		if kerrors.IsNotFound(rerr) { // The remote object does not already exist, hence no further action is required.
+			return nil
+		}
+
+		// Otherwise, let pretend the local object does not exist, so that the remote one gets deleted.
+		lerr = kerrors.NewNotFound(corev1.Resource("service"), local.GetName())
+	}
+
 	tracer.Step("Performed the sanity checks")
 
 	// The local service does no longer exist. Ensure it is also absent from the remote cluster.

--- a/pkg/virtualKubelet/reflection/generic/namespaced.go
+++ b/pkg/virtualKubelet/reflection/generic/namespaced.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
 
+	"github.com/liqotech/liqo/pkg/consts"
 	"github.com/liqotech/liqo/pkg/virtualKubelet/reflection/options"
 )
 
@@ -87,4 +88,10 @@ func (gnr *NamespacedReflector) DeleteRemote(ctx context.Context, deleter Resour
 
 	klog.Infof("Remote %v %q successfully deleted (local: %q)", resource, gnr.RemoteRef(name), gnr.LocalRef(name))
 	return nil
+}
+
+// ShouldSkipReflection returns whether the reflection of the given object should be skipped.
+func (gnr *NamespacedReflector) ShouldSkipReflection(obj metav1.Object) bool {
+	_, ok := obj.GetAnnotations()[consts.SkipReflectionAnnotationKey]
+	return ok
 }

--- a/pkg/virtualKubelet/reflection/options/options.go
+++ b/pkg/virtualKubelet/reflection/options/options.go
@@ -27,8 +27,8 @@ import (
 	liqoinformers "github.com/liqotech/liqo/pkg/client/informers/externalversions"
 )
 
-// Keyer retrieves a NamespacedName referring to the reconciliation target from the object metadata.
-type Keyer func(metadata metav1.Object) types.NamespacedName
+// Keyer retrieves a set of NamespacedNames referring to the reconciliation targets from the object metadata.
+type Keyer func(metadata metav1.Object) []types.NamespacedName
 
 // ReflectorOpts is a structure grouping the parameters to start a Reflector.
 type ReflectorOpts struct {

--- a/pkg/virtualKubelet/reflection/workload/pod.go
+++ b/pkg/virtualKubelet/reflection/workload/pod.go
@@ -304,10 +304,10 @@ func (fpr *FallbackPodReflector) Keys(local, _ string) []types.NamespacedName {
 	pods, err := fpr.localPods.Pods(local).List(labels.Everything())
 	utilruntime.Must(err)
 
-	keys := make([]types.NamespacedName, len(pods))
+	keys := make([]types.NamespacedName, 0, len(pods))
 	keyer := generic.BasicKeyer()
-	for i, pod := range pods {
-		keys[i] = keyer(pod)
+	for _, pod := range pods {
+		keys = append(keys, keyer(pod)...)
 	}
 	return keys
 }


### PR DESCRIPTION
# Description

This PR introduces the possibility to skip the reflection of an arbitrary object living in an offloaded namespace through the addition of an appropriate annotation.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Automated testing (existing + new)
- [x] Manual testing
