### PR TITLE
Helm chart: make container resources configurable

### DIFF
--- a/cmd/liqo-controller-manager/main.go
+++ b/cmd/liqo-controller-manager/main.go
@@ -92,8 +92,8 @@ func main() {
 	var kubeletExtraAnnotations, kubeletExtraLabels argsutils.StringMap
 	var kubeletExtraArgs argsutils.StringList
 	var nodeExtraAnnotations, nodeExtraLabels argsutils.StringMap
-	var kubeletCPURequests, kubeletCPULimits = argsutils.NewQuantity("250m"), argsutils.NewQuantity("1000m")
-	var kubeletRAMRequests, kubeletRAMLimits = argsutils.NewQuantity("100M"), argsutils.NewQuantity("250M")
+	var kubeletCPURequests, kubeletCPULimits argsutils.Quantity
+	var kubeletRAMRequests, kubeletRAMLimits argsutils.Quantity
 
 	webhookPort := flag.Uint("webhook-port", 9443, "The port the webhook server binds to")
 	metricsAddr := flag.String("metrics-address", ":8080", "The address the metric endpoint binds to")

--- a/deployments/liqo/README.md
+++ b/deployments/liqo/README.md
@@ -16,6 +16,7 @@
 | auth.pod.annotations | object | `{}` | auth pod annotations |
 | auth.pod.extraArgs | list | `[]` | auth pod extra arguments |
 | auth.pod.labels | object | `{}` | auth pod labels |
+| auth.pod.resources | object | `{"limits":{},"requests":{}}` | auth pod containers' resource requests and limits (https://kubernetes.io/docs/user-guide/compute-resources/) |
 | auth.service.annotations | object | `{}` | auth service annotations |
 | auth.service.type | string | `"LoadBalancer"` | The type of service used to expose the Authentication Service. If you are exposing this service with an Ingress, you can change it to ClusterIP; if your cluster does not support LoadBalancer services, consider to switch it to NodePort. See https://doc.liqo.io/installation/ for more details. |
 | auth.tls | bool | `true` | Enable TLS for the Authentication Service Pod (using a self-signed certificate). If you are exposing this service with an Ingress consider to disable it or add the appropriate annotations to the Ingress resource. |
@@ -29,11 +30,13 @@
 | controllerManager.pod.annotations | object | `{}` | controller-manager pod annotations |
 | controllerManager.pod.extraArgs | list | `[]` | controller-manager pod extra arguments |
 | controllerManager.pod.labels | object | `{}` | controller-manager pod labels |
+| controllerManager.pod.resources | object | `{"limits":{},"requests":{}}` | controller-manager pod containers' resource requests and limits (https://kubernetes.io/docs/user-guide/compute-resources/) |
 | controllerManager.replicas | int | `1` | The number of controller-manager instances to run, which can be increased for active/passive high availability. |
 | crdReplicator.imageName | string | `"liqo/crd-replicator"` | crdReplicator image repository |
 | crdReplicator.pod.annotations | object | `{}` | crdReplicator pod annotations |
 | crdReplicator.pod.extraArgs | list | `[]` | crdReplicator pod extra arguments |
 | crdReplicator.pod.labels | object | `{}` | crdReplicator pod labels |
+| crdReplicator.pod.resources | object | `{"limits":{},"requests":{}}` | crdReplicator pod containers' resource requests and limits (https://kubernetes.io/docs/user-guide/compute-resources/) |
 | discovery.config.autojoin | bool | `true` | Automatically join discovered clusters |
 | discovery.config.clusterIDOverride | string | `""` | Specify an unique ID (must be a valid uuidv4) for your cluster, instead of letting helm generate it automatically at install time. You can generate it using the command: `uuidgen` Setting this field is necessary when using tools such as ArgoCD, since the helm lookup function is not supported and a new value would be generated at each deployment. |
 | discovery.config.clusterLabels | object | `{}` | A set of labels which characterizes the local cluster when exposed remotely as a virtual node. It is suggested to specify the distinguishing characteristics that may be used to decide whether to offload pods on this cluster. |
@@ -46,6 +49,7 @@
 | discovery.pod.annotations | object | `{}` | discovery pod annotations |
 | discovery.pod.extraArgs | list | `[]` | discovery pod extra arguments |
 | discovery.pod.labels | object | `{}` | discovery pod labels |
+| discovery.pod.resources | object | `{"limits":{},"requests":{}}` | discovery pod containers' resource requests and limits (https://kubernetes.io/docs/user-guide/compute-resources/) |
 | fullnameOverride | string | `""` | full liqo name override |
 | gateway.config.addressOverride | string | `""` | Override the default address where your service is available, you should configure it if behind a reverse proxy or NAT. |
 | gateway.config.listeningPort | int | `5871` | port used by the vpn tunnel. |
@@ -59,6 +63,7 @@
 | gateway.pod.annotations | object | `{}` | gateway pod annotations |
 | gateway.pod.extraArgs | list | `[]` | gateway pod extra arguments |
 | gateway.pod.labels | object | `{}` | gateway pod labels |
+| gateway.pod.resources | object | `{"limits":{},"requests":{}}` | gateway pod containers' resource requests and limits (https://kubernetes.io/docs/user-guide/compute-resources/) |
 | gateway.replicas | int | `1` | The number of gateway instances to run. The gateway component supports active/passive high availability. Make sure that there are enough nodes to accommodate the replicas, because being the instances in host network no more than one replica can be scheduled on a given node. |
 | gateway.service.annotations | object | `{}` |  |
 | gateway.service.type | string | `"LoadBalancer"` | If you plan to use liqo over the Internet, consider to change this field to "LoadBalancer". Instead, if your nodes are directly reachable from the cluster you are peering to, you may change it to "NodePort". |
@@ -68,6 +73,7 @@
 | metricAgent.pod.annotations | object | `{}` | metricAgent pod annotations |
 | metricAgent.pod.extraArgs | list | `[]` | metricAgent pod extra arguments |
 | metricAgent.pod.labels | object | `{}` | metricAgent pod labels |
+| metricAgent.pod.resources | object | `{"limits":{},"requests":{}}` | metricAgent pod containers' resource requests and limits (https://kubernetes.io/docs/user-guide/compute-resources/) |
 | nameOverride | string | `""` | liqo name override |
 | networkConfig.mtu | int | `1340` | set the mtu for the interfaces managed by liqo: vxlan, tunnel and veth interfaces The value is used by the gateway and route operators. The default value is configured to ensure correct functioning regardless of the combination of the underlying environments (e.g., cloud providers). This guarantees improved compatibility at the cost of possible limited performance drops. |
 | networkManager.config.additionalPools | list | `[]` | Set of additional network pools. Network pools are used to map a cluster network into another one in order to prevent conflicts. Default set of network pools is: [10.0.0.0/8, 192.168.0.0/16, 172.16.0.0/12] |
@@ -78,6 +84,7 @@
 | networkManager.pod.annotations | object | `{}` | networkManager pod annotations |
 | networkManager.pod.extraArgs | list | `[]` | networkManager pod extra arguments |
 | networkManager.pod.labels | object | `{}` | networkManager pod labels |
+| networkManager.pod.resources | object | `{"limits":{},"requests":{}}` | networkManager pod containers' resource requests and limits (https://kubernetes.io/docs/user-guide/compute-resources/) |
 | openshiftConfig.enable | bool | `false` | enable the OpenShift support |
 | openshiftConfig.virtualKubeletSCCs | list | `["anyuid"]` | the security context configurations granted to the virtual kubelet in the local cluster. The configuration of one or more SCCs for the virtual kubelet is not strictly required, and privileges can be reduced in production environments. Still, the default configuration (i.e., anyuid) is suggested to prevent problems (i.e., the virtual kubelet fails to add the appropriate labels) when attempting to offload pods not managed by higher-level abstractions (e.g., Deployments), and not associated with a properly privileged service account. Indeed, "anyuid" is the SCC automatically associated with pods created by cluster administrators. Any pod granted a more privileged SCC and not linked to an adequately privileged service account will fail to be offloaded. |
 | proxy.config.listeningPort | int | `8118` | port used by envoy proxy |
@@ -85,6 +92,7 @@
 | proxy.pod.annotations | object | `{}` | proxy pod annotations |
 | proxy.pod.extraArgs | list | `[]` | proxy pod extra arguments |
 | proxy.pod.labels | object | `{}` | proxy pod labels |
+| proxy.pod.resources | object | `{"limits":{},"requests":{}}` | proxy pod containers' resource requests and limits (https://kubernetes.io/docs/user-guide/compute-resources/) |
 | proxy.service.annotations | object | `{}` |  |
 | proxy.service.type | string | `"ClusterIP"` |  |
 | pullPolicy | string | `"IfNotPresent"` | The pullPolicy for liqo pods |
@@ -92,6 +100,7 @@
 | route.pod.annotations | object | `{}` | route pod annotations |
 | route.pod.extraArgs | list | `[]` | route pod extra arguments |
 | route.pod.labels | object | `{}` | route pod labels |
+| route.pod.resources | object | `{"limits":{},"requests":{}}` | route pod containers' resource requests and limits (https://kubernetes.io/docs/user-guide/compute-resources/) |
 | storage.enable | bool | `true` | enable the liqo virtual storage class on the local cluster. You will be able to offload your persistent volumes and other clusters will be able to schedule their persistent workloads on the current cluster. |
 | storage.realStorageClassName | string | `""` | name of the real storage class to use in the local cluster |
 | storage.storageNamespace | string | `"liqo-storage"` | namespace where liqo will deploy specific PVCs |
@@ -100,6 +109,7 @@
 | virtualKubelet.extra.annotations | object | `{}` | virtual kubelet pod extra annotations |
 | virtualKubelet.extra.args | list | `[]` | virtual kubelet pod extra arguments |
 | virtualKubelet.extra.labels | object | `{}` | virtual kubelet pod extra labels |
+| virtualKubelet.extra.resources | object | `{"limits":{},"requests":{}}` | virtual kubelet pod containers' resource requests and limits (https://kubernetes.io/docs/user-guide/compute-resources/) |
 | virtualKubelet.imageName | string | `"liqo/virtual-kubelet"` | virtual kubelet image repository |
 | virtualKubelet.virtualNode.extra.annotations | object | `{}` | virtual node extra annotations |
 | virtualKubelet.virtualNode.extra.labels | object | `{}` | virtual node extra labels |

--- a/deployments/liqo/templates/liqo-auth-deployment.yaml
+++ b/deployments/liqo/templates/liqo-auth-deployment.yaml
@@ -54,10 +54,7 @@ spec:
             - /certs/key.pem
             - -out
             - /certs/cert.pem
-          resources:
-            requests:
-              cpu: "200m"
-              memory: "100M"
+          resources: {{- toYaml .Values.auth.pod.resources | nindent 12 }}
       {{- end }}
       containers:
         - image: {{ .Values.auth.imageName }}{{ include "liqo.suffix" $authConfig }}:{{ include "liqo.version" $authConfig }}
@@ -122,10 +119,7 @@ spec:
                   name: {{ include "liqo.prefixedName" $awsConfig }}
                   key: SECRET_ACCESS_KEY
             {{- end }}
-          resources:
-            requests:
-              cpu: 100m
-              memory: 50M
+          resources: {{- toYaml .Values.auth.pod.resources | nindent 12 }}
           volumeMounts:
             - mountPath: '/certs'
               name: certs

--- a/deployments/liqo/templates/liqo-controller-manager-deployment.yaml
+++ b/deployments/liqo/templates/liqo-controller-manager-deployment.yaml
@@ -107,7 +107,27 @@ spec:
           {{- end }}
           {{- if gt .Values.controllerManager.replicas 1.0 }}
           - --enable-leader-election=true
-          {{- end}}
+          {{- end }}
+          {{- /* virtual kubelet pod containers' requests */ -}}
+          {{- range $resource, $value := .Values.virtualKubelet.extra.resources.requests }}
+          {{- if eq $resource "cpu" }}
+          - --kubelet-cpu-requests={{ $value }}
+          {{- else if eq $resource "memory" }}
+          - --kubelet-ram-requests={{ $value }}
+          {{- else }}
+          {{ fail (printf "Unsupported resource type \"%s\" for virtual kubelet containers' requests" $resource) }}
+          {{- end }}
+          {{- end }}
+          {{- /* virtual kubelet pod containers' limits */ -}}
+          {{- range $resource, $value := .Values.virtualKubelet.extra.resources.limits }}
+          {{- if eq $resource "cpu" }}
+          - --kubelet-cpu-limits={{ $value }}
+          {{- else if eq $resource "memory" }}
+          - --kubelet-ram-limits={{ $value }}
+          {{- else }}
+          {{ fail (printf "Unsupported resource type \"%s\" for virtual kubelet containers' limits" $resource) }}
+          {{- end }}
+          {{- end }}
         env:
           - name: CLUSTER_ID
             valueFrom:
@@ -118,10 +138,7 @@ spec:
             valueFrom:
              fieldRef:
                fieldPath: metadata.namespace
-        resources:
-          requests:
-            cpu: 100m
-            memory: 150M
+        resources: {{- toYaml .Values.controllerManager.pod.resources | nindent 10 }}
         volumeMounts:
           - name: webhook-certs
             mountPath: /tmp/k8s-webhook-server/serving-certs/

--- a/deployments/liqo/templates/liqo-crd-replicator-deployment.yaml
+++ b/deployments/liqo/templates/liqo-crd-replicator-deployment.yaml
@@ -51,8 +51,5 @@ spec:
                 configMapKeyRef:
                   name: {{ include "liqo.clusterIdConfig" . }}
                   key: CLUSTER_NAME
-          resources:
-            requests:
-              cpu: 30m
-              memory: 50M
+          resources: {{- toYaml .Values.crdReplicator.pod.resources | nindent 12 }}
 ---

--- a/deployments/liqo/templates/liqo-discovery-deployment.yaml
+++ b/deployments/liqo/templates/liqo-discovery-deployment.yaml
@@ -58,10 +58,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-          resources:
-            requests:
-              cpu: 50m
-              memory: 50M
+          resources: {{- toYaml .Values.discovery.pod.resources | nindent 12 }}
       hostNetwork: true
 
 {{- end }}

--- a/deployments/liqo/templates/liqo-gateway-deployment.yaml
+++ b/deployments/liqo/templates/liqo-gateway-deployment.yaml
@@ -52,10 +52,7 @@ spec:
           {{- if .Values.gateway.pod.extraArgs }}
           {{- toYaml .Values.gateway.pod.extraArgs | nindent 10 }}
           {{- end }}
-          resources:
-            requests:
-              cpu: 250m
-              memory: 100M
+          resources: {{- toYaml .Values.gateway.pod.resources | nindent 12 }}
           securityContext:
             privileged: true
           env:

--- a/deployments/liqo/templates/liqo-metric-agent-deployment.yaml
+++ b/deployments/liqo/templates/liqo-metric-agent-deployment.yaml
@@ -54,10 +54,7 @@ spec:
             - /certs/key.pem
             - -out
             - /certs/cert.pem
-          resources:
-            requests:
-              cpu: "200m"
-              memory: "100M"
+          resources: {{- toYaml .Values.metricAgent.pod.resources | nindent 12 }}
       containers:
         - image: {{ .Values.metricAgent.imageName }}{{ include "liqo.suffix" $metricConfig }}:{{ include "liqo.version" $metricConfig }}
           securityContext:
@@ -68,10 +65,7 @@ spec:
           args:
           - --key-path=/certs/key.pem
           - --cert-path=/certs/cert.pem
-          resources:
-            requests:
-              cpu: 100m
-              memory: 50M
+          resources: {{- toYaml .Values.metricAgent.pod.resources | nindent 12 }}
           volumeMounts:
             - mountPath: '/certs'
               name: certs

--- a/deployments/liqo/templates/liqo-network-manager-deployment.yaml
+++ b/deployments/liqo/templates/liqo-network-manager-deployment.yaml
@@ -56,7 +56,4 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-          resources:
-            requests:
-              cpu: 50m
-              memory: 50M
+          resources: {{- toYaml .Values.networkManager.pod.resources | nindent 12 }}

--- a/deployments/liqo/templates/liqo-proxy-deployment.yaml
+++ b/deployments/liqo/templates/liqo-proxy-deployment.yaml
@@ -34,10 +34,7 @@ spec:
             {{- include "liqo.containerSecurityContext" . | nindent 12 }}
           ports:
           - containerPort: {{ .Values.proxy.config.listeningPort }}
-          resources:
-            requests:
-              cpu: 250m
-              memory: 100M
+          resources: {{- toYaml .Values.proxy.pod.resources | nindent 12 }}
           volumeMounts:
           - mountPath: /etc/envoy/envoy.yaml
             name: config-volume

--- a/deployments/liqo/templates/liqo-route-daemonset.yaml
+++ b/deployments/liqo/templates/liqo-route-daemonset.yaml
@@ -42,10 +42,7 @@ spec:
           {{- if .Values.route.pod.extraArgs }}
           {{- toYaml .Values.route.pod.extraArgs | nindent 10 }}
           {{- end }}
-          resources:
-            requests:
-              cpu: 100m
-              memory: 80M
+          resources: {{- toYaml .Values.route.pod.resources | nindent 12 }}
           securityContext:
             privileged: true
           env:

--- a/deployments/liqo/values.yaml
+++ b/deployments/liqo/values.yaml
@@ -22,6 +22,10 @@ controllerManager:
     labels: {}
     # -- controller-manager pod extra arguments
     extraArgs: []
+    # -- controller-manager pod containers' resource requests and limits (https://kubernetes.io/docs/user-guide/compute-resources/)
+    resources:
+      limits: {}
+      requests: {}
   # -- controller-manager image repository
   imageName: "liqo/liqo-controller-manager"
   config:
@@ -40,6 +44,10 @@ route:
     labels: {}
     # -- route pod extra arguments
     extraArgs: []
+    # -- route pod containers' resource requests and limits (https://kubernetes.io/docs/user-guide/compute-resources/)
+    resources:
+      limits: {}
+      requests: {}
   # -- route image repository
   imageName: "liqo/liqonet"
 
@@ -56,6 +64,10 @@ gateway:
     labels: {}
     # -- gateway pod extra arguments
     extraArgs: []
+    # -- gateway pod containers' resource requests and limits (https://kubernetes.io/docs/user-guide/compute-resources/)
+    resources:
+      limits: {}
+      requests: {}
   # -- gateway image repository
   imageName: "liqo/liqonet"
   service:
@@ -70,7 +82,7 @@ gateway:
     portOverride: ""
     # -- port used by the vpn tunnel.
     listeningPort: 5871
-  metrics: 
+  metrics:
     # -- expose metrics about network traffic towards cluster peers.
     enabled: false
     # -- port used to expose metrics.
@@ -91,6 +103,10 @@ networkManager:
     labels: {}
     # -- networkManager pod extra arguments
     extraArgs: []
+    # -- networkManager pod containers' resource requests and limits (https://kubernetes.io/docs/user-guide/compute-resources/)
+    resources:
+      limits: {}
+      requests: {}
   # -- networkManager image repository
   imageName: "liqo/liqonet"
   config:
@@ -116,6 +132,10 @@ crdReplicator:
     labels: {}
     # -- crdReplicator pod extra arguments
     extraArgs: []
+    # -- crdReplicator pod containers' resource requests and limits (https://kubernetes.io/docs/user-guide/compute-resources/)
+    resources:
+      limits: {}
+      requests: {}
   # -- crdReplicator image repository
   imageName: "liqo/crd-replicator"
 
@@ -127,6 +147,10 @@ discovery:
     labels: {}
     # -- discovery pod extra arguments
     extraArgs: []
+    # -- discovery pod containers' resource requests and limits (https://kubernetes.io/docs/user-guide/compute-resources/)
+    resources:
+      limits: {}
+      requests: {}
   # -- discovery image repository
   imageName: "liqo/discovery"
   config:
@@ -160,6 +184,10 @@ auth:
     labels: {}
     # -- auth pod extra arguments
     extraArgs: []
+    # -- auth pod containers' resource requests and limits (https://kubernetes.io/docs/user-guide/compute-resources/)
+    resources:
+      limits: {}
+      requests: {}
   # -- auth image repository
   imageName: "liqo/auth-service"
   initContainer:
@@ -203,6 +231,10 @@ metricAgent:
     labels: {}
     # -- metricAgent pod extra arguments
     extraArgs: []
+    # -- metricAgent pod containers' resource requests and limits (https://kubernetes.io/docs/user-guide/compute-resources/)
+    resources:
+      limits: {}
+      requests: {}
   # -- metricAgent image repository
   imageName: "liqo/metric-agent"
   initContainer:
@@ -229,6 +261,10 @@ virtualKubelet:
     labels: {}
     # -- virtual kubelet pod extra arguments
     args: []
+    # -- virtual kubelet pod containers' resource requests and limits (https://kubernetes.io/docs/user-guide/compute-resources/)
+    resources:
+      limits: {}
+      requests: {}
   virtualNode:
     extra:
       # -- virtual node extra annotations
@@ -244,6 +280,10 @@ proxy:
     labels: {}
     # -- proxy pod extra arguments
     extraArgs: []
+    # -- proxy pod containers' resource requests and limits (https://kubernetes.io/docs/user-guide/compute-resources/)
+    resources:
+      limits: {}
+      requests: {}
   # -- proxy image repository
   imageName: "envoyproxy/envoy:v1.21.0"
   service:

--- a/pkg/liqoctl/move/handler.go
+++ b/pkg/liqoctl/move/handler.go
@@ -25,6 +25,7 @@ import (
 	"github.com/liqotech/liqo/pkg/liqoctl/factory"
 	"github.com/liqotech/liqo/pkg/liqoctl/output"
 	"github.com/liqotech/liqo/pkg/utils"
+	"github.com/liqotech/liqo/pkg/utils/pod"
 )
 
 // Options encapsulates the arguments of the move volume command.
@@ -168,21 +169,5 @@ func getResticRepositoryURL(ctx context.Context, cl client.Client, isLocal bool)
 }
 
 func (o *Options) forgeContainerResources() corev1.ResourceRequirements {
-	configure := func(rl corev1.ResourceList, key corev1.ResourceName, value resource.Quantity) {
-		if !value.IsZero() {
-			rl[key] = value
-		}
-	}
-
-	requirements := corev1.ResourceRequirements{
-		Requests: corev1.ResourceList{},
-		Limits:   corev1.ResourceList{},
-	}
-
-	configure(requirements.Requests, corev1.ResourceCPU, o.ContainersCPURequests)
-	configure(requirements.Requests, corev1.ResourceMemory, o.ContainersRAMRequests)
-	configure(requirements.Limits, corev1.ResourceCPU, o.ContainersCPULimits)
-	configure(requirements.Limits, corev1.ResourceMemory, o.ContainersRAMLimits)
-
-	return requirements
+	return pod.ForgeContainerResources(o.ContainersCPURequests, o.ContainersCPULimits, o.ContainersRAMRequests, o.ContainersRAMLimits)
 }

