### PR TITLE
Virtual kubelet: switch to the v1 endpointslices API

### DIFF
--- a/build/liqo-test/Dockerfile
+++ b/build/liqo-test/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.19 as builder
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
 ENV GOPATH /go
-ENV K8S_VERSION=1.19.2
+ENV K8S_VERSION=1.25.0
 
 # Install required go binaries
 RUN go install github.com/ory/go-acc@v0.2.8
@@ -12,7 +12,7 @@ COPY go.sum ./go.sum
 RUN  go mod download
 
 # Install kubebuilder
-RUN curl --fail -sSLo envtest-bins.tar.gz "https://storage.googleapis.com/kubebuilder-tools/kubebuilder-tools-${K8S_VERSION}-$(go env GOOS)-$(go env GOARCH).tar.gz"
+RUN curl --fail -sSLo envtest-bins.tar.gz "https://go.kubebuilder.io/test-tools/${K8S_VERSION}/$(go env GOOS)/$(go env GOARCH)"
 RUN mkdir /usr/local/kubebuilder/
 RUN tar -C /usr/local/kubebuilder/ --strip-components=1 -zvxf envtest-bins.tar.gz
 

--- a/cmd/auth-service/main.go
+++ b/cmd/auth-service/main.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"os"
 	"time"
@@ -64,13 +65,13 @@ func main() {
 
 	clusterIdentity := clusterFlags.ReadOrDie()
 	authService, err := authservice.NewAuthServiceCtrl(
-		config, *namespace, awsConfig, *resync, apiserver.GetConfig(), *enableAuth, *useTLS, clusterIdentity)
+		context.Background(), config, *namespace, awsConfig, *resync, apiserver.GetConfig(), *enableAuth, *useTLS, clusterIdentity)
 	if err != nil {
 		klog.Error(err)
 		os.Exit(1)
 	}
 
