### PR TITLE
Fix: Liqoctl Install EKS

### DIFF
--- a/pkg/liqoctl/install/eks/iam.go
+++ b/pkg/liqoctl/install/eks/iam.go
@@ -149,7 +149,9 @@ func (o *Options) ensurePolicy(iamSvc *iam.IAM) (string, error) {
 }
 
 func (o *Options) getPolicyArn(iamSvc *iam.IAM) (string, error) {
-	getUserResult, err := iamSvc.GetUser(&iam.GetUserInput{})
+	getUserResult, err := iamSvc.GetUser(&iam.GetUserInput{
+		UserName: aws.String(o.iamUser.userName),
+	})
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
# Description

This pr fixes the installation of Liqo on EKS when using non-user credentials (e.g. when using OAuth credentials)

# How Has This Been Tested?

- [x] On EKS cluster with standard IAM authentication
- [x] On EKS cluster with OAuth user authentication (for the liqoctl user)
