### PR TITLE
Collect Liqo Telemetry

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -83,6 +83,7 @@ jobs:
         - uninstaller
         - virtual-kubelet
         - metric-agent
+        - telemetry
     steps:
 
       - name: Set up QEMU

--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,7 @@ rbacs: controller-gen
 	$(CONTROLLER_GEN) paths="./pkg/virtualKubelet/roles/remote" rbac:roleName=liqo-virtual-kubelet-remote output:rbac:stdout | awk -v RS="---\n" 'NR>1{f="./deployments/liqo/files/liqo-virtual-kubelet-remote-" $$4 ".yaml";printf "%s",$$0 > f; close(f)}' &&  sed -i -n '/rules/,$$p' deployments/liqo/files/liqo-virtual-kubelet-remote-ClusterRole.yaml
 	$(CONTROLLER_GEN) paths="./cmd/uninstaller" rbac:roleName=liqo-pre-delete output:rbac:stdout | awk -v RS="---\n" 'NR>1{f="./deployments/liqo/files/liqo-pre-delete-" $$4 ".yaml";printf "%s",$$0 > f; close(f)}' &&  sed -i -n '/rules/,$$p' deployments/liqo/files/liqo-pre-delete-ClusterRole.yaml
 	$(CONTROLLER_GEN) paths="./cmd/metric-agent" rbac:roleName=liqo-metric-agent output:rbac:stdout | awk -v RS="---\n" 'NR>1{f="./deployments/liqo/files/liqo-metric-agent-" $$4 ".yaml";printf "%s",$$0 > f; close(f)}' &&  sed -i -n '/rules/,$$p' deployments/liqo/files/liqo-metric-agent-ClusterRole.yaml
+	$(CONTROLLER_GEN) paths="./cmd/telemetry" rbac:roleName=liqo-telemetry output:rbac:stdout | awk -v RS="---\n" 'NR>1{f="./deployments/liqo/files/liqo-telemetry-" $$4 ".yaml";printf "%s",$$0 > f; close(f)}' &&  sed -i -n '/rules/,$$p' deployments/liqo/files/liqo-telemetry-ClusterRole.yaml
 
 # Install gci if not available
 gci:

--- a/cmd/liqoctl/cmd/install.go
+++ b/cmd/liqoctl/cmd/install.go
@@ -164,6 +164,8 @@ func newInstallCommand(ctx context.Context, f *factory.Factory) *cobra.Command {
 		"(ClusterName, PodCIDR, ServiceCIDR). "+
 		"This is useful when you are sure of what you are doing and the amount of pods and services in your cluster is very large (default false)")
 	cmd.PersistentFlags().BoolVar(&options.EnableMetrics, "enable-metrics", false, "Enable metrics exposition through prometheus (default false)")
+	cmd.PersistentFlags().BoolVar(&options.DisableTelemetry, "disable-telemetry", false,
+		"Disable the anonymous and aggregated Liqo telemetry collection (default false)")
 	f.AddLiqoNamespaceFlag(cmd.PersistentFlags())
 
 	base.RegisterFlags(cmd)

--- a/cmd/telemetry/doc.go
+++ b/cmd/telemetry/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2019-2022 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package main provides the main entrypoint for the Liqo Telemetry job.
+package main

