### PR TITLE
liqoctl peer: improve wait ordering

### DIFF
--- a/pkg/liqoctl/peer/handler.go
+++ b/pkg/liqoctl/peer/handler.go
@@ -79,11 +79,11 @@ func (o *Options) Wait(ctx context.Context, remoteClusterID *discoveryv1alpha1.C
 		return err
 	}
 
-	if err := waiter.ForNetwork(ctx, remoteClusterID); err != nil {
+	if err := waiter.ForOutgoingPeering(ctx, remoteClusterID); err != nil {
 		return err
 	}
 
-	if err := waiter.ForOutgoingPeering(ctx, remoteClusterID); err != nil {
+	if err := waiter.ForNetwork(ctx, remoteClusterID); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
# Description

This PR changes the order of the wait checks for out-of-band peering, as outgoing peering is a precondition for networking.