### PR TITLE
Make it possible to configure IPAM module

### DIFF
--- a/cmd/liqo-controller-manager/main.go
+++ b/cmd/liqo-controller-manager/main.go
@@ -146,6 +146,8 @@ func main() {
 	flag.Var(&kubeletRAMLimits, "kubelet-ram-limits", "RAM limits assigned to the Virtual Kubelet Pod")
 	flag.Var(&nodeExtraAnnotations, "node-extra-annotations", "Extra annotations to add to the Virtual Node")
 	flag.Var(&nodeExtraLabels, "node-extra-labels", "Extra labels to add to the Virtual Node")
+	kubeletIpamServer := flag.String("kubelet-ipam-server", "",
+		"The address of the IPAM server to use for the virtual kubelet (set to empty string to disable IPAM)")
 
 	// Storage Provisioner parameters
 	enableStorage := flag.Bool("enable-storage", false, "enable the liqo virtual storage class")
@@ -296,6 +298,7 @@ func main() {
 		RequestsRAM:          kubeletRAMRequests.Quantity,
 		LimitsCPU:            kubeletCPULimits.Quantity,
 		LimitsRAM:            kubeletRAMLimits.Quantity,
+		IpamEndpoint:         *kubeletIpamServer,
 	}
 
 	resourceOfferReconciler := resourceoffercontroller.NewResourceOfferController(

--- a/cmd/virtual-kubelet/root/flag.go
+++ b/cmd/virtual-kubelet/root/flag.go
@@ -34,7 +34,8 @@ func InstallFlags(flags *pflag.FlagSet, o *Opts) {
 	flags.StringVar(&o.HomeCluster.ClusterName, "home-cluster-name", o.HomeCluster.ClusterName, "The name of the home cluster")
 	flags.StringVar(&o.ForeignCluster.ClusterID, "foreign-cluster-id", o.ForeignCluster.ClusterID, "The ID of the foreign cluster")
 	flags.StringVar(&o.ForeignCluster.ClusterName, "foreign-cluster-name", o.ForeignCluster.ClusterName, "The name of the foreign cluster")
-	flags.StringVar(&o.LiqoIpamServer, "ipam-server", o.LiqoIpamServer, "The address to contact the IPAM module")
+	flags.StringVar(&o.LiqoIpamServer, "ipam-server", o.LiqoIpamServer,
+		"The address to contact the IPAM module (leave it empty to disable the IPAM module)")
 
 	flags.StringVar(&o.NodeIP, "node-ip", o.NodeIP, "The IP address of the virtual kubelet pod, and assigned to the virtual node as internal address")
 	flags.Var(o.CertificateType, "certificate-type", "The type of virtual kubelet server certificate to generate, among kubelet, aws, self-signed")

--- a/cmd/virtual-kubelet/root/opts.go
+++ b/cmd/virtual-kubelet/root/opts.go
@@ -15,7 +15,6 @@
 package root
 
 import (
-	"fmt"
 	"os"
 	"time"
 
@@ -23,7 +22,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
-	"github.com/liqotech/liqo/pkg/consts"
 	argsutils "github.com/liqotech/liqo/pkg/utils/args"
 )
 
@@ -104,8 +102,6 @@ func NewOpts() *Opts {
 		NodeName:             DefaultNodeName,
 		TenantNamespace:      corev1.NamespaceDefault,
 		InformerResyncPeriod: DefaultInformerResyncPeriod,
-
-		LiqoIpamServer: fmt.Sprintf("%v:%v", consts.NetworkManagerServiceName, consts.NetworkManagerIpamPort),
 
 		CertificateType: argsutils.NewEnum([]string{CertificateTypeKubelet, CertificateTypeAWS, CertificateTypeSelfSigned}, CertificateTypeKubelet),
 		ListenPort:      DefaultListenPort,

--- a/deployments/liqo/templates/liqo-controller-manager-deployment.yaml
+++ b/deployments/liqo/templates/liqo-controller-manager-deployment.yaml
@@ -1,6 +1,7 @@
 ---
 {{- $ctrlManagerConfig := (merge (dict "name" "controller-manager" "module" "controller-manager") .) -}}
 {{- $webhookConfig := (merge (dict "name" "webhook" "module" "webhook") .) -}}
+{{- $netManagerConfig := (merge (dict "name" "network-manager" "module" "networking") .) -}}
 
 {{- $vkargs := .Values.virtualKubelet.extra.args }}
 {{- /* Enable the API support if not overridden by the user */ -}}
@@ -65,6 +66,7 @@ spec:
           - --enable-incoming-peering={{ .Values.discovery.config.incomingPeeringEnabled }}
           - --resource-sharing-percentage={{ .Values.controllerManager.config.resourceSharingPercentage }}
           - --kubelet-image={{ .Values.virtualKubelet.imageName }}{{ include "liqo.suffix" $ctrlManagerConfig }}:{{ include "liqo.version" $ctrlManagerConfig }}
+          - --kubelet-ipam-server={{ include "liqo.prefixedName" $netManagerConfig }}.{{ .Release.Namespace }}:6000
           - --auto-join-discovered-clusters={{ .Values.discovery.config.autojoin }}
           - --enable-storage={{ .Values.storage.enable }}
           - --webhook-port={{ .Values.webhook.port }}

--- a/pkg/consts/liqonet.go
+++ b/pkg/consts/liqonet.go
@@ -19,8 +19,6 @@ import "strings"
 const (
 	// NetworkManagerIpamPort is the port used by IPAM gRPCs.
 	NetworkManagerIpamPort = 6000
-	// NetworkManagerServiceName is the service name for IPAM gRPCs.
-	NetworkManagerServiceName = "liqo-network-manager"
 	// DefaultCIDRValue is the default value for a string that contains a CIDR.
 	DefaultCIDRValue = "None"
 	// NatMappingKind is the constant representing

--- a/pkg/virtualKubelet/reflection/workload/podns.go
+++ b/pkg/virtualKubelet/reflection/workload/podns.go
@@ -353,9 +353,17 @@ func (npr *NamespacedPodReflector) HandleStatus(ctx context.Context, local, remo
 
 	// Wrap the address translation logic, so that we do not have to handle errors in the forge logic.
 	var terr error
-	translator := func(original string) (translation string) {
-		translation, terr = npr.MapPodIP(ctx, info, original)
-		return translation
+	var translator func(string) string
+	switch npr.ipamclient.(type) {
+	case nil:
+		translator = func(original string) string {
+			return original
+		}
+	default:
+		translator = func(original string) (translation string) {
+			translation, terr = npr.MapPodIP(ctx, info, original)
+			return translation
+		}
 	}
 
 	// Increase the restart count in case the remote pod changed.

--- a/pkg/vkMachinery/forge/forge.go
+++ b/pkg/vkMachinery/forge/forge.go
@@ -21,7 +21,6 @@ import (
 
 	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
 	sharingv1alpha1 "github.com/liqotech/liqo/apis/sharing/v1alpha1"
-	liqoconst "github.com/liqotech/liqo/pkg/consts"
 	"github.com/liqotech/liqo/pkg/utils/pod"
 	"github.com/liqotech/liqo/pkg/virtualKubelet"
 	vk "github.com/liqotech/liqo/pkg/vkMachinery"
@@ -52,8 +51,10 @@ func forgeVKContainers(
 		stringifyArgument("--tenant-namespace", vkNamespace),
 		stringifyArgument("--home-cluster-id", homeCluster.ClusterID),
 		stringifyArgument("--home-cluster-name", homeCluster.ClusterName),
-		stringifyArgument("--ipam-server",
-			fmt.Sprintf("%v.%v:%v", liqoconst.NetworkManagerServiceName, liqoNamespace, liqoconst.NetworkManagerIpamPort)),
+	}
+
+	if opts.IpamEndpoint != "" {
+		args = append(args, stringifyArgument("--ipam-server", opts.IpamEndpoint))
 	}
 
 	if len(resourceOffer.Spec.StorageClasses) > 0 {

--- a/pkg/vkMachinery/forge/type.go
+++ b/pkg/vkMachinery/forge/type.go
@@ -33,4 +33,5 @@ type VirtualKubeletOpts struct {
 	LimitsCPU            resource.Quantity
 	RequestsRAM          resource.Quantity
 	LimitsRAM            resource.Quantity
+	IpamEndpoint         string
 }


### PR DESCRIPTION
# Description

This pr allows the Liqo users to use different IPAM modules (implementing the Liqo APIs) or to disable the IPAM completely, also disabling the IP translation between the two clusters (this may be useful in case of not overlapping pod CIDRs with an external network layer)

Ref #1671

# How Has This Been Tested?

- [x] locally on KinD with the Liqo network module enabled
- [x] locally on KinD without the IP translation