--- a/cmd/telemetry/main.go
+++ b/cmd/telemetry/main.go
@@ -1,0 +1,109 @@
+// Copyright 2019-2022 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"flag"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/klog/v2"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
+	netv1alpha1 "github.com/liqotech/liqo/apis/net/v1alpha1"
+	offloadingv1alpha1 "github.com/liqotech/liqo/apis/offloading/v1alpha1"
+	sharingv1alpha1 "github.com/liqotech/liqo/apis/sharing/v1alpha1"
+	"github.com/liqotech/liqo/pkg/consts"
+	"github.com/liqotech/liqo/pkg/telemetry"
+	argsutils "github.com/liqotech/liqo/pkg/utils/args"
+	"github.com/liqotech/liqo/pkg/utils/mapper"
+	"github.com/liqotech/liqo/pkg/utils/restcfg"
+)
+
+var scheme = runtime.NewScheme()
+
+func init() {
+	_ = clientgoscheme.AddToScheme(scheme)
+	_ = discoveryv1alpha1.AddToScheme(scheme)
+	_ = offloadingv1alpha1.AddToScheme(scheme)
+	_ = sharingv1alpha1.AddToScheme(scheme)
+	_ = netv1alpha1.AddToScheme(scheme)
+}
+
+// cluster-role
+// +kubebuilder:rbac:groups=core,resources=configmaps;nodes;pods,verbs=get;list;watch
+// +kubebuilder:rbac:groups=discovery.liqo.io,resources=foreignclusters,verbs=get;list;watch
+// +kubebuilder:rbac:groups=sharing.liqo.io,resources=resourceoffers,verbs=get;list;watch
+// +kubebuilder:rbac:groups=offloading.liqo.io,resources=namespaceoffloadings,verbs=get;list;watch
+// +kubebuilder:rbac:groups=net.liqo.io,resources=tunnelendpoints,verbs=get;list;watch
+
+func main() {
+	var clusterLabels argsutils.StringMap
+
+	telemetryEndpoint := flag.String("telemetry-endpoint", "https://api.telemetry.liqo.io/v1", "telemetry endpoint")
+	timeout := flag.Duration("timeout", 10*time.Second, "timeout for requests")
+	namespace := flag.String("namespace", "liqo", "the namespace where liqo is deployed")
+	liqoVersion := flag.String("liqo-version", "", "the liqo version")
+	kubernetesVersion := flag.String("kubernetes-version", "", "the kubernetes version")
+	flag.Var(&clusterLabels, consts.ClusterLabelsParameter,
+		"The set of labels which characterizes the local cluster when exposed remotely as a virtual node")
+
+	flag.Parse()
+
+	ctx, _ := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+
+	config := restcfg.SetRateLimiter(ctrl.GetConfigOrDie())
+	restMapper, err := mapper.LiqoMapperProvider(scheme)(config)
+	if err != nil {
+		klog.Errorf("unable to create mapper: %v", err)
+		os.Exit(1)
+	}
+
+	cl, err := client.New(config, client.Options{
+		Mapper: restMapper,
+		Scheme: scheme,
+	})
+	if err != nil {
+		klog.Errorf("failed to create client: %v", err)
+		os.Exit(1)
+	}
+
+	builder := &telemetry.Builder{
+		Client:            cl,
+		Namespace:         *namespace,
+		LiqoVersion:       *liqoVersion,
+		KubernetesVersion: *kubernetesVersion,
+		ClusterLabels:     clusterLabels.StringMap,
+	}
+
+	telemetryItem, err := builder.ForgeTelemetryItem(ctx)
+	if err != nil {
+		klog.Errorf("failed to forge telemetry item: %v", err)
+		os.Exit(1)
+	}
+
+	err = telemetry.Send(ctx, *telemetryEndpoint, telemetryItem, *timeout)
+	if err != nil {
+		klog.Errorf("failed to send telemetry item: %v", err)
+		// do not exit with code != 0, we want not to fail the job on network errors
+	}
+}

--- a/deployments/liqo/README.md
+++ b/deployments/liqo/README.md
@@ -106,6 +106,13 @@
 | storage.storageNamespace | string | `"liqo-storage"` | namespace where liqo will deploy specific PVCs |
 | storage.virtualStorageClassName | string | `"liqo"` | name to assign to the liqo virtual storage class |
 | tag | string | `""` | Images' tag to select a development version of liqo instead of a release |
+| telemetry.config.schedule | string | `""` | Set the schedule of the telemetry collector CronJob |
+| telemetry.enable | bool | `true` | Enable the telemetry collector |
+| telemetry.imageName | string | `"liqo/telemetry"` | telemetry image repository |
+| telemetry.pod.annotations | object | `{}` | telemetry pod annotations |
+| telemetry.pod.extraArgs | list | `[]` | telemetry pod extra arguments |
+| telemetry.pod.labels | object | `{}` | telemetry pod labels |
+| telemetry.pod.resources | object | `{"limits":{},"requests":{}}` | telemetry pod containers' resource requests and limits (https://kubernetes.io/docs/user-guide/compute-resources/) |
 | virtualKubelet.extra.annotations | object | `{}` | virtual kubelet pod extra annotations |
 | virtualKubelet.extra.args | list | `[]` | virtual kubelet pod extra arguments |
 | virtualKubelet.extra.labels | object | `{}` | virtual kubelet pod extra labels |

