### PR TITLE
Mark local offloaded pods as NotReady when virtual-node is not ready (i.e. remote cluster failure)  

### DIFF
--- a/deployments/liqo/files/liqo-controller-manager-ClusterRole.yaml
+++ b/deployments/liqo/files/liqo-controller-manager-ClusterRole.yaml
@@ -138,9 +138,12 @@ rules:
   resources:
   - pods
   verbs:
+  - create
   - delete
   - get
   - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - ""

--- a/pkg/consts/replication.go
+++ b/pkg/consts/replication.go
@@ -73,4 +73,10 @@ const (
 
 	// PodAntiAffinityLabelsKey is the annotation key used to specify a subset of the pod label keys for the anti-affinity constraints.
 	PodAntiAffinityLabelsKey = "liqo.io/anti-affinity-labels"
+
+	// RemoteUnavailableKey is the annotation key indicating that the remote cluster hosting the local offloaded pod is currently not available.
+	RemoteUnavailableKey = "liqo.io/remote-unavailable"
+	// RemoteUnavailableValue is the annotation value of the label indicating that the remote cluster hosting the local offloaded pod is currently
+	// not available.
+	RemoteUnavailableValue = "true"
 )

--- a/pkg/liqo-controller-manager/podstatus-controller/doc.go
+++ b/pkg/liqo-controller-manager/podstatus-controller/doc.go
@@ -1,0 +1,18 @@
+// Copyright 2019-2023 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package podstatusctrl implements a controller that enforces the presence/absence of the remote unavailable label on
+// local offloaded pods. The presence of the label indicates that the status of the offloaded pod can be managed/updated by the local
+// cluster and can't currently be reflected/updated from the remote cluster, likely due to a remote cluster failure.
+package podstatusctrl

