### PR TITLE
Docs: options not supported on GKE

### DIFF
--- a/docs/installation/install.md
+++ b/docs/installation/install.md
@@ -225,7 +225,11 @@ To change this behavior, check the [network flags](NetworkFlags).
 Liqo supports GKE clusters using the default CNI: [Google GKE - VPC-Native](https://cloud.google.com/kubernetes-engine/docs/how-to/alias-ips).
 
 ```{warning}
-Liqo does not support GKE Autopilot Clusters.
+Liqo does NOT support:
+
+* GKE Autopilot Clusters
+* Container-Optimized OS with containerd (*cos_containerd*) as image type. Use Ubuntu with containerd (*ubuntu_containerd*) instead
+* Intranode visibility: make sure this option is disabled or use the `--no-enable-intra-node-visibility` flag. 
 ```
 
 **Configuration**


### PR DESCRIPTION
# Description

This PR adds to the docs a warning with the options not currently supported on GKE:
- image type *cos_containerd*
- intranode visibility

