### PR TITLE
Bump golang version from 1.19 to 1.20

### DIFF
--- a/.github/workflows/check-generated-artifacts.yml
+++ b/.github/workflows/check-generated-artifacts.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.19'
+          go-version: '1.20'
 
       - name: Run the automatic generation
         working-directory: ./

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,8 +17,8 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.19'
-          cache: false
+          go-version: '1.20'
+
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3.6.0
         with:
@@ -41,7 +41,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.19'
+        go-version: '1.20'
 
     - name: Execute go mod tidy and check the outcome
       working-directory: ./

--- a/build/common/Dockerfile
+++ b/build/common/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19 as builder
+FROM golang:1.20 as builder
 WORKDIR /tmp/builder
 
 COPY go.mod ./go.mod

--- a/build/liqo-test/Dockerfile
+++ b/build/liqo-test/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19 as builder
+FROM golang:1.20 as builder
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
 ENV GOPATH /go
 ENV K8S_VERSION=1.25.0

--- a/build/liqoctl/build.sh
+++ b/build/liqoctl/build.sh
@@ -11,7 +11,7 @@ error() {
 }
 trap 'error "${BASH_SOURCE}" "${LINENO}"' ERR
 
-GO_VERSION="1.19"
+GO_VERSION="1.20"
 
 docker run -v "$PWD:/liqo" -w /liqo -e="CGO_ENABLED=${CGO_ENABLED}" --rm "golang:${GO_VERSION}" \
    go mod tidy && go build -o "./liqoctl-${GOOS}-${GOARCH}" \

--- a/build/liqonet/Dockerfile
+++ b/build/liqonet/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /boringtun
 RUN cargo build --bin boringtun-cli --release
 
 
-FROM golang:1.19 as goBuilder
+FROM golang:1.20 as goBuilder
 WORKDIR /tmp/builder
 
 COPY go.mod ./go.mod

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/liqotech/liqo
 
-go 1.19
+go 1.20
 
 require (
 	github.com/Azure/azure-sdk-for-go v68.0.0+incompatible


### PR DESCRIPTION
# Description

This PR upgrade the golang version from 1.19 to 1.20.