--- a/pkg/liqo-controller-manager/podstatus-controller/podstatus_controller.go
+++ b/pkg/liqo-controller-manager/podstatus-controller/podstatus_controller.go
@@ -1,0 +1,117 @@
+// Copyright 2019-2023 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package podstatusctrl
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/klog/v2"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/liqotech/liqo/pkg/consts"
+	"github.com/liqotech/liqo/pkg/utils"
+	"github.com/liqotech/liqo/pkg/utils/indexer"
+)
+
+// HasRemoteUnavailableLabel return true if the pod has the remote unavailable label.
+func HasRemoteUnavailableLabel(pod *corev1.Pod) bool {
+	value, ok := pod.Labels[consts.RemoteUnavailableKey]
+	return ok && value == consts.RemoteUnavailableValue
+}
+
+// PodStatusReconciler reconciles Liqo nodes.
+type PodStatusReconciler struct {
+	client.Client
+	Scheme          *runtime.Scheme
+	LocalPodsClient client.Client
+}
+
+// +kubebuilder:rbac:groups=core,resources=nodes,verbs=get;list;watch;
+// +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch;create;update;patch;delete
+
+// Reconcile reconciles on Liqo nodes and manages the labels of the pods scheduled on them.
+func (r *PodStatusReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	// Fetch the Node instance
+	var node corev1.Node
+	if err := r.Client.Get(ctx, client.ObjectKey{Name: req.Name}, &node); err != nil {
+		if apierrors.IsNotFound(err) {
+			klog.V(4).Infof("node %s not found", req.Name)
+			return ctrl.Result{}, nil
+		}
+		klog.Errorf("an error occurred while getting node %s: %v", req.Name, err)
+		return ctrl.Result{}, err
+	}
+
+	// Skip reconciliation if it is not a Liqo virtual node
+	if !utils.IsVirtualNode(&node) {
+		klog.V(6).Infof("Skipping reconciliation: node %q is not a Liqo virtual node", req.Name)
+		return ctrl.Result{}, nil
+	}
+
+	klog.V(4).Infof("reconciliation on liqo virtual node: %q", req.Name)
+
+	// List all pods that are local and offloaded (running in another cluster), and scheduled on the reconciled liqo node
+	var pods corev1.PodList
+	localOffloadedPodSelector := client.MatchingLabels{consts.LocalPodLabelKey: consts.LocalPodLabelValue}
+	nodeSelector := client.MatchingFields{indexer.FieldNodeNameFromPod: node.Name}
+	if err := r.LocalPodsClient.List(ctx, &pods, localOffloadedPodSelector, nodeSelector); err != nil {
+		klog.Errorf("unable to list pods: %v", err)
+		return ctrl.Result{}, err
+	}
+
+	// Check node status
+	nodeReady := utils.IsNodeReady(&node)
+
+	// Enforce the presence of the pod remote unavailable label based on the current node readiness status
+	for i := range pods.Items {
+		pod := &pods.Items[i]
+
+		switch {
+		case !nodeReady && !HasRemoteUnavailableLabel(pod):
+			// Ensure the presence of the remote unavailable label
+			if pod.Labels == nil {
+				pod.Labels = map[string]string{}
+			}
+			pod.Labels[consts.RemoteUnavailableKey] = consts.RemoteUnavailableValue
+			if err := r.LocalPodsClient.Update(ctx, pod); err != nil {
+				klog.Errorf("failed to update pod %q: %v", klog.KObj(pod), err)
+				return ctrl.Result{}, err
+			}
+			klog.Infof("Added label %q to pod %q running on NOT ready node %s", consts.RemoteUnavailableKey, klog.KObj(pod), node.Name)
+
+		case nodeReady && HasRemoteUnavailableLabel(pod):
+			// Ensure the absence of the remote unavailable label
+			delete(pod.Labels, consts.RemoteUnavailableKey)
+			if err := r.LocalPodsClient.Update(ctx, pod); err != nil {
+				klog.Errorf("failed to update pod %q: %v", klog.KObj(pod), err)
+				return ctrl.Result{}, err
+			}
+			klog.Infof("Removed label %q to pod %q running on ready node %s", consts.RemoteUnavailableKey, klog.KObj(pod), node.Name)
+		}
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// SetupWithManager monitors updates on nodes.
+func (r *PodStatusReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&corev1.Node{}).
+		Complete(r)
+}

--- a/pkg/liqo-controller-manager/podstatus-controller/podstatus_controller_test.go
+++ b/pkg/liqo-controller-manager/podstatus-controller/podstatus_controller_test.go
@@ -1,0 +1,229 @@
+// Copyright 2019-2023 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package podstatusctrl
+
+import (
+	"bytes"
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
+	"k8s.io/kubectl/pkg/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/liqotech/liqo/pkg/consts"
+	"github.com/liqotech/liqo/pkg/utils/indexer"
+)
+
+var _ = Describe("PodStatusController", func() {
+	const (
+		ns            string = "default"
+		nodeName      string = "node-test"
+		liqoNodeName  string = "liqo-node-test"
+		liqoNodeName2 string = "liqo-node-test-2"
+		podName       string = "test-pod"
+		localPodName  string = "test-local-pod"
+		localPodName2 string = "test-local-pod-2"
+	)
+
+	var (
+		ctx                 context.Context
+		err                 error
+		buffer              *bytes.Buffer
+		fakeClient          client.WithWatch
+		fakeClientBuilder   *fake.ClientBuilder
+		fakeLocalPodsClient client.WithWatch
+		localPod            *corev1.Pod
+		localPod2           *corev1.Pod
+		liqoNode2           *corev1.Node
+
+		reqLiqoNode = ctrl.Request{NamespacedName: types.NamespacedName{Name: liqoNodeName}}
+
+		reqLocalPod = ctrl.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      localPodName,
+				Namespace: ns,
+			},
+		}
+
+		reqLocalPod2 = ctrl.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      localPodName2,
+				Namespace: ns,
+			},
+		}
+
+		newLiqoNode = func(name string, condReadyStatus corev1.ConditionStatus) *corev1.Node {
+			return &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   name,
+					Labels: map[string]string{consts.TypeLabel: consts.TypeNode},
+				},
+				Status: corev1.NodeStatus{
+					Conditions: []corev1.NodeCondition{
+						{
+							Type:   corev1.NodeReady,
+							Status: condReadyStatus,
+						},
+					},
+				},
+			}
+		}
+
+		newPod = func() *corev1.Pod {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      podName,
+					Namespace: ns,
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "nginx",
+							Image: "nginx",
+						},
+					},
+					NodeName: nodeName,
+				},
+			}
+
+			return pod
+		}
+
+		newLocalPod = func() *corev1.Pod {
+			pod := newPod()
+			pod.Name = localPodName
+			pod.Labels = labels.Merge(pod.Labels, labels.Set{consts.LocalPodLabelKey: consts.LocalPodLabelValue})
+			pod.Spec.NodeName = liqoNodeName
+			return pod
+		}
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		buffer = &bytes.Buffer{}
+		klog.SetOutput(buffer)
+
+		fakeClientBuilder = fake.NewClientBuilder().
+			WithScheme(scheme.Scheme).
+			WithIndex(&corev1.Pod{}, indexer.FieldNodeNameFromPod, indexer.ExtractNodeName)
+
+		// Pod scheduled on reconciled liqo node
+		localPod = newLocalPod()
+		localPod.Name = localPodName
+		localPod.Spec.NodeName = liqoNodeName
+
+		// Create extra pod scheduled on an another liqo node different from the one reconciled
+		localPod2 = newLocalPod()
+		localPod2.Name = localPodName2
+		localPod2.Spec.NodeName = liqoNodeName2
+
+		// Create extra node (always ready)
+		liqoNode2 = newLiqoNode(liqoNodeName2, corev1.ConditionTrue)
+
+	})
+
+	JustBeforeEach(func() {
+		r := &PodStatusReconciler{
+			Client:          fakeClient,
+			Scheme:          scheme.Scheme,
+			LocalPodsClient: fakeLocalPodsClient,
+		}
+		_, err = r.Reconcile(ctx, reqLiqoNode)
+		Expect(err).NotTo(HaveOccurred())
+		klog.Flush()
+	})
+
+	When("liqo node not ready", func() {
+		BeforeEach(func() {
+			fakeClient = fakeClientBuilder.WithObjects(newLiqoNode(liqoNodeName, corev1.ConditionFalse), liqoNode2).Build()
+		})
+
+		When("remote unavailable label not present", func() {
+			BeforeEach(func() {
+				fakeLocalPodsClient = fakeClientBuilder.WithObjects(localPod, localPod2).Build()
+			})
+
+			It("should add remote unavailable label to local offloaded pods", func() {
+				localPodAfter := corev1.Pod{}
+				localPod2After := corev1.Pod{}
+				Expect(fakeLocalPodsClient.Get(ctx, reqLocalPod.NamespacedName, &localPodAfter)).To(Succeed())
+				Expect(fakeLocalPodsClient.Get(ctx, reqLocalPod2.NamespacedName, &localPod2After)).To(Succeed())
+				Expect(localPodAfter.Labels).To(HaveKeyWithValue(consts.RemoteUnavailableKey, consts.RemoteUnavailableValue))
+				Expect(localPod2After.Labels).ToNot(HaveKeyWithValue(consts.RemoteUnavailableKey, consts.RemoteUnavailableValue))
+			})
+		})
+
+		When("remote unavailable label present", func() {
+			BeforeEach(func() {
+				localPod.Labels = labels.Merge(localPod.Labels, labels.Set{consts.RemoteUnavailableKey: consts.RemoteUnavailableValue})
+				fakeLocalPodsClient = fakeClientBuilder.WithObjects(localPod, localPod2).Build()
+			})
+
+			It("should keep remote unavailable label to local offloaded pods", func() {
+				localPodAfter := corev1.Pod{}
+				localPod2After := corev1.Pod{}
+				Expect(fakeLocalPodsClient.Get(ctx, reqLocalPod.NamespacedName, &localPodAfter)).To(Succeed())
+				Expect(fakeLocalPodsClient.Get(ctx, reqLocalPod2.NamespacedName, &localPod2After)).To(Succeed())
+				Expect(localPodAfter.Labels).To(HaveKeyWithValue(consts.RemoteUnavailableKey, consts.RemoteUnavailableValue))
+				Expect(localPod2After.Labels).ToNot(HaveKeyWithValue(consts.RemoteUnavailableKey, consts.RemoteUnavailableValue))
+			})
+		})
+	})
+
+	When("liqo node ready", func() {
+		BeforeEach(func() {
+			fakeClient = fakeClientBuilder.WithObjects(newLiqoNode(liqoNodeName, corev1.ConditionTrue), liqoNode2).Build()
+		})
+
+		When("remote unavailable label not present", func() {
+			BeforeEach(func() {
+				fakeLocalPodsClient = fakeClientBuilder.WithObjects(localPod, localPod2).Build()
+			})
+
+			It("should not add remote unavailable label to local offloaded pods", func() {
+				localPodAfter := corev1.Pod{}
+				localPod2After := corev1.Pod{}
+				Expect(fakeLocalPodsClient.Get(ctx, reqLocalPod.NamespacedName, &localPodAfter)).To(Succeed())
+				Expect(fakeLocalPodsClient.Get(ctx, reqLocalPod2.NamespacedName, &localPod2After)).To(Succeed())
+				Expect(localPodAfter.Labels).ToNot(HaveKeyWithValue(consts.RemoteUnavailableKey, consts.RemoteUnavailableValue))
+				Expect(localPod2After.Labels).ToNot(HaveKeyWithValue(consts.RemoteUnavailableKey, consts.RemoteUnavailableValue))
+			})
+		})
+
+		When("remote unavailable label present", func() {
+			BeforeEach(func() {
+				localPod.Labels = labels.Merge(localPod.Labels, labels.Set{consts.RemoteUnavailableKey: consts.RemoteUnavailableValue})
+				fakeLocalPodsClient = fakeClientBuilder.WithObjects(localPod, localPod2).Build()
+			})
+
+			It("should remove remote unavailable label to local offloaded pods", func() {
+				localPod := corev1.Pod{}
+				localPod2 := corev1.Pod{}
+				Expect(fakeLocalPodsClient.Get(ctx, reqLocalPod.NamespacedName, &localPod)).To(Succeed())
+				Expect(fakeLocalPodsClient.Get(ctx, reqLocalPod2.NamespacedName, &localPod2)).To(Succeed())
+				Expect(localPod.Labels).ToNot(HaveKeyWithValue(consts.RemoteUnavailableKey, consts.RemoteUnavailableValue))
+				Expect(localPod2.Labels).ToNot(HaveKeyWithValue(consts.RemoteUnavailableKey, consts.RemoteUnavailableValue))
+			})
+		})
+	})
+})

