### PR TITLE
Virtual kubelet pod forging: anti-affinity presets

### DIFF
--- a/docs/usage/reflection.md
+++ b/docs/usage/reflection.md
@@ -31,6 +31,27 @@ Liqo leverages a custom resource, named *ShadowPod*, combined with an appropriat
 * Mutation of **service account** related information, to allow offloaded pods to transparently interact with the local (i.e., origin) API server, instead of the remote one.
 * Enforcement of the properties concerning the usage of **host namespaces** (e.g., network, IPC, PID) to *false* (i.e., disabled), as potentially invasive and troublesome.
 
+````{admonition} Note
+*Anti-affinity presets* can be leveraged to specify predefined scheduling constraints for offloaded pods, spreading them across different nodes in the remote cluster.
+This feature is enabled through the `liqo.io/anti-affinity-preset` pod annotation, which can take three values:
+
+* `propagate`: the anti-affinity constraints of the pod are propagated *verbatim* when offloaded to the remote cluster.
+  Make sure that they match both the virtual node in the local cluster and at least one physical node in the remote cluster, otherwise the pod will fail to be scheduled (i.e., remain in pending status).
+* `soft`: the pods sharing the same labels are *preferred* to be scheduled on different nodes (i.e., it is translated into a *preferredDuringSchedulingIgnoredDuringExecution* anti-affinity constraint).
+* `hard`: the pods sharing the same labels are *required* to be scheduled on different nodes (i.e., it is translated into a *requiredDuringSchedulingIgnoredDuringExecution* anti-affinity constraint).
+
+When set to *soft* or *hard*, the `liqo.io/anti-affinity-labels` annotation allows to select a subset of the pod label keys to build the anti-affinity constraints:
+
+```yaml
+annotations:
+  liqo.io/anti-affinity-preset: soft
+  liqo.io/anti-affinity-labels: app.kubernetes.io/name,app.kubernetes.io/instance
+```
+
+Given that affinity constraints are *immutable*, the addition/removal of the annotations to/from an already existing pod *does not have any effect*.
+Make sure that the annotations are configured appropriately in the template of the managing object (e.g., *Deployment*, or *StatefulSet*).
+````
+
 Differently, **pod status** is propagated from the remote cluster to the local one, performing the following modifications:
 
 * The *PodIP* is **remapped** according to the network fabric configuration, such as to be reachable from the other pods running in the same cluster.

--- a/pkg/consts/replication.go
+++ b/pkg/consts/replication.go
@@ -56,4 +56,19 @@ const (
 
 	// SkipReflectionAnnotationKey is the annotation key used to indicate that a given object should not be reflected into a remote cluster.
 	SkipReflectionAnnotationKey = "liqo.io/skip-reflection"
+
+	// PodAntiAffinityPresetKey is the annotation key used to express an anti-affinity preset to apply to offloaded pods.
+	PodAntiAffinityPresetKey = "liqo.io/anti-affinity-preset"
+
+	// PodAntiAffinityPresetValueSoft is the annotation value corresponding to the "soft" anti-affinity preset (i.e., preferred).
+	PodAntiAffinityPresetValueSoft = "soft"
+
+	// PodAntiAffinityPresetValueHard is the annotation value corresponding to the "hard" anti-affinity preset (i.e., required).
+	PodAntiAffinityPresetValueHard = "hard"
+
+	// PodAntiAffinityPresetValuePropagate is the annotation value corresponding to the propagation of the original pod anti-affinity constrains.
+	PodAntiAffinityPresetValuePropagate = "propagate"
+
+	// PodAntiAffinityLabelsKey is the annotation key used to specify a subset of the pod label keys for the anti-affinity constraints.
+	PodAntiAffinityLabelsKey = "liqo.io/anti-affinity-labels"
 )

