### PR TITLE
feature: enable per pod remote APIServer support

### DIFF
--- a/pkg/consts/annotations.go
+++ b/pkg/consts/annotations.go
@@ -23,4 +23,16 @@ const (
 	OverrideAddressAnnotation = "liqo.io/override-address"
 	// OverridePortAnnotation is the annotation used to override the port of a service.
 	OverridePortAnnotation = "liqo.io/override-port"
+
+	// APIServerSupportAnnotation is the annotation used to enable the API server support for a pod.
+	APIServerSupportAnnotation = "liqo.io/api-server-support"
+	// APIServerSupportAnnotationValueRemote is the value of the annotation used to enable the API server support for a pod.
+	APIServerSupportAnnotationValueRemote = "remote"
+	// APIServerSupportAnnotationValueDisabled is the value of the annotation used to disable the API server support for a pod.
+	APIServerSupportAnnotationValueDisabled = "disabled"
+
+	// RemoteServiceAccountNameAnnotation is the annotation used to set the name of the service account used by a pod
+	// in the remote cluster. This annotation requires the API server support to be "remote" for the pod and the
+	// remote service account to be created.
+	RemoteServiceAccountNameAnnotation = "liqo.io/remote-service-account-name"
 )

--- a/pkg/virtualKubelet/forge/pods_test.go
+++ b/pkg/virtualKubelet/forge/pods_test.go
@@ -204,6 +204,7 @@ var _ = Describe("Pod forging", func() {
 			apiServerSupport                     forge.APIServerSupportType
 			remote, original                     *corev1.PodSpec
 			homeAPIServerHost, homeAPIServerPort string
+			localAnnotations                     map[string]string
 		)
 
 		BeforeEach(func() {
@@ -215,11 +216,13 @@ var _ = Describe("Pod forging", func() {
 						{ServiceAccountToken: &corev1.ServiceAccountTokenProjection{Path: "other", Audience: "custom"}},
 					}}}}},
 			}
+			localAnnotations = map[string]string{}
 		})
 
 		JustBeforeEach(func() {
 			original = remote.DeepCopy()
-			forge.APIServerSupportMutator(apiServerSupport, saName, SASecretRetriever, KubernetesServiceIPGetter, homeAPIServerHost, homeAPIServerPort)(remote)
+			forge.APIServerSupportMutator(apiServerSupport, localAnnotations, saName, SASecretRetriever,
+				KubernetesServiceIPGetter, homeAPIServerHost, homeAPIServerPort)(remote)
 		})
 
 		When("API server support is enabled", func() {

--- a/pkg/virtualKubelet/reflection/workload/podns.go
+++ b/pkg/virtualKubelet/reflection/workload/podns.go
@@ -325,8 +325,9 @@ func (npr *NamespacedPodReflector) ForgeShadowPod(ctx context.Context, local *co
 
 	// Forge the target shadowpod object.
 	target := forge.RemoteShadowPod(local, shadow, npr.RemoteNamespace(),
-		forge.APIServerSupportMutator(npr.config.APIServerSupport, pod.ServiceAccountName(local), saSecretRetriever,
-			ipGetter, npr.config.HomeAPIServerHost, npr.config.HomeAPIServerPort))
+		forge.APIServerSupportMutator(npr.config.APIServerSupport, local.Annotations, pod.ServiceAccountName(local),
+			saSecretRetriever, ipGetter, npr.config.HomeAPIServerHost, npr.config.HomeAPIServerPort),
+		forge.ServiceAccountMutator(npr.config.APIServerSupport, local.Annotations))
 
 	// Check whether an error occurred during secret name retrieval.
 	if saerr != nil {


### PR DESCRIPTION
# Description

This pr includes two new annotations that can be added to pods to override the general APIServer configurations.

In particular:
* `liqo.io/api-server-support=remote` is used to make the offloaded pod contact the remote API server with the mounted service account (the original pod value by default)
* `liqo.io/api-server-support=disabled` will disable the APIServer support in the same way the general flag disables it for all the pods
* `liqo.io/remote-service-account-name=<remote SA name>` specifies the ServiceAccount name for the remote cluster. Note that this needs to be created in the remote cluster with the related permissions; at the moment, liqo is not replicating and reflecting this kind of resource.

Fixes #1832 

# How Has This Been Tested?

- [x] locally
- [x] with existing tests
