### PR TITLE
Docs: add warning about mismatching versions

### DIFF
--- a/cmd/liqoctl/cmd/peer.go
+++ b/cmd/liqoctl/cmd/peer.go
@@ -49,6 +49,10 @@ This command enables a peering towards an already known remote cluster, without 
 need of specifying all authentication parameters. It adopts the same approach already
 used while peering for the first time with the given remote cluster.
 
+Warning: the establishment of a peering with a remote cluster leveraging a different
+version of Liqo, net of patch releases, is currently *not supported*, and could
+lead to unexpected results.
+
 Examples:
   $ {{ .Executable }} peer eternal-donkey
 or

--- a/docs/installation/liqoctl.md
+++ b/docs/installation/liqoctl.md
@@ -10,12 +10,16 @@ Specifically, it abstracts the creation and modification of Liqo defined custom 
 * Enable and configure **workload offloading** on a per-namespace basis.
 * Retrieve the **status** of Liqo, as well as of given peering relationships and offloading setups.
 
+```{warning}
+Make sure to always **use the *liqoctl* version matching that of Liqo** installed (or to be installed) in your cluster(s).
+```
+
+{{ env.config.html_context.generate_liqoctl_version_warning() }}
+
 ```{admonition} Note
 *liqoctl* displays a *kubectl* compatible behavior concerning Kubernetes API access, hence supporting the `KUBECONFIG` environment variable, as well as all the standard flags, including `--kubeconfig` and `--context`.
 Moreover, subcommands interacting with two clusters (e.g., *liqoctl peer in-band*) feature a parallel set of flags concerning Kubernetes API access to the remote cluster, in the form `--remote-<flag>` (e.g., `--remote-kubeconfig`, `--remote-context`).
 ```
-
-{{ env.config.html_context.generate_liqoctl_version_warning() }}
 
 (InstallationLiqoctlWithHomebrew)=
 

--- a/docs/usage/peer.md
+++ b/docs/usage/peer.md
@@ -3,6 +3,10 @@
 This section describes the procedure to **establish a peering** with a remote cluster, using one of the two alternative approaches featured by Liqo.
 You can refer to the [dedicated features section](FeaturesPeeringApproaches) for a high-level presentation of their characteristics, and the associated trade-offs.
 
+```{warning}
+The establishment of a peering with a remote cluster leveraging a **different version of Liqo**, net of patch releases, is currently **not supported**, and could lead to unexpected results.
+```
+
 ## Overview
 
 The peering process leverages **[liqoctl](/installation/liqoctl.md)** to interact with the clusters, abstracting the creation and update of the appropriate custom resources.

--- a/pkg/liqoctl/install/handler.go
+++ b/pkg/liqoctl/install/handler.go
@@ -187,6 +187,7 @@ func (o *Options) Run(ctx context.Context, provider Provider) error {
 	}
 
 	s.Success(fmt.Sprintf("All Set! You can now proceed establishing a peering (%v peer --help for more information)", o.CommandName))
+	o.Printer.Success.Println("Make sure to use the same version of Liqo on all remote clusters")
 	return nil
 }
 


### PR DESCRIPTION
# Description

This PR extends the documentation adding the warnings concerning mismatching versions, both between liqo and liqoctl, and for the peering process.
