### PR TITLE
docs: adding asdf installation option for liqoctl

### DIFF
--- a/docs/installation/liqoctl.md
+++ b/docs/installation/liqoctl.md
@@ -33,6 +33,26 @@ brew install liqoctl
 
 When installed with Homebrew, autocompletion scripts are automatically configured and should work out of the box.
 
+(InstallationLiqoctlWithasdf)=
+
+## Install liqoctl with asdf
+
+If you are using the [asdf](https://asdf-vm.com/) runtime manager, you can install *liqoctl* with asdf:
+
+```bash
+# Add the liqoctl plugin for asdf
+asdf plugin add liqoctl
+
+# List all installable versions
+asdf list-all liqoctl
+
+# Install the desired version
+asdf install liqoctl <version>
+
+# set it as the global version, unless a project declares it otherwise locally
+asdf global liqoctl <version>
+```
+
 (InstallationLiqoctlManually)=
 
 ## Install liqoctl manually


### PR DESCRIPTION
# Description

Hi, this PR changes the documentation to add a new way of installing liqoctl on Linux and MacOS: using the [asdf runtime manager](https://asdf-vm.com/).

Related to #1546 

# How Has This Been Tested?

- [x] Tested that the plugin work on Linux
- [x] Tested that the plugin work on MacOS
