### PR TITLE
make ctl: automatically set liqoctl version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,8 @@ unit: test-container
 BINDIR?=.
 TARGET?=kind
 ctl:
-	go build -o $(BINDIR) ./cmd/liqoctl
+	$(eval GIT_COMMIT=$(shell git rev-parse HEAD 2>/dev/null || echo "unknown"))
+	go build -o ${BINDIR} -ldflags="-s -w -X 'github.com/liqotech/liqo/pkg/liqoctl/version.liqoctlVersion=$(GIT_COMMIT)'" ./cmd/liqoctl
 
 # Install LIQO into a cluster
 install: manifests ctl

--- a/pkg/liqoctl/version/handler.go
+++ b/pkg/liqoctl/version/handler.go
@@ -23,7 +23,7 @@ import (
 	"github.com/liqotech/liqo/pkg/liqoctl/output"
 )
 
-var liqoctlVersion = "development"
+var liqoctlVersion = "unknown"
 
 // Options encapsulates the arguments of the version command.
 type Options struct {


### PR DESCRIPTION
# Description

This PR slightly modifies the `make ctl` target to automatically configure the liqoctl version in the generated binary to the commit sha, for subsequent reference. In case of errors (e.g., git is not installed, it default to unknown).