### PR TITLE
Documentation: add note about liqoctl remote cluster flags

### DIFF
--- a/docs/installation/install.md
+++ b/docs/installation/install.md
@@ -15,7 +15,7 @@ By default, *liqoctl install* installs the latest stable version of Liqo, althou
 The reminder of this page, then, presents **additional customization options** which apply to all setups, as well as advanced options.
 
 ```{admonition} Note
-*liqoctl* displays a *kubectl* compatible behavior concerning Kubernetes API access, hence supporting the `KUBECONFIG` environment variable, as well as the standard flags, including `--kubeconfig` and `--context`.
+*liqoctl* displays a *kubectl* compatible behavior concerning Kubernetes API access, hence supporting the `KUBECONFIG` environment variable, as well as all the standard flags, including `--kubeconfig` and `--context`.
 Ensure you selected the correct target cluster before issuing *liqoctl* commands (as you would do with *kubectl*).
 ```
 

--- a/docs/installation/liqoctl.md
+++ b/docs/installation/liqoctl.md
@@ -11,7 +11,8 @@ Specifically, it abstracts the creation and modification of Liqo defined custom 
 * Retrieve the **status** of Liqo, as well as of given peering relationships and offloading setups.
 
 ```{admonition} Note
-*liqoctl* displays a *kubectl* compatible behavior concerning Kubernetes API access, hence supporting the `KUBECONFIG` environment variable, as well as the standard flags, including `--kubeconfig` and `--context`.
+*liqoctl* displays a *kubectl* compatible behavior concerning Kubernetes API access, hence supporting the `KUBECONFIG` environment variable, as well as all the standard flags, including `--kubeconfig` and `--context`.
+Moreover, subcommands interacting with two clusters (e.g., *liqoctl peer in-band*) feature a parallel set of flags concerning Kubernetes API access to the remote cluster, in the form `--remote-<flag>` (e.g., `--remote-kubeconfig`, `--remote-context`).
 ```
 
 {{ env.config.html_context.generate_liqoctl_version_warning() }}

--- a/docs/usage/peer.md
+++ b/docs/usage/peer.md
@@ -16,7 +16,7 @@ Additional details are also provided to enable the reverse peering direction, he
 All examples leverage two different *contexts* to refer to *consumer* and *provider* clusters, respectively named `consumer` and `provider`.
 
 ```{admonition} Note
-*liqoctl* displays a *kubectl* compatible behavior concerning Kubernetes API access, hence supporting the `KUBECONFIG` environment variable, as well as the standard flags, including `--kubeconfig` and `--context`.
+*liqoctl* displays a *kubectl* compatible behavior concerning Kubernetes API access, hence supporting the `KUBECONFIG` environment variable, as well as all the standard flags, including `--kubeconfig` and `--context`.
 Ensure you selected the correct target cluster before issuing *liqoctl* commands (as you would do with *kubectl*).
 ```
 
@@ -127,6 +127,7 @@ The remainder of the process, including identity retrieval and resource negotiat
 
 ```{admonition} Note
 The host used to issue the *liqoctl peer in-band* command must have **concurrent access to both clusters** (i.e., *consumer* and *provider*) while carrying out the in-band control plane peering process.
+To this end, these subcommands feature a parallel set of flags concerning Kubernetes API access to the remote cluster, in the form `--remote-<flag>` (e.g., `--remote-kubeconfig`, `--remote-context`).
 ```
 
 <!-- markdownlint-disable-next-line no-duplicate-heading -->


### PR DESCRIPTION
# Description

This PR extends the documentation with information about the format of the liqoctl flags concerning the interaction with the remote cluster (e.g., for the *liqoctl peer/unpeer in-band*) subcommands.
