### PR TITLE
Add PR number in E2E tests dispatch

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -20,6 +20,7 @@ jobs:
       master: ${{ steps.configure.outputs.master }}
       repo-name: ${{ steps.configure.outputs.repo-name }}
       architectures: ${{ steps.configure.outputs.architectures }}
+      pr-number: ${{ steps.configure.outputs.pr-number }}
     steps:
     - name: Get the version
       id: get_version
@@ -33,6 +34,7 @@ jobs:
           echo "master=false" >> $GITHUB_OUTPUT
           echo "architectures=linux/amd64" >> $GITHUB_OUTPUT
           echo "commit-ref=${{ github.event.client_payload.pull_request.head.sha }}" >> $GITHUB_OUTPUT
+          echo "pr-number=${{ github.event.client_payload.pull_request.number }}" >> $GITHUB_OUTPUT
         elif [ "${{ steps.get_version.outputs.VERSION }}" != "" ]; then
           echo "master=false" >> $GITHUB_OUTPUT
           echo "architectures=linux/amd64,linux/arm64" >> $GITHUB_OUTPUT
@@ -185,6 +187,7 @@ jobs:
                "repo-name": "${{ needs.configure.outputs.repo-name }}",
                "base-repo": "${{ github.repository }}",
                "run-id": "${{ github.run_id }}"
+               "pr-number" : "${{ needs.configure.outputs.pr-number }}"
              }
 
   liqoctl:


### PR DESCRIPTION
# Description

This PR adds the PR number to the repository_dispatch sent to liqops to trigger E2E tests.

# How Has This Been Tested?

It cannot be tested because the action can be triggered only by a repository_dispatch that targets the master branch.