--- a/pkg/utils/pod/pod.go
+++ b/pkg/utils/pod/pod.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/utils/pointer"
 )
 
@@ -90,4 +91,25 @@ outer:
 	}
 
 	return true
+}
+
+// ForgeContainerResources forges the container resource requirements, leaving unset the ones not specified.
+func ForgeContainerResources(cpuRequests, cpuLimits, ramRequests, ramLimits resource.Quantity) corev1.ResourceRequirements {
+	configure := func(rl corev1.ResourceList, key corev1.ResourceName, value resource.Quantity) {
+		if !value.IsZero() {
+			rl[key] = value
+		}
+	}
+
+	requirements := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{},
+		Limits:   corev1.ResourceList{},
+	}
+
+	configure(requirements.Requests, corev1.ResourceCPU, cpuRequests)
+	configure(requirements.Requests, corev1.ResourceMemory, ramRequests)
+	configure(requirements.Limits, corev1.ResourceCPU, cpuLimits)
+	configure(requirements.Limits, corev1.ResourceMemory, ramLimits)
+
+	return requirements
 }

--- a/pkg/utils/pod/pod_test.go
+++ b/pkg/utils/pod/pod_test.go
@@ -19,6 +19,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/utils/pointer"
 
 	"github.com/liqotech/liqo/pkg/utils/pod"
