### PR TITLE
Fix readthedocs build job

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,3 +5,4 @@ sphinx-copybutton==0.5.0
 sphinx-design==0.2.0
 sphinx_external_toc==0.3.0
 semver==2.13.0
+urllib3==1.26.15


### PR DESCRIPTION
# Description

Fix ReadTheDocs build job by adding a pin to the urlib3 package version since version >=2.0 requires a newer OpenSSL version than the one available on the server.

```
Running Sphinx v4.5.0

Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/liqo/envs/latest/lib/python3.7/site-packages/sphinx/config.py", line 332, in eval_config_file
    exec(code, namespace)
  File "/home/docs/checkouts/readthedocs.org/user_builds/liqo/checkouts/latest/docs/conf.py", line 2, in <module>
    import requests
  File "/home/docs/checkouts/readthedocs.org/user_builds/liqo/envs/latest/lib/python3.7/site-packages/requests/__init__.py", line 43, in <module>
    import urllib3
  File "/home/docs/checkouts/readthedocs.org/user_builds/liqo/envs/latest/lib/python3.7/site-packages/urllib3/__init__.py", line 39, in <module>
    "urllib3 v2.0 only supports OpenSSL 1.1.1+, currently "
ImportError: urllib3 v2.0 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with OpenSSL 1.0.2n  7 Dec 2017. See: https://github.com/urllib3/urllib3/issues/2168
```
