### PR TITLE
Override Services Address/Port

### DIFF
--- a/cmd/liqo-controller-manager/main.go
+++ b/cmd/liqo-controller-manager/main.go
@@ -117,10 +117,6 @@ func main() {
 	shadowPodWorkers := flag.Int("shadow-pod-ctrl-workers", 10, "The number of workers used to reconcile ShadowPod resources.")
 
 	// Discovery parameters
-	authServiceAddressOverride := flag.String(consts.AuthServiceAddressOverrideParameter, "",
-		"The address the authentication service is reachable from foreign clusters (automatically retrieved if not set")
-	authServicePortOverride := flag.String(consts.AuthServicePortOverrideParameter, "",
-		"The port the authentication service is reachable from foreign clusters (automatically retrieved if not set")
 	autoJoin := flag.Bool("auto-join-discovered-clusters", true, "Whether to automatically peer with discovered clusters")
 
 	// Resource sharing parameters
@@ -237,11 +233,9 @@ func main() {
 		Scheme:        mgr.GetScheme(),
 		LiqoNamespace: *liqoNamespace,
 
-		ResyncPeriod:               *resyncPeriod,
-		HomeCluster:                clusterIdentity,
-		AuthServiceAddressOverride: *authServiceAddressOverride,
-		AuthServicePortOverride:    *authServicePortOverride,
-		AutoJoin:                   *autoJoin,
+		ResyncPeriod: *resyncPeriod,
+		HomeCluster:  clusterIdentity,
+		AutoJoin:     *autoJoin,
 
 		NamespaceManager:  namespaceManager,
 		IdentityManager:   idManager,

--- a/deployments/liqo/README.md
+++ b/deployments/liqo/README.md
@@ -4,7 +4,9 @@
 |-----|------|---------|-------------|
 | apiServer.address | string | `""` | The address that must be used to contact your API server, it needs to be reachable from the clusters that you will peer with (defaults to your master IP) |
 | apiServer.trustedCA | bool | `false` | Indicates that the API Server is exposing a certificate issued by a trusted Certification Authority |
+| auth.config.addressOverride | string | `""` | Override the default address where your service is available, you should configure it if behind a reverse proxy or NAT. |
 | auth.config.enableAuthentication | bool | `true` | Set to false to disable the authentication of discovered clusters. NB: use it only for testing installations |
+| auth.config.portOverride | string | `""` | Overrides the port where your service is available, you should configure it if behind a reverse proxy or NAT or using an Ingress with a port different from 443. |
 | auth.imageName | string | `"liqo/auth-service"` | auth image repository |
 | auth.ingress.annotations | object | `{}` | Auth ingress annotations |
 | auth.ingress.class | string | `""` | Set your ingress class |
@@ -14,7 +16,6 @@
 | auth.pod.annotations | object | `{}` | auth pod annotations |
 | auth.pod.extraArgs | list | `[]` | auth pod extra arguments |
 | auth.pod.labels | object | `{}` | auth pod labels |
-| auth.portOverride | string | `""` | Overrides the port where your service is available, you should configure it if behind a NAT or using an Ingress with a port different from 443. |
 | auth.service.annotations | object | `{}` | auth service annotations |
 | auth.service.type | string | `"LoadBalancer"` | The type of service used to expose the Authentication Service. If you are exposing this service with an Ingress, you can change it to ClusterIP; if your cluster does not support LoadBalancer services, consider to switch it to NodePort. See https://doc.liqo.io/installation/ for more details. |
 | auth.tls | bool | `true` | Enable TLS for the Authentication Service Pod (using a self-signed certificate). If you are exposing this service with an Ingress consider to disable it or add the appropriate annotations to the Ingress resource. |
@@ -46,7 +47,9 @@
 | discovery.pod.extraArgs | list | `[]` | discovery pod extra arguments |
 | discovery.pod.labels | object | `{}` | discovery pod labels |
 | fullnameOverride | string | `""` | full liqo name override |
+| gateway.config.addressOverride | string | `""` | Override the default address where your service is available, you should configure it if behind a reverse proxy or NAT. |
 | gateway.config.listeningPort | int | `5871` | port used by the vpn tunnel. |
+| gateway.config.portOverride | string | `""` | Overrides the port where your service is available, you should configure it if behind a reverse proxy or NAT and is different from the listening port. |
 | gateway.imageName | string | `"liqo/liqonet"` | gateway image repository |
 | gateway.metrics.enabled | bool | `false` | expose metrics about network traffic towards cluster peers. |
 | gateway.metrics.port | int | `5872` | port used to expose metrics. |

--- a/deployments/liqo/templates/liqo-auth-service.yaml
+++ b/deployments/liqo/templates/liqo-auth-service.yaml
@@ -12,6 +12,16 @@ metadata:
     {{- if .Values.auth.service.annotations }}
     {{- toYaml .Values.auth.service.annotations | nindent 4}}
     {{- end }}
+    {{- if .Values.auth.config.addressOverride }}
+    liqo.io/override-address: {{ .Values.auth.config.addressOverride | quote }}
+    {{- else if .Values.auth.ingress.enable }}
+    liqo.io/override-address: {{ .Values.auth.ingress.host | quote }}
+    {{- end }}
+    {{- if .Values.auth.config.portOverride }}
+    liqo.io/override-port: {{ .Values.auth.config.portOverride | quote }}
+    {{- else if .Values.auth.ingress.enable }}
+    liqo.io/override-port: "443"
+    {{- end }}
 spec:
   type: {{ .Values.auth.service.type }}
   selector:

--- a/deployments/liqo/templates/liqo-controller-manager-deployment.yaml
+++ b/deployments/liqo/templates/liqo-controller-manager-deployment.yaml
@@ -78,14 +78,6 @@ spec:
           {{- if .Values.controllerManager.config.enableResourceEnforcement }}
           - --enable-resource-enforcement
           {{- end }}
-          {{- if .Values.auth.ingress.enable }}
-          - --auth-service-address-override={{ .Values.auth.ingress.host }}
-          {{- end }}
-          {{- if .Values.auth.portOverride }}
-          - --auth-service-port-override={{ .Values.auth.portOverride }}
-          {{- else if .Values.auth.ingress.enable }}
-          - --auth-service-port-override=443
-          {{- end }}
           {{- if .Values.virtualKubelet.extra.annotations }}
           {{- $d := dict "commandName" "--kubelet-extra-annotations" "dictionary" .Values.virtualKubelet.extra.annotations }}
           {{- include "liqo.concatenateMap" $d | nindent 10 }}

--- a/deployments/liqo/templates/liqo-gateway-service.yaml
+++ b/deployments/liqo/templates/liqo-gateway-service.yaml
@@ -5,10 +5,16 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "liqo.prefixedName" $gatewayConfig }}
-{{- if .Values.gateway.service.annotations }}
   annotations:
