### PR TITLE
liqoctl help: fix leftover quotes

### DIFF
--- a/cmd/liqoctl/cmd/generate.go
+++ b/cmd/liqoctl/cmd/generate.go
@@ -35,9 +35,9 @@ will get access to a slice of the current cluster, and have the possibility to
 offload workloads through the virtual node abstraction.
 
 Examples:
-  $ {{ .Executable }} generate peer-command"
+  $ {{ .Executable }} generate peer-command
 or
-  $ {{ .Executable }} generate peer-command --namespace liqo-system --only-command"
+  $ {{ .Executable }} generate peer-command --namespace liqo-system --only-command
 `
 
 func newGenerateCommand(ctx context.Context, f *factory.Factory) *cobra.Command {

--- a/cmd/liqoctl/cmd/move.go
+++ b/cmd/liqoctl/cmd/move.go
@@ -43,9 +43,9 @@ in the target cluster. Warning: only PVCs not currently mounted by any pod can
 be moved to a different cluster.
 
 Examples:
-  $ {{ .Executable }} move volume database01 --namespace foo --target-node worker-023"
+  $ {{ .Executable }} move volume database01 --namespace foo --target-node worker-023
 or
-  $ {{ .Executable }} move volume database01 --namespace foo --target-node liqo-neutral-colt"
+  $ {{ .Executable }} move volume database01 --namespace foo --target-node liqo-neutral-colt
       --containers-cpu-limits 1000m --containers-ram-limits 2Gi
 `
 

--- a/cmd/liqoctl/cmd/version.go
+++ b/cmd/liqoctl/cmd/version.go
@@ -31,7 +31,7 @@ The CLI version is embedded in the binary and directly displayed. The deployed
 Liqo version version is determined based on the installed chart version.
 
 Examples:
-  $ {{ .Executable }} version"
+  $ {{ .Executable }} version
 `
 
 func newVersionCommand(ctx context.Context, f *factory.Factory) *cobra.Command {

--- a/pkg/liqoctl/install/k3s/provider.go
+++ b/pkg/liqoctl/install/k3s/provider.go
@@ -41,11 +41,11 @@ func (o *Options) Name() string { return "k3s" }
 func (o *Options) Examples() string {
 	return `Examples:
   $ {{ .Executable }} install k3s --api-server-url https://liqo.example.local:6443 \
-      --cluster-labels "region=europe,environment=staging \
+      --cluster-labels region=europe,environment=staging \
       --reserved-subnets 172.16.0.0/16,192.16.254.0/24
 or
   $ {{ .Executable }} install k3s --api-server-url https://liqo.example.local:6443 \
-      --cluster-labels "region=europe,environment=staging \
+      --cluster-labels region=europe,environment=staging \
       --pod-cidr 10.0.0.0/16 --service-cidr 10.1.0.0/16 \
       --reserved-subnets 172.16.0.0/16,192.16.254.0/24
 `


### PR DESCRIPTION
# Description

This PR removes a few leftover quotes from the help messages of liqoctl.