### PR TITLE
Liqoctl status: removed helm dependency

### DIFF
--- a/pkg/liqoctl/status/local/localinfo_test.go
+++ b/pkg/liqoctl/status/local/localinfo_test.go
@@ -16,13 +16,21 @@ package statuslocal
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/pterm/pterm"
+	appv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	liqoconsts "github.com/liqotech/liqo/pkg/consts"
 	"github.com/liqotech/liqo/pkg/liqoctl/factory"
 	"github.com/liqotech/liqo/pkg/liqoctl/output"
 	"github.com/liqotech/liqo/pkg/liqoctl/status"
@@ -42,70 +50,158 @@ var _ = Describe("LocalInfo", func() {
 		ctx           context.Context
 		text          string
 		options       status.Options
+		baseObjects   []client.Object
 	)
 
 	BeforeEach(func() {
 		ctx = context.Background()
 		clientBuilder = *fake.NewClientBuilder().WithScheme(scheme.Scheme)
-		clientBuilder.WithObjects(
+		var argsClusterLabels []string
+		for k, v := range testutil.ClusterLabels {
+			argsClusterLabels = append(argsClusterLabels, fmt.Sprintf("%s=%s", k, v))
+		}
+		baseObjects = []client.Object{
 			testutil.FakeClusterIDConfigMap(namespace, clusterID, clusterName),
 			testutil.FakeIPAM(namespace),
-		)
+			&appv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "liqo-controller-manager",
+					Namespace: namespace,
+					Labels: map[string]string{
+						liqoconsts.K8sAppNameKey:      "controller-manager",
+						liqoconsts.K8sAppComponentKey: "controller-manager",
+					},
+				},
+				Spec: appv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{Args: []string{"--cluster-labels=" + strings.Join(argsClusterLabels, ",")}},
+							},
+						},
+					},
+				},
+			},
+		}
 		options = status.Options{Factory: factory.NewForLocal()}
 		options.Printer = output.NewFakePrinter(GinkgoWriter)
-		options.CRClient = clientBuilder.Build()
+		options.KubeClient = k8sfake.NewSimpleClientset()
+		_, err := options.KubeClient.CoreV1().Nodes().Create(ctx, &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "fake-node",
+				Labels: map[string]string{
+					"node-role.kubernetes.io/control-plane": "",
+				},
+			},
+			Status: corev1.NodeStatus{
+				Addresses: []corev1.NodeAddress{
+					{Type: corev1.NodeInternalIP, Address: testutil.APIAddress},
+				},
+			},
+		}, metav1.CreateOptions{})
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 	Context("Creating a new LocalInfoChecker", func() {
 		JustBeforeEach(func() {
-			lic = NewLocalInfoCheckerTest(&options, testutil.FakeHelmValues())
+			lic = NewLocalInfoChecker(&options)
 		})
 		It("should return a valid LocalInfoChecker", func() {
 			Expect(lic.localInfoSection).To(Equal(output.NewRootSection()))
-			Expect(lic.getReleaseValues).ToNot(BeNil())
 		})
 	})
 	Context("Collecting and Formatting LocalInfoChecker", func() {
-		BeforeEach(func() {
-			lic = NewLocalInfoCheckerTest(&options, testutil.FakeHelmValues())
-			lic.Collect(ctx)
-		})
-		JustBeforeEach(func() {
-			text = lic.Format()
-			text = pterm.RemoveColorFromString(text)
-			text = testutil.SqueezeWhitespaces(text)
-		})
-		It("should not return errors", func() {
-			Expect(lic.HasSucceeded()).To(BeTrue())
-		})
-		It("should format a valid text", func() {
-			Expect(text).To(ContainSubstring(
-				pterm.Sprintf("Cluster ID: %s", clusterID),
-			))
-			Expect(text).To(ContainSubstring(
-				pterm.Sprintf("Cluster Name: %s", clusterName),
-			))
-			for _, v := range testutil.ClusterLabels {
-				if s, ok := v.(string); ok {
-					Expect(text).To(ContainSubstring(s))
+		When("Standard case", func() {
+			BeforeEach(func() {
+				clientBuilder.WithObjects(
+					append(
+						baseObjects,
+						forgeLiqoAuth(namespace, ""),
+					)...,
+				)
+				options.CRClient = clientBuilder.Build()
+				lic = NewLocalInfoChecker(&options)
+				lic.Collect(ctx)
+			})
+			JustBeforeEach(func() {
+				text = lic.Format()
+				text = pterm.RemoveColorFromString(text)
+				text = testutil.SqueezeWhitespaces(text)
+			})
+			It("should not return errors", func() {
+				Expect(lic.HasSucceeded()).To(BeTrue())
+			})
+			It("should format a valid text", func() {
+				Expect(text).To(ContainSubstring(
+					pterm.Sprintf("Cluster ID: %s", clusterID),
+				))
+				Expect(text).To(ContainSubstring(
+					pterm.Sprintf("Cluster Name: %s", clusterName),
+				))
+				for _, v := range testutil.ClusterLabels {
+					Expect(text).To(ContainSubstring(v))
 				}
-			}
-			Expect(text).To(ContainSubstring(
-				pterm.Sprintf("Pod CIDR: %s", testutil.PodCIDR),
-			))
-			Expect(text).To(ContainSubstring(
-				pterm.Sprintf("Service CIDR: %s", testutil.ServiceCIDR),
-			))
-			Expect(text).To(ContainSubstring(
-				pterm.Sprintf("External CIDR: %s", testutil.ExternalCIDR),
-			))
-			Expect(text).To(ContainSubstring(
-				pterm.Sprintf("Address: %s", testutil.APIAddress),
-			))
-			for _, v := range testutil.ReservedSubnets {
-				Expect(text).To(ContainSubstring(v))
-			}
+				Expect(text).To(ContainSubstring(
+					pterm.Sprintf("Pod CIDR: %s", testutil.PodCIDR),
+				))
+				Expect(text).To(ContainSubstring(
+					pterm.Sprintf("Service CIDR: %s", testutil.ServiceCIDR),
+				))
+				Expect(text).To(ContainSubstring(
+					pterm.Sprintf("External CIDR: %s", testutil.ExternalCIDR),
+				))
+				Expect(text).To(ContainSubstring(
+					pterm.Sprintf("Address: %s", fmt.Sprintf("https://%v:6443", testutil.APIAddress)),
+				))
+				for _, v := range testutil.ReservedSubnets {
+					Expect(text).To(ContainSubstring(v))
+				}
 
+			})
+		})
+		When("API server is overrided", func() {
+			BeforeEach(func() {
+				clientBuilder.WithObjects(
+					append(
+						baseObjects,
+						forgeLiqoAuth(namespace, testutil.OverrideAPIAddress),
+					)...,
+				)
+				options.CRClient = clientBuilder.Build()
+				lic = NewLocalInfoChecker(&options)
+				lic.Collect(ctx)
+			})
+			JustBeforeEach(func() {
+				text = lic.Format()
+				text = pterm.RemoveColorFromString(text)
+				text = testutil.SqueezeWhitespaces(text)
+			})
+			It("should format a valid text", func() {
+				Expect(text).To(ContainSubstring(
+					pterm.Sprintf("Address: %s", fmt.Sprintf("https://%v", testutil.OverrideAPIAddress)),
+				))
+			})
 		})
 	})
 })
+
+func forgeLiqoAuth(namespace, addressOverride string) *appv1.Deployment {
+	return &appv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "liqo-auth",
+			Namespace: namespace,
+			Labels: map[string]string{
+				liqoconsts.K8sAppNameKey: liqoconsts.AuthAppName,
+			},
+		},
+		Spec: appv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Args: []string{"--advertise-api-server-address=" + addressOverride}},
+					},
+				},
+			},
+		},
+	}
+}

