### PR TITLE
ForeignClusters: added mutation webhook 

### DIFF
--- a/cmd/liqo-controller-manager/main.go
+++ b/cmd/liqo-controller-manager/main.go
@@ -205,7 +205,8 @@ func main() {
 	spv := shadowpodswh.NewValidator(mgr.GetClient(), *enableResourceValidation)
 
 	// Register the webhooks.
-	mgr.GetWebhookServer().Register("/validate/foreign-cluster", fcwh.New())
+	mgr.GetWebhookServer().Register("/validate/foreign-cluster", fcwh.NewValidator())
+	mgr.GetWebhookServer().Register("/mutate/foreign-cluster", fcwh.NewMutator())
 	mgr.GetWebhookServer().Register("/validate/shadowpods", &webhook.Admission{Handler: spv})
 	mgr.GetWebhookServer().Register("/validate/namespace-offloading", nsoffwh.New())
 	mgr.GetWebhookServer().Register("/mutate/pod", podwh.New(mgr.GetClient()))

--- a/deployments/liqo/templates/webhooks/liqo-mutating-webhook.yaml
+++ b/deployments/liqo/templates/webhooks/liqo-mutating-webhook.yaml
@@ -28,3 +28,20 @@ webhooks:
     namespaceSelector:
       matchLabels:
         liqo.io/scheduling-enabled: "true"
+  - name: fc.mutate.liqo.io
+    admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: {{ include "liqo.prefixedName" $ctrlManagerConfig }}
+        namespace: {{ .Release.Namespace }}
+        path: "/mutate/foreign-cluster"
+        port: {{ .Values.webhook.port }}
+    rules:
+      - operations: ["CREATE","UPDATE"]
+        apiGroups: ["discovery.liqo.io"]
+        apiVersions: ["v1alpha1"]
+        resources: ["foreignclusters"]
+    sideEffects: None
+    failurePolicy: {{ .Values.webhook.failurePolicy }}

--- a/pkg/liqo-controller-manager/foreign-cluster-operator/validator.go
+++ b/pkg/liqo-controller-manager/foreign-cluster-operator/validator.go
@@ -23,7 +23,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
-	"github.com/liqotech/liqo/pkg/discovery"
 	foreignclusterutils "github.com/liqotech/liqo/pkg/utils/foreignCluster"
 	peeringconditionsutils "github.com/liqotech/liqo/pkg/utils/peeringConditions"
 )
@@ -43,16 +42,6 @@ func (r *ForeignClusterReconciler) validateForeignCluster(ctx context.Context,
 				RequeueAfter: r.ResyncPeriod,
 			}, err
 		}
-		requireUpdate = true
-	}
-
-	// set cluster-id label to easy retrieve ForeignClusters by ClusterId,
-	// if it is added manually, the name maybe not coincide with ClusterId
-	if foreignCluster.ObjectMeta.Labels[discovery.ClusterIDLabel] == "" {
-		if foreignCluster.ObjectMeta.Labels == nil {
-			foreignCluster.ObjectMeta.Labels = map[string]string{}
-		}
-		foreignCluster.ObjectMeta.Labels[discovery.ClusterIDLabel] = foreignCluster.Spec.ClusterIdentity.ClusterID
 		requireUpdate = true
 	}
 

--- a/pkg/liqo-controller-manager/webhooks/foreigncluster/fc.go
+++ b/pkg/liqo-controller-manager/webhooks/foreigncluster/fc.go
@@ -16,6 +16,7 @@ package fcwh
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 
 	admissionv1 "k8s.io/api/admission/v1"
@@ -25,15 +26,28 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
+	"github.com/liqotech/liqo/pkg/discovery"
 )
 
 type fcwh struct {
 	decoder *admission.Decoder
 }
 
