### PR TITLE
Pull Calico from docker proxy to avoid DockerHub ban

### DIFF
--- a/test/e2e/pipeline/infra/cluster-api/cni.sh
+++ b/test/e2e/pipeline/infra/cluster-api/cni.sh
@@ -7,11 +7,14 @@ WORKDIR=$(dirname "$FILEPATH")
 # shellcheck source=./pre-requirements.sh
 source "$WORKDIR/pre-requirements.sh"
 
+DOCKER_PROXY="${DOCKER_PROXY:-docker.io}"
+
 function install_calico() {
     local kubeconfig=$1
     curl https://raw.githubusercontent.com/projectcalico/calico/v3.24.4/manifests/calico.yaml |
         sed -E 's|^( +)# (- name: CALICO_IPV4POOL_CIDR)$|\1\2|g;'"\
 s|^( +)# (  value: )\"192.168.0.0/16\"|\1\2\"$POD_CIDR\"|g;"'/- name: CLUSTER_TYPE/{ n; s/( +value: ").+/\1k8s"/g };''/- name: CALICO_IPV4POOL_IPIP/{ n; s/value: "Always"/value: "Never"/ };''/- name: CALICO_IPV4POOL_VXLAN/{ n; s/value: "Never"/value: "Always"/};''/# Set Felix endpoint to host default action to ACCEPT./a\            - name: FELIX_VXLANPORT\n              value: "6789"' |
+        sed "s|docker.io|$DOCKER_PROXY|g" |
         "${KUBECTL}" apply -f - --kubeconfig "$kubeconfig"
 }
 

--- a/test/e2e/testutils/apiserver/create.go
+++ b/test/e2e/testutils/apiserver/create.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"os"
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -35,10 +36,21 @@ const (
 	JobName = "kubectl"
 
 	containerName      = "kubectl"
-	image              = "bitnami/kubectl"
 	serviceAccountName = "kubectl"
 	clusterRoleName    = "admin"
 )
+
+var (
+	image = "bitnami/kubectl"
+)
+
+func init() {
+	// get the DOCKER_PROXY variable from the environment, if set.
+	dockerProxy, ok := os.LookupEnv("DOCKER_PROXY")
+	if ok {
+		image = dockerProxy + "/" + image
+	}
+}
 
 // CreateKubectlJob creates the offloaded kubectl job to perform a request on the remote API server.
 func CreateKubectlJob(ctx context.Context, cl client.Client, namespace string, v *version.Info) error {

--- a/test/e2e/testutils/net/net.go
+++ b/test/e2e/testutils/net/net.go
@@ -17,6 +17,7 @@ package net
 import (
 	"context"
 	"fmt"
+	"os"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -38,6 +39,14 @@ var (
 	labelSelectorNodes = fmt.Sprintf("%v!=%v", liqoconst.TypeLabel, liqoconst.TypeNode)
 	command            = "timeout 15 curl --retry 60 --fail --max-time 2 -s -o /dev/null -w '%{http_code}' "
 )
+
+func init() {
+	// get the DOCKER_PROXY variable from the environment, if set.
+	dockerProxy, ok := os.LookupEnv("DOCKER_PROXY")
+	if ok {
+		image = dockerProxy + "/" + image
+	}
+}
 
 // ConnectivityCheckNodeToPod creates a NodePort Service and check its availability.
 func ConnectivityCheckNodeToPod(ctx context.Context, homeClusterClient kubernetes.Interface, clusterID, remotePodName string) error {

--- a/test/e2e/testutils/storage/storage.go
+++ b/test/e2e/testutils/storage/storage.go
@@ -17,6 +17,7 @@ package storage
 import (
 	"context"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/gruntwork-io/terratest/modules/k8s"
@@ -41,6 +42,18 @@ const (
 	// StatefulSetName is the name of the test StatefulSet.
 	StatefulSetName = "liqo-storage"
 )
+
+var (
+	image = "nginx"
+)
+
+func init() {
+	// get the DOCKER_PROXY variable from the environment, if set.
+	dockerProxy, ok := os.LookupEnv("DOCKER_PROXY")
+	if ok {
+		image = dockerProxy + "/" + image
+	}
+}
 
 // DeployApp creates the namespace and deploys the applications. It returns an error in case of failures.
 func DeployApp(ctx context.Context, cluster *tester.ClusterContext, namespace string, replicas int32) error {
@@ -78,7 +91,7 @@ func DeployApp(ctx context.Context, cluster *tester.ClusterContext, namespace st
 					Containers: []corev1.Container{
 						{
 							Name:      "tester",
-							Image:     "nginx",
+							Image:     image,
 							Resources: testutils.ResourceRequirements(),
 							VolumeMounts: []corev1.VolumeMount{
 								{
@@ -132,7 +145,7 @@ func DeployApp(ctx context.Context, cluster *tester.ClusterContext, namespace st
 								corev1.ResourceStorage: resource.MustParse("25Mi"),
 							},
 						},
-						StorageClassName: pointer.StringPtr("liqo"),
+						StorageClassName: pointer.String("liqo"),
 					},
 				},
 			},


### PR DESCRIPTION
# Description

This pr allows the liqo e2e tests to pull calico images from a docker proxy registry

# How Has This Been Tested?

- [x] e2e test