--- a/pkg/liqo-controller-manager/podstatus-controller/suite_test.go
+++ b/pkg/liqo-controller-manager/podstatus-controller/suite_test.go
@@ -1,0 +1,36 @@
+// Copyright 2019-2023 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package podstatusctrl
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/kubectl/pkg/scheme"
+
+	"github.com/liqotech/liqo/pkg/utils/testutil"
+)
+
+func TestNodeFailureController(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Pod Status Controller Suite")
+}
+
+var _ = BeforeSuite(func() {
+	testutil.LogsToGinkgoWriter()
+	Expect(corev1.AddToScheme(scheme.Scheme)).To(Succeed())
+})

--- a/pkg/utils/pod/pod.go
+++ b/pkg/utils/pod/pod.go
@@ -34,6 +34,19 @@ func IsPodReady(pod *corev1.Pod) (ready bool, reason string) {
 	return false, "no conditions in pod status"
 }
 
+// GetPodCondition extracts the provided condition from the given status and returns that.
+func GetPodCondition(status *corev1.PodStatus, conditionType corev1.PodConditionType) *corev1.PodCondition {
+	if status == nil {
+		return nil
+	}
+	for i := range status.Conditions {
+		if status.Conditions[i].Type == conditionType {
+			return &status.Conditions[i]
+		}
+	}
+	return nil
+}
+
 // IsPodSpecEqual returns whether two pod specs are equal according to the fields that
 // can be modified after start-up time. Refer to the following link for more information:
 // https://kubernetes.io/docs/concepts/workloads/pods/#pod-update-and-replacement

