### PR TITLE
foreign cluster: fix missing return when not found

### DIFF
--- a/pkg/liqo-controller-manager/foreign-cluster-operator/foreign-cluster-controller.go
+++ b/pkg/liqo-controller-manager/foreign-cluster-operator/foreign-cluster-controller.go
@@ -147,6 +147,7 @@ func (r *ForeignClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		// If the foreigncluster has been removed than remove the mapping between the local tenant namespace and
 		// the foreign cluster.
 		r.ForeignClusters.Delete(foreignCluster.Status.TenantNamespace.Local)
+		return ctrl.Result{}, nil
 	}
 	tracer.Step("Retrieved the foreign cluster")
 


### PR DESCRIPTION
# Description

This PR fixes a missing return in the foreign cluster controller, when the foreign cluster gets deleted. 
