### PR TITLE
liqoctl install: improve handling of required flags

### DIFF
--- a/cmd/liqoctl/cmd/root.go
+++ b/cmd/liqoctl/cmd/root.go
@@ -119,7 +119,7 @@ func WithTemplate(str string) string {
 }
 
 // singleClusterPersistentPreRun initializes the local factory.
-func singleClusterPersistentPreRun(cmd *cobra.Command, f *factory.Factory, opts ...factory.Options) {
+func singleClusterPersistentPreRun(_ *cobra.Command, f *factory.Factory, opts ...factory.Options) {
 	// Populate the factory fields based on the configured parameters.
 	f.Printer.CheckErr(f.Initialize(opts...))
 }

--- a/pkg/liqoctl/output/output.go
+++ b/pkg/liqoctl/output/output.go
@@ -174,6 +174,12 @@ func (p *Printer) CheckErr(err error) {
 	util.CheckErr(err)
 }
 
+// ExitWithMessage prints the error message and exits with a non-zero exit code.
+func (p *Printer) ExitWithMessage(errmsg string) {
+	p.Error.Println(errmsg)
+	os.Exit(util.DefaultErrorExitCode)
+}
+
 // PrettyErr returns a prettified error message, according to standard kubectl style.
 func PrettyErr(err error) string {
 	// Unwrap possible URL errors, to return the prettified message.


### PR DESCRIPTION
# Description

This PR improves the handling of a few required flags by the liqoctl install command, to ensure that conflicting ones are not set at the same time, and dependent ones are set together if one is set.

Note: this PR adopts a manual approach instead of leveraging the newly introduced Cobra utilities, since certain constraints cannot be expressed yet, while others lead to complex, generic error messages.


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Manually, checking the various flags combinations