--- a/pkg/liqo-controller-manager/storageprovisioner/remoteprovisioner.go
+++ b/pkg/liqo-controller-manager/storageprovisioner/remoteprovisioner.go
@@ -25,6 +25,7 @@ import (
 	corev1listers "k8s.io/client-go/listers/core/v1"
 	"sigs.k8s.io/sig-storage-lib-external-provisioner/v7/controller"
 
+	"github.com/liqotech/liqo/pkg/utils/maps"
 	"github.com/liqotech/liqo/pkg/virtualKubelet/forge"
 )
 
@@ -141,20 +142,5 @@ var controllerAnnotations = []string{
 }
 
 func filterAnnotations(annotations map[string]string) map[string]string {
-	filtered := make(map[string]string)
-	for k, v := range annotations {
-		if !isBacklisted(k) {
-			filtered[k] = v
-		}
-	}
-	return filtered
-}
-
-func isBacklisted(key string) bool {
-	for _, k := range controllerAnnotations {
-		if k == key {
-			return true
-		}
-	}
-	return false
+	return maps.Filter(annotations, maps.FilterBlacklist(controllerAnnotations...))
 }

--- a/pkg/utils/maps/doc.go
+++ b/pkg/utils/maps/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2019-2022 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package maps contains utility functions to manage maps.
+package maps

--- a/pkg/utils/maps/maps.go
+++ b/pkg/utils/maps/maps.go
@@ -1,0 +1,69 @@
+// Copyright 2019-2022 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package maps
+
+// Merge merges two maps.
+func Merge[K comparable, V any](m1, m2 map[K]V) map[K]V {
+	if m1 == nil {
+		return m2
+	}
+	for k, v := range m2 {
+		m1[k] = v
+	}
+	return m1
+}
+
+// Sub removes elements of m2 from m1.
+func Sub[K comparable, V any](m1, m2 map[K]V) map[K]V {
+	for k := range m2 {
+		delete(m1, k)
+	}
+	return m1
+}
+
+// FilterType is a function type used to filter a map.
+type FilterType[K comparable] func(key K) bool
+
+// Filter filters a map, returning a duplicate which contains only the elements matching the filter function.
+func Filter[K comparable, V any](m map[K]V, filter FilterType[K]) map[K]V {
+	filtered := make(map[K]V)
+
+	for k, v := range m {
+		if filter(k) {
+			filtered[k] = v
+		}
+	}
+
+	return filtered
+}
+
+// FilterWhitelist returns a filter function returning true if the key is in the whitelist.
+func FilterWhitelist[K comparable](whitelist ...K) FilterType[K] {
+	return func(check K) bool {
+		for _, el := range whitelist {
+			if el == check {
+				return true
+			}
+		}
+		return false
+	}
+}
+
+// FilterBlacklist returns a filter function returning true if the key is not the blacklist.
+func FilterBlacklist[K comparable](blacklist ...K) FilterType[K] {
+	return func(check K) bool {
+		return !FilterWhitelist(blacklist...)(check)
+	}
+}

--- a/pkg/utils/maps/maps_suite_test.go
+++ b/pkg/utils/maps/maps_suite_test.go
@@ -12,23 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package utils
+package maps_test
 
