### PR TITLE
Telemetry: E2E tests + VirtualNode scheme

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -200,6 +200,7 @@ E2E_TARGETS = e2e-dir \
 	ctl \
 	e2e-infra \
 	installer/liqoctl/setup \
+	telemetry \
 	installer/liqoctl/peer \
 	e2e/postinstall \
 	e2e/cruise \
@@ -238,6 +239,9 @@ e2e-infra:
 
 installer/%:
 	${PWD}/test/e2e/pipeline/$@.sh
+
+telemetry:
+	${PWD}/test/e2e/pipeline/telemetry/telemetry.sh
 
 e2e/%:
 	go test ${PWD}/test/$@/... -count=1 -timeout=20m

--- a/pkg/utils/json/doc.go
+++ b/pkg/utils/json/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2019-2023 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package json contains some utilities to work with JSON.
+package json

--- a/pkg/utils/json/json.go
+++ b/pkg/utils/json/json.go
@@ -1,0 +1,26 @@
+// Copyright 2019-2023 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package json
+
+import "encoding/json"
+
+// Pretty returns an indented JSON string to print.
+func Pretty(data interface{}) (string, error) {
+	val, err := json.MarshalIndent(data, "", "    ")
+	if err != nil {
+		return "", err
+	}
+	return string(val), nil
+}

--- a/test/e2e/pipeline/telemetry/telemetry.sh
+++ b/test/e2e/pipeline/telemetry/telemetry.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# This scripts expects the following variables to be set:
+# CLUSTER_NUMBER        -> the number of liqo clusters
+# NAMESPACE             -> the namespace where liqo is running
+# LIQO_VERSION          -> the liqo version to test
+# K8S_VERSION           -> the Kubernetes version
+
+set -e           # Fail in case of error
+set -o nounset   # Fail if undefined variables are used
+set -o pipefail  # Fail if one of the piped commands fails
+
+error() {
+   local sourcefile=$1
+   local lineno=$2
+   echo "An error occurred at $sourcefile:$lineno."
+}
+trap 'error "${BASH_SOURCE}" "${LINENO}"' ERR
+
+for i in $(seq 1 "${CLUSTER_NUMBER}")
+do
+  export KUBECONFIG="${TMPDIR2}/kubeconfigs/liqo_kubeconf_${i}"
+  go run ./cmd/telemetry/main.go --liqo-version "${LIQO_VERSION}" --kubernetes-version "${K8S_VERSION}" --dry-run
+done


### PR DESCRIPTION
# Description

This PR adds the dry-run flag to the Liqo telemetry. This can be useful for integration tests.
It also solves a bug related to the introduction of VIrtualNodes.

# How Has This Been Tested?

- [x] Locally with KinD