+    {{- if .Values.gateway.service.annotations }}
     {{- toYaml .Values.gateway.service.annotations | nindent 4 }}
-{{- end}}
+    {{- end}}
+    {{- if .Values.gateway.config.addressOverride }}
+    liqo.io/override-address: {{ .Values.gateway.config.addressOverride | quote }}
+    {{- end }}
+    {{- if .Values.gateway.config.portOverride }}
+    liqo.io/override-port: {{ .Values.gateway.config.portOverride | quote }}
+    {{- end }}
   labels:
     {{- include "liqo.labels" $gatewayConfig | nindent 4 }}
     {{- include "liqo.gatewayServiceLabels" $gatewayConfig | nindent 4 }}

--- a/deployments/liqo/values.yaml
+++ b/deployments/liqo/values.yaml
@@ -64,6 +64,10 @@ gateway:
     type: "LoadBalancer"
     annotations: {}
   config:
+    # -- Override the default address where your service is available, you should configure it if behind a reverse proxy or NAT.
+    addressOverride: ""
+    # -- Overrides the port where your service is available, you should configure it if behind a reverse proxy or NAT and is different from the listening port.
+    portOverride: ""
     # -- port used by the vpn tunnel.
     listeningPort: 5871
   metrics: 
@@ -172,8 +176,6 @@ auth:
   # -- Enable TLS for the Authentication Service Pod (using a self-signed certificate).
   # If you are exposing this service with an Ingress consider to disable it or add the appropriate annotations to the Ingress resource.
   tls: true
-  # -- Overrides the port where your service is available, you should configure it if behind a NAT or using an Ingress with a port different from 443.
-  portOverride: ""
   ingress:
     # -- Auth ingress annotations
     annotations: {}
@@ -186,6 +188,10 @@ auth:
   config:
     # -- Set to false to disable the authentication of discovered clusters. NB: use it only for testing installations
     enableAuthentication: true
+    # -- Override the default address where your service is available, you should configure it if behind a reverse proxy or NAT.
+    addressOverride: ""
+    # -- Overrides the port where your service is available, you should configure it if behind a reverse proxy or NAT or using an Ingress with a port different from 443.
+    portOverride: ""
 
 metricAgent:
   # -- Enable the metric agent

--- a/pkg/consts/annotations.go
+++ b/pkg/consts/annotations.go
@@ -1,0 +1,26 @@
+// Copyright 2019-2022 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package consts
+
+// These annotations are  either set during the deployment of liqo using the helm
+// chart or during their creation by liqo components.
+// Any change to those annotations on the helm chart has also to be reflected here.
+
+const (
+	// OverrideAddressAnnotation is the annotation used to override the address of a service.
+	OverrideAddressAnnotation = "liqo.io/override-address"
+	// OverridePortAnnotation is the annotation used to override the port of a service.
+	OverridePortAnnotation = "liqo.io/override-port"
+)

