### PR TITLE
Liqonet: wireguard userspace golang

### DIFF
--- a/build/liqonet/Dockerfile
+++ b/build/liqonet/Dockerfile
@@ -1,13 +1,12 @@
-FROM rust:1.70.0 as rustBuilder
+FROM golang:1.20 as goBuilder-wg
 
-ARG VERSION=0.5.2
+ARG VERSION=0.0.20230223
 
-RUN git clone https://github.com/cloudflare/boringtun.git
-
-WORKDIR /boringtun
-
-RUN cargo build --bin boringtun-cli --release
-
+# change with "go install git.zx2c4.com/wireguard-go"
+# waiting for https://github.com/WireGuard/wireguard-go/pull/87 to be merged
+RUN git clone -b ${VERSION} https://git.zx2c4.com/wireguard-go
+WORKDIR /go/wireguard-go
+RUN CGO_ENABLED=0 make
 
 FROM golang:1.20 as goBuilder
 WORKDIR /tmp/builder
@@ -20,15 +19,13 @@ COPY . ./
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=$(go env GOARCH) go build -ldflags="-s -w" ./cmd/liqonet
 
 
-FROM debian:11.7-slim
+FROM alpine:3.15
 
-RUN apt-get update && \
-    apt-get install -y iproute2 iptables bash wireguard-tools tcpdump conntrack curl iputils-ping && \
-    apt-get clean autoclean && \
-    apt-get autoremove -y && \
-    rm -rf /var/lib/apt/lists/*
+RUN apk update && \
+    apk add iptables bash wireguard-tools tcpdump conntrack-tools curl && \
+    rm -rf /var/cache/apk/*
 
 COPY --from=goBuilder /tmp/builder/liqonet /usr/bin/liqonet
-COPY --from=rustBuilder /boringtun/target/release/boringtun-cli /usr/bin/boringtun-cli
+COPY --from=goBuilder-wg /go/wireguard-go/wireguard-go /usr/bin/wireguard-go
 
 ENTRYPOINT [ "/usr/bin/liqonet" ]


### PR DESCRIPTION
# Description

This PR replaces [boringtun](https://github.com/cloudflare/boringtun) with [wireguard-go]()
This allows to replace the Ubuntu docker image with Alpine, which was previously replaced (https://github.com/liqotech/liqo/pull/1852)

It also improves the wireguard userspace performance:

### boringtun
![image](https://github.com/liqotech/liqo/assets/33266330/d315f938-f0aa-462f-856e-9ae20208b268)

### wireguard-go
![image](https://github.com/liqotech/liqo/assets/33266330/16236679-261f-4f69-9cad-c365f91c08e4)

# How Has This Been Tested?

- [x] On KinD  arch:x86_64kernel:5.4.0-155-generic
- [x] On AWS EC2 4.14.256-197.484.amzn2.aarch64
- [x] On AWS EKS with AmazonLinux2 ARM
