### PR TITLE
Docs: update outdated flag for AKS install

### DIFF
--- a/docs/installation/install.md
+++ b/docs/installation/install.md
@@ -110,7 +110,7 @@ By default, the cluster is assigned the same name as that specified through the 
 Alternatively, you can manually specify a different name with the `--cluster-name` *liqoctl* flag.
 
 ```{admonition} Note
-If you are running an [AKS private cluster](https://docs.microsoft.com/en-us/azure/aks/private-clusters), you may need to set the `--disable-endpoint-check` *liqoctl* flag, since the API Server in your kubeconfig may be different from the one retrieved from the Azure APIs.
+If you are running an [AKS private cluster](https://docs.microsoft.com/en-us/azure/aks/private-clusters), you may need to set the `--disable-api-server-sanity-check` *liqoctl* flag, since the API Server in your kubeconfig may be different from the one retrieved from the Azure APIs.
 
 Additionally, since your API Server is not accessible from the public Internet, you shall leverage the [in-band peering approach](FeaturesPeeringInBandControlPlane) towards the clusters not attached to the same Azure Virtual Network.
 ```


### PR DESCRIPTION
# Description

This PR updates an outdated flag from the documentation concerning the installation of liqo on AKS.

