### PR TITLE
Liqoctl: pod status check enhanced

### DIFF
--- a/pkg/liqoctl/output/output.go
+++ b/pkg/liqoctl/output/output.go
@@ -56,6 +56,12 @@ const (
 var (
 	// StatusSectionStyle is the style of the status section.
 	StatusSectionStyle = pterm.NewStyle(pterm.FgMagenta, pterm.Bold)
+	// StatusSectionSuccessStyle is the style of the success status section.
+	StatusSectionSuccessStyle = pterm.NewStyle(pterm.FgGreen, pterm.Bold)
+	// StatusSectionFailureStyle is the style of the failure status section.
+	StatusSectionFailureStyle = pterm.NewStyle(pterm.FgRed, pterm.Bold)
+	// StatusSectionInfoStyle is the style of the info status section.
+	StatusSectionInfoStyle = pterm.NewStyle(pterm.FgDefault, pterm.Bold)
 	// StatusDataStyle is the style of the status data.
 	StatusDataStyle = pterm.NewStyle(pterm.FgLightYellow, pterm.Bold)
 	// StatusInfoStyle is the style of the status info.
@@ -104,6 +110,8 @@ func (p *Printer) BoxSetTitle(title string) {
 func (p *Printer) BulletListSprintForBox() string {
 	// Srender function never throws an error.
 	text, err := p.BulletList.Srender()
+	// Flush Items to avoid printing the same list twice.
+	p.BulletList.Items = []pterm.BulletListItem{}
 	p.CheckErr(err)
 	text = strings.TrimRight(text, "\n")
 	return text

--- a/pkg/liqoctl/status/handler.go
+++ b/pkg/liqoctl/status/handler.go
@@ -40,7 +40,8 @@ func (o *Options) Run(ctx context.Context) error {
 
 	for i, checker := range o.Checkers {
 		checker.Collect(ctx)
-		text := checker.Format()
+		text := ""
+		text = checker.Format()
 
 		if !checker.Silent() || !checker.HasSucceeded() {
 			o.Printer.BoxSetTitle(checker.GetTitle())

--- a/pkg/liqoctl/status/local/localinfo.go
+++ b/pkg/liqoctl/status/local/localinfo.go
@@ -43,7 +43,7 @@ type LocalInfoChecker struct {
 }
 
 const (
-	localInfoCheckerName = "Local Cluster Information"
+	localInfoCheckerName = "Local cluster information"
 )
 
 // NewLocalInfoChecker returns a new LocalInfoChecker.
@@ -66,9 +66,9 @@ func (lic *LocalInfoChecker) Collect(ctx context.Context) {
 	if err != nil {
 		lic.addCollectionError(fmt.Errorf("unable to get cluster identity: %w", err))
 	}
-	clusterIdentitySection := lic.localInfoSection.AddSection("Cluster Identity")
+	clusterIdentitySection := lic.localInfoSection.AddSection("Cluster identity")
 	clusterIdentitySection.AddEntry("Cluster ID", clusterIdentity.ClusterID)
-	clusterIdentitySection.AddEntry("Cluster Name", clusterIdentity.ClusterName)
+	clusterIdentitySection.AddEntry("Cluster name", clusterIdentity.ClusterName)
 
 	ctrlargs, err := liqoctlutils.RetrieveLiqoControllerManagerDeploymentArgs(ctx, lic.options.CRClient, lic.options.LiqoNamespace)
 	if err != nil {
@@ -80,7 +80,7 @@ func (lic *LocalInfoChecker) Collect(ctx context.Context) {
 			if err != nil {
 				lic.addCollectionError(fmt.Errorf("unable to get cluster labels: %w", err))
 			}
-			clusterLabelsSection := clusterIdentitySection.AddSection("Cluster Labels")
+			clusterLabelsSection := clusterIdentitySection.AddSection("Cluster labels")
 			for k, v := range clusterLabels {
 				clusterLabelsSection.AddEntry(k, v)
 			}
@@ -170,7 +170,7 @@ func (lic *LocalInfoChecker) addEndpointsSection(ctx context.Context) error {
 		if ep, err = lic.getVpnEndpointLocalAddress(ctx); err != nil {
 			return fmt.Errorf("unable to get vpn endpoint local address: %w", err)
 		}
-		endpointsSection.AddEntry("Network Gateway", ep)
+		endpointsSection.AddEntry("Network gateway", ep)
 	}
 
 	var aurl string
@@ -189,6 +189,6 @@ func (lic *LocalInfoChecker) addEndpointsSection(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("unable to get api server address: %w", err)
 	}
-	endpointsSection.AddEntry("Kubernetes API Server", apiServerAddress)
+	endpointsSection.AddEntry("Kubernetes API server", apiServerAddress)
 	return nil
 }

--- a/pkg/liqoctl/status/local/localinfo_test.go
+++ b/pkg/liqoctl/status/local/localinfo_test.go
@@ -130,7 +130,7 @@ var _ = Describe("LocalInfo", func() {
 			pterm.Sprintf("Cluster ID: %s", clusterID),
 		))
 		Expect(text).To(ContainSubstring(
-			pterm.Sprintf("Cluster Name: %s", clusterName),
+			pterm.Sprintf("Cluster name: %s", clusterName),
 		))
 		if args.clusterLabels {
 			for _, v := range testutil.ClusterLabels {
@@ -151,7 +151,7 @@ var _ = Describe("LocalInfo", func() {
 				Expect(text).To(ContainSubstring(v))
 			}
 			Expect(text).To(ContainSubstring(
-				pterm.Sprintf("Network Gateway: udp://%s:%d", testutil.EndpointIP, testutil.VPNGatewayPort),
+				pterm.Sprintf("Network gateway: udp://%s:%d", testutil.EndpointIP, testutil.VPNGatewayPort),
 			))
 		} else {
 			Expect(text).To(ContainSubstring(pterm.Sprintf("Status: %s", discoveryv1alpha1.PeeringConditionStatusExternal)))
@@ -161,11 +161,11 @@ var _ = Describe("LocalInfo", func() {
 		))
 		if args.net.apiServerOverride {
 			Expect(text).To(ContainSubstring(
-				pterm.Sprintf("Kubernetes API Server: %s", fmt.Sprintf("https://%v", testutil.OverrideAPIAddress)),
+				pterm.Sprintf("Kubernetes API server: %s", fmt.Sprintf("https://%v", testutil.OverrideAPIAddress)),
 			))
 		} else {
 			Expect(text).To(ContainSubstring(
-				pterm.Sprintf("Kubernetes API Server: %s", fmt.Sprintf("https://%v:6443", testutil.EndpointIP)),
+				pterm.Sprintf("Kubernetes API server: %s", fmt.Sprintf("https://%v:6443", testutil.EndpointIP)),
 			))
 		}
 

--- a/pkg/liqoctl/status/peer/peerinfo.go
+++ b/pkg/liqoctl/status/peer/peerinfo.go
@@ -257,12 +257,12 @@ func (pic *PeerInfoChecker) addVpnSection(ctx context.Context, rootSection outpu
 	te, err := liqogetters.GetTunnelEndpoint(ctx, pic.options.CRClient, &remoteClusterIdentity, tenantNamespace)
 	if err != nil {
 		if kerrors.IsNotFound(err) {
-			rootSection.AddSectionWithDetail("Network Connection", TunnelEndpointNotFoundMsg)
+			rootSection.AddSectionWithDetail("Network connection", TunnelEndpointNotFoundMsg)
 			return nil
 		}
 		return err
 	}
-	tunnelEndpointSection := rootSection.AddSection("Network Connection")
+	tunnelEndpointSection := rootSection.AddSection("Network connection")
 	vpnEndpointSection := tunnelEndpointSection.AddSection("Gateway IPs")
 	vpnEndpointSection.AddEntry("Local", vpnEndpointFromService)
 	vpnEndpointSection.AddEntry("Remote", fmt.Sprintf("%s:%s",

--- a/pkg/utils/slice/slice.go
+++ b/pkg/utils/slice/slice.go
@@ -36,3 +36,14 @@ func RemoveString(slice []string, s string) []string {
 	}
 	return newSlice
 }
+
+// LongestString returns the longest string in a slice of strings.
+func LongestString(slice []string) string {
+	var longest string
+	for _, s := range slice {
+		if len(s) > len(longest) {
+			longest = s
+		}
+	}
+	return longest
+}


### PR DESCRIPTION
# Description

This PR adds new information to the `liqoctl status` **Liqo control plane check** box.

The information included is:

- Liqo Deployments diagnostic
- Liqo DaemonSet diagnostic
- Images used by Liqo components (with `--verbose` flag)

## Screenshots

Standard output
![image](https://user-images.githubusercontent.com/33266330/233411642-2ec9bb76-60c2-4c15-abaf-85f2e65cc047.png)

Verbose output
![image](https://user-images.githubusercontent.com/33266330/233412047-0b89225a-9f7a-49e2-9196-c11d2c984365.png)

Standar output (with errors)
![image](https://user-images.githubusercontent.com/33266330/233412939-cde45cc7-fa67-46fa-bc3a-a2fda9befa27.png)

# How Has This Been Tested?

- [x] Locally using KinD
- [x] Unit Testing