--- a/deployments/liqo/files/liqo-telemetry-ClusterRole.yaml
+++ b/deployments/liqo/files/liqo-telemetry-ClusterRole.yaml
@@ -1,0 +1,43 @@
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - nodes
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - discovery.liqo.io
+  resources:
+  - foreignclusters
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - net.liqo.io
+  resources:
+  - tunnelendpoints
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - offloading.liqo.io
+  resources:
+  - namespaceoffloadings
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - sharing.liqo.io
+  resources:
+  - resourceoffers
+  verbs:
+  - get
+  - list
+  - watch

--- a/deployments/liqo/templates/liqo-telemetry-cronjob.yaml
+++ b/deployments/liqo/templates/liqo-telemetry-cronjob.yaml
@@ -1,0 +1,54 @@
+{{- $telemetryCronConfig := (merge (dict "name" "telemetry" "module" "telemetry") .) -}}
+
+{{- if .Values.telemetry.enable }}
+
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  labels:
+    {{- include "liqo.labels" $telemetryCronConfig | nindent 4 }}
+  name: {{ include "liqo.prefixedName" $telemetryCronConfig }}
+spec:
+  {{- if .Values.telemetry.config.schedule }}
+  schedule: {{ .Values.telemetry.config.schedule | quote }}
+  {{- else }}
+  schedule: "{{ dateInZone "04 15 * * *" (now | mustDateModify "+10m") "UTC"}}"
+  {{- end }}
+  concurrencyPolicy: Replace
+  successfulJobsHistoryLimit: 0
+  jobTemplate:
+    spec:
+      backoffLimit: 3
+      template:
+        metadata:
+      {{- if .Values.telemetry.pod.annotations }}
+          annotations:
+          {{- toYaml .Values.telemetry.pod.annotations | nindent 12 }}
+      {{- end }}
+          labels:
+          {{- include "liqo.labels" $telemetryCronConfig | nindent 12 }}
+          {{- if .Values.telemetry.pod.labels }}
+              {{- toYaml .Values.telemetry.pod.labels | nindent 12 }}
+          {{- end }}
+        spec:
+          securityContext:
+          {{- include "liqo.podSecurityContext" . | nindent 12 }}
+          serviceAccountName: {{ include "liqo.prefixedName" $telemetryCronConfig }}
+          restartPolicy: Never
+          containers:
+          - image: {{ .Values.telemetry.imageName }}{{ include "liqo.suffix" . }}:{{ include "liqo.version" . }}
+            imagePullPolicy: {{ .Values.pullPolicy }}
+            securityContext:
+            {{- include "liqo.containerSecurityContext" . | nindent 14 }}
+            name: {{ $telemetryCronConfig.name }}
+            args:
+              - --liqo-version={{ include "liqo.version" . }}
+              - --kubernetes-version={{ .Capabilities.KubeVersion.GitVersion }}
+              - --namespace={{ .Release.Namespace }}
+              {{- if .Values.discovery.config.clusterLabels }}
+              {{- $d := dict "commandName" "--cluster-labels" "dictionary" .Values.discovery.config.clusterLabels }}
+              {{- include "liqo.concatenateMap" $d | nindent 14 }}
+              {{- end }}
+            resources: {{- toYaml .Values.telemetry.pod.resources | nindent 14 }}
+
+{{- end }}

