### PR TITLE
Bump Golang version to 1.19 (revert)

### DIFF
--- a/.github/workflows/check-generated-artifacts.yml
+++ b/.github/workflows/check-generated-artifacts.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.20'
+          go-version: '1.19'
 
       - name: Run the automatic generation
         working-directory: ./

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.20'
+          go-version: '1.19'
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3.4.0
@@ -41,7 +41,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v3
       with:
-        go-version: '1.20'
+        go-version: '1.19'
 
     - name: Execute go mod tidy and check the outcome
       working-directory: ./

--- a/build/common/Dockerfile
+++ b/build/common/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20 as builder
+FROM golang:1.19 as builder
 WORKDIR /tmp/builder
 
 COPY go.mod ./go.mod

--- a/build/liqo-test/Dockerfile
+++ b/build/liqo-test/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20 as builder
+FROM golang:1.19 as builder
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
 ENV GOPATH /go
 ENV K8S_VERSION=1.25.0

--- a/build/liqoctl/build.sh
+++ b/build/liqoctl/build.sh
@@ -14,7 +14,7 @@ trap 'error "${BASH_SOURCE}" "${LINENO}"' ERR
 GO_VERSION="1.19"
 
 docker run -v "$PWD:/liqo" -w /liqo -e="CGO_ENABLED=${CGO_ENABLED}" --rm "golang:${GO_VERSION}" \
-   go build -o "./liqoctl-${GOOS}-${GOARCH}" \
+   go mod tidy && go build -o "./liqoctl-${GOOS}-${GOARCH}" \
    -ldflags="-s -w -X 'github.com/liqotech/liqo/pkg/liqoctl/version.liqoctlVersion=${LIQOCTLVERSION}'" \
    -buildvcs=false \
    ./cmd/liqoctl

--- a/build/liqonet/Dockerfile
+++ b/build/liqonet/Dockerfile
@@ -5,7 +5,7 @@ ARG VERSION=0.5.2
 RUN cargo install --version $VERSION boringtun-cli
 
 
-FROM golang:1.20 as goBuilder
+FROM golang:1.19 as goBuilder
 WORKDIR /tmp/builder
 
 COPY go.mod ./go.mod

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/liqotech/liqo
 
-go 1.20
+go 1.19
 
 require (
 	github.com/Azure/azure-sdk-for-go v68.0.0+incompatible


### PR DESCRIPTION
# Description

This pr reverts the Golang version to v1.19
It is necessary to align the entire codebase after this PR #1691

# How Has This Been Tested?

- [x] existing unit and e2e tests