### PR TITLE
LiqoNet: externalCIDR forward fix + iptables comments and cleanup

### DIFF
--- a/internal/liqonet/tunnel-operator/tunnel-operator.go
+++ b/internal/liqonet/tunnel-operator/tunnel-operator.go
@@ -332,6 +332,11 @@ func (tc *TunnelController) EnsureIPTablesRulesPerCluster(tep *netv1alpha1.Tunne
 		tc.Eventf(tep, "Warning", "Processing", "unable to insert iptables rules: %v", err)
 		return err
 	}
+	if err := tc.EnsureForwardExtRules(tep); err != nil {
+		klog.Errorf("%s -> an error occurred while inserting iptables forwarding rules for the remote peer: %s", tep.Spec.ClusterIdentity, err.Error())
+		tc.Eventf(tep, "Warning", "Processing", "unable to insert iptables rules: %v", err)
+		return err
+	}
 	if err := tc.EnsurePostroutingRules(tep); err != nil {
 		klog.Errorf("%s -> an error occurred while inserting iptables postrouting rules for the remote peer: %s", tep.Spec.ClusterIdentity, err.Error())
 		tc.Eventf(tep, "Warning", "Processing", "unable to insert iptables rules: %v", err)


### PR DESCRIPTION
This PR avoid packets **forwarding** from **liqo.tunnel** to **liqo.gateway** interface in **liqo-netns** namespace. It helps to prevent the establishment of wrong **conntracks** when externalCIDR NAT rules are not still applied.

It also adds some comments to the **iptables rules** and removes some unused  **chains**.

![image](https://user-images.githubusercontent.com/33266330/194878429-489e7e10-662d-47bb-877e-db1587fe3c65.png)
![image](https://user-images.githubusercontent.com/33266330/194878714-8b992f7e-d1e9-4966-9c19-79641a54c0ac.png)