--- a/deployments/liqo/templates/liqo-telemetry-rbac.yaml
+++ b/deployments/liqo/templates/liqo-telemetry-rbac.yaml
@@ -1,0 +1,37 @@
+{{- $telemetryConfig := (merge (dict "name" "telemetry" "module" "telemetry") .) -}}
+
+{{- if .Values.telemetry.enable }}
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "liqo.prefixedName" $telemetryConfig }}
+  labels:
+    {{- include "liqo.labels" $telemetryConfig | nindent 4 }}
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "liqo.prefixedName" $telemetryConfig }}
+  labels:
+    {{- include "liqo.labels" $telemetryConfig | nindent 4 }}
+{{ .Files.Get (include "liqo.cluster-role-filename" (dict "prefix" ( include "liqo.prefixedName" $telemetryConfig))) }}
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "liqo.prefixedName" $telemetryConfig }}
+  labels:
+    {{- include "liqo.labels" $telemetryConfig | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "liqo.prefixedName" $telemetryConfig }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "liqo.prefixedName" $telemetryConfig }}
+
+{{- end }}

--- a/deployments/liqo/values.yaml
+++ b/deployments/liqo/values.yaml
@@ -243,6 +243,27 @@ metricAgent:
     # -- auth init container image repository
     imageName: "liqo/cert-creator"
 
+telemetry:
+  # -- Enable the telemetry collector
+  enable: true
+  pod:
+    # -- telemetry pod annotations
+    annotations: {}
+    # -- telemetry pod labels
+    labels: {}
+    # -- telemetry pod extra arguments
+    extraArgs: []
+    # -- telemetry pod containers' resource requests and limits (https://kubernetes.io/docs/user-guide/compute-resources/)
+    resources:
+      limits: {}
+      requests: {}
+  # -- telemetry image repository
+  imageName: "liqo/telemetry"
+  config:
+    # -- Set the schedule of the telemetry collector CronJob
+    schedule: ""
+    # schedule: "0 */12 * * *"
+
 webhook:
   # -- the port the webhook server binds to
   port: 9443

--- a/pkg/liqoctl/install/handler.go
+++ b/pkg/liqoctl/install/handler.go
@@ -81,6 +81,7 @@ type Options struct {
 	SharingPercentage uint64
 	EnableHA          bool
 	EnableMetrics     bool
+	DisableTelemetry  bool
 
 	PodCIDR         string
 	ServiceCIDR     string
@@ -196,7 +197,8 @@ func (o *Options) initialize(ctx context.Context, provider Provider) error {
 	switch {
 	// In case a local chart path is specified, use that.
 	case o.ChartPath != "":
-		break
+		// disable telemetry for local charts (development)
+		o.DisableTelemetry = true
 
 	// In case the specified version is valid, add the chart through the client.
 	case o.isRelease():
@@ -216,6 +218,9 @@ func (o *Options) initialize(ctx context.Context, provider Provider) error {
 
 			return err
 		}
+
+		// disable telemetry if the version is not a release
+		o.DisableTelemetry = true
 	}
 
 	// Retrieve the default chart values.
@@ -327,6 +332,10 @@ func (o *Options) values() map[string]interface{} {
 					"enabled": o.EnableMetrics,
 				},
 			},
+		},
+
+		"telemetry": map[string]interface{}{
+			"enable": !o.DisableTelemetry,
 		},
 	}
 }

