### PR TITLE
Liqoctl: install ServiceType refactoring

### DIFF
--- a/pkg/liqoctl/install/k3s/provider.go
+++ b/pkg/liqoctl/install/k3s/provider.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
 
 	"github.com/liqotech/liqo/pkg/liqoctl/install"
 )
@@ -70,13 +71,13 @@ func (o *Options) Values() map[string]interface{} {
 	return map[string]interface{}{
 		"auth": map[string]interface{}{
 			"service": map[string]interface{}{
-				"type": "NodePort",
+				"type": string(corev1.ServiceTypeNodePort),
 			},
 		},
 
 		"gateway": map[string]interface{}{
 			"service": map[string]interface{}{
-				"type": "NodePort",
+				"type": string(corev1.ServiceTypeNodePort),
 			},
 		},
 	}

--- a/pkg/liqoctl/install/kind/provider.go
+++ b/pkg/liqoctl/install/kind/provider.go
@@ -17,6 +17,8 @@ package kind
 import (
 	"context"
 
+	corev1 "k8s.io/api/core/v1"
+
 	"github.com/liqotech/liqo/pkg/liqoctl/install"
 	"github.com/liqotech/liqo/pkg/liqoctl/install/kubeadm"
 )
@@ -57,13 +59,13 @@ func (o *Options) Values() map[string]interface{} {
 	return map[string]interface{}{
 		"auth": map[string]interface{}{
 			"service": map[string]interface{}{
-				"type": "NodePort",
+				"type": string(corev1.ServiceTypeNodePort),
 			},
 		},
 
 		"gateway": map[string]interface{}{
 			"service": map[string]interface{}{
-				"type": "NodePort",
+				"type": string(corev1.ServiceTypeNodePort),
 			},
 		},
 	}


### PR DESCRIPTION
# Description

This PR replaces the data used in **liqoctl install** to force the service type with a standard constant.
