### PR TITLE
Liqo-route: added static mac to vxlan + device sanity check

### DIFF
--- a/build/liqonet/Dockerfile
+++ b/build/liqonet/Dockerfile
@@ -23,7 +23,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=$(go env GOARCH) go build -ldflags="-s -w" .
 FROM debian:11.7-slim
 
 RUN apt-get update && \
-    apt-get install -y iproute2 iptables bash wireguard-tools tcpdump conntrack curl && \
+    apt-get install -y iproute2 iptables bash wireguard-tools tcpdump conntrack curl iputils-ping && \
     apt-get clean autoclean && \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/*

--- a/internal/liqonet/network-manager/tunnelendpointcreator/tunnelendpointcreator.go
+++ b/internal/liqonet/network-manager/tunnelendpointcreator/tunnelendpointcreator.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"os/signal"
 	"reflect"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -38,7 +37,7 @@ import (
 	"github.com/liqotech/liqo/internal/liqonet/network-manager/netcfgcreator"
 	liqoconst "github.com/liqotech/liqo/pkg/consts"
 	liqonetIpam "github.com/liqotech/liqo/pkg/liqonet/ipam"
-	liqonetutils "github.com/liqotech/liqo/pkg/liqonet/utils"
+	liqonetsignals "github.com/liqotech/liqo/pkg/liqonet/utils/signals"
 	"github.com/liqotech/liqo/pkg/utils"
 	foreignclusterutils "github.com/liqotech/liqo/pkg/utils/foreignCluster"
 	"github.com/liqotech/liqo/pkg/utils/getters"
@@ -177,7 +176,7 @@ func (tec *TunnelEndpointCreator) SetupSignalHandlerForTunEndCreator() context.C
 	klog.Infof("starting signal handler for tunnelEndpointCreator-operator")
 	ctx, done := context.WithCancel(context.Background())
 	c := make(chan os.Signal, 1)
-	signal.Notify(c, liqonetutils.ShutdownSignals...)
+	liqonetsignals.NotifyPosix(c, liqonetsignals.ShutdownSignals...)
 	go func() {
 		sig := <-c
 		klog.Infof("received signal: %s", sig.String())

--- a/internal/liqonet/tunnel-operator/tunnel-operator.go
+++ b/internal/liqonet/tunnel-operator/tunnel-operator.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"os/signal"
 	"reflect"
 	"strings"
 	"sync"
@@ -50,6 +49,7 @@ import (
 	"github.com/liqotech/liqo/pkg/liqonet/tunnel"
 	tunnelwg "github.com/liqotech/liqo/pkg/liqonet/tunnel/wireguard"
 	liqonetutils "github.com/liqotech/liqo/pkg/liqonet/utils"
+	liqonetsignals "github.com/liqotech/liqo/pkg/liqonet/utils/signals"
 	liqolabels "github.com/liqotech/liqo/pkg/utils/labels"
 )
 
@@ -419,7 +419,7 @@ func (tc *TunnelController) EnsureIPTablesRulesPerCluster(tep *netv1alpha1.Tunne
 func (tc *TunnelController) SetupSignalHandlerForTunnelOperator() context.Context {
 	ctx, done := context.WithCancel(context.Background())
 	c := make(chan os.Signal, 1)
-	signal.Notify(c, liqonetutils.ShutdownSignals...)
+	liqonetsignals.NotifyPosix(c, liqonetsignals.ShutdownSignals...)
 	go func(tc *TunnelController) {
 		sig := <-c
 		klog.Infof("the operator received signal {%s}: cleaning up", sig.String())

--- a/pkg/liqonet/utils/signals/doc.go
+++ b/pkg/liqonet/utils/signals/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2019-2023 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package signals contains signals utilities which cannot be imported by windows.
+package signals

--- a/pkg/liqonet/utils/signals/signals.go
+++ b/pkg/liqonet/utils/signals/signals.go
@@ -1,0 +1,58 @@
+// Copyright 2019-2023 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package signals
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+var (
+	// ShutdownSignals signals used to terminate the programs.
+	ShutdownSignals = []syscall.Signal{syscall.SIGINT, syscall.SIGTERM, syscall.SIGKILL}
+)
+
+// NotifyPosix returns a channel that receives POSIX signals.
+// Like os/signal.Notify, but for POSIX signals.
+func NotifyPosix(c chan<- os.Signal, signals ...syscall.Signal) {
+	osSignals := make([]os.Signal, len(signals))
+	for i, sig := range signals {
+		osSignals[i] = os.Signal(sig)
+	}
+	signal.Notify(c, osSignals...)
+}
+
+// NotifyContextPosix returns a context that is canceled when one of the given POSIX signals is received.
+// Like os/signal.NotifyContext, but for POSIX signals.
+func NotifyContextPosix(ctx context.Context, signals ...syscall.Signal) (context.Context, context.CancelFunc) {
+	osSignals := make([]os.Signal, len(signals))
+	for i, sig := range signals {
+		osSignals[i] = os.Signal(sig)
+	}
+	return signal.NotifyContext(ctx, osSignals...)
+}
+
+// Shutdown is a function that can be used to terminate the program.
+func Shutdown() error {
+	for _, sig := range ShutdownSignals {
+		if err := syscall.Kill(syscall.Getpid(), sig); err == nil {
+			return nil
+		}
+	}
+	return fmt.Errorf("cannot shutdown gracefully")
+}

--- a/pkg/liqonet/utils/utils.go
+++ b/pkg/liqonet/utils/utils.go
@@ -21,7 +21,6 @@ import (
 	"net/netip"
 	"os"
 	"strings"
-	"syscall"
 	"time"
 
 	"go4.org/netipx"
@@ -31,11 +30,6 @@ import (
 	netv1alpha1 "github.com/liqotech/liqo/apis/net/v1alpha1"
 	"github.com/liqotech/liqo/pkg/consts"
 	liqoneterrors "github.com/liqotech/liqo/pkg/liqonet/errors"
-)
-
-var (
-	// ShutdownSignals signals used to terminate the programs.
-	ShutdownSignals = []os.Signal{os.Interrupt, syscall.SIGTERM, syscall.SIGKILL}
 )
 
 // MapIPToNetwork creates a new IP address obtained by means of the old IP address and the new network.


### PR DESCRIPTION
# Description

This PR adds a static mac address to the liqo-vxlan interface.
This solves an issue with virtualized Ubunutu2204 ( and maybe other distributions... ), where the MAC address I overwritten by the operating system immediately after it has been auto-generated by the operating system itself.

It introduces also a simple sanity check on vxlan interface configuration, which restart the pod in case of troubles.

# How Has This Been Tested?

- [x] KinD (Debian 11)
- [x] CAPK (Ubuntu 2004)
- [x] CAPK (Ubuntu 2204)
- [ ] OpenShift
- [ ] EKS
- [ ] GKE
- [ ] AKS