--- a/pkg/telemetry/builder.go
+++ b/pkg/telemetry/builder.go
@@ -1,0 +1,191 @@
+// Copyright 2019-2022 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package telemetry
+
+import (
+	"context"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/klog/v2"
+
+	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
+	offloadingv1alpha1 "github.com/liqotech/liqo/apis/offloading/v1alpha1"
+	"github.com/liqotech/liqo/pkg/consts"
+	"github.com/liqotech/liqo/pkg/discovery"
+	"github.com/liqotech/liqo/pkg/utils"
+	liqogetters "github.com/liqotech/liqo/pkg/utils/getters"
+	labelsutils "github.com/liqotech/liqo/pkg/utils/labels"
+	peeringconditionsutils "github.com/liqotech/liqo/pkg/utils/peeringConditions"
+)
+
+// ForgeTelemetryItem returns a Telemetry item with the current status of the cluster.
+func (c *Builder) ForgeTelemetryItem(ctx context.Context) (*Telemetry, error) {
+	clusterIdentity, err := utils.GetClusterIdentityWithControllerClient(ctx, c.Client, c.Namespace)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Telemetry{
+		ClusterID:         clusterIdentity.ClusterID,
+		LiqoVersion:       c.LiqoVersion,
+		KubernetesVersion: c.KubernetesVersion,
+		Provider:          c.getProvider(),
+		PeeringInfo:       c.getPeeringInfoSlice(ctx),
+		NamespacesInfo:    c.getNamespacesInfo(ctx),
+	}, nil
+}
+
+func (c *Builder) getProvider() string {
+	return c.ClusterLabels[consts.ProviderClusterLabel]
+}
+
+func (c *Builder) getNamespacesInfo(ctx context.Context) []NamespaceInfo {
+	var namespaceOffloadings offloadingv1alpha1.NamespaceOffloadingList
+	err := c.Client.List(ctx, &namespaceOffloadings)
+	runtime.Must(err)
+
+	virtualNodes, err := liqogetters.ListVirtualNodes(ctx, c.Client)
+	runtime.Must(err)
+
+	nodeNameClusterIDMap := map[string]string{}
+	for i := range virtualNodes.Items {
+		node := &virtualNodes.Items[i]
+		clusterID, err := liqogetters.RetrieveClusterIDFromVirtualNode(node)
+		if err != nil {
+			klog.Errorf("unable to get cluster id from node %s: %v", node.Name, err)
+			continue
+		}
+		nodeNameClusterIDMap[node.Name] = clusterID
+	}
+
+	namespaceInfoSlice := make([]NamespaceInfo, len(namespaceOffloadings.Items))
+	for i := range namespaceOffloadings.Items {
+		namespaceOffloading := &namespaceOffloadings.Items[i]
+		namespaceInfoSlice[i] = c.getNamespaceInfo(ctx, namespaceOffloading, nodeNameClusterIDMap)
+	}
+	return namespaceInfoSlice
+}
+
+func (c *Builder) getNamespaceInfo(ctx context.Context,
+	namespaceOffloading *offloadingv1alpha1.NamespaceOffloading, nodeNameClusterIDMap map[string]string) NamespaceInfo {
+	namespaceInfo := NamespaceInfo{
+		UID:                string(namespaceOffloading.GetUID()),
+		MappingStrategy:    namespaceOffloading.Spec.NamespaceMappingStrategy,
+		OffloadingStrategy: namespaceOffloading.Spec.PodOffloadingStrategy,
+		HasClusterSelector: len(namespaceOffloading.Spec.ClusterSelector.NodeSelectorTerms) > 0,
+		NumOffloadedPods:   map[string]int64{},
+	}
+
+	offloadedPods, err := liqogetters.ListOffloadedPods(ctx, c.Client, namespaceOffloading.Namespace)
+	runtime.Must(err)
+
+	var nodePodBucket = make(map[string]int64)
+	for i := range offloadedPods.Items {
+		pod := &offloadedPods.Items[i]
+		if pod.Spec.NodeName == "" {
+			klog.Warningf("Pod %s has no node assigned", klog.KObj(pod))
+			continue
+		}
+
+		nodePodBucket[pod.Spec.NodeName]++
+	}
+
+	for nodeName, clusterID := range nodeNameClusterIDMap {
+		namespaceInfo.NumOffloadedPods[clusterID] = nodePodBucket[nodeName]
+	}
+	return namespaceInfo
+}
+
+func (c *Builder) getPeeringInfoSlice(ctx context.Context) []PeeringInfo {
+	var foreignClusterList discoveryv1alpha1.ForeignClusterList
+	err := c.Client.List(ctx, &foreignClusterList)
+	runtime.Must(err)
+
+	peeringInfoSlice := make([]PeeringInfo, len(foreignClusterList.Items))
+	for i := range foreignClusterList.Items {
+		foreignCluster := &foreignClusterList.Items[i]
+		peeringInfoSlice[i] = c.getPeeringInfo(ctx, foreignCluster)
+	}
+	return peeringInfoSlice
+}
+
+func (c *Builder) getPeeringInfo(ctx context.Context,
+	foreignCluster *discoveryv1alpha1.ForeignCluster) PeeringInfo {
+	discoveryType := discovery.ManualDiscovery
+	if v, ok := foreignCluster.Labels[discovery.DiscoveryTypeLabel]; ok {
+		discoveryType = discovery.Type(v)
+	}
+
+	var latency time.Duration
+	tunnel, err := liqogetters.GetTunnelEndpoint(ctx, c.Client,
+		&foreignCluster.Spec.ClusterIdentity, foreignCluster.Status.TenantNamespace.Local)
+	switch {
+	case apierrors.IsNotFound(err):
+		// do nothing
+	case err != nil:
+		klog.Errorf("unable to get tunnel endpoint for cluster %q: %v", foreignCluster.Spec.ClusterIdentity.ClusterName, err)
+	default:
+		latency, err = time.ParseDuration(tunnel.Status.Connection.Latency.Value)
+		if err != nil {
+			klog.Errorf("unable to parse latency for cluster %q: %v", foreignCluster.Spec.ClusterIdentity.ClusterName, err)
+		}
+	}
+
+	peeringInfo := PeeringInfo{
+		RemoteClusterID: foreignCluster.Spec.ClusterIdentity.ClusterID,
+		Method:          foreignCluster.Spec.PeeringType,
+		DiscoveryType:   discoveryType,
+		Latency:         latency,
+		Incoming: c.getPeeringDetails(ctx, foreignCluster,
+			discoveryv1alpha1.IncomingPeeringCondition,
+			labelsutils.LocalLabelSelectorForCluster(foreignCluster.Spec.ClusterIdentity.ClusterID)),
+		Outgoing: c.getPeeringDetails(ctx, foreignCluster,
+			discoveryv1alpha1.OutgoingPeeringCondition,
+			labelsutils.RemoteLabelSelectorForCluster(foreignCluster.Spec.ClusterIdentity.ClusterID)),
+	}
+	return peeringInfo
+}
+
+func (c *Builder) getPeeringDetails(ctx context.Context,
+	foreignCluster *discoveryv1alpha1.ForeignCluster,
+	condition discoveryv1alpha1.PeeringConditionType, selector labels.Selector) PeeringDetails {
+	enabled := peeringconditionsutils.GetStatus(foreignCluster,
+		condition) == discoveryv1alpha1.PeeringConditionStatusEstablished
+
+	var resources corev1.ResourceList
+	if enabled && foreignCluster.Status.TenantNamespace.Local != "" {
+		offer, err := liqogetters.GetResourceOfferByLabel(ctx, c.Client,
+			foreignCluster.Status.TenantNamespace.Local,
+			selector)
+		if err != nil {
+			klog.Errorf("unable to get resource offer for cluster %s: %v",
+				foreignCluster.Spec.ClusterIdentity.ClusterID, err)
+			return PeeringDetails{
+				Enabled:   enabled,
+				Resources: corev1.ResourceList{},
+			}
+		}
+		resources = offer.Spec.ResourceQuota.Hard
+	}
+
+	return PeeringDetails{
+		Enabled:   enabled,
+		Resources: resources,
+	}
+}

