### PR TITLE
Add flag to set images to use during volumes move

### DIFF
--- a/cmd/liqoctl/cmd/move.go
+++ b/cmd/liqoctl/cmd/move.go
@@ -99,6 +99,10 @@ func newMoveVolumeCommand(ctx context.Context, f *factory.Factory) *cobra.Comman
 	cmd.Flags().Var(&containersCPULimits, "containers-cpu-limits", "The CPU limits for the Restic containers")
 	cmd.Flags().Var(&containersRAMRequests, "containers-ram-requests", "The RAM requests for the Restic containers")
 	cmd.Flags().Var(&containersRAMLimits, "containers-ram-limits", "The RAM limits for the Restic containers")
+	cmd.Flags().StringVar(&options.ResticServerImage, "restic-server-image", move.DefaultResticServerImage,
+		"The Restic server image to use")
+	cmd.Flags().StringVar(&options.ResticImage, "restic-image", move.DefaultResticImage,
+		"The Restic image to use")
 
 	f.Printer.CheckErr(cmd.MarkFlagRequired("target-node"))
 	f.Printer.CheckErr(cmd.RegisterFlagCompletionFunc("target-node", completion.Nodes(ctx, f, completion.NoLimit)))

--- a/pkg/liqoctl/move/consts.go
+++ b/pkg/liqoctl/move/consts.go
@@ -17,7 +17,10 @@ package move
 const (
 	liqoStorageNamespace = "liqo-storage"
 	resticRegistry       = "restic-registry"
-	resticServerImage    = "restic/rest-server:0.11.0"
-	resticImage          = "restic/restic:0.14.0"
 	resticPort           = 8000
+
+	// DefaultResticServerImage is the default image used for the restic server.
+	DefaultResticServerImage = "restic/rest-server:0.11.0"
+	// DefaultResticImage is the default image used for the restic client.
+	DefaultResticImage = "restic/restic:0.14.0"
 )

--- a/pkg/liqoctl/move/handler.go
+++ b/pkg/liqoctl/move/handler.go
@@ -39,6 +39,9 @@ type Options struct {
 	ContainersRAMRequests, ContainersRAMLimits resource.Quantity
 
 	ResticPassword string
+
+	ResticServerImage string
+	ResticImage       string
 }
 
 // Run implements the move volume command.

