### PR TITLE
Reflection: document the possibility of disabling certain resource types

### DIFF
--- a/cmd/liqoctl/cmd/install.go
+++ b/cmd/liqoctl/cmd/install.go
@@ -155,7 +155,9 @@ func newInstallCommand(ctx context.Context, f *factory.Factory) *cobra.Command {
 	cmd.PersistentFlags().Var(&reservedSubnets, "reserved-subnets",
 		"The private CIDRs to be excluded, as already in use (e.g., the subnet of the cluster nodes); PodCIDR and ServiceCIDR shall not be included.")
 
-	cmd.PersistentFlags().StringSliceVar(&options.OverrideValues, "set", []string{}, "Set additional values on the command line (key1=val1,key2=val2)")
+	// Using StringArray rather than StringSlice: splitting is left to the Helm library, which takes care of special cases (e.g., lists).
+	cmd.PersistentFlags().StringArrayVar(&options.OverrideValues, "set", []string{},
+		"Set additional values on the command line (can specify multiple times or separate values with commas: key1=val1,key2=val2)")
 	cmd.PersistentFlags().BoolVar(&options.DisableAPIServerSanityChecks, "disable-api-server-sanity-check", false,
 		"Disable the sanity checks concerning the retrieved Kubernetes API server URL (default false)")
 	cmd.PersistentFlags().BoolVar(&options.SkipValidation, "skip-validation", false, "Skip the validation of the arguments "+

--- a/docs/usage/reflection.md
+++ b/docs/usage/reflection.md
@@ -9,9 +9,15 @@ Briefly, the set of supported resources includes (by category):
 * [**Storage**](UsageReflectionStorage): *PersistentVolumeClaims*, *PresistentVolumes*
 * [**Configuration**](UsageReflectionConfiguration): *ConfigMaps*, *Secrets*
 
-```{admonition} Note
+````{admonition} Note
 The reflection of a given object belonging to the *Exposition* or *Configuration* categories, and living in a namespace enabled for offloading, can be manually disabled adding the `liqo.io/skip-reflection` annotation to the object itself.
+
+Additionally, the reflection of a given type of resources (e.g., *Secrets*) towards remote clusters can be completely disabled setting the corresponding `--<resource>-reflection-workers=0` virtual kubelet flag at install time:
+
+```bash
+liqoctl install ... --set "virtualKubelet.extra.args={--secret-reflection-workers=0}"
 ```
+````
 
 (UsageReflectionPods)=
 


### PR DESCRIPTION
# Description

This PR documents the possibility of disabling the reflection of certain resource types (e.g., Secrets), by setting the number of workers to 0. Additionally, it fixes an issue with the `liqoctl install ... --set` flag, in case of list arguments.

Ref #1459

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Manually
