### PR TITLE
Adapt E2E tests for #1224, and fix issue

### DIFF
--- a/test/e2e/cruise/basic_test.go
+++ b/test/e2e/cruise/basic_test.go
@@ -341,7 +341,8 @@ var _ = Describe("Liqo E2E", func() {
 
 				By("Moving the statefulset to the virtual node")
 				Expect(util.ExecLiqoctl(testContext.Clusters[0].KubeconfigPath,
-					[]string{"move", "volume", originPvc.Name, "-n", namespace, "--target-node", virtualNodesList.Items[0].Name}, GinkgoWriter)).To(Succeed())
+					[]string{"move", "volume", originPvc.Name, "-n", namespace, "--target-node", virtualNodesList.Items[0].Name,
+						"--containers-cpu-limits", "500m", "--containers-ram-limits", "500Mi"}, GinkgoWriter)).To(Succeed())
 
 				By("Scaling the statefulset to one replica")
 				Expect(storage.ScaleStatefulSet(ctx, GinkgoT(), options, testContext.Clusters[0].NativeClient, namespace, 1)).To(Succeed())

--- a/test/e2e/cruise/conflict_remote_namespace_e2e/conflict_creation_test.go
+++ b/test/e2e/cruise/conflict_remote_namespace_e2e/conflict_creation_test.go
@@ -85,8 +85,10 @@ var _ = Describe("Liqo E2E", func() {
 					return err
 				}
 
-				return util.OffloadNamespace(testContext.Clusters[localIndex].KubeconfigPath, testNamespaceName,
-					"--namespace-mapping-strategy", "EnforceSameName")
+				// Do not use liqoctl to create the resource, since it will fail waiting for offloading to complete.
+				return util.CreateNamespaceOffloading(ctx, testContext.Clusters[localIndex].ControllerClient, testNamespaceName,
+					offloadingv1alpha1.EnforceSameNameMappingStrategyType, offloadingv1alpha1.LocalAndRemotePodOffloadingStrategyType)
+
 			}, timeout, interval).Should(BeNil())
 
 			By(" 3 - Getting the NamespaceOffloading resource")

--- a/test/e2e/pipeline/installer/liqoctl/setup.sh
+++ b/test/e2e/pipeline/installer/liqoctl/setup.sh
@@ -56,7 +56,8 @@ for i in $(seq 1 "${CLUSTER_NUMBER}");
 do
   export KUBECONFIG="${TMPDIR}/kubeconfigs/liqo_kubeconf_${i}"
   CLUSTER_LABELS="$(get_cluster_labels "${i}")"
-  COMMON_ARGS=(--cluster-name "liqo-${i}" --local-chart-path ./deployments/liqo --version "${LIQO_VERSION}")
+  COMMON_ARGS=(--cluster-name "liqo-${i}" --local-chart-path ./deployments/liqo
+    --version "${LIQO_VERSION}" --set controllerManager.config.enableResourceEnforcement=true)
   if [[ "${CLUSTER_LABELS}" != "" ]]; then
     COMMON_ARGS=("${COMMON_ARGS[@]}" --cluster-labels "${CLUSTER_LABELS}")
   fi

