### PR TITLE
openshift: fix security context issue with liqo-controller-manager

### DIFF
--- a/deployments/liqo/templates/_helpers.tpl
+++ b/deployments/liqo/templates/_helpers.tpl
@@ -184,8 +184,8 @@ Get the liqo clusterID ConfigMap name
 Get the Pod security context
 */}}
 {{- define "liqo.podSecurityContext" -}}
-runAsNonRoot: true
 {{- if not .Values.openshiftConfig.enable }}
+runAsNonRoot: true
 runAsUser: 1000
 runAsGroup: 1000
 fsGroup: 1000


### PR DESCRIPTION
# Description

This PR fixes an issue which caused the liqo-controller-manager not to start correctly on openshift, due to the increased SCC permissions introduced in #1264. Specifically, this removes the `runAsNonRoot` enforcement flag, given a non-root user is already automatically set by openshift based on the selected security context when necessary. 

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] Manually, installing liqo on openshift with the iupdated chart.
