### PR TITLE
Gitignore: test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,5 +34,8 @@ token
 # to ease the local development of liqoctl
 /liqoctl
 
+# test generated files
+coverage.txt
+
 hack/code-generator
 docs/_build


### PR DESCRIPTION
This PR excludes the **coverage.txt** file, generated by unit tests.