### PR TITLE
Helm chart: fix semverCompare issue with certain version formats

### DIFF
--- a/deployments/liqo/templates/liqo-controller-manager-deployment.yaml
+++ b/deployments/liqo/templates/liqo-controller-manager-deployment.yaml
@@ -4,7 +4,7 @@
 
 {{- $vkargs := .Values.virtualKubelet.extra.args }}
 {{- /* Enable the API support only in for Kubernetes versions < 1.24 (due to lack of support for third party tokens), if not overridden by the user */ -}}
-{{- if semverCompare "< 1.24.0" .Capabilities.KubeVersion.Version }}
+{{- if semverCompare "< 1.24.0-0" .Capabilities.KubeVersion.Version }}
 {{- if not (or (has "--enable-apiserver-support" $vkargs ) (has "--enable-apiserver-support=true" $vkargs ) (has "--enable-apiserver-support=false" $vkargs )) }}
 {{- $vkargs = append $vkargs "--enable-apiserver-support=true" }}
 {{- end }}


### PR DESCRIPTION
# Description

This PR slightly updates the `semverCompare` check in the helm chart, to fix an issue caused by versions including an hyphen (e.g.,  v1.19.2-1049+f173eb4a83e557-dirty), always returning false.

Fixes #(issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Manually
