### PR TITLE
PR number in rebase (test=true) command

### DIFF
--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -41,6 +41,9 @@ jobs:
                "payload": {
                      "repository": {
                         "full_name": "${{ github.repository }}"
+                      },
+                      "issue": {
+                        "number": "${{ github.event.client_payload.github.payload.issue.number }}"
                       }
                }
             },


### PR DESCRIPTION
# Description

This PR adds PR number propagation inside the test repository-dispatch event triggered by rebase command with argument `test=true`

# How Has This Been Tested?

On my fork checking the generated POST request https://github.com/cheina97/liqo/actions/runs/4644671817/jobs/8220121474
