### PR TITLE
Remote Metrics: Filtering not ready nodes

### DIFF
--- a/pkg/remotemetrics/resources.go
+++ b/pkg/remotemetrics/resources.go
@@ -25,6 +25,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/liqotech/liqo/pkg/consts"
+	liqoutils "github.com/liqotech/liqo/pkg/utils"
 	"github.com/liqotech/liqo/pkg/virtualKubelet/forge"
 )
 
@@ -108,10 +109,12 @@ func (m *resourceGetter) GetNodeNames(ctx context.Context) []string {
 	})
 	utilruntime.Must(err)
 
-	res := make([]string, len(nodes.Items))
+	res := make([]string, 0)
 	for i := range nodes.Items {
 		node := &nodes.Items[i]
-		res[i] = node.Name
+		if liqoutils.IsNodeReady(node) {
+			res = append(res, node.Name)
+		}
 	}
 
 	klog.V(2).Infof("Scraping nodes %+v", res)

--- a/pkg/remotemetrics/resources_test.go
+++ b/pkg/remotemetrics/resources_test.go
@@ -34,10 +34,18 @@ var _ = Context("Resources", func() {
 	var getter ResourceGetter
 	var ctx context.Context
 
-	var getNode = func(name string) *corev1.Node {
+	var getNode = func(name string, conditionReady corev1.ConditionStatus) *corev1.Node {
 		return &corev1.Node{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: name,
+			},
+			Status: corev1.NodeStatus{
+				Conditions: []corev1.NodeCondition{
+					{
+						Type:   corev1.NodeReady,
+						Status: conditionReady,
+					},
+				},
 			},
 		}
 	}
@@ -75,8 +83,9 @@ var _ = Context("Resources", func() {
 		ctx = context.Background()
 
 		cl = fake.NewClientBuilder().WithObjects(
-			getNode("node1"),
-			getNode("node2"),
+			getNode("node1", corev1.ConditionTrue),
+			getNode("node2", corev1.ConditionTrue),
+			getNode("node3", corev1.ConditionFalse),
 			getNamespace("ns1", "origNs1", "cluster1"),
 			getNamespace("ns2", "origNs2", "cluster2"),
 			getPod("pod1", "ns1", "cluster1", "node1"),


### PR DESCRIPTION
# Description

This PR includes a filter on not-ready nodes to skip them while getting remote metrics and avoid communication errors.

# How Has This Been Tested?

Pre-existing tests have been updated. Specifically, I've added a not-ready node in the node list to check that the filter works as expected.

- [x] Updating pre-existing tests
- [x] Manually
