### PR TITLE
Bump golangci-lint version from 1.52.0 to 1.53.3

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,12 +18,12 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: '1.19'
-
+          cache: false
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3.6.0
         with:
           only-new-issues: true
-          version: v1.52.0
+          version: v1.53.3
           args: --timeout=900s
 
   gomodtidy:

--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ fmt: gci addlicense
 # Install golangci-lint if not available
 golangci-lint:
 ifeq (, $(shell which golangci-lint))
-	@go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.52.0
+	@go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.53.3
 GOLANGCILINT=$(GOBIN)/golangci-lint
 else
 GOLANGCILINT=$(shell which golangci-lint)


### PR DESCRIPTION
# Description

This PR upgrade the used golangci-lint version and disables the golang cache (suggested in golangci-lint-action [docs](https://github.com/golangci/golangci-lint-action#how-to-use))
