### PR TITLE
Make it possible to disable the IP reflection

### DIFF
--- a/cmd/virtual-kubelet/root/flag.go
+++ b/cmd/virtual-kubelet/root/flag.go
@@ -36,6 +36,8 @@ func InstallFlags(flags *pflag.FlagSet, o *Opts) {
 	flags.StringVar(&o.ForeignCluster.ClusterName, "foreign-cluster-name", o.ForeignCluster.ClusterName, "The name of the foreign cluster")
 	flags.StringVar(&o.LiqoIpamServer, "ipam-server", o.LiqoIpamServer,
 		"The address to contact the IPAM module (leave it empty to disable the IPAM module)")
+	flags.BoolVar(&o.DisableIPReflection, "disable-ip-reflection", o.DisableIPReflection,
+		"Disable the IP reflection for the offloaded pods")
 
 	flags.StringVar(&o.NodeIP, "node-ip", o.NodeIP, "The IP address of the virtual kubelet pod, and assigned to the virtual node as internal address")
 	flags.Var(o.CertificateType, "certificate-type", "The type of virtual kubelet server certificate to generate, among kubelet, aws, self-signed")

--- a/cmd/virtual-kubelet/root/opts.go
+++ b/cmd/virtual-kubelet/root/opts.go
@@ -63,9 +63,10 @@ type Opts struct {
 	TenantNamespace      string
 	InformerResyncPeriod time.Duration
 
-	HomeCluster    discoveryv1alpha1.ClusterIdentity
-	ForeignCluster discoveryv1alpha1.ClusterIdentity
-	LiqoIpamServer string
+	HomeCluster         discoveryv1alpha1.ClusterIdentity
+	ForeignCluster      discoveryv1alpha1.ClusterIdentity
+	LiqoIpamServer      string
+	DisableIPReflection bool
 
 	// Sets the addresses to listen for requests from the Kubernetes API server
 	NodeIP          string
@@ -104,6 +105,8 @@ func NewOpts() *Opts {
 		NodeName:             DefaultNodeName,
 		TenantNamespace:      corev1.NamespaceDefault,
 		InformerResyncPeriod: DefaultInformerResyncPeriod,
+
+		DisableIPReflection: false,
 
 		CertificateType: argsutils.NewEnum([]string{CertificateTypeKubelet, CertificateTypeAWS, CertificateTypeSelfSigned}, CertificateTypeKubelet),
 		ListenPort:      DefaultListenPort,

--- a/cmd/virtual-kubelet/root/root.go
+++ b/cmd/virtual-kubelet/root/root.go
@@ -94,6 +94,7 @@ func runRootCommand(ctx context.Context, c *Opts) error {
 		NodeIP:    c.NodeIP,
 
 		LiqoIpamServer:       c.LiqoIpamServer,
+		DisableIPReflection:  c.DisableIPReflection,
 		InformerResyncPeriod: c.InformerResyncPeriod,
 
 		PodWorkers:                  c.PodWorkers,

--- a/pkg/virtualKubelet/reflection/workload/pod_test.go
+++ b/pkg/virtualKubelet/reflection/workload/pod_test.go
@@ -42,7 +42,7 @@ import (
 var _ = Describe("Pod Reflection Tests", func() {
 	Describe("the NewPodReflector function", func() {
 		It("should not return a nil reflector", func() {
-			reflector := workload.NewPodReflector(nil, nil, nil, forge.APIServerSupportDisabled, 0)
+			reflector := workload.NewPodReflector(nil, nil, nil, &workload.PodReflectorConfig{forge.APIServerSupportDisabled, false}, 0)
 			Expect(reflector).ToNot(BeNil())
 			Expect(reflector.Reflector).ToNot(BeNil())
 		})
@@ -59,7 +59,7 @@ var _ = Describe("Pod Reflection Tests", func() {
 		BeforeEach(func() {
 			ipam := fakeipam.NewIPAMClient("192.168.200.0/24", "192.168.201.0/24", true)
 			metricsFactory := func(string) metricsv1beta1.PodMetricsInterface { return nil }
-			reflector := workload.NewPodReflector(nil, metricsFactory, ipam, forge.APIServerSupportDisabled, 0)
+			reflector := workload.NewPodReflector(nil, metricsFactory, ipam, &workload.PodReflectorConfig{forge.APIServerSupportDisabled, false}, 0)
 			kubernetesServiceIPGetter = reflector.KubernetesServiceIPGetter()
 		})
 
@@ -106,7 +106,7 @@ var _ = Describe("Pod Reflection Tests", func() {
 			client = fake.NewSimpleClientset(&local)
 			factory := informers.NewSharedInformerFactory(client, 10*time.Hour)
 
-			reflector = workload.NewPodReflector(nil, nil, nil, forge.APIServerSupportDisabled, 0)
+			reflector = workload.NewPodReflector(nil, nil, nil, &workload.PodReflectorConfig{forge.APIServerSupportDisabled, false}, 0)
 
 			opts := options.New(client, factory.Core().V1().Pods()).
 				WithHandlerFactory(FakeEventHandler).

--- a/pkg/virtualKubelet/reflection/workload/podns_test.go
+++ b/pkg/virtualKubelet/reflection/workload/podns_test.go
@@ -72,7 +72,7 @@ var _ = Describe("Namespaced Pod Reflection Tests", func() {
 
 			broadcaster := record.NewBroadcaster()
 			metricsFactory := func(string) metricsv1beta1.PodMetricsInterface { return nil }
-			rfl := workload.NewPodReflector(nil, metricsFactory, ipam, forge.APIServerSupportTokenAPI, 0)
+			rfl := workload.NewPodReflector(nil, metricsFactory, ipam, &workload.PodReflectorConfig{forge.APIServerSupportTokenAPI, false}, 0)
 			rfl.Start(ctx, options.New(client, factory.Core().V1().Pods()).WithEventBroadcaster(broadcaster))
 			reflector = rfl.NewNamespaced(options.NewNamespaced().
 				WithLocal(LocalNamespace, client, factory).WithLiqoLocal(liqoClient, liqoFactory).


### PR DESCRIPTION
# Description

This pr allows the Liqo users to disable the IP reflection. The local copy of the offloaded pods will not have an assigned IP, and the endpoint slice reflection is disabled by default.

Ref #1671

# How Has This Been Tested?

- [x] locally on KinD with the reflection enabled
- [x] locally on KinD with the reflection disabled
