### PR TITLE
Disable the reflection of specific labels and annotations

### DIFF
--- a/cmd/liqo-controller-manager/main.go
+++ b/cmd/liqo-controller-manager/main.go
@@ -106,6 +106,8 @@ func main() {
 	var kubeletRAMRequests, kubeletRAMLimits argsutils.Quantity
 	var kubeletMetricsAddress string
 	var kubeletMetricsEnabled bool
+	var labelsNotReflected argsutils.StringList
+	var annotationsNotReflected argsutils.StringList
 
 	webhookPort := flag.Uint("webhook-port", 9443, "The port the webhook server binds to")
 	metricsAddr := flag.String("metrics-address", ":8080", "The address the metric endpoint binds to")
@@ -166,6 +168,8 @@ func main() {
 	flag.BoolVar(&kubeletMetricsEnabled, "kubelet-metrics-enabled", false, "Enable the kubelet metrics endpoint")
 	flag.Var(&nodeExtraAnnotations, "node-extra-annotations", "Extra annotations to add to the Virtual Node")
 	flag.Var(&nodeExtraLabels, "node-extra-labels", "Extra labels to add to the Virtual Node")
+	flag.Var(&labelsNotReflected, "labels-not-reflected", "List of labels (key) that must not be reflected")
+	flag.Var(&annotationsNotReflected, "annotations-not-reflected", "List of annotations (key) that must not be reflected")
 	kubeletIpamServer := flag.String("kubelet-ipam-server", "",
 		"The address of the IPAM server to use for the virtual kubelet (set to empty string to disable IPAM)")
 
@@ -187,19 +191,21 @@ func main() {
 
 	// Options for the virtual kubelet.
 	virtualKubeletOpts := &forge.VirtualKubeletOpts{
-		ContainerImage:       *kubeletImage,
-		ExtraAnnotations:     kubeletExtraAnnotations.StringMap,
-		ExtraLabels:          kubeletExtraLabels.StringMap,
-		ExtraArgs:            kubeletExtraArgs.StringList,
-		NodeExtraAnnotations: nodeExtraAnnotations,
-		NodeExtraLabels:      nodeExtraLabels,
-		RequestsCPU:          kubeletCPURequests.Quantity,
-		RequestsRAM:          kubeletRAMRequests.Quantity,
-		LimitsCPU:            kubeletCPULimits.Quantity,
-		LimitsRAM:            kubeletRAMLimits.Quantity,
-		IpamEndpoint:         *kubeletIpamServer,
-		MetricsAddress:       kubeletMetricsAddress,
-		MetricsEnabled:       kubeletMetricsEnabled,
+		ContainerImage:          *kubeletImage,
+		ExtraAnnotations:        kubeletExtraAnnotations.StringMap,
+		ExtraLabels:             kubeletExtraLabels.StringMap,
+		ExtraArgs:               kubeletExtraArgs.StringList,
+		NodeExtraAnnotations:    nodeExtraAnnotations,
+		NodeExtraLabels:         nodeExtraLabels,
+		RequestsCPU:             kubeletCPURequests.Quantity,
+		RequestsRAM:             kubeletRAMRequests.Quantity,
+		LimitsCPU:               kubeletCPULimits.Quantity,
+		LimitsRAM:               kubeletRAMLimits.Quantity,
+		IpamEndpoint:            *kubeletIpamServer,
+		MetricsAddress:          kubeletMetricsAddress,
+		MetricsEnabled:          kubeletMetricsEnabled,
+		LabelsNotReflected:      labelsNotReflected.StringList,
+		AnnotationsNotReflected: annotationsNotReflected.StringList,
 	}
 
 	clusterIdentity := clusterIdentityFlags.ReadOrDie()

--- a/cmd/virtual-kubelet/root/flag.go
+++ b/cmd/virtual-kubelet/root/flag.go
@@ -71,6 +71,9 @@ func InstallFlags(flags *pflag.FlagSet, o *Opts) {
 	flags.Var(&o.NodeExtraAnnotations, "node-extra-annotations", "Extra annotations to add to the Virtual Node")
 	flags.Var(&o.NodeExtraLabels, "node-extra-labels", "Extra labels to add to the Virtual Node")
 
+	flags.Var(&o.LabelsNotReflected, "labels-not-reflected", "List of labels (key) that must not be reflected")
+	flags.Var(&o.AnnotationsNotReflected, "annotations-not-reflected", "List of annotations (key) that must not be reflected")
+
 	flags.BoolVar(&o.EnableAPIServerSupport, "enable-apiserver-support", false,
 		"Enable offloaded pods to interact back with the local Kubernetes API server")
 	flags.BoolVar(&o.EnableStorage, "enable-storage", false, "Enable the Liqo storage reflection")

--- a/cmd/virtual-kubelet/root/opts.go
+++ b/cmd/virtual-kubelet/root/opts.go
@@ -89,6 +89,9 @@ type Opts struct {
 	PersistentVolumeClaimWorkers uint
 	EventWorkers                 uint
 
+	LabelsNotReflected      argsutils.StringList
+	AnnotationsNotReflected argsutils.StringList
+
 	NodeLeaseDuration time.Duration
 	NodePingInterval  time.Duration
 	NodePingTimeout   time.Duration
@@ -139,6 +142,9 @@ func NewOpts() *Opts {
 		ServiceAccountWorkers:        DefaultServiceAccountWorkers,
 		PersistentVolumeClaimWorkers: DefaultPersistenVolumeClaimWorkers,
 		EventWorkers:                 DefaultEventWorkers,
+
+		LabelsNotReflected:      argsutils.StringList{},
+		AnnotationsNotReflected: argsutils.StringList{},
 
 		NodeLeaseDuration: node.DefaultLeaseDuration * time.Second,
 		NodePingInterval:  node.DefaultPingInterval,

--- a/cmd/virtual-kubelet/root/root.go
+++ b/cmd/virtual-kubelet/root/root.go
@@ -128,6 +128,9 @@ func runRootCommand(ctx context.Context, c *Opts) error {
 
 		HomeAPIServerHost: c.HomeAPIServerHost,
 		HomeAPIServerPort: c.HomeAPIServerPort,
+
+		LabelsNotReflected:      c.LabelsNotReflected.StringList,
+		AnnotationsNotReflected: c.AnnotationsNotReflected.StringList,
 	}
 
 	eb := record.NewBroadcaster()

--- a/deployments/liqo/README.md
+++ b/deployments/liqo/README.md
@@ -115,6 +115,8 @@
 | proxy.service.annotations | object | `{}` |  |
 | proxy.service.type | string | `"ClusterIP"` |  |
 | pullPolicy | string | `"IfNotPresent"` | The pullPolicy for liqo pods. |
+| reflection.skip.annotations | list | `["metallb.universe.tf/ip-allocated-from-pool","metallb.universe.tf/loadBalancerIPs","metallb.universe.tf/address-pool"]` | List of annotations that must not be reflected on remote clusters. |
+| reflection.skip.labels | list | `[]` | List of labels that must not be reflected on remote clusters. |
 | route.imageName | string | `"ghcr.io/liqotech/liqonet"` | Image repository for the route pod. |
 | route.pod.annotations | object | `{}` | Annotations for the route pod. |
 | route.pod.extraArgs | list | `[]` | Extra arguments for the route pod. |

--- a/deployments/liqo/templates/liqo-controller-manager-deployment.yaml
+++ b/deployments/liqo/templates/liqo-controller-manager-deployment.yaml
@@ -77,6 +77,14 @@ spec:
           - --liqo-namespace=$(POD_NAMESPACE)
           - --enable-incoming-peering={{ .Values.discovery.config.incomingPeeringEnabled }}
           - --resource-sharing-percentage={{ .Values.controllerManager.config.resourceSharingPercentage }}
+          {{- if .Values.reflection.skip.labels }}
+          {{- $d := dict "commandName" "--labels-not-reflected" "list" .Values.reflection.skip.labels }}
+          {{- include "liqo.concatenateList" $d | nindent 10 }}
+          {{- end }}
+          {{- if .Values.reflection.skip.annotations }}
+          {{- $d := dict "commandName" "--annotations-not-reflected" "list" .Values.reflection.skip.annotations }}
+          {{- include "liqo.concatenateList" $d | nindent 10 }}
+          {{- end }}
           - --kubelet-image={{ .Values.virtualKubelet.imageName }}{{ include "liqo.suffix" $ctrlManagerConfig }}:{{ include "liqo.version" $ctrlManagerConfig }}
           {{- if .Values.virtualKubelet.metrics.enabled }}
           - --kubelet-metrics-address=:{{ .Values.virtualKubelet.metrics.port }}

--- a/deployments/liqo/values.yaml
+++ b/deployments/liqo/values.yaml
@@ -18,6 +18,17 @@ networking:
   # -- Reflect pod IPs and EnpointSlices to the remote clusters.
   reflectIPs: true
 
+reflection:
+  skip:
+    # -- List of labels that must not be reflected on remote clusters.
+    labels: []
+    # -- List of annotations that must not be reflected on remote clusters.
+    annotations: [
+      metallb.universe.tf/ip-allocated-from-pool,
+      metallb.universe.tf/loadBalancerIPs,
+      metallb.universe.tf/address-pool,
+    ]
+
 controllerManager:
   # -- The number of controller-manager instances to run, which can be increased for active/passive high availability.
   replicas: 1

--- a/pkg/utils/testutil/consts.go
+++ b/pkg/utils/testutil/consts.go
@@ -35,6 +35,10 @@ const (
 	VPNGatewayPort = 32406
 	// AuthenticationPort is the port of the liqo-auth service used for testing.
 	AuthenticationPort = 32407
+	// FakeNotReflectedLabelKey is the key of the fake not reflected label used for testing.
+	FakeNotReflectedLabelKey = "not-reflected-label"
+	// FakeNotReflectedAnnotKey is the key of the fake not reflected annotation used for testing.
+	FakeNotReflectedAnnotKey = "not-reflected-annot"
 )
 
 var (

--- a/pkg/utils/testutil/liqo.go
+++ b/pkg/utils/testutil/liqo.go
@@ -27,6 +27,7 @@ import (
 	netv1alpha1 "github.com/liqotech/liqo/apis/net/v1alpha1"
 	sharingv1alpha1 "github.com/liqotech/liqo/apis/sharing/v1alpha1"
 	liqoconsts "github.com/liqotech/liqo/pkg/consts"
+	"github.com/liqotech/liqo/pkg/virtualKubelet/forge"
 )
 
 // FakeLiqoAuthService returns a fake liqo-auth service.
@@ -246,5 +247,13 @@ func FakeNetworkConfig(local bool, clusterName, tenantNamespace,
 			PodCIDRNAT:      podCIDRNAT,
 			ExternalCIDRNAT: extCIDRNAT,
 		},
+	}
+}
+
+// FakeForgingOpts returns a fake ForgingOpts.
+func FakeForgingOpts() *forge.ForgingOpts {
+	return &forge.ForgingOpts{
+		LabelsNotReflected:      []string{FakeNotReflectedLabelKey},
+		AnnotationsNotReflected: []string{FakeNotReflectedAnnotKey},
 	}
 }

--- a/pkg/virtualKubelet/forge/configmaps.go
+++ b/pkg/virtualKubelet/forge/configmaps.go
@@ -23,10 +23,10 @@ import (
 const RootCAConfigMapName = "kube-root-ca.crt"
 
 // RemoteConfigMap forges the apply patch for the reflected configmap, given the local one.
-func RemoteConfigMap(local *corev1.ConfigMap, targetNamespace string) *corev1apply.ConfigMapApplyConfiguration {
+func RemoteConfigMap(local *corev1.ConfigMap, targetNamespace string, forgingOpts *ForgingOpts) *corev1apply.ConfigMapApplyConfiguration {
 	applyConfig := corev1apply.ConfigMap(RemoteConfigMapName(local.GetName()), targetNamespace).
-		WithLabels(local.GetLabels()).WithLabels(ReflectionLabels()).
-		WithAnnotations(local.GetAnnotations()).
+		WithLabels(FilterNotReflected(local.GetLabels(), forgingOpts.LabelsNotReflected)).WithLabels(ReflectionLabels()).
+		WithAnnotations(FilterNotReflected(local.GetAnnotations(), forgingOpts.AnnotationsNotReflected)).
 		WithBinaryData(local.BinaryData).
 		WithData(local.Data)
 

--- a/pkg/virtualKubelet/forge/forge.go
+++ b/pkg/virtualKubelet/forge/forge.go
@@ -67,3 +67,17 @@ func ApplyOptions() metav1.ApplyOptions {
 		FieldManager: ReflectionFieldManager,
 	}
 }
+
+// ForgingOpts contains options to forge the reflected resources.
+type ForgingOpts struct {
+	LabelsNotReflected      []string
+	AnnotationsNotReflected []string
+}
+
+// NewForgingOpts returns a new ForgingOpts instance.
+func NewForgingOpts(labelsNotReflected, annotationsNotReflected []string) ForgingOpts {
+	return ForgingOpts{
+		LabelsNotReflected:      labelsNotReflected,
+		AnnotationsNotReflected: annotationsNotReflected,
+	}
+}

--- a/pkg/virtualKubelet/forge/ingresses.go
+++ b/pkg/virtualKubelet/forge/ingresses.go
@@ -22,10 +22,10 @@ import (
 )
 
 // RemoteIngress forges the apply patch for the reflected ingress, given the local one.
-func RemoteIngress(local *netv1.Ingress, targetNamespace string) *netv1apply.IngressApplyConfiguration {
+func RemoteIngress(local *netv1.Ingress, targetNamespace string, forgingOpts *ForgingOpts) *netv1apply.IngressApplyConfiguration {
 	return netv1apply.Ingress(local.GetName(), targetNamespace).
-		WithLabels(local.GetLabels()).WithLabels(ReflectionLabels()).
-		WithAnnotations(FilterIngressAnnotations(local.GetAnnotations())).
+		WithLabels(FilterNotReflected(local.GetLabels(), forgingOpts.LabelsNotReflected)).WithLabels(ReflectionLabels()).
+		WithAnnotations(FilterNotReflected(FilterIngressAnnotations(local.GetAnnotations()), forgingOpts.AnnotationsNotReflected)).
 		WithSpec(RemoteIngressSpec(local.Spec.DeepCopy()))
 }
 

--- a/pkg/virtualKubelet/forge/meta.go
+++ b/pkg/virtualKubelet/forge/meta.go
@@ -19,6 +19,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	corev1apply "k8s.io/client-go/applyconfigurations/core/v1"
+
+	"github.com/liqotech/liqo/pkg/utils/maps"
 )
 
 const (
@@ -90,4 +92,10 @@ func RemoteTypedLocalObjectReference(local *corev1.TypedLocalObjectReference) *c
 // RemoteKind prepends "Remote" to a kind name, to identify remote objects.
 func RemoteKind(kind string) string {
 	return "Remote" + kind
+}
+
+// FilterNotReflected returns a map filtering out entries that match the given keys.
+func FilterNotReflected(m map[string]string, blackListedKeys []string) map[string]string {
+	filter := maps.FilterBlacklist(blackListedKeys...)
+	return maps.Filter(m, filter)
 }

--- a/pkg/virtualKubelet/forge/secrets.go
+++ b/pkg/virtualKubelet/forge/secrets.go
@@ -61,10 +61,10 @@ func IsServiceAccountSecret(obj metav1.Object) bool {
 }
 
 // RemoteSecret forges the apply patch for the reflected secret, given the local one.
-func RemoteSecret(local *corev1.Secret, targetNamespace string) *corev1apply.SecretApplyConfiguration {
+func RemoteSecret(local *corev1.Secret, targetNamespace string, forgingOpts *ForgingOpts) *corev1apply.SecretApplyConfiguration {
 	applyConfig := corev1apply.Secret(local.GetName(), targetNamespace).
-		WithLabels(local.GetLabels()).WithLabels(ReflectionLabels()).
-		WithAnnotations(local.GetAnnotations()).
+		WithLabels(FilterNotReflected(local.GetLabels(), forgingOpts.LabelsNotReflected)).WithLabels(ReflectionLabels()).
+		WithAnnotations(FilterNotReflected(local.GetAnnotations(), forgingOpts.AnnotationsNotReflected)).
 		WithData(local.Data).
 		WithType(local.Type)
 

--- a/pkg/virtualKubelet/forge/services.go
+++ b/pkg/virtualKubelet/forge/services.go
@@ -26,10 +26,10 @@ import (
 const nodePortUnset = 0
 
 // RemoteService forges the apply patch for the reflected service, given the local one.
-func RemoteService(local *corev1.Service, targetNamespace string) *corev1apply.ServiceApplyConfiguration {
+func RemoteService(local *corev1.Service, targetNamespace string, forgingOpts *ForgingOpts) *corev1apply.ServiceApplyConfiguration {
 	return corev1apply.Service(local.GetName(), targetNamespace).
-		WithLabels(local.GetLabels()).WithLabels(ReflectionLabels()).
-		WithAnnotations(local.GetAnnotations()).
+		WithLabels(FilterNotReflected(local.GetLabels(), forgingOpts.LabelsNotReflected)).WithLabels(ReflectionLabels()).
+		WithAnnotations(FilterNotReflected(local.GetAnnotations(), forgingOpts.AnnotationsNotReflected)).
 		WithSpec(RemoteServiceSpec(local.Spec.DeepCopy(), getForceRemoteNodePort(local)))
 }
 

--- a/pkg/virtualKubelet/provider/provider.go
+++ b/pkg/virtualKubelet/provider/provider.go
@@ -81,6 +81,9 @@ type InitConfig struct {
 
 	HomeAPIServerHost string
 	HomeAPIServerPort string
+
+	LabelsNotReflected      []string
+	AnnotationsNotReflected []string
 }
 
 // LiqoProvider implements the virtual-kubelet provider interface and stores pods in memory.
@@ -133,7 +136,8 @@ func NewLiqoProvider(ctx context.Context, cfg *InitConfig, eb record.EventBroadc
 	}
 
 	podreflector := workload.NewPodReflector(cfg.RemoteConfig, remoteMetricsClient, ipamClient, &podReflectorConfig, cfg.PodWorkers)
-	reflectionManager := manager.New(localClient, remoteClient, localLiqoClient, remoteLiqoClient, cfg.InformerResyncPeriod, eb).
+	reflectionManager := manager.New(localClient, remoteClient, localLiqoClient, remoteLiqoClient,
+		cfg.InformerResyncPeriod, eb, cfg.LabelsNotReflected, cfg.AnnotationsNotReflected).
 		With(podreflector).
 		With(exposition.NewServiceReflector(cfg.ServiceWorkers)).
 		With(exposition.NewIngressReflector(cfg.IngressWorkers)).

--- a/pkg/virtualKubelet/reflection/configuration/configmap.go
+++ b/pkg/virtualKubelet/reflection/configuration/configmap.go
@@ -134,7 +134,7 @@ func (ncr *NamespacedConfigMapReflector) Handle(ctx context.Context, name string
 	}
 
 	// Forge the mutation to be applied to the remote cluster.
-	mutation := forge.RemoteConfigMap(local, ncr.RemoteNamespace())
+	mutation := forge.RemoteConfigMap(local, ncr.RemoteNamespace(), ncr.ForgingOpts)
 	tracer.Step("Remote mutation created")
 
 	defer tracer.Step("Enforced the correctness of the remote object")

--- a/pkg/virtualKubelet/reflection/configuration/secret.go
+++ b/pkg/virtualKubelet/reflection/configuration/secret.go
@@ -137,7 +137,7 @@ func (nsr *NamespacedSecretReflector) Handle(ctx context.Context, name string) e
 	}
 
 	// Forge the mutation to be applied to the remote cluster.
-	mutation := forge.RemoteSecret(local, nsr.RemoteNamespace())
+	mutation := forge.RemoteSecret(local, nsr.RemoteNamespace(), nsr.ForgingOpts)
 	tracer.Step("Remote mutation created")
 
 	defer tracer.Step("Enforced the correctness of the remote object")

--- a/pkg/virtualKubelet/reflection/event/event.go
+++ b/pkg/virtualKubelet/reflection/event/event.go
@@ -170,8 +170,8 @@ func (ner *NamespacedEventReflector) Handle(ctx context.Context, name string) er
 			ObjectMeta: metav1.ObjectMeta{
 				Name:        remote.Name,
 				Namespace:   ner.LocalNamespace(),
-				Labels:      labels.Merge(remote.GetLabels(), forge.ReflectionLabels()),
-				Annotations: remote.GetAnnotations(),
+				Labels:      labels.Merge(forge.FilterNotReflected(remote.GetLabels(), ner.ForgingOpts.LabelsNotReflected), forge.ReflectionLabels()),
+				Annotations: forge.FilterNotReflected(remote.GetAnnotations(), ner.ForgingOpts.AnnotationsNotReflected),
 			},
 			InvolvedObject: corev1.ObjectReference{
 				APIVersion: remote.InvolvedObject.APIVersion,

--- a/pkg/virtualKubelet/reflection/exposition/endpointslice.go
+++ b/pkg/virtualKubelet/reflection/exposition/endpointslice.go
@@ -181,7 +181,7 @@ func (ner *NamespacedEndpointSliceReflector) Handle(ctx context.Context, name st
 		return translations
 	}
 
-	target := forge.RemoteShadowEndpointSlice(local, remote, ner.localNodeClient, ner.RemoteNamespace(), translator)
+	target := forge.RemoteShadowEndpointSlice(local, remote, ner.localNodeClient, ner.RemoteNamespace(), translator, ner.ForgingOpts)
 	if terr != nil {
 		klog.Errorf("Reflection of local EndpointSlice %q to %q failed: %v", ner.LocalRef(name), ner.RemoteRef(name), terr)
 		ner.Event(local, corev1.EventTypeWarning, forge.EventFailedReflection, forge.EventFailedReflectionMsg(terr))

--- a/pkg/virtualKubelet/reflection/exposition/ingress.go
+++ b/pkg/virtualKubelet/reflection/exposition/ingress.go
@@ -121,7 +121,7 @@ func (nir *NamespacedIngressReflector) Handle(ctx context.Context, name string) 
 	}
 
 	// Forge the mutation to be applied to the remote cluster.
-	mutation := forge.RemoteIngress(local, nir.RemoteNamespace())
+	mutation := forge.RemoteIngress(local, nir.RemoteNamespace(), nir.ForgingOpts)
 	tracer.Step("Remote mutation created")
 
 	defer tracer.Step("Enforced the correctness of the remote object")

--- a/pkg/virtualKubelet/reflection/exposition/ingress_test.go
+++ b/pkg/virtualKubelet/reflection/exposition/ingress_test.go
@@ -22,6 +22,7 @@ import (
 	netv1 "k8s.io/api/networking/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/trace"
@@ -112,7 +113,8 @@ var _ = Describe("Ingress Reflection Tests", func() {
 				WithLocal(LocalNamespace, client, factory).
 				WithRemote(RemoteNamespace, client, factory).
 				WithHandlerFactory(FakeEventHandler).
-				WithEventBroadcaster(record.NewBroadcaster()))
+				WithEventBroadcaster(record.NewBroadcaster()).
+				WithForgingOpts(FakeForgingOpts()))
 
 			factory.Start(ctx.Done())
 			factory.WaitForCacheSync(ctx.Done())
@@ -127,8 +129,8 @@ var _ = Describe("Ingress Reflection Tests", func() {
 
 		When("the local object does exist", func() {
 			BeforeEach(func() {
-				local.SetLabels(map[string]string{"foo": "bar"})
-				local.SetAnnotations(map[string]string{"bar": "baz"})
+				local.SetLabels(map[string]string{"foo": "bar", FakeNotReflectedLabelKey: "true"})
+				local.SetAnnotations(map[string]string{"bar": "baz", FakeNotReflectedAnnotKey: "true"})
 				ForgeIngressSpec(&local)
 				CreateIngress(&local)
 			})
@@ -140,7 +142,9 @@ var _ = Describe("Ingress Reflection Tests", func() {
 					Expect(remoteAfter.Labels).To(HaveKeyWithValue(forge.LiqoOriginClusterIDKey, LocalClusterID))
 					Expect(remoteAfter.Labels).To(HaveKeyWithValue(forge.LiqoDestinationClusterIDKey, RemoteClusterID))
 					Expect(remoteAfter.Labels).To(HaveKeyWithValue("foo", "bar"))
+					Expect(remoteAfter.Labels).ToNot(HaveKey(FakeNotReflectedLabelKey))
 					Expect(remoteAfter.Annotations).To(HaveKeyWithValue("bar", "baz"))
+					Expect(remoteAfter.Annotations).ToNot(HaveKey(FakeNotReflectedAnnotKey))
 				})
 				It("the spec should have been correctly replicated to the remote object", func() {
 					remoteAfter := GetIngress(RemoteNamespace)
@@ -151,8 +155,8 @@ var _ = Describe("Ingress Reflection Tests", func() {
 
 			When("the remote object already exists", func() {
 				BeforeEach(func() {
-					remote.SetLabels(forge.ReflectionLabels())
-					remote.SetAnnotations(map[string]string{"bar": "previous", "existing": "existing"})
+					remote.SetLabels(labels.Merge(forge.ReflectionLabels(), map[string]string{FakeNotReflectedLabelKey: "true"}))
+					remote.SetAnnotations(map[string]string{"bar": "previous", "existing": "existing", FakeNotReflectedAnnotKey: "true"})
 					ForgeIngressSpec(&remote)
 					CreateIngress(&remote)
 				})
@@ -163,8 +167,10 @@ var _ = Describe("Ingress Reflection Tests", func() {
 					Expect(remoteAfter.Labels).To(HaveKeyWithValue(forge.LiqoOriginClusterIDKey, LocalClusterID))
 					Expect(remoteAfter.Labels).To(HaveKeyWithValue(forge.LiqoDestinationClusterIDKey, RemoteClusterID))
 					Expect(remoteAfter.Labels).To(HaveKeyWithValue("foo", "bar"))
+					Expect(remoteAfter.Labels).To(HaveKey(FakeNotReflectedLabelKey))
 					Expect(remoteAfter.Annotations).To(HaveKeyWithValue("bar", "baz"))
 					Expect(remoteAfter.Annotations).To(HaveKeyWithValue("existing", "existing"))
+					Expect(remoteAfter.Annotations).To(HaveKey(FakeNotReflectedAnnotKey))
 				})
 				It("the spec should have been correctly replicated to the remote object", func() {
 					remoteAfter := GetIngress(RemoteNamespace)

--- a/pkg/virtualKubelet/reflection/exposition/service.go
+++ b/pkg/virtualKubelet/reflection/exposition/service.go
@@ -129,7 +129,7 @@ func (nsr *NamespacedServiceReflector) Handle(ctx context.Context, name string) 
 	}
 
 	// Forge the mutation to be applied to the remote cluster.
-	mutation := forge.RemoteService(local, nsr.RemoteNamespace())
+	mutation := forge.RemoteService(local, nsr.RemoteNamespace(), nsr.ForgingOpts)
 	tracer.Step("Remote mutation created")
 
 	defer tracer.Step("Enforced the correctness of the remote object")

--- a/pkg/virtualKubelet/reflection/exposition/service_test.go
+++ b/pkg/virtualKubelet/reflection/exposition/service_test.go
@@ -22,6 +22,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/tools/record"
@@ -100,7 +101,8 @@ var _ = Describe("Service Reflection Tests", func() {
 				WithLocal(LocalNamespace, client, factory).
 				WithRemote(RemoteNamespace, client, factory).
 				WithHandlerFactory(FakeEventHandler).
-				WithEventBroadcaster(record.NewBroadcaster()))
+				WithEventBroadcaster(record.NewBroadcaster()).
+				WithForgingOpts(FakeForgingOpts()))
 
 			factory.Start(ctx.Done())
 			factory.WaitForCacheSync(ctx.Done())
@@ -115,8 +117,8 @@ var _ = Describe("Service Reflection Tests", func() {
 
 		When("the local object does exist", func() {
 			BeforeEach(func() {
-				local.SetLabels(map[string]string{"foo": "bar"})
-				local.SetAnnotations(map[string]string{"bar": "baz"})
+				local.SetLabels(map[string]string{"foo": "bar", FakeNotReflectedLabelKey: "true"})
+				local.SetAnnotations(map[string]string{"bar": "baz", FakeNotReflectedAnnotKey: "true"})
 				local.Spec = corev1.ServiceSpec{
 					Type:  corev1.ServiceTypeLoadBalancer,
 					Ports: []corev1.ServicePort{{Name: "http", Port: 80, TargetPort: intstr.FromInt(8080)}},
@@ -131,7 +133,9 @@ var _ = Describe("Service Reflection Tests", func() {
 					Expect(remoteAfter.Labels).To(HaveKeyWithValue(forge.LiqoOriginClusterIDKey, LocalClusterID))
 					Expect(remoteAfter.Labels).To(HaveKeyWithValue(forge.LiqoDestinationClusterIDKey, RemoteClusterID))
 					Expect(remoteAfter.Labels).To(HaveKeyWithValue("foo", "bar"))
+					Expect(remoteAfter.Labels).ToNot(HaveKey(FakeNotReflectedLabelKey))
 					Expect(remoteAfter.Annotations).To(HaveKeyWithValue("bar", "baz"))
+					Expect(remoteAfter.Annotations).ToNot(HaveKey(FakeNotReflectedAnnotKey))
 				})
 				It("the spec should have been correctly replicated to the remote object", func() {
 					remoteAfter := GetService(RemoteNamespace)
@@ -142,8 +146,8 @@ var _ = Describe("Service Reflection Tests", func() {
 
 			When("the remote object already exists", func() {
 				BeforeEach(func() {
-					remote.SetLabels(forge.ReflectionLabels())
-					remote.SetAnnotations(map[string]string{"bar": "previous", "existing": "existing"})
+					remote.SetLabels(labels.Merge(forge.ReflectionLabels(), map[string]string{FakeNotReflectedLabelKey: "true"}))
+					remote.SetAnnotations(map[string]string{"bar": "previous", "existing": "existing", FakeNotReflectedAnnotKey: "true"})
 					remote.Spec.Ports = []corev1.ServicePort{{Name: "http", Port: 80, TargetPort: intstr.FromInt(8080)}}
 					CreateService(&remote)
 				})
@@ -154,8 +158,10 @@ var _ = Describe("Service Reflection Tests", func() {
 					Expect(remoteAfter.Labels).To(HaveKeyWithValue(forge.LiqoOriginClusterIDKey, LocalClusterID))
 					Expect(remoteAfter.Labels).To(HaveKeyWithValue(forge.LiqoDestinationClusterIDKey, RemoteClusterID))
 					Expect(remoteAfter.Labels).To(HaveKeyWithValue("foo", "bar"))
+					Expect(remoteAfter.Labels).To(HaveKey(FakeNotReflectedLabelKey))
 					Expect(remoteAfter.Annotations).To(HaveKeyWithValue("bar", "baz"))
 					Expect(remoteAfter.Annotations).To(HaveKeyWithValue("existing", "existing"))
+					Expect(remoteAfter.Annotations).To(HaveKey(FakeNotReflectedAnnotKey))
 				})
 				It("the spec should have been correctly replicated to the remote object", func() {
 					remoteAfter := GetService(RemoteNamespace)

--- a/pkg/virtualKubelet/reflection/generic/namespaced.go
+++ b/pkg/virtualKubelet/reflection/generic/namespaced.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/klog/v2"
 
 	"github.com/liqotech/liqo/pkg/consts"
+	"github.com/liqotech/liqo/pkg/virtualKubelet/forge"
 	"github.com/liqotech/liqo/pkg/virtualKubelet/reflection/options"
 )
 
@@ -38,6 +39,8 @@ type NamespacedReflector struct {
 
 	local  string
 	remote string
+
+	ForgingOpts *forge.ForgingOpts
 }
 
 // ResourceDeleter know how to delete a Kubernetes object with the given name.
@@ -49,7 +52,7 @@ type ResourceDeleter interface {
 func NewNamespacedReflector(opts *options.NamespacedOpts, name string) NamespacedReflector {
 	return NamespacedReflector{
 		EventRecorder: opts.EventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: "liqo-" + strings.ToLower(name) + "-reflection"}),
-		local:         opts.LocalNamespace, remote: opts.RemoteNamespace, ready: opts.Ready,
+		local:         opts.LocalNamespace, remote: opts.RemoteNamespace, ready: opts.Ready, ForgingOpts: opts.ForgingOpts,
 	}
 }
 

--- a/pkg/virtualKubelet/reflection/generic/namespaced_test.go
+++ b/pkg/virtualKubelet/reflection/generic/namespaced_test.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/klog/v2"
 
 	. "github.com/liqotech/liqo/pkg/utils/testutil"
+	"github.com/liqotech/liqo/pkg/virtualKubelet/forge"
 	"github.com/liqotech/liqo/pkg/virtualKubelet/reflection/options"
 )
 
@@ -40,15 +41,21 @@ var _ = Describe("NamespacedReflector tests", func() {
 
 	Context("the NewNamespacedReflector function", func() {
 		var (
-			nsrfl NamespacedReflector
-			ready bool
+			nsrfl       NamespacedReflector
+			ready       bool
+			forgingOpts *forge.ForgingOpts
 		)
 
-		BeforeEach(func() { ready = false })
+		BeforeEach(func() {
+			ready = false
+			forgingOpts = &forge.ForgingOpts{}
+		})
+
 		JustBeforeEach(func() {
 			opts := options.NamespacedOpts{
 				LocalNamespace: localNamespace, RemoteNamespace: remoteNamespace,
 				Ready: func() bool { return ready }, EventBroadcaster: record.NewBroadcaster(),
+				ForgingOpts: forgingOpts,
 			}
 			nsrfl = NewNamespacedReflector(&opts, name)
 		})
@@ -58,6 +65,7 @@ var _ = Describe("NamespacedReflector tests", func() {
 			Expect(nsrfl.local).To(BeIdenticalTo(localNamespace))
 			Expect(nsrfl.remote).To(BeIdenticalTo(remoteNamespace))
 			Expect(nsrfl.ready).ToNot(BeNil())
+			Expect(nsrfl.ForgingOpts).To(BeIdenticalTo(forgingOpts))
 		})
 
 		Context("the readiness property", func() {

--- a/pkg/virtualKubelet/reflection/manager/manager_test.go
+++ b/pkg/virtualKubelet/reflection/manager/manager_test.go
@@ -36,12 +36,14 @@ var _ = Describe("Manager tests", func() {
 	)
 
 	var (
-		mgr              Manager
-		localClient      kubernetes.Interface
-		remoteClient     kubernetes.Interface
-		localLiqoClient  liqoclient.Interface
-		remoteLiqoClient liqoclient.Interface
-		broadcaster      record.EventBroadcaster
+		mgr                     Manager
+		localClient             kubernetes.Interface
+		remoteClient            kubernetes.Interface
+		localLiqoClient         liqoclient.Interface
+		remoteLiqoClient        liqoclient.Interface
+		broadcaster             record.EventBroadcaster
+		labelsNotReflected      []string
+		annotationsNotReflected []string
 
 		ctx    context.Context
 		cancel context.CancelFunc
@@ -58,7 +60,7 @@ var _ = Describe("Manager tests", func() {
 	AfterEach(func() { cancel() })
 
 	JustBeforeEach(func() {
-		mgr = New(localClient, remoteClient, localLiqoClient, remoteLiqoClient, 1*time.Hour, broadcaster)
+		mgr = New(localClient, remoteClient, localLiqoClient, remoteLiqoClient, 1*time.Hour, broadcaster, labelsNotReflected, annotationsNotReflected)
 	})
 
 	Context("a new manager is created", func() {
@@ -78,6 +80,8 @@ var _ = Describe("Manager tests", func() {
 
 			Expect(mgr.(*manager).started).To(BeFalse())
 			Expect(mgr.(*manager).stop).ToNot(BeNil())
+
+			Expect(mgr.(*manager).forgingOpts).ToNot(BeNil())
 		})
 
 		Context("a NamespaceMapEventHandler is registered", func() {
@@ -153,6 +157,7 @@ var _ = Describe("Manager tests", func() {
 						Expect(opts.EventBroadcaster).To(Equal(broadcaster))
 						Expect(opts.Ready).ToNot(BeNil())
 						Expect(opts.HandlerFactory).To(BeNil())
+						Expect(opts.ForgingOpts).ToNot(BeNil())
 					})
 					It("should eventually mark the namespace as ready", func() {
 						Eventually(reflector.NamespaceStarted[localNamespace].Ready).Should(BeTrue())

--- a/pkg/virtualKubelet/reflection/options/options.go
+++ b/pkg/virtualKubelet/reflection/options/options.go
@@ -26,6 +26,7 @@ import (
 
 	liqoclient "github.com/liqotech/liqo/pkg/client/clientset/versioned"
 	liqoinformers "github.com/liqotech/liqo/pkg/client/informers/externalversions"
+	"github.com/liqotech/liqo/pkg/virtualKubelet/forge"
 )
 
 // Keyer retrieves a set of NamespacedNames referring to the reconciliation targets from the object metadata.
@@ -87,6 +88,8 @@ type NamespacedOpts struct {
 
 	Ready          func() bool
 	HandlerFactory func(Keyer, ...EventFilter) cache.ResourceEventHandler
+
+	ForgingOpts *forge.ForgingOpts
 }
 
 // NewNamespaced returns a new NamespacedOpts object.
@@ -139,6 +142,12 @@ func (ro *NamespacedOpts) WithReadinessFunc(ready func() bool) *NamespacedOpts {
 // WithEventBroadcaster configures the event broadcaster of the NamespacedOpts.
 func (ro *NamespacedOpts) WithEventBroadcaster(broadcaster record.EventBroadcaster) *NamespacedOpts {
 	ro.EventBroadcaster = broadcaster
+	return ro
+}
+
+// WithForgingOpts configures the reflection options of the NamespacedOpts.
+func (ro *NamespacedOpts) WithForgingOpts(opts *forge.ForgingOpts) *NamespacedOpts {
+	ro.ForgingOpts = opts
 	return ro
 }
 

--- a/pkg/virtualKubelet/reflection/options/options_test.go
+++ b/pkg/virtualKubelet/reflection/options/options_test.go
@@ -29,6 +29,7 @@ import (
 	liqoclient "github.com/liqotech/liqo/pkg/client/clientset/versioned"
 	liqoclientfake "github.com/liqotech/liqo/pkg/client/clientset/versioned/fake"
 	liqoinformers "github.com/liqotech/liqo/pkg/client/informers/externalversions"
+	"github.com/liqotech/liqo/pkg/virtualKubelet/forge"
 	"github.com/liqotech/liqo/pkg/virtualKubelet/reflection/options"
 )
 
@@ -115,6 +116,7 @@ var _ = Describe("Options", func() {
 			Expect(opts.EventBroadcaster).To(BeNil())
 			Expect(opts.HandlerFactory).To(BeNil())
 			Expect(opts.Ready).To(BeNil())
+			Expect(opts.ForgingOpts).To(BeNil())
 		})
 	})
 
@@ -129,6 +131,7 @@ var _ = Describe("Options", func() {
 			factory     informers.SharedInformerFactory
 			liqoFactory liqoinformers.SharedInformerFactory
 			broadcaster record.EventBroadcaster
+			forgingOpts *forge.ForgingOpts
 		)
 
 		BeforeEach(func() {
@@ -137,6 +140,7 @@ var _ = Describe("Options", func() {
 			factory = informers.NewSharedInformerFactory(client, 10*time.Hour)
 			liqoFactory = liqoinformers.NewSharedInformerFactory(liqoClient, 10*time.Hour)
 			broadcaster = record.NewBroadcaster()
+			forgingOpts = &forge.ForgingOpts{}
 		})
 
 		JustBeforeEach(func() { original = options.NewNamespaced() })
@@ -160,6 +164,7 @@ var _ = Describe("Options", func() {
 				Expect(opts.EventBroadcaster).To(BeNil())
 				Expect(opts.HandlerFactory).To(BeNil())
 				Expect(opts.Ready).To(BeNil())
+				Expect(opts.ForgingOpts).To(BeNil())
 			})
 		})
 
@@ -182,6 +187,7 @@ var _ = Describe("Options", func() {
 				Expect(opts.EventBroadcaster).To(BeNil())
 				Expect(opts.HandlerFactory).To(BeNil())
 				Expect(opts.Ready).To(BeNil())
+				Expect(opts.ForgingOpts).To(BeNil())
 			})
 		})
 
@@ -204,6 +210,7 @@ var _ = Describe("Options", func() {
 				Expect(opts.EventBroadcaster).To(BeNil())
 				Expect(opts.HandlerFactory).To(BeNil())
 				Expect(opts.Ready).To(BeNil())
+				Expect(opts.ForgingOpts).To(BeNil())
 			})
 		})
 
@@ -226,6 +233,7 @@ var _ = Describe("Options", func() {
 				Expect(opts.EventBroadcaster).To(BeNil())
 				Expect(opts.HandlerFactory).To(BeNil())
 				Expect(opts.Ready).To(BeNil())
+				Expect(opts.ForgingOpts).To(BeNil())
 			})
 		})
 
@@ -251,6 +259,7 @@ var _ = Describe("Options", func() {
 				Expect(opts.RemoteLiqoFactory).To(BeNil())
 				Expect(opts.EventBroadcaster).To(BeNil())
 				Expect(opts.Ready).To(BeNil())
+				Expect(opts.ForgingOpts).To(BeNil())
 			})
 		})
 
@@ -275,6 +284,7 @@ var _ = Describe("Options", func() {
 				Expect(opts.RemoteLiqoFactory).To(BeNil())
 				Expect(opts.EventBroadcaster).To(BeNil())
 				Expect(opts.HandlerFactory).To(BeNil())
+				Expect(opts.ForgingOpts).To(BeNil())
 			})
 		})
 
@@ -297,6 +307,30 @@ var _ = Describe("Options", func() {
 				Expect(opts.RemoteLiqoFactory).To(BeNil())
 				Expect(opts.HandlerFactory).To(BeNil())
 				Expect(opts.Ready).To(BeNil())
+				Expect(opts.ForgingOpts).To(BeNil())
+			})
+		})
+
+		Describe("The WithForgingOpts function", func() {
+			JustBeforeEach(func() { opts = original.WithForgingOpts(forgingOpts) })
+
+			It("should return a non-nil pointer", func() { Expect(opts).ToNot(BeNil()) })
+			It("should return the same pointer of the receiver", func() { Expect(opts).To(BeIdenticalTo(original)) })
+			It("should correctly set the forging options value", func() { Expect(opts.ForgingOpts).To(BeIdenticalTo(forgingOpts)) })
+			It("should leave the other fields unset", func() {
+				Expect(opts.LocalNamespace).To(BeEmpty())
+				Expect(opts.RemoteNamespace).To(BeEmpty())
+				Expect(opts.LocalClient).To(BeNil())
+				Expect(opts.LocalFactory).To(BeNil())
+				Expect(opts.LocalLiqoClient).To(BeNil())
+				Expect(opts.LocalFactory).To(BeNil())
+				Expect(opts.RemoteClient).To(BeNil())
+				Expect(opts.RemoteLiqoClient).To(BeNil())
+				Expect(opts.RemoteFactory).To(BeNil())
+				Expect(opts.RemoteLiqoFactory).To(BeNil())
+				Expect(opts.HandlerFactory).To(BeNil())
+				Expect(opts.Ready).To(BeNil())
+				Expect(opts.EventBroadcaster).To(BeNil())
 			})
 		})
 	})

--- a/pkg/virtualKubelet/reflection/storage/persistentvolumeclaim.go
+++ b/pkg/virtualKubelet/reflection/storage/persistentvolumeclaim.go
@@ -181,7 +181,8 @@ func (npvcr *NamespacedPersistentVolumeClaimReflector) Handle(ctx context.Contex
 
 			pv, state, err := liqostorageprovisioner.ProvisionRemotePVC(ctx,
 				options, npvcr.RemoteNamespace(), npvcr.remoteRealStorageClassName,
-				npvcr.remotePersistentVolumeClaims, npvcr.remotePersistentVolumesClaimsClient)
+				npvcr.remotePersistentVolumeClaims, npvcr.remotePersistentVolumesClaimsClient,
+				npvcr.ForgingOpts)
 			if err == nil && state == controller.ProvisioningFinished {
 				local.Spec.VolumeName = options.PVName
 			}

--- a/pkg/virtualKubelet/reflection/storage/persistentvolumeclaim_test.go
+++ b/pkg/virtualKubelet/reflection/storage/persistentvolumeclaim_test.go
@@ -83,6 +83,9 @@ var _ = Describe("reflector methods", func() {
 					Expect(err).ToNot(HaveOccurred())
 					Expect(offloadedPvc).ToNot(BeNil())
 
+					Expect(offloadedPvc.Labels).ToNot(HaveKey(FakeNotReflectedLabelKey))
+					Expect(offloadedPvc.Annotations).ToNot(HaveKey(FakeNotReflectedAnnotKey))
+
 					Expect(offloadedPvc.Spec.StorageClassName).To(PointTo(Equal(RealRemoteStorageClassName)))
 				})
 

--- a/pkg/virtualKubelet/reflection/storage/storage_suite_test.go
+++ b/pkg/virtualKubelet/reflection/storage/storage_suite_test.go
@@ -154,9 +154,13 @@ var _ = BeforeEach(func() {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      localPvcName,
 			Namespace: LocalNamespace,
+			Labels: map[string]string{
+				testutil.FakeNotReflectedLabelKey: "true",
+			},
 			Annotations: map[string]string{
-				annStorageProvisioner: consts.StorageProvisionerName,
-				annSelectedNode:       RealNodeName,
+				annStorageProvisioner:             consts.StorageProvisionerName,
+				annSelectedNode:                   RealNodeName,
+				testutil.FakeNotReflectedAnnotKey: "true",
 			},
 		},
 		Spec: corev1.PersistentVolumeClaimSpec{
@@ -218,7 +222,8 @@ var _ = JustBeforeEach(func() {
 	options := options.NewNamespaced().
 		WithLocal(LocalNamespace, k8sClient, factory).
 		WithRemote(RemoteNamespace, k8sClient, factory).
-		WithHandlerFactory(FakeEventHandler).WithEventBroadcaster(record.NewBroadcaster())
+		WithHandlerFactory(FakeEventHandler).WithEventBroadcaster(record.NewBroadcaster()).
+		WithForgingOpts(testutil.FakeForgingOpts())
 
 	reflector = reflectorBuilder(options).(*NamespacedPersistentVolumeClaimReflector)
 	Expect(reflector).ToNot(BeNil())

--- a/pkg/virtualKubelet/reflection/workload/podns.go
+++ b/pkg/virtualKubelet/reflection/workload/podns.go
@@ -217,7 +217,7 @@ func (npr *NamespacedPodReflector) Handle(ctx context.Context, name string) erro
 	info.PreventCreationUntilSeen = false
 
 	// The local pod is currently running, and it is necessary to enforce its presence in the remote cluster.
-	target, terr := npr.ForgeShadowPod(ctx, local, shadow, info)
+	target, terr := npr.ForgeShadowPod(ctx, local, shadow, info, npr.ForgingOpts)
 	if terr != nil {
 		klog.Errorf("Reflection of local pod %q to %q failed: %v", npr.LocalRef(local.GetName()), npr.RemoteRef(local.GetName()), terr)
 		npr.Event(local, corev1.EventTypeWarning, forge.EventFailedReflection, forge.EventFailedReflectionMsg(terr))
@@ -298,7 +298,7 @@ func (npr *NamespacedPodReflector) HandleLabels(ctx context.Context, local *core
 
 // ForgeShadowPod forges the ShadowPod object to be enforced by the reflection process.
 func (npr *NamespacedPodReflector) ForgeShadowPod(ctx context.Context, local *corev1.Pod,
-	shadow *vkv1alpha1.ShadowPod, info *PodInfo) (*vkv1alpha1.ShadowPod, error) {
+	shadow *vkv1alpha1.ShadowPod, info *PodInfo, forgingOpts *forge.ForgingOpts) (*vkv1alpha1.ShadowPod, error) {
 	var saerr, kserr error
 
 	// Wrap the secret name retrieval from the service account, so that we do not have to handle errors in the forge logic.
@@ -325,7 +325,7 @@ func (npr *NamespacedPodReflector) ForgeShadowPod(ctx context.Context, local *co
 	}
 
 	// Forge the target shadowpod object.
-	target := forge.RemoteShadowPod(local, shadow, npr.RemoteNamespace(),
+	target := forge.RemoteShadowPod(local, shadow, npr.RemoteNamespace(), forgingOpts,
 		forge.APIServerSupportMutator(npr.config.APIServerSupport, local.Annotations, pod.ServiceAccountName(local),
 			saSecretRetriever, ipGetter, npr.config.HomeAPIServerHost, npr.config.HomeAPIServerPort),
 		forge.ServiceAccountMutator(npr.config.APIServerSupport, local.Annotations))

--- a/pkg/vkMachinery/forge/forge.go
+++ b/pkg/vkMachinery/forge/forge.go
@@ -64,6 +64,14 @@ func forgeVKContainers(
 				getDefaultStorageClass(storageClasses).StorageClassName))
 	}
 
+	if len(opts.LabelsNotReflected) > 0 {
+		args = append(args, stringifyArgument(string(LabelsNotReflected), strings.Join(opts.LabelsNotReflected, ",")))
+	}
+
+	if len(opts.AnnotationsNotReflected) > 0 {
+		args = append(args, stringifyArgument(string(AnnotationsNotReflected), strings.Join(opts.AnnotationsNotReflected, ",")))
+	}
+
 	if extraAnnotations := opts.NodeExtraAnnotations.StringMap; len(extraAnnotations) != 0 {
 		args = append(args, stringifyArgument(string(NodeExtraAnnotations), opts.NodeExtraAnnotations.String()))
 	}

--- a/pkg/vkMachinery/forge/type.go
+++ b/pkg/vkMachinery/forge/type.go
@@ -23,19 +23,21 @@ import (
 // VirtualKubeletOpts defines the custom options associated with the virtual kubelet deployment forging.
 type VirtualKubeletOpts struct {
 	// ContainerImage contains the virtual kubelet image name and tag.
-	ContainerImage       string
-	ExtraAnnotations     map[string]string
-	ExtraLabels          map[string]string
-	ExtraArgs            []string
-	NodeExtraAnnotations argsutils.StringMap
-	NodeExtraLabels      argsutils.StringMap
-	RequestsCPU          resource.Quantity
-	LimitsCPU            resource.Quantity
-	RequestsRAM          resource.Quantity
-	LimitsRAM            resource.Quantity
-	IpamEndpoint         string
-	MetricsEnabled       bool
-	MetricsAddress       string
+	ContainerImage          string
+	ExtraAnnotations        map[string]string
+	ExtraLabels             map[string]string
+	ExtraArgs               []string
+	NodeExtraAnnotations    argsutils.StringMap
+	NodeExtraLabels         argsutils.StringMap
+	RequestsCPU             resource.Quantity
+	LimitsCPU               resource.Quantity
+	RequestsRAM             resource.Quantity
+	LimitsRAM               resource.Quantity
+	IpamEndpoint            string
+	MetricsEnabled          bool
+	MetricsAddress          string
+	LabelsNotReflected      []string
+	AnnotationsNotReflected []string
 }
 
 // VirtualKubeletOptsFlag defines the custom options flags associated with the virtual kubelet deployment forging.
@@ -75,4 +77,8 @@ const (
 	MetricsAddress VirtualKubeletOptsFlag = "--metrics-address"
 	// CreateNode is the flag used to specify if the node must be created.
 	CreateNode VirtualKubeletOptsFlag = "--create-node"
+	// LabelsNotReflected is the flag used to specify the labels not reflected.
+	LabelsNotReflected VirtualKubeletOptsFlag = "--labels-not-reflected"
+	// AnnotationsNotReflected is the flag used to specify the annotations not reflected.
+	AnnotationsNotReflected VirtualKubeletOptsFlag = "--annotations-not-reflected"
 )


### PR DESCRIPTION
# Description

This PR introduces the possibility of disabling the reflection of custom labels and annotations (from local cluster to remote and vice-versa). The list of labels and annotations that must not be reflected can be specified with the Helm values (respectively `reflection.skip.labels` and `reflection.skip.annotations`).

Ref #1860 

# How Has This Been Tested?

- [x] locally
- [x] e2e tests
- [x] unit tests
