### PR TITLE
ShadowEndpointSlice controller check for foreign API server status

### DIFF
--- a/pkg/utils/foreignCluster/peeringStatus.go
+++ b/pkg/utils/foreignCluster/peeringStatus.go
@@ -82,3 +82,9 @@ func IsNetworkingExternal(foreignCluster *discoveryv1alpha1.ForeignCluster) bool
 func IsNetworkingEstablishedOrExternal(foreignCluster *discoveryv1alpha1.ForeignCluster) bool {
 	return IsNetworkingEstablished(foreignCluster) || IsNetworkingExternal(foreignCluster)
 }
+
+// IsAPIServerReady checks if the api server is ready.
+func IsAPIServerReady(foreignCluster *discoveryv1alpha1.ForeignCluster) bool {
+	curPhase := peeringconditionsutils.GetStatus(foreignCluster, discoveryv1alpha1.APIServerStatusCondition)
+	return curPhase == discoveryv1alpha1.PeeringConditionStatusEstablished
+}


### PR DESCRIPTION
# Description

This PR modifies the ShadowEndpointSlice controller to also check the status of the foreign API server.

In the remote cluster, the controller sets the status of the local pods endpoints to Ready/NotReady depending on whether the local API server is ready or not.

Ref #1705 

# How Has This Been Tested?
- [x] Locally on Kind
- [x] Unit tests
- [x] e2e tests
