### PR TITLE
Docs: New documentation section called Add-Ons and new add-on

### DIFF
--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -35,6 +35,11 @@ subtrees:
     entries:
       - file: contributing/contributing.md
 
+  - caption: Add-Ons
+    entries:
+      - url: https://github.com/LucaRocco/liqo-public-peering-dashboard
+        title: Public Peering Dashboard
+
   - caption: More
     entries:
       - url: https://github.com/liqotech/liqo


### PR DESCRIPTION
Add a new documentation section that contains add-ons for liqo. 

The PR includes the first add-on, which is a dashboard that shows information about resources shared by active peerings in terms of vCPUs and Memory.