-	if err = authService.Start(*address, *useTLS, *certPath, *keyPath); err != nil {
+	if err = authService.Start(context.Background(), *address, *useTLS, *certPath, *keyPath); err != nil {
 		klog.Error(err)
 		os.Exit(1)
 	}

--- a/cmd/crd-replicator/main.go
+++ b/cmd/crd-replicator/main.go
@@ -55,6 +55,7 @@ func main() {
 
 	flag.Parse()
 
+	ctx := ctrl.SetupSignalHandler()
 	clusterIdentity := clusterFlags.ReadOrDie()
 
 	cfg := restcfg.SetRateLimiter(ctrl.GetConfigOrDie())
@@ -71,11 +72,10 @@ func main() {
 	// Create a clientSet.
 	k8sClient := kubernetes.NewForConfigOrDie(cfg)
 
-	namespaceManager := tenantnamespace.NewCachedManager(k8sClient)
+	namespaceManager := tenantnamespace.NewCachedManager(ctx, k8sClient)
 
 	dynClient := dynamic.NewForConfigOrDie(cfg)
 
-	ctx := ctrl.SetupSignalHandler()
 	reflectionManager := reflection.NewManager(dynClient, clusterIdentity.ClusterID, *workers, *resyncPeriod)
 	reflectionManager.Start(ctx, resources.GetResourcesToReplicate())
 

--- a/cmd/liqo-controller-manager/main.go
+++ b/cmd/liqo-controller-manager/main.go
@@ -202,7 +202,7 @@ func main() {
 
 	clientset := kubernetes.NewForConfigOrDie(config)
 
-	namespaceManager := tenantnamespace.NewCachedManager(clientset)
+	namespaceManager := tenantnamespace.NewCachedManager(ctx, clientset)
 	idManager := identitymanager.NewCertificateIdentityManager(clientset, clusterIdentity, namespaceManager)
 
 	// populate the lists of ClusterRoles to bind in the different peering states

--- a/docs/contributing/contributing.md
+++ b/docs/contributing/contributing.md
@@ -82,13 +82,17 @@ make e2e
 ### Unit tests
 
 Most unit tests can be run directly using [the *ginkgo* CLI](https://onsi.github.io/ginkgo/#installing-ginkgo), which in turn supports the standard testing API (*go test*, IDE features, ...).
-The only requirement is the [controller-runtime envtest environment](https://book.kubebuilder.io/reference/envtest.html), which can be installed through:
+The only requirement is the [controller-runtime envtest environment](https://book.kubebuilder.io/reference/envtest.html), which can be installed through [`setup-envtest`](https://pkg.go.dev/sigs.k8s.io/controller-runtime/tools/setup-envtest):
 
 ```bash
-export K8S_VERSION=1.19.2
-curl --fail -sSLo envtest-bins.tar.gz "https://storage.googleapis.com/kubebuilder-tools/kubebuilder-tools-${K8S_VERSION}-$(go env GOOS)-$(go env GOARCH).tar.gz"
-mkdir /usr/local/kubebuilder/
-tar -C /usr/local/kubebuilder/ --strip-components=1 -zvxf envtest-bins.tar.gz
+go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+setup-envtest use 1.25.x!
+```
+
+To enable the downloaded envtest, you can append the following line to your `~/.bashrc` or `~/.zshrc` file:
+
+```bash
+source <(setup-envtest use --installed-only --print env 1.25.x)
 ```
 
 Some networking tests, however, require an isolated environment.

--- a/internal/auth-service/auth_test.go
+++ b/internal/auth-service/auth_test.go
@@ -15,7 +15,6 @@
 package authservice
 
 import (
-	"context"
 	"encoding/base64"
 	"fmt"
 	"io"
@@ -144,7 +143,7 @@ var _ = Describe("Auth", func() {
 				Expect(err).To(BeNil())
 				c.request.CertificateSigningRequest = base64.StdEncoding.EncodeToString(req)
 
-				response, err := authService.handleIdentity(context.TODO(), c.request)
+				response, err := authService.handleIdentity(ctx, c.request)
 				Expect(err).To(c.expectedOutput)
 				c.expectedResponse(response)
 			},

--- a/internal/liqonet/tunnel-operator/natmapping_operator_test.go
+++ b/internal/liqonet/tunnel-operator/natmapping_operator_test.go
@@ -15,7 +15,6 @@
 package tunneloperator
 
 import (
-	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -66,7 +65,7 @@ var _ = Describe("NatmappingOperator", func() {
 		}
 	})
 	AfterEach(func() {
-		err := k8sClient.DeleteAllOf(context.Background(), &v1alpha1.NatMapping{}, &client.DeleteAllOfOptions{
+		err := k8sClient.DeleteAllOf(ctx, &v1alpha1.NatMapping{}, &client.DeleteAllOfOptions{
 			ListOptions: client.ListOptions{
 				Namespace: namespace,
 			},
@@ -77,7 +76,7 @@ var _ = Describe("NatmappingOperator", func() {
 		It("the controller should return no errors", func() {
 			nm2.ObjectMeta.Name = "resource-not-exists"
 			request.Name = nm2.ObjectMeta.Name
-			Consistently(func() error { _, err := controller.Reconcile(context.TODO(), request); return err }).Should(BeNil())
+			Consistently(func() error { _, err := controller.Reconcile(ctx, request); return err }).Should(BeNil())
 		})
 	})
 	Context("If the cluster is not ready", func() {
@@ -93,11 +92,11 @@ var _ = Describe("NatmappingOperator", func() {
 			nm2.Spec.ClusterMappings[oldIP1] = newIP1
 			nm2.Spec.ClusterMappings[oldIP2] = newIP2
 			Eventually(func() error {
-				err := k8sClient.Create(context.Background(), nm2, &client.CreateOptions{})
+				err := k8sClient.Create(ctx, nm2, &client.CreateOptions{})
 				return err
 			}).Should(BeNil())
 
-			Eventually(func() error { _, err := controller.Reconcile(context.TODO(), request); return err }).
+			Eventually(func() error { _, err := controller.Reconcile(ctx, request); return err }).
 				Should(MatchError(fmt.Sprintf("tunnel for cluster {%s} is not ready", clusterID2)))
 
 			Consistently(func() []string {
@@ -120,10 +119,10 @@ var _ = Describe("NatmappingOperator", func() {
 			nm1.Spec.ClusterMappings[oldIP1] = newIP1
 			nm1.Spec.ClusterMappings[oldIP2] = newIP2
 			Eventually(func() error {
-				err := k8sClient.Create(context.Background(), nm1, &client.CreateOptions{})
+				err := k8sClient.Create(ctx, nm1, &client.CreateOptions{})
 				return err
 			}).Should(BeNil())
-			Consistently(func() error { _, err := controller.Reconcile(context.TODO(), request); return err }).Should(BeNil())
+			Consistently(func() error { _, err := controller.Reconcile(ctx, request); return err }).Should(BeNil())
 			Eventually(func() []string {
 				rules, err := ListRulesInChainInCustomNs(getClusterPreRoutingMappingChain(clusterID1))
 				if err != nil {
@@ -143,11 +142,11 @@ var _ = Describe("NatmappingOperator", func() {
 			// Insert mapping for oldIP1
 			nm1.Spec.ClusterMappings[oldIP1] = newIP1
 			Eventually(func() error {
-				err := k8sClient.Create(context.Background(), nm1, &client.CreateOptions{})
+				err := k8sClient.Create(ctx, nm1, &client.CreateOptions{})
 				return err
 			}).Should(BeNil())
 
-			Consistently(func() error { _, err := controller.Reconcile(context.TODO(), request); return err }).Should(BeNil())
+			Consistently(func() error { _, err := controller.Reconcile(ctx, request); return err }).Should(BeNil())
 
 			Eventually(func() []string {
 				rules, err := ListRulesInChainInCustomNs(getClusterPreRoutingMappingChain(clusterID1))
@@ -160,7 +159,7 @@ var _ = Describe("NatmappingOperator", func() {
 			))
 
 			Eventually(func() bool {
-				err := k8sClient.Get(context.Background(), types.NamespacedName{Name: nm1.ObjectMeta.Name, Namespace: namespace}, nm1)
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: nm1.ObjectMeta.Name, Namespace: namespace}, nm1)
 				if err != nil {
 					return false
 				}
@@ -168,11 +167,11 @@ var _ = Describe("NatmappingOperator", func() {
 				delete(nm1.Spec.ClusterMappings, oldIP1)
 				// Insert mapping for oldIP2
 				nm1.Spec.ClusterMappings[oldIP2] = newIP2
-				err = k8sClient.Update(context.Background(), nm1, &client.UpdateOptions{})
+				err = k8sClient.Update(ctx, nm1, &client.UpdateOptions{})
 				return err == nil
 			}).Should(BeTrue())
 
-			Consistently(func() error { _, err := controller.Reconcile(context.TODO(), request); return err }).Should(BeNil())
+			Consistently(func() error { _, err := controller.Reconcile(ctx, request); return err }).Should(BeNil())
 
 			Eventually(func() bool {
 				rules, err := ListRulesInChainInCustomNs(getClusterPreRoutingMappingChain(clusterID1))
@@ -200,22 +199,22 @@ var _ = Describe("NatmappingOperator", func() {
 			// Insert mapping for oldIP1 in cluster1
 			nm1.Spec.ClusterMappings[oldIP1] = newIP1
 			Eventually(func() error {
-				err := k8sClient.Create(context.Background(), nm1, &client.CreateOptions{})
+				err := k8sClient.Create(ctx, nm1, &client.CreateOptions{})
 				return err
 			}).Should(BeNil())
 
-			Consistently(func() error { _, err := controller.Reconcile(context.TODO(), request); return err }).Should(BeNil())
+			Consistently(func() error { _, err := controller.Reconcile(ctx, request); return err }).Should(BeNil())
 
 			// Insert mapping for oldIP2 in cluster2
 			nm2.ObjectMeta.Name = "more-clusters-2"
 			request.Name = nm2.ObjectMeta.Name
 			nm2.Spec.ClusterMappings[oldIP2] = newIP2
 			Eventually(func() error {
-				err := k8sClient.Create(context.Background(), nm2, &client.CreateOptions{})
+				err := k8sClient.Create(ctx, nm2, &client.CreateOptions{})
 				return err
 			}).Should(BeNil())
 
-			Consistently(func() error { _, err := controller.Reconcile(context.TODO(), request); return err }).Should(BeNil())
+			Consistently(func() error { _, err := controller.Reconcile(ctx, request); return err }).Should(BeNil())
 
 			Eventually(func() bool {
 				cluster1Rules, err := ListRulesInChainInCustomNs(getClusterPreRoutingMappingChain(clusterID1))

--- a/pkg/identityManager/identityManager_suite_test.go
+++ b/pkg/identityManager/identityManager_suite_test.go
@@ -39,7 +39,8 @@ import (
 )
 
 var (
-	ctx context.Context
+	ctx    context.Context
+	cancel context.CancelFunc
 
 	cluster       testutil.Cluster
 	client        kubernetes.Interface
@@ -67,7 +68,7 @@ func TestIdentityManager(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	testutil.LogsToGinkgoWriter()
-	ctx = context.Background()
+	ctx, cancel = context.WithCancel(context.Background())
 
 	apiProxyURL = "http://192.168.0.0:8118"
 
@@ -164,5 +165,6 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = AfterSuite(func() {
+	cancel()
 	Expect(cluster.GetEnv().Stop()).To(Succeed())
 })

--- a/pkg/liqo-controller-manager/resource-request-controller/resourceRequest_operator_test.go
+++ b/pkg/liqo-controller-manager/resource-request-controller/resourceRequest_operator_test.go
@@ -161,9 +161,11 @@ var _ = Describe("ResourceRequest Operator", func() {
 			return rrl.Items
 		}, timeout, interval).Should(HaveLen(0))
 
-		Expect(k8sClient.DeleteAllOf(ctx, &sharingv1alpha1.ResourceOffer{}, client.InNamespace(ResourcesNamespace))).To(Succeed())
-		Expect(k8sClient.DeleteAllOf(ctx, &sharingv1alpha1.ResourceOffer{}, client.InNamespace(ResourcesNamespace2))).To(Succeed())
 		Eventually(func() []sharingv1alpha1.ResourceOffer {
+			// These two operations are performed here, as leaving them outside seems to cause tests to be more flaky.
+			Expect(k8sClient.DeleteAllOf(ctx, &sharingv1alpha1.ResourceOffer{}, client.InNamespace(ResourcesNamespace))).To(Succeed())
+			Expect(k8sClient.DeleteAllOf(ctx, &sharingv1alpha1.ResourceOffer{}, client.InNamespace(ResourcesNamespace2))).To(Succeed())
+
 			var rro sharingv1alpha1.ResourceOfferList
 			Expect(k8sClient.List(ctx, &rro)).To(Succeed())
 			return rro.Items
@@ -174,6 +176,11 @@ var _ = Describe("ResourceRequest Operator", func() {
 		Expect(clientset.StorageV1().StorageClasses().DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{})).To(Succeed())
 
 		Expect(k8sClient.DeleteAllOf(ctx, &discoveryv1alpha1.ForeignCluster{})).To(Succeed())
+		Eventually(func() []discoveryv1alpha1.ForeignCluster {
+			var fc discoveryv1alpha1.ForeignClusterList
+			Expect(k8sClient.List(ctx, &fc)).To(Succeed())
+			return fc.Items
+		}, timeout, interval).Should(HaveLen(0))
 	})
 
 	When("Creating a new ResourceRequest", func() {

--- a/pkg/liqo-controller-manager/storageprovisioner/suite_test.go
+++ b/pkg/liqo-controller-manager/storageprovisioner/suite_test.go
@@ -21,6 +21,8 @@ import (
 	. "github.com/onsi/gomega"
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
+
+	"github.com/liqotech/liqo/pkg/utils/testutil"
 )
 
 var (
@@ -34,6 +36,8 @@ func TestStorageProvisioner(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
+	testutil.LogsToGinkgoWriter()
+
 	testEnv = envtest.Environment{}
 	cfg, err := testEnv.Start()
 	Expect(err).ToNot(HaveOccurred())

--- a/pkg/liqo-controller-manager/virtualNode-controller/virtualnode_controller_test.go
+++ b/pkg/liqo-controller-manager/virtualNode-controller/virtualnode_controller_test.go
@@ -15,7 +15,6 @@
 package virtualnodectrl
 
 import (
-	"context"
 	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -55,22 +54,22 @@ var _ = Describe("VirtualNode controller", func() {
 				},
 			}
 			By(fmt.Sprintf("Create the virtual-node '%s'", nameVirtualNode1))
-			Expect(k8sClient.Create(context.TODO(), virtualNode1)).Should(Succeed())
+			Expect(k8sClient.Create(ctx, virtualNode1)).Should(Succeed())
 			By(fmt.Sprintf("Create the virtual-node '%s'", nameVirtualNode2))
-			Expect(k8sClient.Create(context.TODO(), virtualNode2)).Should(Succeed())
+			Expect(k8sClient.Create(ctx, virtualNode2)).Should(Succeed())
 		})
 
 		AfterEach(func() {
 			By(fmt.Sprintf("Delete the virtual-node '%s'", nameVirtualNode1))
-			Expect(k8sClient.Delete(context.TODO(), virtualNode1)).Should(Succeed())
+			Expect(k8sClient.Delete(ctx, virtualNode1)).Should(Succeed())
 			Eventually(func() bool {
-				err := k8sClient.Get(context.TODO(), types.NamespacedName{Name: nameVirtualNode1}, virtualNode1)
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: nameVirtualNode1}, virtualNode1)
 				return apierrors.IsNotFound(err)
 			}, timeout, interval).Should(BeTrue())
 			By(fmt.Sprintf("Delete the virtual-node '%s'", nameVirtualNode2))
-			Expect(k8sClient.Delete(context.TODO(), virtualNode2)).Should(Succeed())
+			Expect(k8sClient.Delete(ctx, virtualNode2)).Should(Succeed())
 			Eventually(func() bool {
-				err := k8sClient.Get(context.TODO(), types.NamespacedName{Name: nameVirtualNode2}, virtualNode2)
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: nameVirtualNode2}, virtualNode2)
 				return apierrors.IsNotFound(err)
 			}, timeout, interval).Should(BeTrue())
 		})
@@ -79,7 +78,7 @@ var _ = Describe("VirtualNode controller", func() {
 
 			By(fmt.Sprintf("Try to get NamespaceMap associated to: %s", remoteClusterID1))
 			Eventually(func() bool {
-				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(tenantNamespaceNameID1),
+				if err := k8sClient.List(ctx, nms, client.InNamespace(tenantNamespaceNameID1),
 					client.MatchingLabels{liqoconst.RemoteClusterID: remoteClusterID1}); err != nil {
 					return false
 				}
@@ -88,7 +87,7 @@ var _ = Describe("VirtualNode controller", func() {
 
 			By(fmt.Sprintf("Try to get NamespaceMap associated to: %s", remoteClusterID2))
 			Eventually(func() bool {
-				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(tenantNamespaceNameID2),
+				if err := k8sClient.List(ctx, nms, client.InNamespace(tenantNamespaceNameID2),
 					client.MatchingLabels{liqoconst.RemoteClusterID: remoteClusterID2}); err != nil {
 					return false
 				}
@@ -101,13 +100,13 @@ var _ = Describe("VirtualNode controller", func() {
 
 			By(fmt.Sprintf("Try to get virtual-node: %s", nameVirtualNode1))
 			Eventually(func() bool {
-				err := k8sClient.Get(context.TODO(), types.NamespacedName{Name: nameVirtualNode1}, virtualNode1)
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: nameVirtualNode1}, virtualNode1)
 				return err == nil
 			}, timeout, interval).Should(BeTrue())
 
 			By(fmt.Sprintf("Try to get NamespaceMap associated to: %s", remoteClusterID1))
 			Eventually(func() bool {
-				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(tenantNamespaceNameID1),
+				if err := k8sClient.List(ctx, nms, client.InNamespace(tenantNamespaceNameID1),
 					client.MatchingLabels{liqoconst.RemoteClusterID: remoteClusterID1}); err != nil {
 					return false
 				}
@@ -128,7 +127,7 @@ var _ = Describe("VirtualNode controller", func() {
 
 			By(fmt.Sprintf("Try to check presence of finalizer on the virtual-Node: %s", virtualNode1.GetName()))
 			Eventually(func() bool {
-				if err := k8sClient.Get(context.TODO(), types.NamespacedName{Name: nameVirtualNode1},
+				if err := k8sClient.Get(ctx, types.NamespacedName{Name: nameVirtualNode1},
 					virtualNode1); err != nil {
 					return false
 				}
@@ -141,13 +140,13 @@ var _ = Describe("VirtualNode controller", func() {
 
 			By(fmt.Sprintf("Try to get virtual-node: %s", nameVirtualNode2))
 			Eventually(func() bool {
-				err := k8sClient.Get(context.TODO(), types.NamespacedName{Name: nameVirtualNode2}, virtualNode2)
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: nameVirtualNode2}, virtualNode2)
 				return err == nil
 			}, timeout, interval).Should(BeTrue())
 
 			By(fmt.Sprintf("Try to get NamespaceMap associated to: %s", remoteClusterID2))
 			Eventually(func() bool {
-				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(tenantNamespaceNameID2),
+				if err := k8sClient.List(ctx, nms, client.InNamespace(tenantNamespaceNameID2),
 					client.MatchingLabels{liqoconst.RemoteClusterID: remoteClusterID2}); err != nil {
 					return false
 				}
@@ -169,7 +168,7 @@ var _ = Describe("VirtualNode controller", func() {
 			By(fmt.Sprintf("Try to check presence of finalizer in VirtualNode: %s", virtualNode2.GetName()))
 			// i have to update my node instance, because finalizer could be updated after my first get
 			Eventually(func() bool {
-				if err := k8sClient.Get(context.TODO(), types.NamespacedName{Name: nameVirtualNode2},
+				if err := k8sClient.Get(ctx, types.NamespacedName{Name: nameVirtualNode2},
 					virtualNode2); err != nil {
 					return false
 				}
@@ -195,17 +194,17 @@ var _ = Describe("VirtualNode controller", func() {
 				},
 			}
 			By(fmt.Sprintf("Create the simple-node '%s'", nameSimpleNode))
-			Expect(k8sClient.Create(context.TODO(), simpleNode)).Should(Succeed())
+			Expect(k8sClient.Create(ctx, simpleNode)).Should(Succeed())
 
 			By(fmt.Sprintf("Try to get not virtual-node: %s", nameSimpleNode))
 			Eventually(func() bool {
-				err := k8sClient.Get(context.TODO(), types.NamespacedName{Name: nameSimpleNode}, simpleNode)
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: nameSimpleNode}, simpleNode)
 				return err == nil
 			}, timeout, interval).Should(BeTrue())
 
 			By(fmt.Sprintf("Check absence of finalizer %s: ", virtualNodeControllerFinalizer))
 			Consistently(func() bool {
-				if err := k8sClient.Get(context.TODO(), types.NamespacedName{Name: nameSimpleNode},
+				if err := k8sClient.Get(ctx, types.NamespacedName{Name: nameSimpleNode},
 					simpleNode); err != nil {
 					return false
 				}
@@ -213,7 +212,7 @@ var _ = Describe("VirtualNode controller", func() {
 			}, timeout/5, interval).Should(BeTrue())
 
 			By(fmt.Sprintf("Delete the simple-node '%s'", nameSimpleNode))
-			Expect(k8sClient.Delete(context.TODO(), simpleNode)).Should(Succeed())
+			Expect(k8sClient.Delete(ctx, simpleNode)).Should(Succeed())
 
 		})
 
@@ -233,12 +232,12 @@ var _ = Describe("VirtualNode controller", func() {
 				},
 			}
 			By(fmt.Sprintf("Create the virtual-node '%s'", nameVirtualNode1))
-			Expect(k8sClient.Create(context.TODO(), virtualNode1)).Should(Succeed())
+			Expect(k8sClient.Create(ctx, virtualNode1)).Should(Succeed())
 
 			var oldUUID types.UID
 			By(fmt.Sprintf("Try to delete NamespaceMap associated to: %s", remoteClusterID1))
 			Eventually(func() bool {
-				if err := k8sClient.List(context.TODO(), nms,
+				if err := k8sClient.List(ctx, nms,
 					client.MatchingLabels{liqoconst.RemoteClusterID: remoteClusterID1}); err != nil {
 					return false
 				}
@@ -246,13 +245,13 @@ var _ = Describe("VirtualNode controller", func() {
 					return false
 				}
 				oldUUID = nms.Items[0].UID
-				err := k8sClient.Delete(context.TODO(), &nms.Items[0])
+				err := k8sClient.Delete(ctx, &nms.Items[0])
 				return err == nil
 			}, timeout, interval).Should(BeTrue())
 
 			By(fmt.Sprintf("Try to get new NamespaceMap associated to: %s", remoteClusterID1))
 			Eventually(func() bool {
-				if err := k8sClient.List(context.TODO(), nms, client.InNamespace(tenantNamespaceNameID1),
+				if err := k8sClient.List(ctx, nms, client.InNamespace(tenantNamespaceNameID1),
 					client.MatchingLabels{liqoconst.RemoteClusterID: remoteClusterID1}); err != nil {
 					return false
 				}
@@ -260,9 +259,9 @@ var _ = Describe("VirtualNode controller", func() {
 			}, timeout, interval).Should(BeTrue())
 
 			By(fmt.Sprintf("Delete the virtual-node '%s'", nameVirtualNode1))
-			Expect(k8sClient.Delete(context.TODO(), virtualNode1)).Should(Succeed())
+			Expect(k8sClient.Delete(ctx, virtualNode1)).Should(Succeed())
 			Eventually(func() bool {
-				err := k8sClient.Get(context.TODO(), types.NamespacedName{Name: nameVirtualNode1}, virtualNode1)
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: nameVirtualNode1}, virtualNode1)
 				return apierrors.IsNotFound(err)
 			}, timeout, interval).Should(BeTrue())
 

--- a/pkg/liqonet/ipam/ipam_suite_test.go
+++ b/pkg/liqonet/ipam/ipam_suite_test.go
@@ -19,9 +19,15 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"github.com/liqotech/liqo/pkg/utils/testutil"
 )
 
 func TestIpam(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Ipam Suite")
 }
+
+var _ = BeforeSuite(func() {
+	testutil.LogsToGinkgoWriter()
+})

--- a/pkg/tenantNamespace/namespaceManager.go
+++ b/pkg/tenantNamespace/namespaceManager.go
@@ -62,11 +62,7 @@ func NewManager(client kubernetes.Interface) Manager {
 }
 
 // NewCachedManager creates a new TenantNamespaceManager object, supporting cached retrieval of namespaces for increased efficiency.
-func NewCachedManager(client kubernetes.Interface) Manager {
-	// TODO: the context should be propagated from the caller. It is currently set here to avoid
-	// modifying all callers, since most to not even have a proper context themselves.
-	ctx := context.Background()
-
+func NewCachedManager(ctx context.Context, client kubernetes.Interface) Manager {
 	// Here, we create a new namepace lister, so that it is possible to perform cached get/list operations.
 	// The informer factory is configured with an appropriate filter to cache only tenant namespaces.
 	req, err := labels.NewRequirement(discovery.TenantNamespaceLabel, selection.Exists, []string{})

--- a/pkg/tenantNamespace/tenantNamespace_suite_test.go
+++ b/pkg/tenantNamespace/tenantNamespace_suite_test.go
@@ -33,6 +33,7 @@ func TestTenantNamespace(t *testing.T) {
 
 var (
 	ctx         context.Context
+	cancel      context.CancelFunc
 	cluster     testutil.Cluster
 	homeCluster discoveryv1alpha1.ClusterIdentity
 
@@ -41,7 +42,7 @@ var (
 
 var _ = BeforeSuite(func() {
 	testutil.LogsToGinkgoWriter()
-	ctx = context.Background()
+	ctx, cancel = context.WithCancel(context.Background())
 
 	homeCluster = discoveryv1alpha1.ClusterIdentity{
 		ClusterID:   "home-cluster-id",
@@ -52,9 +53,10 @@ var _ = BeforeSuite(func() {
 	cluster, _, err = testutil.NewTestCluster([]string{filepath.Join("..", "..", "deployments", "liqo", "crds")})
 	Expect(err).ToNot(HaveOccurred())
 
-	namespaceManager = NewCachedManager(cluster.GetClient())
+	namespaceManager = NewCachedManager(ctx, cluster.GetClient())
 })
 
 var _ = AfterSuite(func() {
+	cancel()
 	Expect(cluster.GetEnv().Stop()).To(Succeed())
 })

--- a/pkg/virtualKubelet/forge/endpointslices.go
+++ b/pkg/virtualKubelet/forge/endpointslices.go
@@ -15,11 +15,11 @@
 package forge
 
 import (
-	corev1 "k8s.io/api/core/v1"
-	discoveryv1beta1 "k8s.io/api/discovery/v1beta1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	discoveryv1beta1apply "k8s.io/client-go/applyconfigurations/discovery/v1beta1"
+	discoveryv1apply "k8s.io/client-go/applyconfigurations/discovery/v1"
+	"k8s.io/utils/pointer"
 )
 
 // EndpointSliceManagedBy -> The manager associated with the reflected EndpointSlices.
@@ -30,7 +30,7 @@ type EndpointTranslator func([]string) []string
 
 // EndpointSliceLabels returns the labels assigned to the reflected EndpointSlices.
 func EndpointSliceLabels() labels.Set {
-	return map[string]string{discoveryv1beta1.LabelManagedBy: EndpointSliceManagedBy}
+	return map[string]string{discoveryv1.LabelManagedBy: EndpointSliceManagedBy}
 }
 
 // IsEndpointSliceManagedByReflection returns whether the EndpointSlice is managed by the reflection logic.
@@ -39,20 +39,14 @@ func IsEndpointSliceManagedByReflection(obj metav1.Object) bool {
 }
 
 // EndpointToBeReflected filters out the endpoints targeting pods already running on the remote cluster.
-func EndpointToBeReflected(endpoint *discoveryv1beta1.Endpoint) bool {
-	// NodeName needs to be enabled through a feature gate in the v1beta1 API.
-	if endpoint.NodeName != nil {
-		return *endpoint.NodeName != LiqoNodeName
-	}
-
-	// The topology field is deprecated and will be removed when the v1beta1 API is removed (no sooner than kubernetes v1.24).
-	return endpoint.Topology[corev1.LabelHostname] != LiqoNodeName
+func EndpointToBeReflected(endpoint *discoveryv1.Endpoint) bool {
+	return !pointer.StringEqual(endpoint.NodeName, &LiqoNodeName)
 }
 
 // RemoteEndpointSlice forges the apply patch for the reflected endpointslice, given the local one.
-func RemoteEndpointSlice(local *discoveryv1beta1.EndpointSlice, targetNamespace string,
-	translator EndpointTranslator) *discoveryv1beta1apply.EndpointSliceApplyConfiguration {
-	return discoveryv1beta1apply.EndpointSlice(local.GetName(), targetNamespace).
+func RemoteEndpointSlice(local *discoveryv1.EndpointSlice, targetNamespace string,
+	translator EndpointTranslator) *discoveryv1apply.EndpointSliceApplyConfiguration {
+	return discoveryv1apply.EndpointSlice(local.GetName(), targetNamespace).
 		WithLabels(local.GetLabels()).WithLabels(ReflectionLabels()).
 		WithLabels(EndpointSliceLabels()).WithAnnotations(local.GetAnnotations()).
 		WithAddressType(local.AddressType).
@@ -61,9 +55,9 @@ func RemoteEndpointSlice(local *discoveryv1beta1.EndpointSlice, targetNamespace 
 }
 
 // RemoteEndpointSliceEndpoints forges the apply patch for the endpoints of the reflected endpointslice, given the local ones.
-func RemoteEndpointSliceEndpoints(locals []discoveryv1beta1.Endpoint,
-	translator EndpointTranslator) []*discoveryv1beta1apply.EndpointApplyConfiguration {
-	var remotes []*discoveryv1beta1apply.EndpointApplyConfiguration
+func RemoteEndpointSliceEndpoints(locals []discoveryv1.Endpoint,
+	translator EndpointTranslator) []*discoveryv1apply.EndpointApplyConfiguration {
+	var remotes []*discoveryv1apply.EndpointApplyConfiguration
 
 	for i := range locals {
 		if !EndpointToBeReflected(&locals[i]) {
@@ -72,13 +66,14 @@ func RemoteEndpointSliceEndpoints(locals []discoveryv1beta1.Endpoint,
 		}
 
 		local := locals[i].DeepCopy()
-		conditions := &discoveryv1beta1apply.EndpointConditionsApplyConfiguration{Ready: local.Conditions.Ready}
+		conditions := &discoveryv1apply.EndpointConditionsApplyConfiguration{Ready: local.Conditions.Ready}
 
-		remote := discoveryv1beta1apply.Endpoint().
+		remote := discoveryv1apply.Endpoint().
 			WithAddresses(translator(local.Addresses)...).WithConditions(conditions).
-			WithTopology(local.Topology).WithTopology(map[string]string{corev1.LabelHostname: LocalCluster.ClusterID}).
+			WithNodeName(LocalCluster.ClusterName).WithHints(RemoteEndpointHints(local.Hints)).
 			WithTargetRef(RemoteObjectReference(local.TargetRef))
 		remote.Hostname = local.Hostname
+		remote.Zone = local.Zone
 
 		remotes = append(remotes, remote)
 	}
@@ -87,16 +82,29 @@ func RemoteEndpointSliceEndpoints(locals []discoveryv1beta1.Endpoint,
 }
 
 // RemoteEndpointSlicePorts forges the apply patch for the ports of the reflected endpointslice, given the local ones.
-func RemoteEndpointSlicePorts(locals []discoveryv1beta1.EndpointPort) []*discoveryv1beta1apply.EndpointPortApplyConfiguration {
-	var remotes []*discoveryv1beta1apply.EndpointPortApplyConfiguration
+func RemoteEndpointSlicePorts(locals []discoveryv1.EndpointPort) []*discoveryv1apply.EndpointPortApplyConfiguration {
+	var remotes []*discoveryv1apply.EndpointPortApplyConfiguration
 
 	for i := range locals {
 		// DeepCopy the local object, to avoid mutating the cache.
 		local := locals[i].DeepCopy()
-		remotes = append(remotes, &discoveryv1beta1apply.EndpointPortApplyConfiguration{
+		remotes = append(remotes, &discoveryv1apply.EndpointPortApplyConfiguration{
 			Name: local.Name, Port: local.Port, Protocol: local.Protocol, AppProtocol: local.AppProtocol,
 		})
 	}
 
 	return remotes
+}
+
+// RemoteEndpointHints forges the apply patch for the endpoint hints of the reflected endpointslice, given the local ones.
+func RemoteEndpointHints(local *discoveryv1.EndpointHints) *discoveryv1apply.EndpointHintsApplyConfiguration {
+	if local == nil {
+		return nil
+	}
+
+	hints := discoveryv1apply.EndpointHints()
+	for _, zone := range local.ForZones {
+		hints.WithForZones(discoveryv1apply.ForZone().WithName(zone.Name))
+	}
+	return hints
 }

--- a/test/integration/endpoint_reflection_test.go
+++ b/test/integration/endpoint_reflection_test.go
@@ -15,7 +15,6 @@
 package integration_tests_test
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/containernetworking/plugins/pkg/ns"
@@ -42,7 +41,7 @@ var _ = Describe("EndpointReflection", func() {
 	Describe("Endpoint IP mapping", func() {
 		Context("Map the endpoint IP of a remote endpoint", func() {
 			It("DNAT rule should be inserted by the natmappingoperator", func() {
-				response, err := ipam.MapEndpointIP(context.Background(), &liqonetIpam.MapRequest{
+				response, err := ipam.MapEndpointIP(ctx, &liqonetIpam.MapRequest{
 					ClusterID: clusterID1,
 					Ip:        remoteEndpointIP,
 				})
@@ -64,7 +63,7 @@ var _ = Describe("EndpointReflection", func() {
 		Context("Ask to map more IPs of a remote endpoints", func() {
 			It("DNAT rules should be inserted for each of them"+
 				" by the natmappingoperator", func() {
-				response, err := ipam.MapEndpointIP(context.Background(), &liqonetIpam.MapRequest{
+				response, err := ipam.MapEndpointIP(ctx, &liqonetIpam.MapRequest{
 					ClusterID: clusterID1,
 					Ip:        remoteEndpointIP,
 				})
@@ -81,7 +80,7 @@ var _ = Describe("EndpointReflection", func() {
 					}
 					return false
 				}, timeout, interval).Should(BeTrue())
-				response, err = ipam.MapEndpointIP(context.Background(), &liqonetIpam.MapRequest{
+				response, err = ipam.MapEndpointIP(ctx, &liqonetIpam.MapRequest{
 					ClusterID: clusterID1,
 					Ip:        remoteEndpointIP2,
 				})
@@ -104,7 +103,7 @@ var _ = Describe("EndpointReflection", func() {
 		})
 		Context("Map the same endpoint IP on more clusters", func() {
 			It("DNAT rules should be inserted by the natmappingoperator", func() {
-				response, err := ipam.MapEndpointIP(context.Background(), &liqonetIpam.MapRequest{
+				response, err := ipam.MapEndpointIP(ctx, &liqonetIpam.MapRequest{
 					ClusterID: clusterID1,
 					Ip:        remoteEndpointIP,
 				})
@@ -121,7 +120,7 @@ var _ = Describe("EndpointReflection", func() {
 					}
 					return false
 				}, timeout, interval).Should(BeTrue())
-				response, err = ipam.MapEndpointIP(context.Background(), &liqonetIpam.MapRequest{
+				response, err = ipam.MapEndpointIP(ctx, &liqonetIpam.MapRequest{
 					ClusterID: clusterID2,
 					Ip:        remoteEndpointIP,
 				})
@@ -145,7 +144,7 @@ var _ = Describe("EndpointReflection", func() {
 		Context("Ask to terminate to map the IP of a remote endpoint", func() {
 			It("IPAM module should return no errors and a DNAT rule should be deleted"+
 				" by the natmappingoperator", func() {
-				response, err := ipam.MapEndpointIP(context.Background(), &liqonetIpam.MapRequest{
+				response, err := ipam.MapEndpointIP(ctx, &liqonetIpam.MapRequest{
 					ClusterID: clusterID1,
 					Ip:        remoteEndpointIP,
 				})
@@ -161,7 +160,7 @@ var _ = Describe("EndpointReflection", func() {
 					}
 					return false
 				}, timeout, interval).Should(BeTrue())
-				_, err = ipam.UnmapEndpointIP(context.Background(), &liqonetIpam.UnmapRequest{
+				_, err = ipam.UnmapEndpointIP(ctx, &liqonetIpam.UnmapRequest{
 					ClusterID: clusterID1,
 					Ip:        remoteEndpointIP,
 				})
@@ -182,14 +181,14 @@ var _ = Describe("EndpointReflection", func() {
 			It("DNAT rule should be deleted only for the requested endpoint"+
 				" by the natmappingoperator", func() {
 				// Map remoteEndpointIP and remoteEndpointIP2
-				response, err := ipam.MapEndpointIP(context.Background(), &liqonetIpam.MapRequest{
+				response, err := ipam.MapEndpointIP(ctx, &liqonetIpam.MapRequest{
 					ClusterID: clusterID1,
 					Ip:        remoteEndpointIP,
 				})
 				Expect(err).To(BeNil())
 				newEndpointIP := response.GetIp()
 				Expect(newEndpointIP).To(HavePrefix("10.80.")) // Local NAT ExternalCIDR is 10.80.0.0/24
-				response, err = ipam.MapEndpointIP(context.Background(), &liqonetIpam.MapRequest{
+				response, err = ipam.MapEndpointIP(ctx, &liqonetIpam.MapRequest{
 					ClusterID: clusterID1,
 					Ip:        remoteEndpointIP2,
 				})
@@ -209,7 +208,7 @@ var _ = Describe("EndpointReflection", func() {
 					return false
 				}, timeout, interval).Should(BeTrue())
 				// Terminate only mapping of remoteEndpointIP
-				_, err = ipam.UnmapEndpointIP(context.Background(), &liqonetIpam.UnmapRequest{
+				_, err = ipam.UnmapEndpointIP(ctx, &liqonetIpam.UnmapRequest{
 					ClusterID: clusterID1,
 					Ip:        remoteEndpointIP,
 				})


### PR DESCRIPTION
# Description

This PR modifies the virtual kubelet to leverage the v1 endpointslice API, which has been introduced in kubernetes v1.21, and it is the only one present in v1.25. This is required to support the latest version of kubernetes, although dropping the support for older v1.19 and 1.20.

Additionally, it updates the version of envtest from v1.19 to v1.25, and fixes a set of context-related problems which caused the tests not to complete correctly with the new version of envtest.

Fixes #(issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Existing tests
- [x] Manual testing on k8s v1.25
