### PR TITLE
Liqoctl: confirm

### DIFF
--- a/cmd/liqoctl/cmd/root.go
+++ b/cmd/liqoctl/cmd/root.go
@@ -104,6 +104,7 @@ func NewRootCommand(ctx context.Context) *cobra.Command {
 
 	// Add the flags regarding Kubernetes access options.
 	f.AddFlags(cmd.PersistentFlags(), cmd.RegisterFlagCompletionFunc)
+	cmd.PersistentFlags().BoolVar(&f.SkipConfirm, "skip-confirm", false, "Skip the confirmation prompt (suggested for automation)")
 
 	cmd.AddCommand(newInstallCommand(ctx, f))
 	cmd.AddCommand(newUninstallCommand(ctx, f))

--- a/cmd/liqoctl/cmd/uninstall.go
+++ b/cmd/liqoctl/cmd/uninstall.go
@@ -50,6 +50,10 @@ func newUninstallCommand(ctx context.Context, f *factory.Factory) *cobra.Command
 		Long:  WithTemplate(liqoctlUninstallLongHelp),
 		Args:  cobra.NoArgs,
 
+		PreRun: func(cmd *cobra.Command, args []string) {
+			output.ExitOnErr(options.Printer.AskConfirm("uninstall", f.SkipConfirm))
+		},
+
 		Run: func(cmd *cobra.Command, args []string) {
 			output.ExitOnErr(options.Run(ctx))
 		},

--- a/cmd/liqoctl/cmd/unoffload.go
+++ b/cmd/liqoctl/cmd/unoffload.go
@@ -59,6 +59,10 @@ func newUnoffloadNamespaceCommand(ctx context.Context, f *factory.Factory) *cobr
 		Args:              cobra.ExactArgs(1),
 		ValidArgsFunction: completion.OffloadedNamespaces(ctx, f, 1),
 
+		PreRun: func(cmd *cobra.Command, args []string) {
+			output.ExitOnErr(f.Printer.AskConfirm("unoffload", f.SkipConfirm))
+		},
+
 		Run: func(cmd *cobra.Command, args []string) {
 			options.Namespace = args[0]
 			output.ExitOnErr(options.Run(ctx))

--- a/cmd/liqoctl/cmd/unpeer.go
+++ b/cmd/liqoctl/cmd/unpeer.go
@@ -118,6 +118,10 @@ func newUnpeerOutOfBandCommand(ctx context.Context, options *unpeeroob.Options) 
 		Args:              cobra.ExactArgs(1),
 		ValidArgsFunction: completion.ForeignClusters(ctx, options.Factory, 1),
 
+		PreRun: func(cmd *cobra.Command, args []string) {
+			output.ExitOnErr(options.Printer.AskConfirm("unpeer", options.SkipConfirm))
+		},
+
 		Run: func(cmd *cobra.Command, args []string) {
 			options.ClusterName = args[0]
 			options.UnpeerOOBMode = true
@@ -142,6 +146,10 @@ func newUnpeerInBandCommand(ctx context.Context, unpeerOptions *unpeeroob.Option
 
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			twoClustersPersistentPreRun(cmd, local, remote, factory.WithScopedPrinter)
+		},
+
+		PreRun: func(cmd *cobra.Command, args []string) {
+			output.ExitOnErr(local.Printer.AskConfirm("unpeer", local.SkipConfirm))
 		},
 
 		Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/liqoctl/factory/factory.go
+++ b/pkg/liqoctl/factory/factory.go
@@ -55,6 +55,8 @@ type Factory struct {
 
 	// Printer is the object used to output messages in the appropriate format.
 	Printer *output.Printer
+	// SkipConfirm determines whether to skip confirmations.
+	SkipConfirm bool
 	// Whether to add a scope to the printer (i.e., local/remote).
 	ScopedPrinter bool
 

--- a/pkg/liqoctl/output/output.go
+++ b/pkg/liqoctl/output/output.go
@@ -72,6 +72,17 @@ var (
 
 var spinnerCharset = []string{"⠈⠁", "⠈⠑", "⠈⠱", "⠈⡱", "⢀⡱", "⢄⡱", "⢄⡱", "⢆⡱", "⢎⡱", "⢎⡰", "⢎⡠", "⢎⡀", "⢎⠁", "⠎⠁", "⠊⠁"}
 
+var confirm = &pterm.InteractiveConfirmPrinter{
+	DefaultValue: false,
+	DefaultText:  "Are you sure you want to continue?",
+	TextStyle:    pterm.NewStyle(pterm.FgYellow, pterm.Bold),
+	ConfirmText:  "yes",
+	ConfirmStyle: pterm.NewStyle(pterm.FgDefault),
+	RejectText:   "no",
+	RejectStyle:  pterm.NewStyle(pterm.FgDefault),
+	SuffixStyle:  pterm.NewStyle(pterm.FgDefault, pterm.Bold),
+}
+
 // Printer manages all kinds of outputs.
 type Printer struct {
 	Info    *pterm.PrefixPrinter
@@ -85,6 +96,19 @@ type Printer struct {
 	Section    *pterm.SectionPrinter
 	Paragraph  *pterm.ParagraphPrinter
 	verbose    bool
+}
+
+// AskConfirm asks the user to confirm an action.
+func (p *Printer) AskConfirm(cmdName string, skip bool) error {
+	if skip {
+		return nil
+	}
+	pterm.NewStyle(pterm.FgYellow, pterm.Bold).Printfln("%s is a potentially destructive command.", cmdName)
+	r, e := confirm.Show()
+	if e != nil || !r {
+		return errors.New("action aborted")
+	}
+	return nil
 }
 
 // BoxPrintln prints a message through the box printer.

--- a/test/e2e/pipeline/installer/liqoctl/uninstall.sh
+++ b/test/e2e/pipeline/installer/liqoctl/uninstall.sh
@@ -56,6 +56,6 @@ sleep 3
 for i in $(seq 1 "${CLUSTER_NUMBER}");
 do
   export KUBECONFIG="${TMPDIR}/kubeconfigs/liqo_kubeconf_${i}"
-  "${LIQOCTL}" uninstall --purge
+  "${LIQOCTL}" uninstall --purge --skip-confirm
   wait_for_crds
 done;

--- a/test/e2e/pipeline/installer/liqoctl/unpeer.sh
+++ b/test/e2e/pipeline/installer/liqoctl/unpeer.sh
@@ -33,6 +33,6 @@ do
 
   for foreignCluster in $(${KUBECTL} get foreignclusters.discovery.liqo.io --no-headers -o custom-columns=":metadata.name");
   do
-    "${LIQOCTL}" unpeer out-of-band "${foreignCluster}"
+    "${LIQOCTL}" unpeer out-of-band "${foreignCluster}" --skip-confirm
   done;
 done;

--- a/test/e2e/testutils/util/namespace.go
+++ b/test/e2e/testutils/util/namespace.go
@@ -93,5 +93,5 @@ func OffloadNamespace(kubeconfig, namespace string, args ...string) error {
 
 // UnoffloadNamespace unoffloads a namespace using liqoctl.
 func UnoffloadNamespace(kubeconfig, namespace string) error {
-	return ExecLiqoctl(kubeconfig, []string{"unoffload", "namespace", namespace}, ginkgo.GinkgoWriter)
+	return ExecLiqoctl(kubeconfig, []string{"unoffload", "namespace", "--skip-confirm", namespace}, ginkgo.GinkgoWriter)
 }


### PR DESCRIPTION
# Description

This PR adds a confirmation prompt to **potentially distructive** commands.

The affected commands are:

- uninstall
- unpeer (in-band and out-of-band)
- unoffload

The flag `--skip-confirm` has been added and enabled globally for all the commands. It allows skipping the confirmation prompt.

## Screenshot

![image](https://github.com/liqotech/liqo/assets/33266330/3488da5c-3ba2-4100-b94d-5c59d71e736f)

# How Has This Been Tested?

- [x] Locally with KinD
