### PR TITLE
Helm fixes to ease usage with Helm-related tools

### DIFF
--- a/deployments/liqo/README.md
+++ b/deployments/liqo/README.md
@@ -33,6 +33,7 @@
 | crdReplicator.pod.extraArgs | list | `[]` | crdReplicator pod extra arguments |
 | crdReplicator.pod.labels | object | `{}` | crdReplicator pod labels |
 | discovery.config.autojoin | bool | `true` | Automatically join discovered clusters |
+| discovery.config.clusterIDOverride | string | `""` | Specify an unique ID (must be a valid uuidv4) for your cluster, instead of letting helm generate it automatically at install time. You can generate it using the command: `uuidgen` Setting this field is necessary when using tools such as ArgoCD, since the helm lookup function is not supported and a new value would be generated at each deployment. |
 | discovery.config.clusterLabels | object | `{}` | A set of labels which characterizes the local cluster when exposed remotely as a virtual node. It is suggested to specify the distinguishing characteristics that may be used to decide whether to offload pods on this cluster. |
 | discovery.config.clusterName | string | `""` | Set a mnemonic name for your cluster |
 | discovery.config.enableAdvertisement | bool | `false` | Enable the mDNS advertisement on LANs, set to false to not be discoverable from other clusters in the same LAN |

--- a/deployments/liqo/templates/liqo-clusterid-configmap.yaml
+++ b/deployments/liqo/templates/liqo-clusterid-configmap.yaml
@@ -9,10 +9,18 @@ metadata:
     {{- include "liqo.labels" $clusterIdConfig | nindent 4 }}
   name: {{ include "liqo.prefixedName" $clusterIdConfig }}
 data:
-  {{- if (not $oldObject) }}
-  CLUSTER_ID: {{ uuidv4 }}
-  {{- else }}
+  {{- if $oldObject }}
+  {{- if and (.Values.discovery.config.clusterIDOverride) (ne $oldObject.data.CLUSTER_ID .Values.discovery.config.clusterIDOverride) }}
+    {{ fail "Changing the cluster ID by providing a different .discovery.config.clusterIDOverride value is not allowed." }}
+  {{- end}}
   CLUSTER_ID: {{ $oldObject.data.CLUSTER_ID }}
+  {{- else if .Values.discovery.config.clusterIDOverride }}
+    {{- if not (regexMatch "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$" .Values.discovery.config.clusterIDOverride) }}
+      {{ fail "Provided cluster ID must be a valid UUID"}}
+    {{- end}}
+  CLUSTER_ID: {{ .Values.discovery.config.clusterIDOverride }}
+  {{- else }}
+  CLUSTER_ID: {{ uuidv4 }}
   {{- end }}
   {{- if .Values.discovery.config.clusterName }}
   CLUSTER_NAME: {{ .Values.discovery.config.clusterName }}

--- a/deployments/liqo/templates/webhooks/job-patch/job-create-secret.yaml
+++ b/deployments/liqo/templates/webhooks/job-patch/job-create-secret.yaml
@@ -1,4 +1,5 @@
-{{- $cfg := (merge (dict "name" "webhook-certificate-patch" "module" "webhook-certificate-patch") .) -}}
+{{- $cfg := (merge (dict "name" "webhook-certificate-patch-pre" "module" "webhook-certificate-patch") .) -}}
+{{- $rbacConfig := (merge (dict "name" "webhook-certificate-patch") .) -}}
 {{- $webhookConfig := (merge (dict "name" "webhook" "module" "webhook") .) -}}
 {{- $ctrlManagerConfig := (merge (dict "name" "controller-manager" "module" "controller-manager") .) -}}
 
@@ -33,6 +34,6 @@ spec:
         securityContext:
           {{- include "liqo.containerSecurityContext" . | nindent 10 }}
       restartPolicy: OnFailure
-      serviceAccountName: {{ include "liqo.prefixedName" $cfg }}
+      serviceAccountName: {{ include "liqo.prefixedName" $rbacConfig }}
       securityContext:
         {{- include "liqo.podSecurityContext" . | nindent 8 }}

--- a/deployments/liqo/templates/webhooks/job-patch/job-patch-webhook.yaml
+++ b/deployments/liqo/templates/webhooks/job-patch/job-patch-webhook.yaml
@@ -1,4 +1,5 @@
-{{- $cfg := (merge (dict "name" "webhook-certificate-patch" "module" "webhook-certificate-patch") .) -}}
+{{- $cfg := (merge (dict "name" "webhook-certificate-patch-post" "module" "webhook-certificate-patch") .) -}}
+{{- $rbacConfig := (merge (dict "name" "webhook-certificate-patch") .) -}}
 {{- $webhookConfig := (merge (dict "name" "webhook" "module" "webhook") .) -}}
 
 apiVersion: batch/v1
@@ -30,6 +31,6 @@ spec:
         securityContext:
           {{- include "liqo.containerSecurityContext" . | nindent 10 }}
       restartPolicy: OnFailure
-      serviceAccountName: {{ include "liqo.prefixedName" $cfg }}
+      serviceAccountName: {{ include "liqo.prefixedName" $rbacConfig }}
       securityContext:
         {{- include "liqo.podSecurityContext" . | nindent 8 }}

--- a/deployments/liqo/values.yaml
+++ b/deployments/liqo/values.yaml
@@ -122,6 +122,9 @@ discovery:
   # -- discovery image repository
   imageName: "liqo/discovery"
   config:
+    # -- Specify an unique ID (must be a valid uuidv4) for your cluster, instead of letting helm generate it automatically at install time. You can generate it using the command: `uuidgen`
+    # Setting this field is necessary when using tools such as ArgoCD, since the helm lookup function is not supported and a new value would be generated at each deployment.
+    clusterIDOverride: ""
     # -- Set a mnemonic name for your cluster
     clusterName: ""
     # -- A set of labels which characterizes the local cluster when exposed remotely as a virtual node.


### PR DESCRIPTION
# Description

This PR 
- changes the name of webhook related jobs in order to differentiate them;
- imposes a CLUSTER_ID taken from values if exists (certain tools like ArgoCD cannot retrieve current value while templating)

Fixes #1437

# How Has This Been Tested?

- [x] Local Helm templating
- [x] Cluster deployment through Helm
