### PR TITLE
Update of lables and annotations from shadowPod to pod

### DIFF
--- a/cmd/metric-agent/main.go
+++ b/cmd/metric-agent/main.go
@@ -33,7 +33,7 @@ import (
 
 	"github.com/liqotech/liqo/pkg/consts"
 	"github.com/liqotech/liqo/pkg/remotemetrics"
-	cachedclient "github.com/liqotech/liqo/pkg/utils/cachedClient"
+	clientutils "github.com/liqotech/liqo/pkg/utils/clients"
 	"github.com/liqotech/liqo/pkg/utils/mapper"
 	"github.com/liqotech/liqo/pkg/utils/restcfg"
 )
@@ -81,7 +81,7 @@ func main() {
 		klog.Fatalf("error creating cache: %s", err)
 	}
 
-	cl, err := cachedclient.GetCachedClientWithConfig(ctx, scheme, config, clientCache)
+	cl, err := clientutils.GetCachedClientWithConfig(ctx, scheme, config, clientCache)
 	if err != nil {
 		klog.Fatal(err)
 	}

--- a/pkg/liqo-controller-manager/shadowpod-controller/shadowpod_controller.go
+++ b/pkg/liqo-controller-manager/shadowpod-controller/shadowpod_controller.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	corev1apply "k8s.io/client-go/applyconfigurations/core/v1"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -33,12 +34,20 @@ import (
 
 	vkv1alpha1 "github.com/liqotech/liqo/apis/virtualkubelet/v1alpha1"
 	"github.com/liqotech/liqo/pkg/consts"
+	clientutils "github.com/liqotech/liqo/pkg/utils/clients"
 )
 
 // Reconciler reconciles a ShadowPod object.
 type Reconciler struct {
 	client.Client
 	Scheme *runtime.Scheme
+}
+
+func podShouldBeUpdated(newObj, oldObj client.Object) bool {
+	changesInLabels := !labels.Equals(newObj.GetLabels(), oldObj.GetLabels())
+	changesInAnnots := !labels.Equals(newObj.GetAnnotations(), oldObj.GetAnnotations())
+
+	return changesInLabels || changesInAnnots
 }
 
 // +kubebuilder:rbac:groups=virtualkubelet.liqo.io,resources=shadowpods,verbs=get;list;watch;update;patch;delete
@@ -49,7 +58,6 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	nsName := req.NamespacedName
 	klog.V(4).Infof("reconcile shadowpod %s", nsName)
-
 	shadowPod := vkv1alpha1.ShadowPod{}
 	if err := r.Get(ctx, nsName, &shadowPod); err != nil {
 		err = client.IgnoreNotFound(err)
@@ -59,50 +67,69 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{}, err
 	}
 
-	pod := corev1.Pod{
+	// update shadowpod labels to include the "managed-by"
+	shadowPod.SetLabels(labels.Merge(shadowPod.Labels, labels.Set{consts.ManagedByLabelKey: consts.ManagedByShadowPodValue}))
+
+	// if any existing pod is already been created from the shadowpod...
+	existingPod := corev1.Pod{}
+	if err := r.Get(ctx, nsName, &existingPod); err != nil && !errors.IsNotFound(err) {
+		klog.Errorf("unable to get pod %s: %v", nsName, err)
+		return ctrl.Result{}, err
+	} else if err == nil {
+		// Update Labels and Annotations
+		klog.V(4).Infof("pod %q found running, will update it with labels: %v and annotations: %v",
+			klog.KObj(&existingPod), existingPod.Labels, existingPod.Annotations)
+
+		// Create Apply object for Existing Pod
+		apply := corev1apply.Pod(existingPod.Name, existingPod.Namespace).
+			WithLabels(shadowPod.GetLabels()).
+			WithAnnotations(shadowPod.GetAnnotations())
+
+		if err := r.Patch(ctx, &existingPod, clientutils.Patch(apply), client.ForceOwnership, client.FieldOwner("shadow-pod")); err != nil {
+			klog.Errorf("unable to update pod %q: %v", klog.KObj(&existingPod), err)
+			return ctrl.Result{}, err
+		}
+
+		klog.Infof("updated pod %q with success", klog.KObj(&existingPod))
+
+		return ctrl.Result{}, nil
+	}
+
+	// ...Else, a brand new Pod must be created, based on the shadowpod.
+	newPod := corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        nsName.Name,
 			Namespace:   nsName.Namespace,
-			Labels:      labels.Merge(shadowPod.Labels, labels.Set{consts.ManagedByLabelKey: consts.ManagedByShadowPodValue}),
+			Labels:      shadowPod.Labels,
 			Annotations: shadowPod.Annotations,
 		},
 		Spec: shadowPod.Spec.Pod,
 	}
 
