### PR TITLE
Resource Plugins: Add doc and change helm variable

### DIFF
--- a/cmd/liqo-controller-manager/main.go
+++ b/cmd/liqo-controller-manager/main.go
@@ -120,8 +120,8 @@ func main() {
 	autoJoin := flag.Bool("auto-join-discovered-clusters", true, "Whether to automatically peer with discovered clusters")
 
 	// Resource sharing parameters
-	externalResourceMonitorAddress := flag.String(consts.ExternalResourceMonitorParameter, "",
-		"The address of a resource monitor service (default: monitor local resources)")
+	resourcePluginAddress := flag.String(consts.ResourcePluginAddressParameter, "",
+		"The address of a resource plugin service (default: monitor local resources)")
 	flag.Var(&clusterLabels, consts.ClusterLabelsParameter,
 		"The set of labels which characterizes the local cluster when exposed remotely as a virtual node")
 	resourceSharingPercentage := argsutils.Percentage{Val: 50}
@@ -253,8 +253,8 @@ func main() {
 
 	var resourceRequestReconciler *resourceRequestOperator.ResourceRequestReconciler
 	var monitor resourcemonitors.ResourceReader
-	if *externalResourceMonitorAddress != "" {
-		externalMonitor, err := resourcemonitors.NewExternalMonitor(ctx, *externalResourceMonitorAddress, 3*time.Second)
+	if *resourcePluginAddress != "" {
+		externalMonitor, err := resourcemonitors.NewExternalMonitor(ctx, *resourcePluginAddress, 3*time.Second)
 		if err != nil {
 			klog.Errorf("error on creating external resource monitor: %s", err)
 			os.Exit(1)

--- a/deployments/liqo/README.md
+++ b/deployments/liqo/README.md
@@ -25,8 +25,8 @@
 | awsConfig.region | string | `""` | AWS region where the clsuter is runnnig |
 | awsConfig.secretAccessKey | string | `""` | secretAccessKey for the Liqo user |
 | controllerManager.config.enableResourceEnforcement | bool | `false` | It enforces offerer-side that offloaded pods do not exceed offered resources (based on container limits). This feature is suggested to be enabled when consumer-side enforcement is not sufficient. It has the same tradeoffs of resource quotas (i.e, it requires all offloaded pods to have resource limits set). |
-| controllerManager.config.externalMonitorAddress | string | `""` | The address of an external resource monitor service, overriding the default resource computation logic based on the percentage of available resources. Leave it empty to use the standard local resource monitor. |
 | controllerManager.config.offerUpdateThresholdPercentage | string | `""` | the threshold (in percentage) of resources quantity variation which triggers a ResourceOffer update. |
+| controllerManager.config.resourcePluginAddress | string | `""` | The address of an external resource plugin service (see https://github.com/liqotech/liqo-resource-plugins for additional information), overriding the default resource computation logic based on the percentage of available resources. Leave it empty to use the standard local resource monitor. |
 | controllerManager.config.resourceSharingPercentage | int | `30` | It defines the percentage of available cluster resources that you are willing to share with foreign clusters. |
 | controllerManager.imageName | string | `"ghcr.io/liqotech/liqo-controller-manager"` | controller-manager image repository |
 | controllerManager.pod.annotations | object | `{}` | controller-manager pod annotations |

--- a/deployments/liqo/templates/liqo-controller-manager-deployment.yaml
+++ b/deployments/liqo/templates/liqo-controller-manager-deployment.yaml
@@ -128,8 +128,8 @@ spec:
           {{ fail (printf "Unsupported resource type \"%s\" for virtual kubelet containers' limits" $resource) }}
           {{- end }}
           {{- end }}
-          {{- if .Values.controllerManager.config.externalMonitorAddress }}
-          - --external-monitor={{ .Values.controllerManager.config.externalMonitorAddress }}
+          {{- if .Values.controllerManager.config.resourcePluginAddress }}
+          - --resource-plugin-address={{ .Values.controllerManager.config.resourcePluginAddress }}
           - --offer-update-threshold-percentage={{ .Values.controllerManager.config.offerUpdateThresholdPercentage | default 0 }} 
           {{- else }}
           - --offer-update-threshold-percentage={{ .Values.controllerManager.config.offerUpdateThresholdPercentage | default 5 }}

--- a/deployments/liqo/values.yaml
+++ b/deployments/liqo/values.yaml
@@ -33,8 +33,8 @@ controllerManager:
     resourceSharingPercentage: 30
     # -- the threshold (in percentage) of resources quantity variation which triggers a ResourceOffer update.
     offerUpdateThresholdPercentage: ""
-    # -- The address of an external resource monitor service, overriding the default resource computation logic based on the percentage of available resources. Leave it empty to use the standard local resource monitor.
-    externalMonitorAddress: ""
+    # -- The address of an external resource plugin service (see https://github.com/liqotech/liqo-resource-plugins for additional information), overriding the default resource computation logic based on the percentage of available resources. Leave it empty to use the standard local resource monitor.
+    resourcePluginAddress: ""
     # -- It enforces offerer-side that offloaded pods do not exceed offered resources (based on container limits).
     # This feature is suggested to be enabled when consumer-side enforcement is not sufficient.
     # It has the same tradeoffs of resource quotas (i.e, it requires all offloaded pods to have resource limits set).

--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -38,6 +38,8 @@ subtrees:
 
   - caption: Add-Ons
     entries:
+      - url: https://github.com/liqotech/liqo-resource-plugins
+        title: Liqo Resource Plugins
       - url: https://github.com/LucaRocco/liqo-public-peering-dashboard
         title: Public Peering Dashboard
 

--- a/docs/installation/install.md
+++ b/docs/installation/install.md
@@ -351,7 +351,7 @@ The main control plane flags include:
 This name is propagated to remote clusters during the peering process, and used to identify the corresponding virtual nodes and the technical resources leveraged for the negotiation process. Additionally, it is leveraged as part of the suffix to ensure namespace names uniqueness during the offloading process. In case a cluster name is not specified, it is defaulted to that of the cluster in the cloud provider, if any, or it is automatically generated.
 * `--cluster-labels`: a set of **labels** (i.e., key/value pairs) **identifying the cluster in Liqo** (e.g., geographical region, Kubernetes distribution, cloud provider, ...) and automatically propagated during the peering process to the corresponding virtual nodes.
 These labels can be used later to **restrict workload offloading to a subset of clusters**, as detailed in the [namespace offloading usage section](/usage/namespace-offloading).
-* `--sharing-percentage`: the maximum percentage of available **cluster resources** that could be shared with remote clusters.
+* `--sharing-percentage`: the maximum percentage of available **cluster resources** that could be shared with remote clusters. This is the Liqo's default behavior but you can change it by using a custom [resource plugin](https://github.com/liqotech/liqo-resource-plugins).
 
 ### Networking
 

--- a/docs/usage/peer.md
+++ b/docs/usage/peer.md
@@ -17,6 +17,9 @@ The following sections present the respective procedures to **peer a local clust
 At the end of the process, a new **virtual node** is created in the consumer, abstracting the resources shared by the provider, and enabling seamless **pod offloading** to the remote cluster.
 Additional details are also provided to enable the reverse peering direction, hence achieving a **bidirectional peering**, allowing both clusters to offload a part of their workloads to the other.
 
+By default, Liqo shares a configurable percentage of the currently available resources of the **provider** cluster with **consumers**.
+You can change this behavior by using a custom [resource plugin](https://github.com/liqotech/liqo-resource-plugins).
+
 All examples leverage two different *contexts* to refer to *consumer* and *provider* clusters, respectively named `consumer` and `provider`.
 
 ```{admonition} Note

--- a/pkg/consts/parameters.go
+++ b/pkg/consts/parameters.go
@@ -26,6 +26,6 @@ const (
 	// GenerateNameParameter is the name of the parameter specifying whether to generate a random name for the cluster.
 	GenerateNameParameter = "generate-name"
 
-	// ExternalResourceMonitorParameter is the name of the parameter specifying the address of an ExternalResourceMonitor.
-	ExternalResourceMonitorParameter = "external-monitor"
+	// ResourcePluginAddressParameter is the name of the parameter specifying the address of a resource plugin.
+	ResourcePluginAddressParameter = "resource-plugin-address"
 )


### PR DESCRIPTION
# Description

This PR introduces references to the external plugins' git repository in the liqo documentation and changes the helm variable name from externalMonitorAddress to resourcePluginAddress.