### PR TITLE
Virtual node checks the status of the API server via the ForeignCluster

### DIFF
--- a/deployments/liqo/files/liqo-virtual-kubelet-local-ClusterRole.yaml
+++ b/deployments/liqo/files/liqo-virtual-kubelet-local-ClusterRole.yaml
@@ -121,6 +121,22 @@ rules:
   - list
   - watch
 - apiGroups:
+  - discovery.liqo.io
+  resources:
+  - foreignclusters
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - discovery.liqo.io
+  resources:
+  - foreignclusters/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - net.liqo.io
   resources:
   - tunnelendpoints

--- a/pkg/utils/foreignCluster/getForeignCluster.go
+++ b/pkg/utils/foreignCluster/getForeignCluster.go
@@ -24,9 +24,11 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -48,13 +50,38 @@ func GetForeignClusterByID(ctx context.Context, cl client.Client, clusterID stri
 		return nil, err
 	}
 
+	return getForeignCluster(&foreignClusterList, clusterID)
+}
+
+// GetForeignClusterByIDWithDynamicClient returns a ForeignCluster CR retrieving it by its clusterID, using the dynamic interface.
+func GetForeignClusterByIDWithDynamicClient(ctx context.Context, dynClient dynamic.Interface, clusterID string) (
+	*discoveryv1alpha1.ForeignCluster, error) {
+	lSelector := labels.SelectorFromSet(labels.Set{
+		discovery.ClusterIDLabel: clusterID,
+	})
+	unstr, err := dynClient.Resource(discoveryv1alpha1.ForeignClusterGroupVersionResource).List(ctx, metav1.ListOptions{
+		LabelSelector: lSelector.String()})
+	if err != nil {
+		return nil, err
+	}
+
+	foreignClusterList := discoveryv1alpha1.ForeignClusterList{}
+	err = runtime.DefaultUnstructuredConverter.FromUnstructured(unstr.UnstructuredContent(), &foreignClusterList)
+	if err != nil {
+		return nil, err
+	}
+
+	return getForeignCluster(&foreignClusterList, clusterID)
+}
+
+func getForeignCluster(foreignClusterList *discoveryv1alpha1.ForeignClusterList, clusterID string) (*discoveryv1alpha1.ForeignCluster, error) {
 	switch len(foreignClusterList.Items) {
 	case 0:
 		return nil, kerrors.NewNotFound(discoveryv1alpha1.ForeignClusterGroupResource, fmt.Sprintf("foreign cluster with ID %s", clusterID))
 	case 1:
 		return &foreignClusterList.Items[0], nil
 	default:
-		return GetOlderForeignCluster(&foreignClusterList), nil
+		return GetOlderForeignCluster(foreignClusterList), nil
 	}
 }
 

--- a/pkg/virtualKubelet/roles/local/role.go
+++ b/pkg/virtualKubelet/roles/local/role.go
@@ -32,6 +32,8 @@ package local
 // +kubebuilder:rbac:groups=virtualkubelet.liqo.io,resources=namespacemaps,verbs=get;list;watch;
 // +kubebuilder:rbac:groups=net.liqo.io,resources=tunnelendpoints,verbs=get;list;watch
 // +kubebuilder:rbac:groups=sharing.liqo.io,resources=resourceoffers,verbs=get;list;watch;update;patch;delete
+// +kubebuilder:rbac:groups=discovery.liqo.io,resources=foreignclusters,verbs=get;list;watch
+// +kubebuilder:rbac:groups=discovery.liqo.io,resources=foreignclusters/status,verbs=get;list;watch
 
 // +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;create;update;delete
 


### PR DESCRIPTION
# Description

This PR changes the virtual node to check the status of the API server by looking at the *APIServerStatusCondition* of the ForeignCluster.

Ref #1705 

# How Has This Been Tested?
- [x] Locally on Kind
- [x] Unit tests
- [x] e2e tests