-	utilruntime.Must(ctrl.SetControllerReference(&shadowPod, &pod, r.Scheme))
+	utilruntime.Must(ctrl.SetControllerReference(&shadowPod, &newPod, r.Scheme))
 
-	if err := r.Get(ctx, nsName, &pod); err == nil {
-		klog.V(4).Infof("skip: pod %q already running", klog.KObj(&pod))
-		return ctrl.Result{}, nil
-	}
-
-	if err := r.Create(ctx, &pod); err != nil {
-		if errors.IsAlreadyExists(err) {
-			klog.V(4).Infof("pod %q already exists", klog.KObj(&pod))
-			return ctrl.Result{}, nil
-		}
-
+	if err := r.Create(ctx, &newPod, client.FieldOwner("shadow-pod")); err != nil {
 		klog.Errorf("unable to create pod for shadowpod %q: %v", klog.KObj(&shadowPod), err)
 		return ctrl.Result{}, err
 	}
 
-	klog.Infof("created pod %q for shadowpod %q", klog.KObj(&pod), klog.KObj(&shadowPod))
+	klog.Infof("created pod %q for shadowpod %q", klog.KObj(&newPod), klog.KObj(&shadowPod))
 
 	return ctrl.Result{}, nil
 }
 
 // SetupWithManager monitors only updates on ShadowPods.
 func (r *Reconciler) SetupWithManager(mgr ctrl.Manager, workers int) error {
-	// Trigger a reconciliation only for DeleteEvent.
-	deletedPredicate := predicate.Funcs{
+	// Trigger a reconciliation only for Delete and Update Events.
+	reconciledPredicates := predicate.Funcs{
 		DeleteFunc:  func(e event.DeleteEvent) bool { return true },
 		CreateFunc:  func(e event.CreateEvent) bool { return false },
-		UpdateFunc:  func(e event.UpdateEvent) bool { return false },
+		UpdateFunc:  func(e event.UpdateEvent) bool { return podShouldBeUpdated(e.ObjectNew, e.ObjectOld) },
 		GenericFunc: func(e event.GenericEvent) bool { return false },
 	}
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&vkv1alpha1.ShadowPod{}).
-		Owns(&corev1.Pod{}, builder.WithPredicates(deletedPredicate)).
+		Owns(&corev1.Pod{}, builder.WithPredicates(reconciledPredicates)).
 		WithOptions(controller.Options{MaxConcurrentReconciles: workers}).
 		Complete(r)
 }

