### PR TITLE
liqoctl install: support k3d through k3s provider

### DIFF
--- a/pkg/liqoctl/install/validation.go
+++ b/pkg/liqoctl/install/validation.go
@@ -82,6 +82,7 @@ func (o *Options) validateAPIServer() error {
 	var localhostValues = []string{
 		"localhost",
 		"127.0.0.1",
+		"0.0.0.0", // Configured by k3d
 	}
 
 	// In case the API server URL is not set, fallback to the one specified in the REST config.

--- a/pkg/liqoctl/install/validation_test.go
+++ b/pkg/liqoctl/install/validation_test.go
@@ -81,6 +81,11 @@ var _ = Describe("Validation", func() {
 				apiServerAddress: "https://127.0.0.1",
 				expectedOutput:   HaveOccurred(),
 			}),
+
+			Entry("invalid 0.0.0.0 address", apiServerValidatorTestcase{
+				apiServerAddress: "https://0.0.0.0",
+				expectedOutput:   HaveOccurred(),
+			}),
 		)
 
 		type checkEndpointTestcase struct {


### PR DESCRIPTION
# Description

This PR introduces a minor modification in *liqoctl install* to support the installation of liqo on k3s clusters created through k3d.

Fixes #1090

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Manually, with two k3d clusters
- [x] Existing tests
