### PR TITLE
Bump golang-ci version to 1.52.0

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,7 +23,7 @@ jobs:
         uses: golangci/golangci-lint-action@v3.4.0
         with:
           only-new-issues: true
-          version: v1.51.2
+          version: v1.52.0
           args: --timeout=900s
 
   gomodtidy:

--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ fmt: gci addlicense
 # Install golangci-lint if not available
 golangci-lint:
 ifeq (, $(shell which golangci-lint))
-	@go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.2
+	@go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.52.0
 GOLANGCILINT=$(GOBIN)/golangci-lint
 else
 GOLANGCILINT=$(shell which golangci-lint)


### PR DESCRIPTION
# Description

This pr bumps the golang-ci version to 1.52.0 with full support of generics
