### PR TITLE
liqoctl move pvc: bump restic and make container resources configurable

### DIFF
--- a/pkg/liqoctl/move/consts.go
+++ b/pkg/liqoctl/move/consts.go
@@ -17,7 +17,7 @@ package move
 const (
 	liqoStorageNamespace = "liqo-storage"
 	resticRegistry       = "restic-registry"
-	resticServerImage    = "restic/rest-server:0.10.0"
-	resticImage          = "restic/restic:0.12.1"
+	resticServerImage    = "restic/rest-server:0.11.0"
+	resticImage          = "restic/restic:0.14.0"
 	resticPort           = 8000
 )

--- a/pkg/liqoctl/move/restic.go
+++ b/pkg/liqoctl/move/restic.go
@@ -29,14 +29,14 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
-func ensureResticRepository(ctx context.Context, cl client.Client, targetPvc *corev1.PersistentVolumeClaim) error {
+func (o *Options) ensureResticRepository(ctx context.Context, targetPvc *corev1.PersistentVolumeClaim) error {
 	svc := corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      resticRegistry,
 			Namespace: liqoStorageNamespace,
 		},
 	}
-	_, err := controllerutil.CreateOrUpdate(ctx, cl, &svc, func() error {
+	_, err := controllerutil.CreateOrUpdate(ctx, o.CRClient, &svc, func() error {
 		svc.Spec = corev1.ServiceSpec{
 			Selector: map[string]string{
 				"app": resticRegistry,
@@ -61,7 +61,7 @@ func ensureResticRepository(ctx context.Context, cl client.Client, targetPvc *co
 			Namespace: liqoStorageNamespace,
 		},
 	}
-	_, err = controllerutil.CreateOrUpdate(ctx, cl, &statefulSet, func() error {
+	_, err = controllerutil.CreateOrUpdate(ctx, o.CRClient, &statefulSet, func() error {
 		statefulSet.Spec = appsv1.StatefulSetSpec{
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
@@ -96,6 +96,7 @@ func ensureResticRepository(ctx context.Context, cl client.Client, targetPvc *co
 									ContainerPort: resticPort,
 								},
 							},
+							Resources: o.forgeContainerResources(),
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      "restic-registry-data",


### PR DESCRIPTION
# Description

This PR extends the `liqoctl move pvc` command, to allow for the configuration of the resources of the different containers created. This is especially required when used in conjunction with resource quotas, or #1224. Additionally, it bumps Restic to the latest version. 

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Automatic tests (new + existing)
- [x] Manually