@@ -144,6 +145,31 @@ var _ = Describe("Pod utility functions", func() {
 				previous: []corev1.Container{{Name: "foo", Image: "bar"}, {Name: "bar", Image: "baz"}},
 				updated:  []corev1.Container{{Name: "bar", Image: "baz"}},
 				expected: BeFalse(),
+			}),
+		)
+	})
+
+	Describe("The ForgeContainerResources function", func() {
+		DescribeTable("tests table",
+			func(resources corev1.ResourceRequirements) {
+				Expect(pod.ForgeContainerResources(
+					resources.Requests[corev1.ResourceCPU],
+					resources.Limits[corev1.ResourceCPU],
+					resources.Requests[corev1.ResourceMemory],
+					resources.Limits[corev1.ResourceMemory],
+				)).To(Equal(resources))
+			},
+			Entry("no resources are set", corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{},
+				Limits:   corev1.ResourceList{},
+			}),
+			Entry("only some resources are set", corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("100m")},
+				Limits:   corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("200Mi")},
+			}),
+			Entry("all resources are set", corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("100m"), corev1.ResourceMemory: resource.MustParse("100Mi")},
+				Limits:   corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("200m"), corev1.ResourceMemory: resource.MustParse("200Mi")},
 			}),
 		)
 	})