-// New returns a new NamespaceOffloadingWebhook instance.
-func New() *webhook.Admission {
-	return &webhook.Admission{Handler: &fcwh{}}
+type fcwhm struct {
+	fcwh
+}
+type fcwhv struct {
+	fcwh
+}
+
+// NewMutator returns a new ForeignCluster mutating webhook.
+func NewMutator() *webhook.Admission {
+	return &webhook.Admission{Handler: &fcwhm{}}
+}
+
+// NewValidator returns a new ForeignCluster validating webhook.
+func NewValidator() *webhook.Admission {
+	return &webhook.Admission{Handler: &fcwhv{}}
 }
 
 // InjectDecoder injects the decoder - this method is used by controller runtime.
@@ -49,10 +63,37 @@ func (w *fcwh) DecodeForeignCluster(obj runtime.RawExtension) (*discoveryv1alpha
 	return &fc, err
 }
 
+// Handle implements the ForeignCluster mutating webhook logic.
+//
+//nolint:gocritic // The signature of this method is imposed by controller runtime.
+func (w *fcwhm) Handle(ctx context.Context, req admission.Request) admission.Response {
+	fc, err := w.DecodeForeignCluster(req.Object)
+	if err != nil {
+		klog.Errorf("Failed decoding ForeignCluster object: %v", err)
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+
+	// Enforce the ClusterID label, to allow retrieving the foreign cluster by ID.
+	if fc.Spec.ClusterIdentity.ClusterID != "" {
+		if fc.ObjectMeta.Labels == nil {
+			fc.ObjectMeta.Labels = map[string]string{}
+		}
+		fc.ObjectMeta.Labels[discovery.ClusterIDLabel] = fc.Spec.ClusterIdentity.ClusterID
+	}
+
+	marshaledFc, err := json.Marshal(fc)
+	if err != nil {
+		klog.Errorf("Failed marshaling ForeignCluster object: %v", err)
+		return admission.Errored(http.StatusInternalServerError, err)
+	}
+
+	return admission.PatchResponseFromRaw(req.Object.Raw, marshaledFc)
+}
+
 // Handle implements the ForeignCluster validating webhook logic.
 //
 //nolint:gocritic // The signature of this method is imposed by controller runtime.
-func (w *fcwh) Handle(ctx context.Context, req admission.Request) admission.Response {
+func (w *fcwhv) Handle(ctx context.Context, req admission.Request) admission.Response {
 	if req.Operation != admissionv1.Update {
 		return admission.Allowed("")
 	}
@@ -72,6 +113,14 @@ func (w *fcwh) Handle(ctx context.Context, req admission.Request) admission.Resp
 
 	if fcold.Spec.PeeringType != fcnew.Spec.PeeringType {
 		return admission.Denied("The PeeringType value cannot be modified after creation")
+	}
+
+	if fcold.Spec.ClusterIdentity.ClusterID != "" && fcold.Spec.ClusterIdentity.ClusterID != fcnew.Spec.ClusterIdentity.ClusterID {
+		return admission.Denied("The ClusterID value cannot be modified after creation")
+	}
+
+	if fcold.Spec.ClusterIdentity.ClusterName != "" && fcold.Spec.ClusterIdentity.ClusterName != fcnew.Spec.ClusterIdentity.ClusterName {
+		return admission.Denied("The ClusterName value cannot be modified after creation")
 	}
 
 	return admission.Allowed("")

--- a/pkg/liqoctl/peerib/handler.go
+++ b/pkg/liqoctl/peerib/handler.go
@@ -146,16 +146,6 @@ func (o *Options) Run(ctx context.Context) error {
 		return err
 	}
 
-	// Waiting for VPN connection to be established in cluster 1.
-	if err := cluster1.Waiter.ForNetwork(ctx, cluster2.GetClusterID()); err != nil {
-		return err
-	}
-
-	// Waiting for VPN connection to be established in cluster 2.
-	if err := cluster2.Waiter.ForNetwork(ctx, cluster1.GetClusterID()); err != nil {
-		return err
-	}
-
 	// Waiting for authentication to complete in cluster 1.
 	if err := cluster1.Waiter.ForAuth(ctx, cluster2.GetClusterID()); err != nil {
 		return err

--- a/pkg/utils/foreignCluster/pollevent.go
+++ b/pkg/utils/foreignCluster/pollevent.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"time"
 
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -40,10 +39,6 @@ func PollForEvent(ctx context.Context, cl client.Client, identity *discoveryv1al
 	err := wait.PollImmediateUntilWithContext(ctx, interval, func(ctx context.Context) (done bool, err error) {
 		fc, err := GetForeignClusterByID(ctx, cl, identity.ClusterID)
 		if err != nil {
-			// Avoid to return an error if the Foreign Clusters labels have not been applied yet by the corresponding operator.
-			if apierrors.IsNotFound(err) {
-				return false, nil
-			}
 			return false, err
 		}
 


### PR DESCRIPTION
This PR adds a **mutating webhook** for the **ForeignCluster** resources, which forces the presence of **clusterID** inside resource labels.
It solves an issue about peering. Liqoctl tries to get the peered cluster's ForeignCluster resource (using the clusterID label ) during the process and if the clusterID label has not been set yet, it returns an error. 

The PR also adds validation about **clusterID** and **clusterName** inside the validating webhook.