--- a/pkg/liqoctl/move/movevolume_test.go
+++ b/pkg/liqoctl/move/movevolume_test.go
@@ -232,7 +232,8 @@ var _ = Context("Move Volumes", func() {
 
 				cl = fake.NewClientBuilder().WithObjects(pv, pvc).Build()
 				o = Options{Factory: &factory.Factory{CRClient: cl}, ResticPassword: resticPassword,
-					ContainersCPURequests: resource.MustParse("100m"), ContainersRAMLimits: resource.MustParse("100M")}
+					ContainersCPURequests: resource.MustParse("100m"), ContainersRAMLimits: resource.MustParse("100M"),
+					ResticImage: DefaultResticImage, ResticServerImage: DefaultResticServerImage}
 			})
 
 			When("creates a snapshotter job", func() {
@@ -261,7 +262,7 @@ var _ = Context("Move Volumes", func() {
 
 				It("should populate the initContainers", func() {
 					Expect(podSpec.InitContainers).To(HaveLen(1))
-					Expect(podSpec.InitContainers[0].Image).To(Equal(resticImage))
+					Expect(podSpec.InitContainers[0].Image).To(Equal(DefaultResticImage))
 					Expect(podSpec.InitContainers[0].Args).To(Equal([]string{
 						"-r",
 						fmt.Sprintf("%s%s", resticRepositoryURL, pvc.GetUID()),
@@ -277,7 +278,7 @@ var _ = Context("Move Volumes", func() {
 
 				It("should populate the containers", func() {
 					Expect(podSpec.Containers).To(HaveLen(1))
-					Expect(podSpec.Containers[0].Image).To(Equal(resticImage))
+					Expect(podSpec.Containers[0].Image).To(Equal(DefaultResticImage))
 					Expect(podSpec.Containers[0].Args).To(Equal([]string{
 						"-r",
 						fmt.Sprintf("%s%s", resticRepositoryURL, pvc.GetUID()),
@@ -328,7 +329,8 @@ var _ = Context("Move Volumes", func() {
 
 				cl = fake.NewClientBuilder().WithObjects(oPvc, nPvc).Build()
 				o = Options{Factory: &factory.Factory{CRClient: cl}, ResticPassword: resticPassword, TargetNode: "node1",
-					ContainersCPURequests: resource.MustParse("100m"), ContainersRAMLimits: resource.MustParse("100M")}
+					ContainersCPURequests: resource.MustParse("100m"), ContainersRAMLimits: resource.MustParse("100M"),
+					ResticImage: DefaultResticImage, ResticServerImage: DefaultResticServerImage}
 			})
 
 			When("creates a restorer job", func() {
@@ -357,7 +359,7 @@ var _ = Context("Move Volumes", func() {
 
 				It("should populate the containers", func() {
 					Expect(podSpec.Containers).To(HaveLen(1))
-					Expect(podSpec.Containers[0].Image).To(Equal(resticImage))
+					Expect(podSpec.Containers[0].Image).To(Equal(DefaultResticImage))
 					Expect(podSpec.Containers[0].Args).To(Equal([]string{
 						"-r",
 						fmt.Sprintf("%s%s", resticRepositoryURL, oPvc.GetUID()),
@@ -430,7 +432,8 @@ var _ = Context("Move Volumes", func() {
 
 			BeforeEach(func() {
 				cl = fake.NewClientBuilder().Build()
-				o = Options{Factory: &factory.Factory{CRClient: cl}}
+				o = Options{Factory: &factory.Factory{CRClient: cl},
+					ResticServerImage: DefaultResticServerImage, ResticPassword: resticPassword}
 
 				targetPvc = newPvc("pvc1")
 				targetPvc.Spec.Resources = corev1.ResourceRequirements{

--- a/pkg/liqoctl/move/restic.go
+++ b/pkg/liqoctl/move/restic.go
@@ -80,7 +80,7 @@ func (o *Options) ensureResticRepository(ctx context.Context, targetPvc *corev1.
 					Containers: []corev1.Container{
 						{
 							Name:  resticRegistry,
-							Image: resticServerImage,
+							Image: o.ResticServerImage,
 							Env: []corev1.EnvVar{
 								{
 									Name:  "DISABLE_AUTHENTICATION",

--- a/pkg/liqoctl/move/restorer.go
+++ b/pkg/liqoctl/move/restorer.go
@@ -66,7 +66,7 @@ func (o *Options) createRestorerJob(ctx context.Context,
 					Containers: []corev1.Container{
 						{
 							Name:            "restic",
-							Image:           resticImage,
+							Image:           o.ResticImage,
 							ImagePullPolicy: corev1.PullIfNotPresent,
 							Args: []string{
 								"-r",

--- a/pkg/liqoctl/move/snapshotter.go
+++ b/pkg/liqoctl/move/snapshotter.go
@@ -54,7 +54,7 @@ func (o *Options) createSnapshotterJob(ctx context.Context, pvc *corev1.Persiste
 					InitContainers: []corev1.Container{
 						{
 							Name:            "restic-init",
-							Image:           resticImage,
+							Image:           o.ResticImage,
 							ImagePullPolicy: corev1.PullIfNotPresent,
 							Args: []string{
 								"-r",
@@ -73,7 +73,7 @@ func (o *Options) createSnapshotterJob(ctx context.Context, pvc *corev1.Persiste
 					Containers: []corev1.Container{
 						{
 							Name:            "restic",
-							Image:           resticImage,
+							Image:           o.ResticImage,
 							ImagePullPolicy: corev1.PullIfNotPresent,
 							Args: []string{
 								"-r",


### PR DESCRIPTION
# Description

This pr adds two new flags to specify the image to use to move volumes between clusters

# How Has This Been Tested?

- [x] e2e test
