### PR TITLE
Foreign cluster resource: enforce peering type

### DIFF
--- a/apis/discovery/v1alpha1/foreigncluster_types.go
+++ b/apis/discovery/v1alpha1/foreigncluster_types.go
@@ -48,6 +48,20 @@ const (
 	PeeringConditionStatusSuccess PeeringConditionStatusType = "Success"
 )
 
+// PeeringType defines the type of peering to be established.
+type PeeringType string
+
+const (
+	// PeeringTypeOutOfBand represents an out-of-band control-plane peering
+	// (i.e., control plane traffic flows outside the network fabric).
+	PeeringTypeOutOfBand PeeringType = "OutOfBand"
+	// PeeringTypeInBand represents an in-band control-plane peering.
+	// (i.e., control plane traffic flows inside the network fabric).
+	PeeringTypeInBand PeeringType = "InBand"
+	// PeeringTypeUnknown represents the empty value for the peering type.
+	PeeringTypeUnknown PeeringType = ""
+)
+
 // PeeringEnabledType indicates the desired state for the peering with this remote cluster.
 type PeeringEnabledType string
 
@@ -55,9 +69,9 @@ const (
 	// PeeringEnabledAuto indicates to use the default settings for the discovery method.
 	// This is useful to track that the user did not set the peering state for that cluster,
 	// if the peering is Auto liqo will use the default for that discovery method:
-	// manual -> No
-	// incomingPeering -> No
-	// LAN -> Yes
+	// manual -> No.
+	// incomingPeering -> No.
+	// LAN -> Yes.
 	PeeringEnabledAuto PeeringEnabledType = "Auto"
 	// PeeringEnabledNo indicates to disable the peering with this remote cluster.
 	PeeringEnabledNo PeeringEnabledType = "No"
@@ -65,22 +79,13 @@ const (
 	PeeringEnabledYes PeeringEnabledType = "Yes"
 )
 
-// NetworkingEnabledType indicates the desired state for the network interconnection with this remote cluster.
-type NetworkingEnabledType string
-
-const (
-	// NetworkingEnabledNo indicates to not handle the network interconnection with this remote cluster.
-	NetworkingEnabledNo NetworkingEnabledType = "No"
-	// NetworkingEnabledYes indicates to handle the network interconnection with this remote cluster.
-	NetworkingEnabledYes NetworkingEnabledType = "Yes"
-	// NetworkingEnabledNone is a placeholder to be used when the state of the networking is not known.
-	NetworkingEnabledNone NetworkingEnabledType = "None"
-)
-
 // ForeignClusterSpec defines the desired state of ForeignCluster.
 type ForeignClusterSpec struct {
-	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
-	// Important: Run "make" to regenerate code after modifying this file
+	// The type of peering to be established.
+	// +kubebuilder:validation:Enum="OutOfBand";"InBand"
+	// +kubebuilder:default="OutOfBand"
+	// +kubebuilder:validation:Optional
+	PeeringType PeeringType `json:"peeringType,omitempty"`
 
 	// Foreign Cluster Identity.
 	ClusterIdentity ClusterIdentity `json:"clusterIdentity,omitempty"`
@@ -94,11 +99,6 @@ type ForeignClusterSpec struct {
 	// +kubebuilder:default="Auto"
 	// +kubebuilder:validation:Optional
 	IncomingPeeringEnabled PeeringEnabledType `json:"incomingPeeringEnabled"`
-	// Indicates if Liqo has to handle the network interconnection with the remote cluster.
-	// +kubebuilder:validation:Enum="No";"Yes"
-	// +kubebuilder:default="Yes"
-	// +kubebuilder:validation:Optional
-	NetworkingEnabled NetworkingEnabledType `json:"networkingEnabled,omitempty"`
 	// URL where to contact foreign Auth service.
 	// +kubebuilder:validation:Pattern=`https:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)`
 	ForeignAuthURL string `json:"foreignAuthUrl"`
@@ -190,6 +190,7 @@ type TenantNamespaceType struct {
 // +kubebuilder:subresource:status
 
 // ForeignCluster is the Schema for the foreignclusters API.
+// +kubebuilder:printcolumn:name="Type",type=string,JSONPath=`.spec.peeringType`
 // +kubebuilder:printcolumn:name="ClusterID",type=string,priority=1,JSONPath=`.spec.clusterIdentity.clusterID`
 // +kubebuilder:printcolumn:name="ClusterName",type=string,priority=1,JSONPath=`.spec.clusterIdentity.clusterName`
 // +kubebuilder:printcolumn:name="Outgoing peering",type=string,JSONPath=`.status.peeringConditions[?(@.type == 'OutgoingPeering')].status`

--- a/cmd/liqo-controller-manager/main.go
+++ b/cmd/liqo-controller-manager/main.go
@@ -57,6 +57,7 @@ import (
 	shadowpodctrl "github.com/liqotech/liqo/pkg/liqo-controller-manager/shadowpod-controller"
 	liqostorageprovisioner "github.com/liqotech/liqo/pkg/liqo-controller-manager/storageprovisioner"
 	virtualNodectrl "github.com/liqotech/liqo/pkg/liqo-controller-manager/virtualNode-controller"
+	fcwh "github.com/liqotech/liqo/pkg/liqo-controller-manager/webhooks/foreigncluster"
 	nsoffwh "github.com/liqotech/liqo/pkg/liqo-controller-manager/webhooks/namespaceoffloading"
 	podwh "github.com/liqotech/liqo/pkg/liqo-controller-manager/webhooks/pod"
 	peeringroles "github.com/liqotech/liqo/pkg/peering-roles"
@@ -197,6 +198,7 @@ func main() {
 	}
 
 	// Register the webhooks.
+	mgr.GetWebhookServer().Register("/validate/foreign-cluster", fcwh.New())
 	mgr.GetWebhookServer().Register("/validate/namespace-offloading", nsoffwh.New())
 	mgr.GetWebhookServer().Register("/mutate/pod", podwh.New(mgr.GetClient()))
 

--- a/cmd/liqoctl/cmd/peer.go
+++ b/cmd/liqoctl/cmd/peer.go
@@ -82,8 +82,8 @@ The command above can be generated executing the following from the target clust
 
 const liqoctlPeerIBLongHelp = `Enable an in-band peering towards a remote cluster.
 
-The in-band control plane peering is an peering approach, characterized by all
-Liqo control-plane traffic flowing inside the VPN tunnel interconnecting the
+The in-band control plane peering is an alternative peering approach, characterized
+by all Liqo control-plane traffic flowing inside the VPN tunnel interconnecting the
 two clusters. The VPN tunnel is established by {{ .Executable }} before starting the
 remainder of the peering process.
 

--- a/cmd/liqoctl/cmd/unpeer.go
+++ b/cmd/liqoctl/cmd/unpeer.go
@@ -31,7 +31,7 @@ const liqoctlUnpeerLongHelp = `Disable a peering towards a remote cluster.
 
 Depending on the approach adopted to initially establish the peering towards a
 remote cluster, the corresponding unpeer command performs the symmetrical
-operations to tear the peering down (although with slightly different semantic).
+operations to tear the peering down.
 
 This command disables an *outgoing peering* towards a remote cluster, causing
 the local virtual node (abstracting the remote cluster) to be destroyed, and all
@@ -40,8 +40,7 @@ and the remote cluster can continue offloading workloads to its virtual node
 representing the local cluster.
 
 The same operation can be executed regardless of whether the peering is
-out-of-band or in-band, although in the latter case the VPN tunnel is not teared
-down (as the *unpeer in-band* instead would do).
+out-of-band or in-band.
 
 Examples:
   $ {{ .Executable }} unpeer eternal-donkey
@@ -51,13 +50,12 @@ const liqoctlUnpeerOOBLongHelp = `Disable an out-of-band peering towards a remot
 
 This command disables an *out-of-band outgoing peering* towards a remote cluster,
 causing the local virtual node (abstracting the remote cluster) to be destroyed,
-and all offloaded workloads to be rescheduled. The reverse peering, if any, is
-preserved, and the remote cluster can continue offloading workloads to its
-virtual node representing the local cluster.
+and all offloaded workloads to be rescheduled. In addition, it attempts to remove
+the foreign cluster resource, giving up and issuing a warning if an incoming
+peering is still active.
 
-The same operation can be executed regardless of whether the peering is
-out-of-band or in-band, although in the latter case the VPN tunnel is not teared
-down (as the *unpeer in-band* instead would do).
+In case the peering needs to be disabled only in one direction, while preserving
+the other, it is possible to leverage the *unpeer <cluster-name>* command.
 
 Examples:
   $ {{ .Executable }} unpeer out-of-band eternal-donkey
@@ -72,7 +70,7 @@ everything is restored to the same status as if the *peer in-band* command
 towards that cluster had never been executed.
 
 In case the peering needs to be disabled only in one direction, while preserving
-the other, it is possible to leverage the *unpeer out-of-band* command.
+the other, it is possible to leverage the *unpeer <cluster-name>* command.
 
 Examples:
   $ {{ .Executable }} unpeer in-band --remote-kubeconfig "~/kube/config-remote"
@@ -122,6 +120,7 @@ func newUnpeerOutOfBandCommand(ctx context.Context, options *unpeeroob.Options) 
 
 		Run: func(cmd *cobra.Command, args []string) {
 			options.ClusterName = args[0]
+			options.UnpeerOOBMode = true
 			output.ExitOnErr(options.Run(ctx))
 		},
 	}

--- a/deployments/liqo/crds/discovery.liqo.io_foreignclusters.yaml
+++ b/deployments/liqo/crds/discovery.liqo.io_foreignclusters.yaml
@@ -18,6 +18,9 @@ spec:
   scope: Cluster
   versions:
   - additionalPrinterColumns:
+    - jsonPath: .spec.peeringType
+      name: Type
+      type: string
     - jsonPath: .spec.clusterIdentity.clusterID
       name: ClusterID
       priority: 1
@@ -98,14 +101,6 @@ spec:
                 description: Indicates if the local cluster has to skip the tls verification
                   over the remote Authentication Service or not.
                 type: boolean
-              networkingEnabled:
-                default: "Yes"
-                description: Indicates if Liqo has to handle the network interconnection
-                  with the remote cluster.
-                enum:
-                - "No"
-                - "Yes"
-                type: string
               outgoingPeeringEnabled:
                 default: Auto
                 description: Enable the peering process to the remote cluster.
@@ -113,6 +108,13 @@ spec:
                 - Auto
                 - "No"
                 - "Yes"
+                type: string
+              peeringType:
+                default: OutOfBand
+                description: The type of peering to be established.
+                enum:
+                - OutOfBand
+                - InBand
                 type: string
               ttl:
                 description: If discoveryType is LAN, this indicates the number of

--- a/deployments/liqo/templates/webhooks/liqo-validating-webhook.yaml
+++ b/deployments/liqo/templates/webhooks/liqo-validating-webhook.yaml
@@ -8,6 +8,23 @@ metadata:
   labels:
     {{- include "liqo.labels" $webhookConfig | nindent 4 }}
 webhooks:
+  - name: fc.validate.liqo.io
+    admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: {{ include "liqo.prefixedName" $ctrlManagerConfig }}
+        namespace: {{ .Release.Namespace }}
+        path: "/validate/foreign-cluster"
+        port: {{ .Values.webhook.port }}
+    rules:
+      - operations: ["UPDATE"]
+        apiGroups: ["discovery.liqo.io"]
+        apiVersions: ["v1alpha1"]
+        resources: ["foreignclusters"]
+    sideEffects: None
+    failurePolicy: {{ .Values.webhook.failurePolicy }}
   - name: nsoff.validate.liqo.io
     admissionReviewVersions:
       - v1

--- a/docs/examples/global-ingress.md
+++ b/docs/examples/global-ingress.md
@@ -70,8 +70,8 @@ kubectl get foreignclusters
 The output should look like the following, indicating that an outgoing peering is currently active towards the *gslb-us* cluster, as well as that the cross-cluster network tunnel has been established:
 
 ```text
-NAME      OUTGOING PEERING   INCOMING PEERING   NETWORKING    AUTHENTICATION   AGE
-gslb-us   Established        None               Established   Established      57s
+NAME      TYPE        OUTGOING PEERING   INCOMING PEERING   NETWORKING    AUTHENTICATION   AGE
+gslb-us   OutOfBand   Established        None               Established   Established      57s
 ```
 
 Additionally, you should see a new virtual node (`liqo-gslb-us`) in the *gslb-eu* cluster, and representing the whole *gslb-us* cluster.

--- a/docs/examples/offloading-with-policies.md
+++ b/docs/examples/offloading-with-policies.md
@@ -73,9 +73,9 @@ kubectl get foreignclusters
 The output should look like the following, indicating that an outgoing peering is currently active towards both the *Florence* and the *Naples* clusters, as well as the cross-cluster network tunnels have been established:
 
 ```text
-NAME       OUTGOING PEERING   INCOMING PEERING   NETWORKING    AUTHENTICATION   AGE
-florence   Established        None               Established   Established      111s
-naples     Established        None               Established   Established      98s
+NAME       TYPE        OUTGOING PEERING   INCOMING PEERING   NETWORKING    AUTHENTICATION   AGE
+florence   OutOfBand   Established        None               Established   Established      111s
+naples     OutOfBand   Established        None               Established   Established      98s
 ```
 
 Additionally, you should have two new virtual nodes in the *Venice* cluster, characterized by the install-time provided labels:

--- a/docs/examples/quick-start.md
+++ b/docs/examples/quick-start.md
@@ -153,8 +153,8 @@ kubectl get foreignclusters
 The output should look like the following, indicating that the cross-cluster network tunnel has been established, and an outgoing peering is currently active (i.e., the *Rome* cluster can offload workloads to the *Milan* one, but not vice versa):
 
 ```text
-NAME    OUTGOING PEERING   INCOMING PEERING   NETWORKING    AUTHENTICATION   AGE
-milan   Established        None               Established   Established      12s
+NAME    TYPE        OUTGOING PEERING   INCOMING PEERING   NETWORKING    AUTHENTICATION   AGE
+milan   OutOfBand   Established        None               Established   Established      12s
 ```
 
 At the same time, you should see a virtual node (`liqo-milan`) in addition to your physical nodes:

--- a/docs/examples/service-offloading.md
+++ b/docs/examples/service-offloading.md
@@ -53,8 +53,8 @@ kubectl get foreignclusters
 The output should look like the following, indicating that an outgoing peering is currently active towards the *New York* cluster, as well as that the cross-cluster network tunnel has been established:
 
 ```text
-NAME      OUTGOING PEERING   INCOMING PEERING   NETWORKING    AUTHENTICATION   AGE
-newyork   Established        None               Established   Established      61s
+NAME      TYPE        OUTGOING PEERING   INCOMING PEERING   NETWORKING    AUTHENTICATION   AGE
+newyork   OutOfBand   Established        None               Established   Established      61s
 ```
 
 ## Offload a service

--- a/docs/examples/stateful-applications.md
+++ b/docs/examples/stateful-applications.md
@@ -55,8 +55,8 @@ kubectl get foreignclusters
 The output should look like the following, indicating that an outgoing peering is currently active towards the *Lyon* cluster,, as well as that the cross-cluster network tunnel has been established:
 
 ```text
-NAME   OUTGOING PEERING   INCOMING PEERING   NETWORKING    AUTHENTICATION   AGE
-lyon   Established        None               Established   Established      1m28s
+NAME   TYPE        OUTGOING PEERING   INCOMING PEERING   NETWORKING    AUTHENTICATION   AGE
+lyon   OutOfBand   Established        None               Established   Established      1m28s
 ```
 
 ## Deploy a stateful application

--- a/docs/usage/peer.md
+++ b/docs/usage/peer.md
@@ -67,8 +67,8 @@ kubectl --context=consumer get foreignclusters
 If the peering process completed successfully, you should observe an output similar to the following, indicating that the cross-cluster network tunnel has been established, and an outgoing peering is currently active (i.e., the *consumer* cluster can offload workloads to the *provider* one, but not vice versa):
 
 ```text
-NAME       OUTGOING PEERING   INCOMING PEERING   NETWORKING    AUTHENTICATION
-provider   Established        None               Established   Established
+NAME       TYPE        OUTGOING PEERING   INCOMING PEERING   NETWORKING    AUTHENTICATION
+provider   OutOfBand   Established        None               Established   Established
 ```
 
 At the same time, a new *virtual node* should have been created in the *consumer* cluster.
@@ -108,7 +108,14 @@ liqoctl --context=consumer unpeer out-of-band
 ```{admonition} Note
 The reverse peering direction, if any, is preserved, and the remote cluster can continue offloading workloads to its virtual
 node representing the local cluster.
+In this case, the command *emits a warning*, and it does not proceed deleting the *ForeignCluster* resource.
 Hence, the same command shall be executed on both clusters to completely tear down a bidirectional peering.
+```
+
+In case only one peering direction shall be teared down, while preserving the opposite, it is suggested to leverage the appropriate *liqoctl unpeer* command to disable the outgoing peering (e.g., on the *provider* cluster):
+
+```bash
+liqoctl --context=provider unpeer consumer
 ```
 
 (UsagePeerInBand)=
@@ -144,8 +151,8 @@ kubectl --context=consumer get foreignclusters
 If the peering process completed successfully, you should observe an output similar to the following, indicating that the cross-cluster network tunnel has been established, and an outgoing peering is currently active (i.e., the *consumer* cluster can offload workloads to the *provider* one, but not vice versa):
 
 ```text
-NAME       OUTGOING PEERING   INCOMING PEERING   NETWORKING    AUTHENTICATION
-provider   Established        None               Established   Established
+NAME       TYPE     OUTGOING PEERING   INCOMING PEERING   NETWORKING    AUTHENTICATION
+provider   InBand   Established        None               Established   Established
 ```
 
 At the same time, a new *virtual node* should have been created in the *consumer* cluster.

--- a/internal/crdReplicator/networkingState.go
+++ b/internal/crdReplicator/networkingState.go
@@ -14,48 +14,16 @@
 
 package crdreplicator
 
-import (
-	"k8s.io/klog/v2"
-
-	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
-	netv1alpha1 "github.com/liqotech/liqo/apis/net/v1alpha1"
-	"github.com/liqotech/liqo/internal/crdReplicator/resources"
-)
-
 // getNetworkingState returns the state of the networking for a cluster given its clusterID.
-func (c *Controller) getNetworkingState(clusterID string) discoveryv1alpha1.NetworkingEnabledType {
-	c.networkingStateMutex.RLock()
-	defer c.networkingStateMutex.RUnlock()
-	if state, ok := c.networkingStates[clusterID]; ok {
-		return state
-	}
-	return discoveryv1alpha1.NetworkingEnabledNone
+func (c *Controller) getNetworkingEnabled(clusterID string) bool {
+	c.networkingEnabledMutex.RLock()
+	defer c.networkingEnabledMutex.RUnlock()
+	return c.networkingEnabled[clusterID]
 }
 
 // setNetworkingState sets the networking state for a given clusterID.
-func (c *Controller) setNetworkingState(clusterID string, state discoveryv1alpha1.NetworkingEnabledType) {
-	c.networkingStateMutex.RLock()
-	defer c.networkingStateMutex.RUnlock()
-	if c.networkingStates == nil {
-		c.networkingStates = map[string]discoveryv1alpha1.NetworkingEnabledType{}
-	}
-	c.networkingStates[clusterID] = state
-}
-
-// isNetworkingEnabled indicates if the replication for the networkconfigs has to be enabled based on the state
-// of the networking.
-func isNetworkingEnabled(networkingState discoveryv1alpha1.NetworkingEnabledType, resource *resources.Resource) bool {
-	// We are interested only for the networkconfigs resources.
-	if resource.GroupVersionResource != netv1alpha1.NetworkConfigGroupVersionResource {
-		return true
-	}
-	switch networkingState {
-	case discoveryv1alpha1.NetworkingEnabledNone, discoveryv1alpha1.NetworkingEnabledNo:
-		return false
-	case discoveryv1alpha1.NetworkingEnabledYes:
-		return true
-	default:
-		klog.Warning("Unknown networking state %v", resource.PeeringPhase)
-		return false
-	}
+func (c *Controller) setNetworkingEnabled(clusterID string, enabled bool) {
+	c.networkingEnabledMutex.RLock()
+	defer c.networkingEnabledMutex.RUnlock()
+	c.networkingEnabled[clusterID] = enabled
 }

--- a/internal/liqonet/network-manager/netcfgcreator/networkconfig_test.go
+++ b/internal/liqonet/network-manager/netcfgcreator/networkconfig_test.go
@@ -227,8 +227,7 @@ var _ = Describe("Network config functions", func() {
 				},
 				ObjectMeta: metav1.ObjectMeta{Name: "whatever", UID: "8a402261-9cf4-402e-89e8-4d743fb315fb"},
 				Spec: discoveryv1alpha1.ForeignClusterSpec{
-					ClusterIdentity:   discoveryv1alpha1.ClusterIdentity{ClusterID: clusterID, ClusterName: clusterName},
-					NetworkingEnabled: discoveryv1alpha1.NetworkingEnabledYes,
+					ClusterIdentity: discoveryv1alpha1.ClusterIdentity{ClusterID: clusterID, ClusterName: clusterName},
 				},
 				Status: discoveryv1alpha1.ForeignClusterStatus{
 					TenantNamespace: discoveryv1alpha1.TenantNamespaceType{Local: namespace},

--- a/pkg/liqo-controller-manager/webhooks/foreigncluster/doc.go
+++ b/pkg/liqo-controller-manager/webhooks/foreigncluster/doc.go
@@ -12,11 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package foreigncluster
-
-import discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
-
-// IsNetworkingEnabled checks if the automatic creation/propagation of NetworkConfigs is enabled.
-func IsNetworkingEnabled(foreignCluster *discoveryv1alpha1.ForeignCluster) bool {
-	return foreignCluster.Spec.PeeringType == discoveryv1alpha1.PeeringTypeOutOfBand
-}
+// Package fcwh contains the logic of the ForeignCluster webhook.
+package fcwh

--- a/pkg/liqo-controller-manager/webhooks/foreigncluster/fc.go
+++ b/pkg/liqo-controller-manager/webhooks/foreigncluster/fc.go
@@ -1,0 +1,78 @@
+// Copyright 2019-2022 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fcwh
+
+import (
+	"context"
+	"net/http"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
+)
+
+type fcwh struct {
+	decoder *admission.Decoder
+}
+
+// New returns a new NamespaceOffloadingWebhook instance.
+func New() *webhook.Admission {
+	return &webhook.Admission{Handler: &fcwh{}}
+}
+
+// InjectDecoder injects the decoder - this method is used by controller runtime.
+func (w *fcwh) InjectDecoder(decoder *admission.Decoder) error {
+	w.decoder = decoder
+	return nil
+}
+
+// DecodeForeignCluster decodes the ForeignCluster from the incoming request.
+func (w *fcwh) DecodeForeignCluster(obj runtime.RawExtension) (*discoveryv1alpha1.ForeignCluster, error) {
+	var fc discoveryv1alpha1.ForeignCluster
+	err := w.decoder.DecodeRaw(obj, &fc)
+	return &fc, err
+}
+
+// Handle implements the ForeignCluster validating webhook logic.
+//
+//nolint:gocritic // The signature of this method is imposed by controller runtime.
+func (w *fcwh) Handle(ctx context.Context, req admission.Request) admission.Response {
+	if req.Operation != admissionv1.Update {
+		return admission.Allowed("")
+	}
+
+	// In case of updates, prevent the mutation of the PeeringType field.
+	fcnew, err := w.DecodeForeignCluster(req.Object)
+	if err != nil {
+		klog.Errorf("Failed decoding ForeignCluster object: %v", err)
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+
+	fcold, err := w.DecodeForeignCluster(req.OldObject)
+	if err != nil {
+		klog.Errorf("Failed decoding ForeignCluster object: %v", err)
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+
+	if fcold.Spec.PeeringType != fcnew.Spec.PeeringType {
+		return admission.Denied("The PeeringType value cannot be modified after creation")
+	}
+
+	return admission.Allowed("")
+}

--- a/pkg/liqoctl/peerib/handler.go
+++ b/pkg/liqoctl/peerib/handler.go
@@ -48,6 +48,16 @@ func (o *Options) Run(ctx context.Context) error {
 		return err
 	}
 
+	// Check whether a ForeignCluster resource already exists in cluster 1 for cluster 2, and perform sanity checks.
+	if err := cluster1.CheckForeignCluster(ctx, cluster2.GetClusterID()); err != nil {
+		return err
+	}
+
+	// Check whether a ForeignCluster resource already exists in cluster 2 for cluster 1, and perform sanity checks.
+	if err := cluster2.CheckForeignCluster(ctx, cluster1.GetClusterID()); err != nil {
+		return err
+	}
+
 	// SetUp tenant namespace for cluster 2 in cluster 1.
 	if err := cluster1.SetUpTenantNamespace(ctx, cluster2.GetClusterID()); err != nil {
 		return err


### PR DESCRIPTION
# Description

This PR introduces an "immutable" PeeringType field as part of the ForeignCluster API, in order to explicit the type of peering and prevent switching from one to another, which would cause potential issues. This also enables a better UX through liqoctl.

Fixes #(issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Existing tests
- [x] Manual testing