--- a/test/e2e/testutils/apiserver/create.go
+++ b/test/e2e/testutils/apiserver/create.go
@@ -26,6 +26,8 @@ import (
 	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/liqotech/liqo/test/e2e/testutils/util"
 )
 
 const (
@@ -46,9 +48,10 @@ func CreateKubectlJob(ctx context.Context, cl client.Client, namespace string, v
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{{
-						Name:  containerName,
-						Image: fmt.Sprintf("%s:%s.%s", image, v.Major, v.Minor),
-						Args:  []string{"get", "pods", "-n", namespace, "--no-headers", "-o", "custom-columns=:.metadata.name"},
+						Name:      containerName,
+						Image:     fmt.Sprintf("%s:%s.%s", image, v.Major, v.Minor),
+						Args:      []string{"get", "pods", "-n", namespace, "--no-headers", "-o", "custom-columns=:.metadata.name"},
+						Resources: util.ResourceRequirements(),
 					}},
 					ServiceAccountName: serviceAccountName,
 					RestartPolicy:      corev1.RestartPolicyNever,

--- a/test/e2e/testutils/net/pod.go
+++ b/test/e2e/testutils/net/pod.go
@@ -125,7 +125,7 @@ func forgeTesterPod(image, namespace string, opts *TesterOpts) *v1.Pod {
 				{
 					Name:            "tester",
 					Image:           image,
-					Resources:       v1.ResourceRequirements{},
+					Resources:       util.ResourceRequirements(),
 					ImagePullPolicy: "IfNotPresent",
 					Ports: []v1.ContainerPort{{
 						ContainerPort: 80,
@@ -145,7 +145,6 @@ func forgeTesterPod(image, namespace string, opts *TesterOpts) *v1.Pod {
 				},
 			},
 		},
-		Status: v1.PodStatus{},
 	}
 	return &pod1
 }

--- a/test/e2e/testutils/storage/storage.go
+++ b/test/e2e/testutils/storage/storage.go
@@ -77,8 +77,9 @@ func DeployApp(ctx context.Context, cluster *tester.ClusterContext, namespace st
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
 						{
-							Name:  "tester",
-							Image: "nginx",
+							Name:      "tester",
+							Image:     "nginx",
+							Resources: testutils.ResourceRequirements(),
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      "liqo-storage-claim",

--- a/test/e2e/testutils/util/namespace.go
+++ b/test/e2e/testutils/util/namespace.go
@@ -25,8 +25,11 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
+	offloadingv1alpha1 "github.com/liqotech/liqo/apis/offloading/v1alpha1"
+	"github.com/liqotech/liqo/pkg/consts"
 	"github.com/liqotech/liqo/test/e2e/testconsts"
 )
 
@@ -68,6 +71,19 @@ func EnsureNamespaceDeletion(ctx context.Context, cl kubernetes.Interface, label
 		_ = cl.CoreV1().Namespaces().Delete(ctx, namespaceList.Items[i].Name, metav1.DeleteOptions{})
 	}
 	return fmt.Errorf("still deleting namespaces")
+}
+
+// CreateNamespaceOffloading creates a new NamespaceOffloading resource, with the given parameters.
+func CreateNamespaceOffloading(ctx context.Context, cl client.Client, namespace string,
+	nms offloadingv1alpha1.NamespaceMappingStrategyType, pof offloadingv1alpha1.PodOffloadingStrategyType) error {
+	nsoff := &offloadingv1alpha1.NamespaceOffloading{
+		ObjectMeta: metav1.ObjectMeta{Name: consts.DefaultNamespaceOffloadingName, Namespace: namespace},
+		Spec: offloadingv1alpha1.NamespaceOffloadingSpec{
+			NamespaceMappingStrategy: nms, PodOffloadingStrategy: pof,
+			ClusterSelector: corev1.NodeSelector{NodeSelectorTerms: []corev1.NodeSelectorTerm{}}},
+	}
+
+	return cl.Create(ctx, nsoff)
 }
 
 // OffloadNamespace offloads a namespace using liqoctl.

--- a/test/e2e/testutils/util/pod.go
+++ b/test/e2e/testutils/util/pod.go
@@ -17,6 +17,8 @@ package util
 import (
 	"context"
 
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
@@ -68,4 +70,12 @@ func ArePodsUp(ctx context.Context, clientset kubernetes.Interface, namespace st
 		ready = append(ready, pods.Items[index].Name)
 	}
 	return ready, notReady, nil
+}
+
+// ResourceRequirements returns the default resource requirements for a pod during tests.
+func ResourceRequirements() corev1.ResourceRequirements {
+	return corev1.ResourceRequirements{Limits: corev1.ResourceList{
+		corev1.ResourceCPU:    *resource.NewScaledQuantity(250, resource.Milli),
+		corev1.ResourceMemory: *resource.NewScaledQuantity(100, resource.Mega),
+	}}
 }


### PR DESCRIPTION
# Description

This PR adds the configuration of the resource limits to E2E pods, to ensure correct functioning when the enforcement feature introduced in #1224 is enabled. Additionally, it fixes an issue concerning the conflict creation test, which did not work with newer versions of liqoctl.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Automated tests
