### PR TITLE
Bump Liqoctl Golang version to 1.19

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -203,7 +203,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.20'
+          go-version: '1.19'
         env:
           GOPATH: ${{ github.workspace }}
 


### PR DESCRIPTION
# Description
This pr bumps the Liqoctl Golang version to v1.19 because Liqoctl is not able to pass the e2e tests if compiled with version 1.20 .