### PR TITLE
Add well known labels/annotations that must not be reflected

### DIFF
--- a/deployments/liqo/README.md
+++ b/deployments/liqo/README.md
@@ -115,7 +115,7 @@
 | proxy.service.annotations | object | `{}` |  |
 | proxy.service.type | string | `"ClusterIP"` |  |
 | pullPolicy | string | `"IfNotPresent"` | The pullPolicy for liqo pods. |
-| reflection.skip.annotations | list | `["metallb.universe.tf/ip-allocated-from-pool","metallb.universe.tf/loadBalancerIPs","metallb.universe.tf/address-pool"]` | List of annotations that must not be reflected on remote clusters. |
+| reflection.skip.annotations | list | `["cloud.google.com/neg","cloud.google.com/neg-status","kubernetes.digitalocean.com/load-balancer-id","ingress.kubernetes.io/backends","ingress.kubernetes.io/forwarding-rule","ingress.kubernetes.io/target-proxy","ingress.kubernetes.io/url-map","metallb.universe.tf/address-pool","metallb.universe.tf/ip-allocated-from-pool","metallb.universe.tf/loadBalancerIPs"]` | List of annotations that must not be reflected on remote clusters. |
 | reflection.skip.labels | list | `[]` | List of labels that must not be reflected on remote clusters. |
 | route.imageName | string | `"ghcr.io/liqotech/liqonet"` | Image repository for the route pod. |
 | route.pod.annotations | object | `{}` | Annotations for the route pod. |

--- a/deployments/liqo/values.yaml
+++ b/deployments/liqo/values.yaml
@@ -24,9 +24,16 @@ reflection:
     labels: []
     # -- List of annotations that must not be reflected on remote clusters.
     annotations: [
+      cloud.google.com/neg,
+      cloud.google.com/neg-status,
+      kubernetes.digitalocean.com/load-balancer-id,
+      ingress.kubernetes.io/backends,
+      ingress.kubernetes.io/forwarding-rule,
+      ingress.kubernetes.io/target-proxy,
+      ingress.kubernetes.io/url-map,
+      metallb.universe.tf/address-pool,
       metallb.universe.tf/ip-allocated-from-pool,
       metallb.universe.tf/loadBalancerIPs,
-      metallb.universe.tf/address-pool,
     ]
 
 controllerManager:


### PR DESCRIPTION
# Description

This PR updates the `reflection.skip` lists with some well-known labels/annotations (from major cloud providers) known to cause problems when reflected.

Close #1860

# How Has This Been Tested?

- [x] GKE
- [x] EKS
- [x] AKS
- [x] MetalLB
- [x] DigitalOcean