--- a/pkg/consts/parameters.go
+++ b/pkg/consts/parameters.go
@@ -26,13 +26,6 @@ const (
 	// GenerateNameParameter is the name of the parameter specifying whether to generate a random name for the cluster.
 	GenerateNameParameter = "generate-name"
 
-	// AuthServiceAddressOverrideParameter is the name of the parameter overriding
-	// the automatically detected authentication service address.
-	AuthServiceAddressOverrideParameter = "auth-service-address-override"
-	// AuthServicePortOverrideParameter is the name of the parameter overriding
-	// the automatically detected authentication service address.
-	AuthServicePortOverrideParameter = "auth-service-port-override"
-
 	// ExternalResourceMonitorParameter is the name of the parameter specifying the address of an ExternalResourceMonitor.
 	ExternalResourceMonitorParameter = "external-monitor"
 )

--- a/pkg/liqo-controller-manager/foreign-cluster-operator/foreign-cluster-controller.go
+++ b/pkg/liqo-controller-manager/foreign-cluster-operator/foreign-cluster-controller.go
@@ -87,11 +87,9 @@ type ForeignClusterReconciler struct {
 
 	LiqoNamespace string
 
-	ResyncPeriod               time.Duration
-	HomeCluster                discoveryv1alpha1.ClusterIdentity
-	AuthServiceAddressOverride string
-	AuthServicePortOverride    string
-	AutoJoin                   bool
+	ResyncPeriod time.Duration
+	HomeCluster  discoveryv1alpha1.ClusterIdentity
+	AutoJoin     bool
 
 	NamespaceManager tenantnamespace.Manager
 	IdentityManager  identitymanager.IdentityManager

--- a/pkg/liqo-controller-manager/foreign-cluster-operator/resourceRequest.go
+++ b/pkg/liqo-controller-manager/foreign-cluster-operator/resourceRequest.go
@@ -36,8 +36,7 @@ func (r *ForeignClusterReconciler) ensureResourceRequest(ctx context.Context,
 	remoteClusterID := foreignCluster.Spec.ClusterIdentity.ClusterID
 	localNamespace := foreignCluster.Status.TenantNamespace.Local
 
-	authURL, err := foreigncluster.GetHomeAuthURL(ctx, r.Client,
-		r.AuthServiceAddressOverride, r.AuthServicePortOverride, r.LiqoNamespace)
+	authURL, err := foreigncluster.GetHomeAuthURL(ctx, r.Client, r.LiqoNamespace)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/liqoctl/generate/handler.go
+++ b/pkg/liqoctl/generate/handler.go
@@ -20,11 +20,9 @@ import (
 	"strings"
 
 	"github.com/liqotech/liqo/pkg/auth"
-	"github.com/liqotech/liqo/pkg/consts"
 	"github.com/liqotech/liqo/pkg/liqoctl/factory"
 	"github.com/liqotech/liqo/pkg/liqoctl/output"
 	"github.com/liqotech/liqo/pkg/liqoctl/peeroob"
-	"github.com/liqotech/liqo/pkg/liqoctl/util"
 	"github.com/liqotech/liqo/pkg/utils"
 	foreigncluster "github.com/liqotech/liqo/pkg/utils/foreignCluster"
 )
@@ -74,17 +72,7 @@ func (o *Options) generate(ctx context.Context) (string, error) {
 		return "", err
 	}
 
-	// Retrieve the liqo controller manager deployment args
-	args, err := util.RetrieveLiqoControllerManagerDeploymentArgs(ctx, o.CRClient, o.LiqoNamespace)
-	if err != nil {
-		return "", err
-	}
-
-	// The error is discarded, since an empty string is returned in case the key is not found, which is fine.
-	authServiceAddressOverride, _ := util.ExtractValueFromArgumentList(fmt.Sprintf("--%v", consts.AuthServiceAddressOverrideParameter), args)
-	authServicePortOverride, _ := util.ExtractValueFromArgumentList(fmt.Sprintf("--%v", consts.AuthServicePortOverrideParameter), args)
-
-	authEP, err := foreigncluster.GetHomeAuthURL(ctx, o.CRClient, authServiceAddressOverride, authServicePortOverride, o.LiqoNamespace)
+	authEP, err := foreigncluster.GetHomeAuthURL(ctx, o.CRClient, o.LiqoNamespace)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/utils/foreignCluster/getauthendpoint_test.go
+++ b/pkg/utils/foreignCluster/getauthendpoint_test.go
@@ -57,7 +57,7 @@ var _ = Describe("Test fetching Liqo Auth service name", func() {
 	DescribeTable("Ensure correct resources are created or an exception is raised",
 		func(svc *corev1.Service, expectedResult string) {
 			client := fake.NewClientBuilder().WithRuntimeObjects(svc, node).Build()
-			endpoint, err := GetHomeAuthURL(ctx, client, "", "", liqoNamespace)
+			endpoint, err := GetHomeAuthURL(ctx, client, liqoNamespace)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(endpoint).To(BeEquivalentTo(expectedResult))
 		},


### PR DESCRIPTION
# Description

This pr adds the possibility to override the address and the port for Liqo external services. It can be helpful when using reverse proxies or NATs.
