### PR TITLE
Fix deployment on ArgoCD

### DIFF
--- a/deployments/liqo/README.md
+++ b/deployments/liqo/README.md
@@ -117,7 +117,7 @@
 | storage.storageNamespace | string | `"liqo-storage"` | Namespace where liqo will deploy specific PVCs. Internal parameter, do not change. |
 | storage.virtualStorageClassName | string | `"liqo"` | Name to assign to the liqo virtual storage class. |
 | tag | string | `""` | Images' tag to select a development version of liqo instead of a release |
-| telemetry.config.schedule | string | `""` | Set the schedule of the telemetry collector CronJob |
+| telemetry.config.schedule | string | `""` | Set the schedule of the telemetry collector CronJob. Consider setting this value on ArgoCD deployments to avoid randomization. |
 | telemetry.enable | bool | `true` | Enable/Disable the telemetry collector. |
 | telemetry.imageName | string | `"ghcr.io/liqotech/telemetry"` | Image repository for the telemetry pod. |
 | telemetry.pod.annotations | object | `{}` | Annotations for the telemetry pod. |

--- a/deployments/liqo/templates/webhooks/job-patch/job-create-secret.yaml
+++ b/deployments/liqo/templates/webhooks/job-patch/job-create-secret.yaml
@@ -13,7 +13,7 @@ metadata:
   labels:
     {{- include "liqo.labels" $cfg | nindent 4 }}
 spec:
-  ttlSecondsAfterFinished: 0
+  ttlSecondsAfterFinished: 150
   template:
     metadata:
       name:  {{ include "liqo.prefixedName" $cfg }}

--- a/deployments/liqo/templates/webhooks/job-patch/job-patch-webhook.yaml
+++ b/deployments/liqo/templates/webhooks/job-patch/job-patch-webhook.yaml
@@ -12,7 +12,7 @@ metadata:
   labels:
     {{- include "liqo.labels" $cfg | nindent 4 }}
 spec:
-  ttlSecondsAfterFinished: 0
+  ttlSecondsAfterFinished: 150
   template:
     metadata:
       name:  {{ include "liqo.prefixedName" $cfg }}

--- a/deployments/liqo/values.yaml
+++ b/deployments/liqo/values.yaml
@@ -292,7 +292,7 @@ telemetry:
   # -- Image repository for the telemetry pod.
   imageName: "ghcr.io/liqotech/telemetry"
   config:
-    # -- Set the schedule of the telemetry collector CronJob
+    # -- Set the schedule of the telemetry collector CronJob. Consider setting this value on ArgoCD deployments to avoid randomization.
     schedule: ""
     # schedule: "0 */12 * * *"
 


### PR DESCRIPTION
# Description

This PR fixes deployment on ArgoCD that ended up being stuck because of Argo wanting to delete hook jobs that had ttl set: the jobs controller deleted the jobs instead of Argo and this stopped the deployment from progressing.

Added a side note on telemetry cronjob schedule helm value.

# How Has This Been Tested?
- [x] On ArgoCD-driven cluster
- [ ] On liqoctl provisioned cluster