--- a/pkg/utils/apiserver/address.go
+++ b/pkg/utils/apiserver/address.go
@@ -22,7 +22,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/klog/v2"
 
 	"github.com/liqotech/liqo/pkg/discovery"
 )
@@ -45,12 +44,10 @@ func GetAddressFromMasterNode(ctx context.Context,
 	clientset kubernetes.Interface) (address string, err error) {
 	nodes, err := getMasterNodes(ctx, clientset)
 	if err != nil {
-		klog.Error(err)
 		return "", err
 	}
 	host, err := discovery.GetAddressFromNodeList(nodes.Items)
 	if err != nil {
-		klog.Error(err)
 		return "", err
 	}
 	return fmt.Sprintf("https://%v:6443", host), nil
@@ -72,7 +69,6 @@ func getMasterNodes(ctx context.Context, clientset kubernetes.Interface) (*v1.No
 			LabelSelector: selector,
 		})
 		if err != nil {
-			klog.Error(err)
 			return nodes, err
 		}
 		if len(nodes.Items) != 0 {
@@ -82,7 +78,6 @@ func getMasterNodes(ctx context.Context, clientset kubernetes.Interface) (*v1.No
 
 	if len(nodes.Items) == 0 {
 		err = fmt.Errorf("no ApiServer.Address variable provided and no master node found, one of the two values must be present")
-		klog.Error(err)
 		return nodes, err
 	}
 	return nodes, nil

--- a/pkg/utils/testutil/consts.go
+++ b/pkg/utils/testutil/consts.go
@@ -16,7 +16,7 @@ package testutil
 
 const (
 	// APIAddress is the address of the API server used for testing.
-	APIAddress = "fake API address"
+	APIAddress = "1.0.0.1"
 	// PodCIDR is the CIDR of the pod network used for testing.
 	PodCIDR = "fake pod CIDR"
 	// ServiceCIDR is the CIDR of the service network used for testing.
@@ -34,7 +34,10 @@ var (
 		"reserved subnet 4",
 	}
 	// ClusterLabels is the map of labels used for testing.
-	ClusterLabels = map[string]interface{}{
+	ClusterLabels = map[string]string{
 		"liqo.io/testLabel": "fake label",
 	}
+
+	// OverrideAPIAddress is the overrided address of the API server used for testing.
+	OverrideAPIAddress = "1.0.0.2:6443"
 )

--- a/pkg/utils/testutil/kubernetes.go
+++ b/pkg/utils/testutil/kubernetes.go
@@ -23,20 +23,6 @@ import (
 	"github.com/liqotech/liqo/pkg/consts"
 )
 
-// FakeHelmValues returns a fake helm values map.
-func FakeHelmValues() map[string]interface{} {
-	return map[string]interface{}{
-		"apiServer": map[string]interface{}{
-			"address": APIAddress,
-		},
-		"discovery": map[string]interface{}{
-			"config": map[string]interface{}{
-				"clusterLabels": ClusterLabels,
-			},
-		},
-	}
-}
-
 // FakeClusterIDConfigMap returns a fake ClusterID ConfigMap.
 func FakeClusterIDConfigMap(namespace, clusterID, clusterName string) *corev1.ConfigMap {
 	return &corev1.ConfigMap{


### PR DESCRIPTION
This PR changes how `liqoctl status` get information about **local cluster name** and **kubernetes API addres**.
Before this PR **helm** was used to get this information, but this can be a problem if **Liqo** is installed without helm (for example **ArgoCD** uses **helm** to create manifests, without making a **helm release**).
Now `liqoctl status` uses other methods avoiding helm dependencies.