### PR TITLE
Fix AWS IAM User Creation

### DIFF
--- a/pkg/identityManager/const.go
+++ b/pkg/identityManager/const.go
@@ -23,6 +23,13 @@ const (
 )
 
 const (
+	localClusterIDTagKey  = "liqo.io/local-cluster-id"
+	remoteClusterIDTagKey = "liqo.io/remote-cluster-id"
+	managedByTagKey       = "liqo.io/managed-by"
+	managedByTagValue     = "liqo"
+)
+
+const (
 	certificateExpireTimeAnnotation = "discovery.liqo.io/certificate-expire-time"
 )
 

--- a/pkg/liqoctl/install/eks/iam.go
+++ b/pkg/liqoctl/install/eks/iam.go
@@ -200,7 +200,7 @@ func (o *Options) checkPolicy(iamSvc *iam.IAM) (string, error) {
 	}
 
 	if tmp != policyDocument {
-		return "", fmt.Errorf("the %v IAM policy has not the permission required by Liqo",
+		return "", fmt.Errorf("the %v IAM policy has not the permission required by Liqo, try deleting or updating it",
 			o.iamUser.policyName)
 	}
 

--- a/pkg/liqoctl/install/eks/policy.go
+++ b/pkg/liqoctl/install/eks/policy.go
@@ -43,6 +43,14 @@ var policy = PolicyDocument{
 		{
 			Effect: "Allow",
 			Action: []string{
+				"iam:GetUser",
+				"iam:TagUser",
+			},
+			Resource: "arn:aws:iam::*:user/liqo-*",
+		},
+		{
+			Effect: "Allow",
+			Action: []string{
 				"eks:DescribeCluster",
 			},
 			Resource: "*",


### PR DESCRIPTION
# Description

This pr fixes a bug that prevents two EKS clusters to re-do an in-band peering after the unpeering

Fixes #(issue)

# How Has This Been Tested?

- [x] Manually on EKS
