### PR TITLE
Docs: sphinx-autobuild

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -3,8 +3,10 @@
 
 # You can set these variables from the command line, and also
 # from the environment for the first two.
-SPHINXOPTS    ?= -W --keep-going -n
+SPHINXOPTS    ?= -W -n --keep-going
+SPHINXAUTOOPTS    ?= -W -n
 SPHINXBUILD   ?= sphinx-build
+SPHINXAUTOBUILD ?= sphinx-autobuild
 SOURCEDIR     = .
 BUILDDIR      = _build
 
@@ -24,6 +26,9 @@ install:
 
 serve: install html
 	docker run --rm -it -v $(PWD)/_build/html:/usr/share/nginx/html -p 8080:80 nginx
+
+autoserve: install
+	@$(SPHINXAUTOBUILD) "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXAUTOOPTS) $(O)
 
 lint:
 	markdownlint lint -c ../.markdownlint.yml **/*.md

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,3 +6,4 @@ sphinx-design==0.2.0
 sphinx_external_toc==0.3.0
 semver==2.13.0
 urllib3==1.26.15
+sphinx-autobuild==2021.3.14


### PR DESCRIPTION
# Description

This PR adds [sphinx-autobuild](https://pypi.org/project/sphinx-autobuild/) to the documentation Makefile.
It is a tool that triggers building and browser reloading when a docs file change.

The `--keep-going` option is not currently supported https://github.com/executablebooks/sphinx-autobuild/pull/134