--- a/pkg/telemetry/doc.go
+++ b/pkg/telemetry/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2019-2022 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package telemetry builds and sends telemetry data to the Liqo telemetry server.
+package telemetry

--- a/pkg/telemetry/send.go
+++ b/pkg/telemetry/send.go
@@ -1,0 +1,70 @@
+// Copyright 2019-2022 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package telemetry
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"k8s.io/klog/v2"
+)
+
+// Send sends the telemetry item to the Liqo telemetry server.
+func Send(ctx context.Context, endpoint string, item *Telemetry, timeout time.Duration) error {
+	body, err := json.Marshal(item)
+	if err != nil {
+		return fmt.Errorf("failed to marshal telemetry item: %w", err)
+	}
+
+	buff := bytes.NewBuffer(body)
+	httpClient := http.Client{
+		Timeout: timeout,
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, buff)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to send telemetry item: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		message, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return fmt.Errorf("failed to send telemetry item: %w", err)
+		}
+		return fmt.Errorf("unexpected status code: %d: %s", resp.StatusCode, message)
+	}
+	if err = resp.Body.Close(); err != nil {
+		return fmt.Errorf("failed to close response body: %w", err)
+	}
+
+	prettyMarshal, err := json.MarshalIndent(item, "", "  ")
+	if err != nil {
+		klog.Errorf("failed to marshal telemetry item: %s", err)
+		return nil
+	}
+
+	klog.Infof("successfully sent telemetry item %s to %s", string(prettyMarshal), endpoint)
+	return nil
+}