--- a/pkg/vkMachinery/forge/forge.go
+++ b/pkg/vkMachinery/forge/forge.go
@@ -22,6 +22,7 @@ import (
 	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
 	sharingv1alpha1 "github.com/liqotech/liqo/apis/sharing/v1alpha1"
 	liqoconst "github.com/liqotech/liqo/pkg/consts"
+	"github.com/liqotech/liqo/pkg/utils/pod"
 	"github.com/liqotech/liqo/pkg/virtualKubelet"
 	vk "github.com/liqotech/liqo/pkg/vkMachinery"
 )
@@ -73,7 +74,7 @@ func forgeVKContainers(
 	return []v1.Container{
 		{
 			Name:      "virtual-kubelet",
-			Resources: forgeVKResources(opts),
+			Resources: pod.ForgeContainerResources(opts.RequestsCPU, opts.LimitsCPU, opts.RequestsRAM, opts.LimitsRAM),
 			Image:     vkImage,
 			Command:   command,
 			Args:      args,
@@ -96,19 +97,6 @@ func forgeVKPodSpec(
 		Containers: forgeVKContainers(opts.ContainerImage, homeCluster, remoteCluster,
 			nodeName, vkNamespace, liqoNamespace, opts, resourceOffer),
 		ServiceAccountName: vk.ServiceAccountName,
-	}
-}
-
-func forgeVKResources(opts *VirtualKubeletOpts) v1.ResourceRequirements {
-	return v1.ResourceRequirements{
-		Limits: v1.ResourceList{
-			v1.ResourceCPU:    opts.LimitsCPU,
-			v1.ResourceMemory: opts.LimitsRAM,
-		},
-		Requests: v1.ResourceList{
-			v1.ResourceCPU:    opts.RequestsCPU,
-			v1.ResourceMemory: opts.RequestsRAM,
-		},
 	}
 }
 


### PR DESCRIPTION
# Description

This PR removes the default liqo containers resources definitions, and makes them configurable through the helm chart. This enables to adapt them to the specific characteristics of the installation, as well as simplifies the deployment of liqo on constrained clusters for testing reasons.

Fixes #(issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Existing tests
- [x] Manually