--- a/pkg/virtualKubelet/reflection/workload/podns.go
+++ b/pkg/virtualKubelet/reflection/workload/podns.go
@@ -50,6 +50,7 @@ import (
 	vkv1alpha1 "github.com/liqotech/liqo/apis/virtualkubelet/v1alpha1"
 	vkv1alpha1clients "github.com/liqotech/liqo/pkg/client/clientset/versioned/typed/virtualkubelet/v1alpha1"
 	vkv1alpha1listers "github.com/liqotech/liqo/pkg/client/listers/virtualkubelet/v1alpha1"
+	podstatusctrl "github.com/liqotech/liqo/pkg/liqo-controller-manager/podstatus-controller"
 	"github.com/liqotech/liqo/pkg/liqonet/ipam"
 	"github.com/liqotech/liqo/pkg/utils/pod"
 	"github.com/liqotech/liqo/pkg/virtualKubelet/forge"
@@ -134,7 +135,7 @@ func (npr *NamespacedPodReflector) Handle(ctx context.Context, name string) erro
 
 	// Abort the reflection if the remote object is not managed by us, as we do not want to mutate others' objects.
 	if (remoteExists && !forge.IsReflected(remote)) || (shadowExists && !forge.IsReflected(shadow)) {
-		if localExists { // Do not output the warning event in case the event was triggered by the remote object (i.e., the local one does not exists).
+		if localExists { // Do not output the warning event in case the event was triggered by the remote object (i.e., the local one does not exist).
 			klog.Infof("Skipping reflection of local pod %q as remote already exists and is not managed by us", npr.LocalRef(name))
 			npr.Event(local, corev1.EventTypeWarning, forge.EventFailedReflection, forge.EventFailedReflectionAlreadyExistsMsg())
 		}
@@ -247,8 +248,13 @@ func (npr *NamespacedPodReflector) Handle(ctx context.Context, name string) erro
 		return nil
 	}
 
+	// The remote unavailable label indicates that the status can be modified by the local cluster due to a failure of the
+	// remote cluster (e.g., virtual node is not ready or unreachable). In this case we skip updating the remote shadowpod
+	// since the request will likely fail.
+	skipUpdateRemote := podstatusctrl.HasRemoteUnavailableLabel(local)
+
 	// If so, perform the actual update operation.
-	if npr.ShouldUpdateShadowPod(ctx, shadow, target) {
+	if !skipUpdateRemote && npr.ShouldUpdateShadowPod(ctx, shadow, target) {
 		_, rerr = npr.remoteShadowPodsClient.Update(ctx, target, metav1.UpdateOptions{FieldManager: forge.ReflectionFieldManager})
 		if rerr != nil {
 			klog.Errorf("Failed to update remote shadowpod %q (local pod: %q): %v", npr.RemoteRef(name), npr.LocalRef(name), rerr)
@@ -392,6 +398,16 @@ func (npr *NamespacedPodReflector) HandleStatus(ctx context.Context, local, remo
 		klog.Errorf("Reflection of local pod %q to %q failed: %v", npr.LocalRef(local.GetName()), npr.RemoteRef(local.GetName()), terr)
 		npr.Event(local, corev1.EventTypeWarning, forge.EventFailedReflection, forge.EventFailedStatusReflectionMsg(terr))
 		return terr
+	}
+
+	// Update Ready condition to False if pod has the remote unavailable label. The label indicate that the status can be modified
+	// by the local cluster due to a failure of the remote cluster (e.g., virtual node is not ready or unreachable).
+	// We mark the pod as NotReady because the Kubernetes node controller skips this update (likely due to a bug). This
+	// is necessary to prevent services redirecting traffic to not ready pods (since the endpointslice controller keeps
+	// in sync the endpointslice Ready condition with the associated pod Ready condition).
+	if podstatusctrl.HasRemoteUnavailableLabel(local) {
+		cond := pod.GetPodCondition(&po.Status, corev1.PodReady)
+		cond.Status = corev1.ConditionFalse
 	}
 
 	// Do not attempt to perform an update if not necessary.


### PR DESCRIPTION
# Description

This PR changes the virtual-kubelet logic to mark local offloaded pods as *NotReady* when the remote cluster has a failure (i.e., the liqo virtual node has the *Ready* condition set to *False* or *Unknown*). 
In summary, it sets the *Ready* pod condition to *False* on all pods scheduled on a *NotReady* virtual node.

### Implementation
- A new controller in the *liqo-controller-manager* enforces the presence/absence of a custom label on
local offloaded pods. The presence of the label indicates that the status of the offloaded pod can be managed/updated by the local cluster and can't currently be reflected/updated from the remote cluster (likely due to a remote cluster failure).
- The virtual-kubelet makes sure that the *Ready* conditions of the local offloaded pods are set to *False* if the label is present.

### Motivation
We mark pods as NotReady because the Kubernetes node controller skips this update (likely due to a bug). This is necessary to prevent services redirecting traffic to not ready pods (since the endpointslice controller keeps in sync the endpointslice *Ready* condition with the associated pod *Ready* condition).

# How Has This Been Tested?

- [x] Locally
- [x] Unit tests
- [x] e2e tests
