### PR TITLE
Add to "liqoctl status peer" status and URL of the remote API server

### DIFF
--- a/apis/discovery/v1alpha1/foreigncluster_types.go
+++ b/apis/discovery/v1alpha1/foreigncluster_types.go
@@ -145,6 +145,10 @@ type ForeignClusterStatus struct {
 	// PeeringConditions contains the conditions about the peering related to this
 	// ForeignCluster.
 	PeeringConditions []PeeringCondition `json:"peeringConditions,omitempty"`
+
+	// URL of the forign cluster's API server.
+	// +kubebuilder:validation:Optional
+	APIServerURL string `json:"apiServerUrl,omitempty"`
 }
 
 // PeeringConditionType represents different conditions that a peering could assume.

--- a/deployments/liqo/crds/discovery.liqo.io_foreignclusters.yaml
+++ b/deployments/liqo/crds/discovery.liqo.io_foreignclusters.yaml
@@ -132,6 +132,9 @@ spec:
           status:
             description: ForeignClusterStatus defines the observed state of ForeignCluster.
             properties:
+              apiServerUrl:
+                description: URL of the forign cluster's API server.
+                type: string
               peeringConditions:
                 description: PeeringConditions contains the conditions about the peering
                   related to this ForeignCluster.

--- a/pkg/liqo-controller-manager/foreign-cluster-operator/auth.go
+++ b/pkg/liqo-controller-manager/foreign-cluster-operator/auth.go
@@ -75,7 +75,7 @@ func (r *ForeignClusterReconciler) ensureRemoteIdentity(ctx context.Context,
 		peeringconditionsutils.EnsureStatus(foreignCluster, discoveryv1alpha1.AuthenticationStatusCondition, status, reason, message)
 	}()
 
-	_, err = r.IdentityManager.GetConfig(foreignCluster.Spec.ClusterIdentity, foreignCluster.Status.TenantNamespace.Local)
+	config, err := r.IdentityManager.GetConfig(foreignCluster.Spec.ClusterIdentity, foreignCluster.Status.TenantNamespace.Local)
 	if err != nil && !kerrors.IsNotFound(err) {
 		return err
 	}
@@ -98,6 +98,8 @@ func (r *ForeignClusterReconciler) ensureRemoteIdentity(ctx context.Context,
 	status = discoveryv1alpha1.PeeringConditionStatusEstablished
 	reason = identityAcceptedReason
 	message = identityAcceptedMessage
+
+	foreignCluster.Status.APIServerURL = config.Host
 
 	return nil
 }

--- a/pkg/liqoctl/status/peer/peerinfo_test.go
+++ b/pkg/liqoctl/status/peer/peerinfo_test.go
@@ -230,6 +230,19 @@ var _ = Describe("PeerInfo", func() {
 				))
 			}
 
+			// API Server
+			Expect(text).To(ContainSubstring(
+				pterm.Sprintf("API Server Status: %s", discoveryv1alpha1.PeeringConditionStatusEstablished),
+			))
+			if args.verbose {
+				Expect(text).To(ContainSubstring(
+					pterm.Sprintf("API Server URL: %s", testutil.ForeignAPIServerURL),
+				))
+				Expect(text).To(ContainSubstring(
+					pterm.Sprintf("API Server Proxy URL: %s", testutil.ForeignProxyURL),
+				))
+			}
+
 			// Resources
 			if args.peer.outgoingPeeringEnabled {
 				Expect(text).To(ContainSubstring(

--- a/pkg/utils/testutil/consts.go
+++ b/pkg/utils/testutil/consts.go
@@ -27,6 +27,8 @@ const (
 	OverrideAPIAddress = "1.0.0.2:6443"
 	// ForeignAuthURL is the URL of the foreign cluster used for testing.
 	ForeignAuthURL = "https://fake-auth-url:32407"
+	// ForeignAPIServerURL is the URL of the foreign cluster used for testing.
+	ForeignAPIServerURL = "https://fake-apiserver-url:6443"
 	// ForeignProxyURL is the URL of the foreign cluster used for testing.
 	ForeignProxyURL = "https://fake-proxy-url:32408"
 	// VPNGatewayPort is the port of the liqo-gateway service used for testing.

--- a/pkg/utils/testutil/liqo.go
+++ b/pkg/utils/testutil/liqo.go
@@ -159,7 +159,12 @@ func FakeForeignCluster(clusterIdentity discoveryv1alpha1.ClusterIdentity, tenan
 					Type:   discoveryv1alpha1.NetworkStatusCondition,
 					Status: networkConditionStatus,
 				},
+				{
+					Type:   discoveryv1alpha1.APIServerStatusCondition,
+					Status: discoveryv1alpha1.PeeringConditionStatusEstablished,
+				},
 			},
+			APIServerURL: ForeignAPIServerURL,
 		},
 	}
 }


### PR DESCRIPTION
# Description

This PR adds to "liqoctl status peer" the status and the URL of the remote API server.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Locally
- [x] Unit tests
- [x] E2E tests
