### PR TITLE
Bump golangci-lint version to 1.49.0 and remove deprecated linters

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,7 +23,7 @@ jobs:
         uses: golangci/golangci-lint-action@v3.2.0
         with:
           only-new-issues: true
-          version: v1.48.0
+          version: v1.49.0
           args: --timeout=900s
 
   gomodtidy:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -74,7 +74,6 @@ linters:
   enable:
     - asciicheck
     - bodyclose
-    - deadcode
     - depguard
     - dogsled
     - dupl
@@ -114,14 +113,12 @@ linters:
     - revive
     - rowserrcheck
     - staticcheck
-    - structcheck
     - stylecheck
   # - testpackage
     - typecheck
     - unconvert
     - unparam
     - unused
-    - varcheck
     - whitespace
   # - wsl
 

--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ fmt: gci addlicense
 # Install golangci-lint if not available
 golangci-lint:
 ifeq (, $(shell which golangci-lint))
-	@go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.48.0
+	@go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.49.0
 GOLANGCILINT=$(GOBIN)/golangci-lint
 else
 GOLANGCILINT=$(shell which golangci-lint)

--- a/pkg/identityManager/const.go
+++ b/pkg/identityManager/const.go
@@ -42,6 +42,6 @@ const (
 	awsAccessKeyIDSecretKey     = "awsAccessKeyID"
 	awsSecretAccessKeySecretKey = "awsSecretAccessKey"
 	awsRegionSecretKey          = "awsRegion"
-	awsEKSClusterIDSecretKey    = "awsEksClusterID" // nolint:gosec // not a credential
-	awsIAMUserArnSecretKey      = "awsIamUserArn"   // nolint:gosec // not a credential
+	awsEKSClusterIDSecretKey    = "awsEksClusterID" //nolint:gosec // not a credential
+	awsIAMUserArnSecretKey      = "awsIamUserArn"   //nolint:gosec // not a credential
 )

--- a/pkg/liqo-controller-manager/webhooks/namespaceoffloading/nsoff.go
+++ b/pkg/liqo-controller-manager/webhooks/namespaceoffloading/nsoff.go
@@ -51,7 +51,7 @@ func (w *nsoffwh) DecodeNamespaceOffloading(obj runtime.RawExtension) (*offv1alp
 }
 
 // Handle implements the NamespaceOffloading validating webhook logic.
-// nolint:gocritic // The signature of this method is imposed by controller runtime.
+//nolint:gocritic // The signature of this method is imposed by controller runtime.
 func (w *nsoffwh) Handle(ctx context.Context, req admission.Request) admission.Response {
 	var warnings []string
 

--- a/pkg/liqo-controller-manager/webhooks/pod/pod.go
+++ b/pkg/liqo-controller-manager/webhooks/pod/pod.go
@@ -70,7 +70,7 @@ func (w *podwh) CreatePatchResponse(req *admission.Request, pod *corev1.Pod) adm
 }
 
 // Handle implements the pod mutating webhook logic.
-// nolint:gocritic // The signature of this method is imposed by controller runtime.
+//nolint:gocritic // The signature of this method is imposed by controller runtime.
 func (w *podwh) Handle(ctx context.Context, req admission.Request) admission.Response {
 	pod, err := w.DecodePod(req.Object)
 	if err != nil {

--- a/pkg/liqoctl/install/eks/iam.go
+++ b/pkg/liqoctl/install/eks/iam.go
@@ -132,7 +132,7 @@ func (o *Options) ensurePolicy(iamSvc *iam.IAM) (string, error) {
 
 	createPolicyResult, err := iamSvc.CreatePolicy(createPolicyRequest)
 	if err != nil {
-		if aerr, ok := err.(awserr.Error); ok { // nolint:errorlint // we need to access methods of the aws error interface
+		if aerr, ok := err.(awserr.Error); ok { //nolint:errorlint // we need to access methods of the aws error interface
 			switch aerr.Code() {
 			case iam.ErrCodeEntityAlreadyExistsException:
 				return o.checkPolicy(iamSvc)

--- a/pkg/liqoctl/install/validation.go
+++ b/pkg/liqoctl/install/validation.go
@@ -63,7 +63,7 @@ func (o *Options) validate(ctx context.Context) error {
 func (o *Options) validateClusterName() (err error) {
 	// If at this point the name is still empty, generate a new cluster name
 	if o.ClusterName == "" {
-		randomName := namegenerator.NewNameGenerator(rand.Int63()).Generate() // nolint:gosec // don't need crypto/rand
+		randomName := namegenerator.NewNameGenerator(rand.Int63()).Generate() //nolint:gosec // don't need crypto/rand
 		o.ClusterName = strings.ReplaceAll(randomName, "_", "-")
 		o.Printer.Info.Printf("No cluster name specified. Generated: %q", o.ClusterName)
 	}

--- a/pkg/utils/args/cluster-identity.go
+++ b/pkg/utils/args/cluster-identity.go
@@ -44,7 +44,7 @@ type ClusterIdentityFlags struct {
 func NewClusterIdentityFlags(local bool, flags *flag.FlagSet) ClusterIdentityFlags {
 	var prefix, description string
 	if local {
-		prefix = "cluster" // nolint:goconst // No need to make the word "cluster" a const...
+		prefix = "cluster" //nolint:goconst // No need to make the word "cluster" a const...
 		description = "The %s of the current cluster"
 	} else {
 		prefix = "foreign-cluster"

--- a/pkg/utils/random.go
+++ b/pkg/utils/random.go
@@ -22,7 +22,7 @@ const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 func RandomString(n int) string {
 	b := make([]byte, n)
 	for i := range b {
-		b[i] = letterBytes[rand.Int63()%int64(len(letterBytes))] // nolint:gosec // don't need crypto/rand
+		b[i] = letterBytes[rand.Int63()%int64(len(letterBytes))] //nolint:gosec // don't need crypto/rand
 	}
 	return string(b)
 }

--- a/test/e2e/testutils/util/exec.go
+++ b/test/e2e/testutils/util/exec.go
@@ -38,7 +38,7 @@ func ExecLiqoctl(kubeconfig string, args []string, output io.Writer) error {
 		return errors.New("failed to retrieve liqoctl executable")
 	}
 
-	// nolint:gosec // running in a trusted environment
+	//nolint:gosec // running in a trusted environment
 	cmd := exec.Command(liqoctl, args...)
 	cmd.Stdout = output
 	cmd.Stderr = output


### PR DESCRIPTION
# Description

This PR bumps the golangci-lint version to 1.49.0 and removes a few deprecated linters. Additionally, it fixes a few trivial issues.
