### PR TITLE
Liqonet: wg userspace metric

### DIFF
--- a/build/liqonet/Dockerfile
+++ b/build/liqonet/Dockerfile
@@ -1,8 +1,8 @@
 FROM ekidd/rust-musl-builder as rustBuilder
 
-ARG VERSION=0.4.0
+ARG VERSION=0.5.2
 
-RUN cargo install --version $VERSION boringtun
+RUN cargo install --version $VERSION boringtun-cli
 
 
 FROM golang:1.19 as goBuilder
@@ -23,6 +23,6 @@ RUN apk update && \
     rm -rf /var/cache/apk/*
 
 COPY --from=goBuilder /tmp/builder/liqonet /usr/bin/liqonet
-COPY --from=rustBuilder /home/rust/.cargo/bin/boringtun /usr/bin/boringtun
+COPY --from=rustBuilder /home/rust/.cargo/bin/boringtun-cli /usr/bin/boringtun-cli
 
 ENTRYPOINT [ "/usr/bin/liqonet" ]

--- a/deployments/liqo/README.md
+++ b/deployments/liqo/README.md
@@ -57,6 +57,7 @@
 | gateway.config.addressOverride | string | `""` | Override the default address where your service is available, you should configure it if behind a reverse proxy or NAT. |
 | gateway.config.listeningPort | int | `5871` | port used by the vpn tunnel. |
 | gateway.config.portOverride | string | `""` | Overrides the port where your service is available, you should configure it if behind a reverse proxy or NAT and is different from the listening port. |
+| gateway.config.wireguardImplementation | string | `"kernel"` | implementation used by wireguard. Possible values are "userspace" and "kernel". Do not use "userspace" unless strictly necessary. |
 | gateway.imageName | string | `"ghcr.io/liqotech/liqonet"` | gateway image repository |
 | gateway.metrics.enabled | bool | `false` | expose metrics about network traffic towards cluster peers. |
 | gateway.metrics.port | int | `5872` | port used to expose metrics. |

--- a/deployments/liqo/templates/liqo-gateway-deployment.yaml
+++ b/deployments/liqo/templates/liqo-gateway-deployment.yaml
@@ -68,4 +68,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
+            - name: WIREGUARD_IMPLEMENTATION
+              value: {{ .Values.gateway.config.wireguardImplementation }}
       hostNetwork: true

--- a/deployments/liqo/values.yaml
+++ b/deployments/liqo/values.yaml
@@ -90,6 +90,8 @@ gateway:
     portOverride: ""
     # -- port used by the vpn tunnel.
     listeningPort: 5871
+    # -- implementation used by wireguard. Possible values are "userspace" and "kernel". Do not use "userspace" unless strictly necessary.
+    wireguardImplementation: "kernel"
   metrics:
     # -- expose metrics about network traffic towards cluster peers.
     enabled: false

--- a/docs/_downloads/grafana/liqonetwork.json
+++ b/docs/_downloads/grafana/liqonetwork.json
@@ -95,7 +95,7 @@
       },
       "gridPos": {
         "h": 3,
-        "w": 4,
+        "w": 3,
         "x": 0,
         "y": 1
       },
@@ -132,6 +132,71 @@
       ],
       "title": "Connected clusters",
       "transformations": [],
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P1809F7CD0C75ACF3"
+      },
+      "description": "Describe which wireguard implementation Liqo is using, between \"kernel\" and \"userspace\".",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "orange",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 3,
+        "x": 3,
+        "y": 1
+      },
+      "id": 41,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^implementation$/",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.0.4",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
+          "editorMode": "builder",
+          "exemplar": false,
+          "expr": "liqo_wireguard_implementation{driver=\"wireguard\"}",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Wireguard implementation",
       "type": "stat"
     },
     {
@@ -192,8 +257,8 @@
       },
       "gridPos": {
         "h": 6,
-        "w": 10,
-        "x": 4,
+        "w": 9,
+        "x": 6,
         "y": 1
       },
       "id": 4,
@@ -279,8 +344,8 @@
       },
       "gridPos": {
         "h": 6,
-        "w": 10,
-        "x": 14,
+        "w": 9,
+        "x": 15,
         "y": 1
       },
       "id": 39,
@@ -343,7 +408,7 @@
       },
       "gridPos": {
         "h": 3,
-        "w": 4,
+        "w": 3,
         "x": 0,
         "y": 4
       },
@@ -448,9 +513,9 @@
         "orientation": "auto",
         "reduceOptions": {
           "calcs": [
-            "lastNotNull"
+            "last"
           ],
-          "fields": "",
+          "fields": "/^Value$/",
           "values": false
         },
         "textMode": "auto"
@@ -463,7 +528,11 @@
             "uid": "P1809F7CD0C75ACF3"
           },
           "editorMode": "builder",
-          "expr": "label_replace(liqo_peer_is_connected{cluster_id=\"$clusterid\"}, \"pod\", \"\", \"\", \"\")",
+          "exemplar": false,
+          "expr": "liqo_peer_is_connected{cluster_id=\"$clusterid\"}",
+          "format": "table",
+          "instant": false,
+          "interval": "",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"


### PR DESCRIPTION
# Description

This PR add the possibility to force **wireguard userspace** implementation using helm **values.yaml** file.
In addition the information about what implementation Liqo is using has been added in **metrics** and in **grafana**. 

![image](https://user-images.githubusercontent.com/33266330/217189097-3c6b6c91-05f7-471d-9e38-71e02ceb2898.png)

![image](https://user-images.githubusercontent.com/33266330/217317358-c306a4b2-c354-426c-90af-d29e6519b6de.png)