--- a/pkg/telemetry/types.go
+++ b/pkg/telemetry/types.go
@@ -1,0 +1,70 @@
+// Copyright 2019-2022 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package telemetry
+
+import (
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
+	offloadingv1alpha1 "github.com/liqotech/liqo/apis/offloading/v1alpha1"
+	"github.com/liqotech/liqo/pkg/discovery"
+)
+
+// NamespaceInfo contains information about an offloaded namespace.
+type NamespaceInfo struct {
+	UID                string                                          `json:"uid,omitempty"`
+	MappingStrategy    offloadingv1alpha1.NamespaceMappingStrategyType `json:"mappingStrategy,omitempty"`
+	OffloadingStrategy offloadingv1alpha1.PodOffloadingStrategyType    `json:"offloadingStrategy,omitempty"`
+	HasClusterSelector bool                                            `json:"hasClusterSelector,omitempty"`
+	NumOffloadedPods   map[string]int64                                `json:"numOffloadedPods,omitempty"`
+}
+
+// PeeringDetails contains information about a peering direction.
+type PeeringDetails struct {
+	Enabled   bool                `json:"enabled"`
+	Resources corev1.ResourceList `json:"resources,omitempty"`
+}
+
+// PeeringInfo contains information about a peering.
+type PeeringInfo struct {
+	RemoteClusterID string                        `json:"remoteClusterID"`
+	Method          discoveryv1alpha1.PeeringType `json:"method,omitempty"`
+	DiscoveryType   discovery.Type                `json:"discoveryType,omitempty"`
+	Latency         time.Duration                 `json:"latency,omitempty"`
+	Incoming        PeeringDetails                `json:"incoming"`
+	Outgoing        PeeringDetails                `json:"outgoing"`
+}
+
+// Telemetry contains information about the cluster.
+type Telemetry struct {
+	ClusterID         string          `json:"clusterID"`
+	LiqoVersion       string          `json:"liqoVersion,omitempty"`
+	KubernetesVersion string          `json:"kubernetesVersion,omitempty"`
+	Provider          string          `json:"provider,omitempty"`
+	PeeringInfo       []PeeringInfo   `json:"peeringInfo,omitempty"`
+	NamespacesInfo    []NamespaceInfo `json:"namespacesInfo,omitempty"`
+}
+
+// Builder is the constructor for the Telemetry struct.
+type Builder struct {
+	Client            client.Client
+	Namespace         string
+	LiqoVersion       string
+	KubernetesVersion string
+	ClusterLabels     map[string]string
+}

--- a/pkg/utils/getters/dataGetters.go
+++ b/pkg/utils/getters/dataGetters.go
@@ -56,6 +56,14 @@ func RetrieveClusterIDFromConfigMap(cm *corev1.ConfigMap) (*discoveryv1alpha1.Cl
 	}, nil
 }
 
+// RetrieveClusterIDFromVirtualNode retrieves the cluster id from the given node labels.
+func RetrieveClusterIDFromVirtualNode(node *corev1.Node) (string, error) {
+	if v, ok := node.Labels[liqoconsts.RemoteClusterID]; ok {
+		return v, nil
+	}
+	return "", fmt.Errorf("no %s label found in node %q", liqoconsts.RemoteClusterID, node.Name)
+}
+
 // RetrieveEndpointFromService retrieves an ip address and port from a given service object
 // based on the service and port name.
 func RetrieveEndpointFromService(svc *corev1.Service, svcType corev1.ServiceType, portName string) (endpointIP, endpointPort string, err error) {


### PR DESCRIPTION
# Description

This pr adds a client to collect anonymous and aggregated Liqo installation telemetries.

The collection is enabled by default, but it can be disabled by adding the `--set telemetry.enable=false` flag during installations and/or updates.
