### PR TITLE
CI: disable linter cache

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: '1.20'
+          cache: false
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3.6.0


### PR DESCRIPTION
# Description

This PR disables the cache, in linter workflow, for golangci-lint.

This change has already been applied in #1921  but it has been reverted accidentally in #1922 