-// MergeMaps merges two maps.
-func MergeMaps(m1, m2 map[string]string) map[string]string {
-	if m1 == nil {
-		return m2
-	}
-	for k, v := range m2 {
-		m1[k] = v
-	}
-	return m1
-}
+import (
+	"testing"
 
-// SubMaps removes elements of m2 from m1.
-func SubMaps(m1, m2 map[string]string) map[string]string {
-	for k := range m2 {
-		delete(m1, k)
-	}
-	return m1
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestMaps(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Maps Suite")
 }

--- a/pkg/utils/maps/maps_test.go
+++ b/pkg/utils/maps/maps_test.go
@@ -1,0 +1,65 @@
+// Copyright 2019-2022 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package maps_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/liqotech/liqo/pkg/utils/maps"
+)
+
+var _ = Describe("Maps", func() {
+	Describe("The FilterMap function", func() {
+		var (
+			input, output map[string]string
+			filter        maps.FilterType[string]
+		)
+
+		BeforeEach(func() {
+			input = map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+				"key3": "value3",
+				"key4": "value4",
+			}
+		})
+
+		JustBeforeEach(func() { output = maps.Filter(input, filter) })
+
+		Context("whitelist filtering", func() {
+			BeforeEach(func() { filter = maps.FilterWhitelist("key1", "key3") })
+
+			It("should not mutate the original map", func() { Expect(input).To(HaveLen(4)) })
+			It("should correctly preserve only the whitelisted elements", func() {
+				Expect(output).To(HaveLen(2))
+				Expect(output).To(HaveKeyWithValue("key1", "value1"))
+				Expect(output).To(HaveKeyWithValue("key3", "value3"))
+			})
+		})
+
+		Context("blacklist filtering", func() {
+			BeforeEach(func() { filter = maps.FilterBlacklist("key2", "key4") })
+
+			It("should not mutate the original map", func() { Expect(input).To(HaveLen(4)) })
+			It("should correctly remove only the blacklisted elements", func() {
+				GinkgoWriter.Println(output)
+				Expect(output).To(HaveLen(2))
+				Expect(output).To(HaveKeyWithValue("key1", "value1"))
+				Expect(output).To(HaveKeyWithValue("key3", "value3"))
+			})
+		})
+	})
+})

--- a/pkg/utils/pod/pod.go
+++ b/pkg/utils/pod/pod.go
@@ -113,3 +113,13 @@ func ForgeContainerResources(cpuRequests, cpuLimits, ramRequests, ramLimits reso
 
 	return requirements
 }
+
+// ServiceAccountName returns the name of the service account, or default if not set.
+// Indeed, the ServiceAccountName field in the pod specifications is optional, and empty means default.
+func ServiceAccountName(pod *corev1.Pod) string {
+	if pod.Spec.ServiceAccountName != "" {
+		return pod.Spec.ServiceAccountName
+	}
+
+	return "default"
+}

--- a/pkg/virtualKubelet/forge/ingresses.go
+++ b/pkg/virtualKubelet/forge/ingresses.go
@@ -17,6 +17,8 @@ package forge
 import (
 	netv1 "k8s.io/api/networking/v1"
 	netv1apply "k8s.io/client-go/applyconfigurations/networking/v1"
+
+	"github.com/liqotech/liqo/pkg/utils/maps"
 )
 
 // RemoteIngress forges the apply patch for the reflected ingress, given the local one.
@@ -29,13 +31,7 @@ func RemoteIngress(local *netv1.Ingress, targetNamespace string) *netv1apply.Ing
 
 // FilterIngressAnnotations filters the ingress annotations to be reflected, removing the ingress class annotation.
 func FilterIngressAnnotations(local map[string]string) map[string]string {
-	res := make(map[string]string)
-	for k, v := range local {
-		if k != "kubernetes.io/ingress.class" {
-			res[k] = v
-		}
-	}
-	return res
+	return maps.Filter(local, maps.FilterBlacklist("kubernetes.io/ingress.class"))
 }
 
 // RemoteIngressSpec forges the apply patch for the specs of the reflected ingress, given the local one.

