### PR TITLE
VirtualKubelet: pod nil labels map

### DIFF
--- a/pkg/virtualKubelet/forge/pods.go
+++ b/pkg/virtualKubelet/forge/pods.go
@@ -157,6 +157,9 @@ func RemoteShadowPod(local *corev1.Pod, remote *vkv1alpha1.ShadowPod,
 
 	// Remove the label which identifies offloaded pods, as meaningful only locally.
 	localMetaFiltered := local.ObjectMeta.DeepCopy()
+	if localMetaFiltered.GetLabels() == nil {
+		localMetaFiltered.Labels = map[string]string{}
+	}
 	delete(localMetaFiltered.GetLabels(), liqoconst.LocalPodLabelKey)
 	localMetaFiltered.GetLabels()[LiqoOriginClusterNodeName] = LiqoNodeName
 


### PR DESCRIPTION
# Description

This PR fix a bug which cause a panic in virtual kubelet when a pod without labels is reflected.

# How Has This Been Tested?

- [x] Locally with KinD
