### PR TITLE
resource offer: ensure deletion in invalid status

### DIFF
--- a/apis/sharing/v1alpha1/resourceoffer_types.go
+++ b/apis/sharing/v1alpha1/resourceoffer_types.go
@@ -67,6 +67,8 @@ const (
 type VirtualKubeletStatus string
 
 const (
+	// VirtualKubeletStatusUnknown indicates that the VirtualKubelet Deployment status is unknown.
+	VirtualKubeletStatusUnknown VirtualKubeletStatus = ""
 	// VirtualKubeletStatusNone indicates that there is no VirtualKubelet Deployment.
 	VirtualKubeletStatusNone VirtualKubeletStatus = "None"
 	// VirtualKubeletStatusCreated indicates that the VirtualKubelet Deployment has been created.

--- a/pkg/liqo-controller-manager/foreign-cluster-operator/foreign-cluster-controller.go
+++ b/pkg/liqo-controller-manager/foreign-cluster-operator/foreign-cluster-controller.go
@@ -69,7 +69,7 @@ const (
 	virtualKubeletPendingMessage = "The remote cluster has not started the VirtualKubelet for the peering yet"
 
 	tunnelEndpointNotFoundReason  = "TunnelEndpointNotFound"
-	tunnelEndpointNotFoundMessage = "The TunnelEndpointNotFound has not been found in the Tenant Namespace %v"
+	tunnelEndpointNotFoundMessage = "The TunnelEndpoint has not been found in the Tenant Namespace %v"
 
 	tunnelEndpointAvailableReason  = "TunnelEndpointAvailable"
 	tunnelEndpointAvailableMessage = "The TunnelEndpoint has been successfully found in the Tenant Namespace %v and it is connected"

--- a/pkg/liqo-controller-manager/resource-request-controller/resourceRequest_controller.go
+++ b/pkg/liqo-controller-manager/resource-request-controller/resourceRequest_controller.go
@@ -82,7 +82,6 @@ func (r *ResourceRequestReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return ctrl.Result{}, err
 	}
 
-	newRequireSpecUpdate := false
 	// ensure creation and deletion of the ClusterRole and the ClusterRoleBinding for the remote cluster
 	switch resourceReqPhase {
 	case deletingResourceRequestPhase, denyResourceRequestPhase:
@@ -106,7 +105,6 @@ func (r *ResourceRequestReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 			return ctrl.Result{}, err
 		}
 	}
-	requireSpecUpdate = requireSpecUpdate || newRequireSpecUpdate
 
 	if requireSpecUpdate {
 		if err = r.Client.Update(ctx, &resourceRequest); err != nil {

--- a/pkg/liqo-controller-manager/resource-request-controller/utils.go
+++ b/pkg/liqo-controller-manager/resource-request-controller/utils.go
@@ -135,7 +135,9 @@ func (r *ResourceRequestReconciler) invalidateResourceOffer(ctx context.Context,
 		}
 		klog.Infof("%s -> Offer: %s/%s", r.HomeCluster.ClusterName, offer.Namespace, offer.Name)
 		return nil
-	case sharingv1alpha1.VirtualKubeletStatusNone:
+	case sharingv1alpha1.VirtualKubeletStatusNone, sharingv1alpha1.VirtualKubeletStatusUnknown:
+		// The unknown status might occur in case we never succeeded in reflecting the resource offer
+		// to the remote cluster, e.g., due to an authentication issue.
 		err = client.IgnoreNotFound(r.Client.Delete(ctx, &offer))
 		if err != nil {
 			return err


### PR DESCRIPTION
# Description

This PR ensures that a resource offer gets correctly withdrawn in case the virtual kubelet status is unset, which happens in case of asymmetric authentication issues (i.e., if the resource offer is never reflected to the remote cluster). This ensures that the peering can be correctly tore down in the above mentioned conditions.

Fixes #(issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Manually, in case of reverse authentication does not work
- [x] Existing tests
