### PR TITLE
foreign cluster: improve remote identity enforcement

### DIFF
--- a/internal/auth-service/auth_test.go
+++ b/internal/auth-service/auth_test.go
@@ -29,7 +29,7 @@ import (
 	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
 	"github.com/liqotech/liqo/pkg/auth"
 	autherrors "github.com/liqotech/liqo/pkg/auth/errors"
-	"github.com/liqotech/liqo/pkg/utils/testutil"
+	csrutil "github.com/liqotech/liqo/pkg/utils/csr"
 )
 
 type tokenManagerMock struct {
@@ -139,7 +139,7 @@ var _ = Describe("Auth", func() {
 
 		DescribeTable("Certificate Identity Creation table",
 			func(c certificateTestcase) {
-				req, err := testutil.FakeCSRRequest(authService.localCluster.ClusterID)
+				_, req, err := csrutil.NewKeyAndRequest(authService.localCluster.ClusterID)
 				Expect(err).To(BeNil())
 				c.request.CertificateSigningRequest = base64.StdEncoding.EncodeToString(req)
 

--- a/pkg/identityManager/client.go
+++ b/pkg/identityManager/client.go
@@ -40,7 +40,6 @@ func (certManager *identityManager) GetConfig(remoteCluster discoveryv1alpha1.Cl
 		secret, err = certManager.getSecretInNamespace(remoteCluster, namespace)
 	}
 	if err != nil {
-		klog.Error(err)
 		return nil, err
 	}
 

--- a/pkg/identityManager/interface.go
+++ b/pkg/identityManager/interface.go
@@ -15,7 +15,8 @@
 package identitymanager
 
 import (
-	v1 "k8s.io/api/core/v1"
+	"context"
+
 	"k8s.io/client-go/rest"
 
 	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
@@ -33,9 +34,8 @@ type IdentityReader interface {
 type IdentityManager interface {
 	IdentityReader
 
-	CreateIdentity(remoteCluster discoveryv1alpha1.ClusterIdentity) (*v1.Secret, error)
-	GetSigningRequest(remoteCluster discoveryv1alpha1.ClusterIdentity) ([]byte, error)
-	StoreCertificate(remoteCluster discoveryv1alpha1.ClusterIdentity, remoteProxyURL string, identityResponse *auth.CertificateIdentityResponse) error
+	StoreIdentity(ctx context.Context, remoteCluster discoveryv1alpha1.ClusterIdentity, namespace string, key []byte,
+		remoteProxyURL string, identityResponse *auth.CertificateIdentityResponse) error
 }
 
 // IdentityProvider provides the interface to retrieve and approve remote cluster identities.

--- a/pkg/liqo-controller-manager/foreign-cluster-operator/foreign-cluster-controller.go
+++ b/pkg/liqo-controller-manager/foreign-cluster-operator/foreign-cluster-controller.go
@@ -215,7 +215,7 @@ func (r *ForeignClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 
 	// ensure the existence of an identity to operate in the remote cluster remote cluster
 	if err = r.ensureRemoteIdentity(ctx, &foreignCluster); err != nil {
-		klog.Error(err)
+		klog.Errorf("Failed to ensure identity for remote cluster %q: %v", foreignCluster.Spec.ClusterIdentity, err)
 		return ctrl.Result{}, err
 	}
 	tracer.Step("Ensured the existence of the remote identity")

--- a/pkg/utils/csr/create.go
+++ b/pkg/utils/csr/create.go
@@ -1,0 +1,56 @@
+// Copyright 2019-2022 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package csr
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"encoding/pem"
+	"fmt"
+)
+
+// NewKeyAndRequest returns a new private key, and the corresponding CSR for the given subject.
+func NewKeyAndRequest(commonName string) (keyBytes, csrBytes []byte, err error) {
+	_, key, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to generate private key: %w", err)
+	}
+
+	keyBytes, err = x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to marshal private key: %w", err)
+	}
+
+	asn1Subj, err := asn1.Marshal(pkix.Name{CommonName: commonName, Organization: []string{"liqo.io"}}.ToRDNSequence())
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to marshal subject information: %w", err)
+	}
+
+	template := x509.CertificateRequest{
+		RawSubject:         asn1Subj,
+		SignatureAlgorithm: x509.PureEd25519,
+	}
+
+	csrBytes, err = x509.CreateCertificateRequest(rand.Reader, &template, key)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create certificate request: %w", err)
+	}
+
+	return pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyBytes}),
+		pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE REQUEST", Bytes: csrBytes}), nil
+}

--- a/pkg/utils/csr/watcher_test.go
+++ b/pkg/utils/csr/watcher_test.go
@@ -53,7 +53,7 @@ var _ = Describe("Watcher functions", func() {
 		)
 
 		CSRForger := func(name, label string) *certv1.CertificateSigningRequest {
-			req, err := testutil.FakeCSRRequest("foobar")
+			_, req, err := NewKeyAndRequest("foobar")
 			Expect(err).ToNot(HaveOccurred())
 
 			return &certv1.CertificateSigningRequest{

--- a/pkg/utils/testutil/csr.go
+++ b/pkg/utils/testutil/csr.go
@@ -19,40 +19,10 @@ import (
 	"crypto/rand"
 	"crypto/x509"
 	"crypto/x509/pkix"
-	"encoding/asn1"
 	"encoding/pem"
 	"math/big"
 	"time"
-
-	"k8s.io/klog/v2"
 )
-
-// FakeCSRRequest returns the content of a CSR request for testing purposes.
-func FakeCSRRequest(commonName string) (csrBytes []byte, err error) {
-	_, key, err := ed25519.GenerateKey(rand.Reader)
-	if err != nil {
-		return nil, err
-	}
-
-	asn1Subj, err := asn1.Marshal(pkix.Name{CommonName: commonName, Organization: []string{"liqo.io"}}.ToRDNSequence())
-	if err != nil {
-		klog.Error(err)
-		return nil, err
-	}
-
-	template := x509.CertificateRequest{
-		RawSubject:         asn1Subj,
-		SignatureAlgorithm: x509.PureEd25519,
-	}
-
-	csrBytes, err = x509.CreateCertificateRequest(rand.Reader, &template, key)
-	if err != nil {
-		klog.Error(err)
-		return nil, err
-	}
-
-	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE REQUEST", Bytes: csrBytes}), nil
-}
 
 // FakeSelfSignedCertificate returns the content of a self-signed certificate for testing purposes.
 func FakeSelfSignedCertificate(commonName string) (certificate []byte, err error) {


### PR DESCRIPTION
# Description

This PR improves the remote identity enforcement logic in the foreign cluster controller to a) give better feedback to users in case of failure and b) avoid generating tons of secrets in case of repeated failures.

Fixes #(issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Manually, in case of successful/failing authentication
- [x] Existing tests