--- a/pkg/utils/clients/get_cached_client.go
+++ b/pkg/utils/clients/get_cached_client.go
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package cachedclient contains utility methods to create a new controller runtime client with cache.
-package cachedclient
+// Package clients contains utility methods to create and manage clients with custom features.
+package clients
 
 import (
 	"context"

--- a/pkg/utils/clients/get_ssa_client_patch.go
+++ b/pkg/utils/clients/get_ssa_client_patch.go
@@ -1,0 +1,44 @@
+// Copyright 2019-2023 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package clients contains utility methods to create and manage clients with custom features.
+package clients
+
+import (
+	"encoding/json"
+
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ssaPatch uses server-side apply to patch the object.
+type ssaPatch struct {
+	patch any
+}
+
+// Patch returns a client.Patch object to perform a server side apply operation, associated with the given configuration.
+// The argument must be a pointer to an *ApplyConfiguration object (e.g., PodApplyConfiguration).
+func Patch(patch any) client.Patch {
+	return ssaPatch{patch: patch}
+}
+
+// Type implements the client.Patch interface.
+func (p ssaPatch) Type() types.PatchType {
+	return types.ApplyPatchType
+}
+
+// Data implements the client.Patch interface.
+func (p ssaPatch) Data(_ client.Object) ([]byte, error) {
+	return json.Marshal(p.patch)
+}

--- a/pkg/virtualKubelet/forge/meta.go
+++ b/pkg/virtualKubelet/forge/meta.go
@@ -46,11 +46,11 @@ func IsReflected(obj metav1.Object) bool {
 	return ReflectedLabelSelector().Matches(labels.Set(obj.GetLabels()))
 }
 
-// RemoteObjectMeta merges the remote and local ObjectMeta for a reflected object.
+// RemoteObjectMeta forges the local ObjectMeta for a reflected object.
 func RemoteObjectMeta(local, remote *metav1.ObjectMeta) metav1.ObjectMeta {
 	output := remote.DeepCopy()
-	output.SetLabels(labels.Merge(remote.GetLabels(), labels.Merge(local.GetLabels(), ReflectionLabels())))
-	output.SetAnnotations(labels.Merge(remote.GetAnnotations(), local.GetAnnotations()))
+	output.SetLabels(labels.Merge(local.GetLabels(), ReflectionLabels()))
+	output.SetAnnotations(local.GetAnnotations())
 	return *output
 }
 

--- a/pkg/virtualKubelet/forge/meta_test.go
+++ b/pkg/virtualKubelet/forge/meta_test.go
@@ -104,14 +104,14 @@ var _ = Describe("Meta forging", func() {
 			// Check whether the local labels are present (higher precedence if a remote label matches)
 			Expect(output.Labels).To(HaveKeyWithValue("foo", "bar"))
 			// Check whether the remote labels are present
-			Expect(output.Labels).To(HaveKeyWithValue("bar", "baz"))
+			Expect(output.Labels).NotTo(HaveKeyWithValue("bar", "baz"))
 		})
 
 		It("should correctly set the annotations", func() {
 			// Check whether the local annotations are present (higher precedence if a remote annotation matches)
 			Expect(output.Annotations).To(HaveKeyWithValue("bar", "baz"))
 			// Check whether the remote annotations are present
-			Expect(output.Annotations).To(HaveKeyWithValue("baz", "foo"))
+			Expect(output.Annotations).NotTo(HaveKeyWithValue("baz", "foo"))
 		})
 
 		It("should not mutate the local object", func() { Expect(local).To(Equal(original)) })

--- a/pkg/virtualKubelet/reflection/workload/podns_test.go
+++ b/pkg/virtualKubelet/reflection/workload/podns_test.go
@@ -208,7 +208,7 @@ var _ = Describe("Namespaced Pod Reflection Tests", func() {
 						Expect(shadowAfter.Labels).To(HaveKeyWithValue(forge.LiqoDestinationClusterIDKey, RemoteClusterID))
 						Expect(shadowAfter.Labels).To(HaveKeyWithValue("foo", "bar"))
 						Expect(shadowAfter.Annotations).To(HaveKeyWithValue("bar", "baz"))
-						Expect(shadowAfter.Annotations).To(HaveKeyWithValue("existing", "existing"))
+						Expect(shadowAfter.Annotations).NotTo(HaveKeyWithValue("existing", "existing"))
 					})
 					It("the spec should not have been replicated to the remote object, to prevent possible issues", func() {
 						shadowAfter := GetShadowPod(liqoClient, RemoteNamespace, PodName)
@@ -220,7 +220,7 @@ var _ = Describe("Namespaced Pod Reflection Tests", func() {
 				When("the remote object already exists and is correct", func() {
 					BeforeEach(func() {
 						shadow.SetLabels(labels.Merge(map[string]string{"foo": "bar"}, forge.ReflectionLabels()))
-						shadow.SetAnnotations(map[string]string{"bar": "baz", "existing": "existing"})
+						shadow.SetAnnotations(map[string]string{"bar": "baz"})
 						shadow.Spec.Pod.Containers = []corev1.Container{{Name: "bar", Image: "foo"}}
 
 						// Here, we create a modified fake client which returns an error when trying to perform an update operation.


### PR DESCRIPTION

Changes to the shadowpodController allow the update of the labels and annotations of the offloaded pod from its shadowpod.

Unit tests have been updated to also cover the new features.