### PR TITLE
Bump gci version to 0.7.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ rbacs: controller-gen
 # Install gci if not available
 gci:
 ifeq (, $(shell which gci))
-	@go install github.com/daixiang0/gci@v0.2.9
+	@go install github.com/daixiang0/gci@v0.7.0
 GCI=$(GOBIN)/gci
 else
 GCI=$(shell which gci)
@@ -89,7 +89,7 @@ endif
 fmt: gci addlicense
 	go mod tidy
 	go fmt ./...
-	find . -type f -name '*.go' -a ! -name '*zz_generated*' -exec $(GCI) -local github.com/liqotech/liqo -w {} \;
+	find . -type f -name '*.go' -a ! -name '*zz_generated*' -exec $(GCI) write -s standard -s default -s "prefix(github.com/liqotech/liqo)" {} \;
 	find . -type f -name '*.go' -exec $(ADDLICENSE) -l apache -c "The Liqo Authors" -y "2019-$(shell date +%Y)" {} \;
 
 # Install golangci-lint if not available


### PR DESCRIPTION
The older version recognizes **standard** packages with **"/"** inside (e.g "net/netip") like t**hird parties** packages. 
This version doesn't have this issue.