### PR TITLE
LiqoNet: gateway service monitor fix

### DIFF
--- a/deployments/liqo/templates/liqo-gateway-servicemonitor.yaml
+++ b/deployments/liqo/templates/liqo-gateway-servicemonitor.yaml
@@ -11,7 +11,6 @@ spec:
   selector:
     matchLabels:
       {{- include "liqo.labels" $gatewayMetricsConfig | nindent 6 }}
-      {{- include "liqo.gatewayServiceLabels" $gatewayMetricsConfig | nindent 6 }}
   endpoints:
   - port: metrics
     interval: {{ .Values.gateway.metrics.serviceMonitor.interval }}


### PR DESCRIPTION
This PR fixes **liqo-gateway** service monitor **match labels**.