--- a/pkg/virtualKubelet/liqoNodeProvider/reconciler.go
+++ b/pkg/virtualKubelet/liqoNodeProvider/reconciler.go
@@ -34,7 +34,7 @@ import (
 	netv1alpha1 "github.com/liqotech/liqo/apis/net/v1alpha1"
 	sharingv1alpha1 "github.com/liqotech/liqo/apis/sharing/v1alpha1"
 	"github.com/liqotech/liqo/pkg/consts"
-	"github.com/liqotech/liqo/pkg/utils"
+	"github.com/liqotech/liqo/pkg/utils/maps"
 )
 
 func isResourceOfferTerminating(resourceOffer *sharingv1alpha1.ResourceOffer) bool {
@@ -271,8 +271,8 @@ func (p *LiqoNodeProvider) patchLabels(labels map[string]string) error {
 
 	if err := p.patchNode(func(node *v1.Node) error {
 		nodeLabels := node.GetLabels()
-		nodeLabels = utils.SubMaps(nodeLabels, p.lastAppliedLabels)
-		nodeLabels = utils.MergeMaps(nodeLabels, labels)
+		nodeLabels = maps.Sub(nodeLabels, p.lastAppliedLabels)
+		nodeLabels = maps.Merge(nodeLabels, labels)
 		node.Labels = nodeLabels
 		return nil
 	}); err != nil {

--- a/pkg/virtualKubelet/reflection/workload/podns.go
+++ b/pkg/virtualKubelet/reflection/workload/podns.go
@@ -297,7 +297,8 @@ func (npr *NamespacedPodReflector) ForgeShadowPod(ctx context.Context, local *co
 	}
 
 	// Forge the target shadowpod object.
-	target := forge.RemoteShadowPod(local, shadow, npr.RemoteNamespace(), npr.enableAPIServerSupport, saSecretRetriever, ipGetter)
+	target := forge.RemoteShadowPod(local, shadow, npr.RemoteNamespace(),
+		forge.APIServerSupportMutator(npr.enableAPIServerSupport, pod.ServiceAccountName(local), saSecretRetriever, ipGetter))
 
 	// Check whether an error occurred during secret name retrieval.
 	if saerr != nil {

--- a/pkg/virtualKubelet/reflection/workload/podns_test.go
+++ b/pkg/virtualKubelet/reflection/workload/podns_test.go
@@ -193,12 +193,10 @@ var _ = Describe("Namespaced Pod Reflection Tests", func() {
 						Expect(shadowAfter.Annotations).To(HaveKeyWithValue("bar", "baz"))
 						Expect(shadowAfter.Annotations).To(HaveKeyWithValue("existing", "existing"))
 					})
-					It("the spec should have been correctly replicated to the remote object", func() {
+					It("the spec should not have replicated to the remote object, to prevent possible issues", func() {
 						shadowAfter := GetShadowPod(liqoClient, RemoteNamespace, PodName)
 						// Here, we assert only a few fields, as already tested in the forge package.
-						Expect(shadowAfter.Spec.Pod.Containers).To(HaveLen(1))
-						Expect(shadowAfter.Spec.Pod.Containers[0].Name).To(BeIdenticalTo("bar"))
-						Expect(shadowAfter.Spec.Pod.Containers[0].Image).To(BeIdenticalTo("foo"))
+						Expect(shadowAfter.Spec.Pod).To(Equal(shadow.Spec.Pod))
 					})
 				})
 

--- a/pkg/virtualKubelet/reflection/workload/podns_test.go
+++ b/pkg/virtualKubelet/reflection/workload/podns_test.go
@@ -193,7 +193,7 @@ var _ = Describe("Namespaced Pod Reflection Tests", func() {
 						Expect(shadowAfter.Annotations).To(HaveKeyWithValue("bar", "baz"))
 						Expect(shadowAfter.Annotations).To(HaveKeyWithValue("existing", "existing"))
 					})
-					It("the spec should not have replicated to the remote object, to prevent possible issues", func() {
+					It("the spec should not have been replicated to the remote object, to prevent possible issues", func() {
 						shadowAfter := GetShadowPod(liqoClient, RemoteNamespace, PodName)
 						// Here, we assert only a few fields, as already tested in the forge package.
 						Expect(shadowAfter.Spec.Pod).To(Equal(shadow.Spec.Pod))


### PR DESCRIPTION
# Description

This PR introduces  the possibility to add appropriate pod annotations to specify anti-affinity presets. Hence, constraining the scheduling of the pods in the remote cluster through automatically generated affinity specifications for the shadow pod.

In particular, it supports the propagation of the original pod anti-affinity constraints, as well as the generation of soft (i.e., preferred) and hard (i.e., required) anti-affinity constraints, based on the pod labels. In addition, the pod labels used to generate the affinity constraint can be customized through a dedicated annotation.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Existing tests
- [x] Additional tests
- [x] Manual tests
