### PR TITLE
E2E Tests: CNI parametrized

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -74,7 +74,10 @@ jobs:
         repository: ${{github.event.pull_request.head.repo.full_name}}
         persist-credentials: false
     - name: Run Shellcheck
-      uses: azohra/shell-linter@v0.6.0
+      uses: ludeeus/action-shellcheck@2.0.0
+      env:
+        # Allow 'source' outside of FILES
+        SHELLCHECK_OPTS: -x
 
   markdownlint:
     name: Lint markdown files

--- a/test/e2e/pipeline/infra/cluster-api/cni.sh
+++ b/test/e2e/pipeline/infra/cluster-api/cni.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+function install_calico () {
+    local kubeconfig=$1
+    curl https://raw.githubusercontent.com/projectcalico/calico/v3.24.4/manifests/calico.yaml \
+        | sed -E 's|^( +)# (- name: CALICO_IPV4POOL_CIDR)$|\1\2|g;'\
+"s|^( +)# (  value: )\"192.168.0.0/16\"|\1\2\"$POD_CIDR\"|g;"\
+'/- name: CLUSTER_TYPE/{ n; s/( +value: ").+/\1k8s"/g };'\
+'/- name: CALICO_IPV4POOL_IPIP/{ n; s/value: "Always"/value: "Never"/ };'\
+'/- name: CALICO_IPV4POOL_VXLAN/{ n; s/value: "Never"/value: "Always"/};'\
+'/# Set Felix endpoint to host default action to ACCEPT./a\            - name: FELIX_VXLANPORT\n              value: "6789"' \
+        | "${KUBECTL}" apply -f - --kubeconfig "$kubeconfig"
+}

--- a/test/e2e/pipeline/infra/k3s/pre-requirements.sh
+++ b/test/e2e/pipeline/infra/k3s/pre-requirements.sh
@@ -84,6 +84,6 @@ fi
 
 if [[ ! -f "${BINDIR}/k3d" ]]; then
     echo "k3d could not be found. Downloading https://k3d.sigs.k8s.io/dl/${K3D_VERSION}/k3d-${OS}-${ARCH} ..."
-	curl -Lo "${BINDIR}"/k3d https://github.com/k3d-io/k3d/releases/download/${K3D_VERSION}/k3d-${OS}-${ARCH}
+	curl -Lo "${BINDIR}"/k3d "https://github.com/k3d-io/k3d/releases/download/${K3D_VERSION}/k3d-${OS}-${ARCH}"
 	chmod +x "${BINDIR}"/k3d
 fi

--- a/test/e2e/pipeline/infra/kind/pre-requirements.sh
+++ b/test/e2e/pipeline/infra/kind/pre-requirements.sh
@@ -80,6 +80,6 @@ chmod +x "${KUBECTL}"
 
 if [[ ! -f "${BINDIR}/kind" ]]; then
     echo "kind could not be found. Downloading https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-${OS}-${ARCH} ..."
-	curl -Lo "${BINDIR}"/kind https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-${OS}-${ARCH}
+	curl -Lo "${BINDIR}"/kind "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-${OS}-${ARCH}"
 	chmod +x "${BINDIR}"/kind
 fi


### PR DESCRIPTION
# Description

This PR allows to parametrize the CNI used inside **cluster-api** infra, enabling the possibility to specify different CNI configuration for each infra

It also updates the **github action** used for _bash linting_ and allows to use external sources in _shell scripts_.

# How Has This Been Tested?

- [x] Running E2E tests
