### PR TITLE
Fix typo in FC status condition reason

### DIFF
--- a/pkg/liqo-controller-manager/foreign-cluster-operator/validator.go
+++ b/pkg/liqo-controller-manager/foreign-cluster-operator/validator.go
@@ -107,7 +107,7 @@ func (r *ForeignClusterReconciler) isClusterProcessable(ctx context.Context,
 		peeringconditionsutils.EnsureStatus(foreignCluster,
 			discoveryv1alpha1.ProcessForeignClusterStatusCondition,
 			discoveryv1alpha1.PeeringConditionStatusSuccess,
-			"ForeignClusterProcesssable",
+			"ForeignClusterProcessable",
 			"This ForeignCluster seems to be processable",
 		)
 


### PR DESCRIPTION
# Description

This pr fixes a typo in the ForeignCluster status condition reason
