### PR TITLE
AllowList-based and DenyList-based Resource Reflection

### DIFF
--- a/deployments/liqo/README.md
+++ b/deployments/liqo/README.md
@@ -117,6 +117,21 @@
 | proxy.service.annotations | object | `{}` |  |
 | proxy.service.type | string | `"ClusterIP"` |  |
 | pullPolicy | string | `"IfNotPresent"` | The pullPolicy for liqo pods. |
+| reflection.configmap.type | string | `"DenyList"` | The type of reflection used for the configmaps reflector. Ammitted values: "DenyList", "AllowList". |
+| reflection.configmap.workers | int | `3` | The number of workers used for the configmaps reflector. Set 0 to disable the reflection of configmaps. |
+| reflection.endpointslice.type | string | `"DenyList"` | The type of reflection used for the endpointslices reflector Ammitted values: "DenyList", "AllowList". |
+| reflection.endpointslice.workers | int | `10` | The number of workers used for the endpointslices reflector. Set 0 to disable the reflection of endpointslices. |
+| reflection.event.type | string | `"DenyList"` | The type of reflection used for the events reflector. Ammitted values: "DenyList", "AllowList". |
+| reflection.event.workers | int | `3` | The number of workers used for the events reflector. Set 0 to disable the reflection of events. |
+| reflection.ingress.type | string | `"DenyList"` | The type of reflection used for the ingresses reflector. Ammitted values: "DenyList", "AllowList". |
+| reflection.ingress.workers | int | `3` | The number of workers used for the ingresses reflector. Set 0 to disable the reflection of ingresses. |
+| reflection.persistentvolumeclaim.workers | int | `3` | The number of workers used for the persistentvolumeclaims reflector. Set 0 to disable the reflection of persistentvolumeclaims. |
+| reflection.pod.workers | int | `10` | The number of workers used for the pods reflector. Set 0 to disable the reflection of pods. |
+| reflection.secret.type | string | `"DenyList"` | The type of reflection used for the secrets reflector. Ammitted values: "DenyList", "AllowList". |
+| reflection.secret.workers | int | `3` | The number of workers used for the secrets reflector. Set 0 to disable the reflection of secrets. |
+| reflection.service.type | string | `"DenyList"` | The type of reflection used for the services reflector. Ammitted values: "DenyList", "AllowList". |
+| reflection.service.workers | int | `3` | The number of workers used for the services reflector. Set 0 to disable the reflection of services. |
+| reflection.serviceaccount.workers | int | `3` | The number of workers used for the serviceaccounts reflector. Set 0 to disable the reflection of serviceaccounts. |
 | reflection.skip.annotations | list | `["cloud.google.com/neg","cloud.google.com/neg-status","kubernetes.digitalocean.com/load-balancer-id","ingress.kubernetes.io/backends","ingress.kubernetes.io/forwarding-rule","ingress.kubernetes.io/target-proxy","ingress.kubernetes.io/url-map","metallb.universe.tf/address-pool","metallb.universe.tf/ip-allocated-from-pool","metallb.universe.tf/loadBalancerIPs"]` | List of annotations that must not be reflected on remote clusters. |
 | reflection.skip.labels | list | `[]` | List of labels that must not be reflected on remote clusters. |
 | route.imageName | string | `"ghcr.io/liqotech/liqonet"` | Image repository for the route pod. |

--- a/deployments/liqo/templates/liqo-controller-manager-deployment.yaml
+++ b/deployments/liqo/templates/liqo-controller-manager-deployment.yaml
@@ -77,6 +77,21 @@ spec:
           - --liqo-namespace=$(POD_NAMESPACE)
           - --enable-incoming-peering={{ .Values.discovery.config.incomingPeeringEnabled }}
           - --resource-sharing-percentage={{ .Values.controllerManager.config.resourceSharingPercentage }}
+          - --pod-reflection-workers={{ .Values.reflection.pod.workers }}
+          - --service-reflection-workers={{ .Values.reflection.service.workers }}
+          - --endpointslice-reflection-workers={{ .Values.reflection.endpointslice.workers }}
+          - --ingress-reflection-workers={{ .Values.reflection.ingress.workers }}
+          - --configmap-reflection-workers={{ .Values.reflection.configmap.workers }}
+          - --secret-reflection-workers={{ .Values.reflection.secret.workers }}
+          - --serviceaccount-reflection-workers={{ .Values.reflection.serviceaccount.workers }}
+          - --persistentvolumeclaim-reflection-workers={{ .Values.reflection.persistentvolumeclaim.workers }}
+          - --event-reflection-workers={{ .Values.reflection.event.workers }}
+          - --service-reflection-type={{ .Values.reflection.service.type }}
+          - --endpointslice-reflection-type={{ .Values.reflection.endpointslice.type }}
+          - --ingress-reflection-type={{ .Values.reflection.ingress.type }}
+          - --configmap-reflection-type={{ .Values.reflection.configmap.type }}
+          - --secret-reflection-type={{ .Values.reflection.secret.type }}
+          - --event-reflection-type={{ .Values.reflection.event.type }}
           {{- if .Values.reflection.skip.labels }}
           {{- $d := dict "commandName" "--labels-not-reflected" "list" .Values.reflection.skip.labels }}
           {{- include "liqo.concatenateList" $d | nindent 10 }}

--- a/deployments/liqo/values.yaml
+++ b/deployments/liqo/values.yaml
@@ -53,6 +53,45 @@ reflection:
       metallb.universe.tf/ip-allocated-from-pool,
       metallb.universe.tf/loadBalancerIPs,
     ]
+  pod:
+    # -- The number of workers used for the pods reflector. Set 0 to disable the reflection of pods.
+    workers: 10
+  service:
+    # -- The number of workers used for the services reflector. Set 0 to disable the reflection of services.
+    workers: 3
+    # -- The type of reflection used for the services reflector. Ammitted values: "DenyList", "AllowList".
+    type: DenyList
+  endpointslice:
+    # -- The number of workers used for the endpointslices reflector. Set 0 to disable the reflection of endpointslices.
+    workers: 10
+    # -- The type of reflection used for the endpointslices reflector Ammitted values: "DenyList", "AllowList".
+    type: DenyList
+  ingress:
+    # -- The number of workers used for the ingresses reflector. Set 0 to disable the reflection of ingresses.
+    workers: 3
+    # -- The type of reflection used for the ingresses reflector. Ammitted values: "DenyList", "AllowList".
+    type: DenyList
+  configmap:
+    # -- The number of workers used for the configmaps reflector. Set 0 to disable the reflection of configmaps.
+    workers: 3
+    # -- The type of reflection used for the configmaps reflector. Ammitted values: "DenyList", "AllowList".
+    type: DenyList
+  secret:
+    # -- The number of workers used for the secrets reflector. Set 0 to disable the reflection of secrets.
+    workers: 3
+    # -- The type of reflection used for the secrets reflector. Ammitted values: "DenyList", "AllowList".
+    type: DenyList
+  serviceaccount:
+    # -- The number of workers used for the serviceaccounts reflector. Set 0 to disable the reflection of serviceaccounts.
+    workers: 3
+  persistentvolumeclaim:
+    # -- The number of workers used for the persistentvolumeclaims reflector. Set 0 to disable the reflection of persistentvolumeclaims.
+    workers: 3
+  event:
+    # -- The number of workers used for the events reflector. Set 0 to disable the reflection of events.
+    workers: 3
+    # -- The type of reflection used for the events reflector. Ammitted values: "DenyList", "AllowList".
+    type: DenyList
 
 controllerManager:
   # -- The number of controller-manager instances to run, which can be increased for active/passive high availability.

--- a/pkg/consts/replication.go
+++ b/pkg/consts/replication.go
@@ -17,6 +17,9 @@ package consts
 // OwnershipType indicates the type of ownership over a resource.
 type OwnershipType string
 
+// ReflectionType is the type of reflection.
+type ReflectionType string
+
 const (
 	// OwnershipLocal indicates that the resource is owned by the local cluster.
 	OwnershipLocal OwnershipType = "Local"
@@ -25,6 +28,13 @@ const (
 	// - the spec of the resource is owned by the local cluster.
 	// - the status by the remote cluster.
 	OwnershipShared OwnershipType = "Shared"
+
+	// AllowList reflects only the resources with a specific annotation.
+	AllowList ReflectionType = "AllowList"
+	// DenyList reflects all the resources excluding the ones with a specific annotation.
+	DenyList ReflectionType = "DenyList"
+	// CustomLiqo reflects the resources following the custom Liqo logic.
+	CustomLiqo ReflectionType = "CustomLiqo"
 
 	// ReplicationRequestedLabel is the key of a label indicating whether the given resource should be replicated remotely.
 	ReplicationRequestedLabel = "liqo.io/replication"
@@ -60,6 +70,9 @@ const (
 
 	// SkipReflectionAnnotationKey is the annotation key used to indicate that a given object should not be reflected into a remote cluster.
 	SkipReflectionAnnotationKey = "liqo.io/skip-reflection"
+
+	// AllowReflectionAnnotationKey is the annotation key used to indicate that a given object should be reflected into a remote cluster.
+	AllowReflectionAnnotationKey = "liqo.io/allow-reflection"
 
 	// PodAntiAffinityPresetKey is the annotation key used to express an anti-affinity preset to apply to offloaded pods.
 	PodAntiAffinityPresetKey = "liqo.io/anti-affinity-preset"

--- a/pkg/virtualKubelet/forge/events.go
+++ b/pkg/virtualKubelet/forge/events.go
@@ -14,7 +14,11 @@
 
 package forge
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/liqotech/liqo/pkg/consts"
+)
 
 const (
 	// EventSuccessfulReflection -> the reason for the event when the reflection completes successfully.
@@ -83,8 +87,8 @@ func EventReflectionDisabledErrorMsg(namespace string, err error) string {
 }
 
 // EventObjectReflectionDisabledMsg returns the message for the event when reflection is disabled for a given resource.
-func EventObjectReflectionDisabledMsg() string {
-	return fmt.Sprintf("Reflection to cluster %q disabled for the current object", RemoteCluster.ClusterName)
+func EventObjectReflectionDisabledMsg(reflectionType consts.ReflectionType) string {
+	return fmt.Sprintf("Reflection to cluster %q disabled for the current object (policy: %q)", RemoteCluster.ClusterName, reflectionType)
 }
 
 // EventSAReflectionDisabledMsg returns the message for the event when service account reflection is disabled.

--- a/pkg/virtualKubelet/reflection/configuration/serviceaccount.go
+++ b/pkg/virtualKubelet/reflection/configuration/serviceaccount.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/utils/trace"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/liqotech/liqo/pkg/consts"
 	"github.com/liqotech/liqo/pkg/utils"
 	"github.com/liqotech/liqo/pkg/utils/pod"
 	"github.com/liqotech/liqo/pkg/utils/virtualkubelet"
@@ -75,14 +76,14 @@ type FallbackServiceAccountReflector struct {
 }
 
 // NewServiceAccountReflector builds a ServiceAccountReflector.
-func NewServiceAccountReflector(enableSAReflection bool, workers uint) manager.Reflector {
+func NewServiceAccountReflector(enableSAReflection bool, reflectorConfig *generic.ReflectorConfig) manager.Reflector {
 	if !enableSAReflection {
-		workers = 0
+		reflectorConfig.NumWorkers = 0
 	}
 
 	reflector := &ServiceAccountReflector{}
 	genericReflector := generic.NewReflector(ServiceAccountReflectorName, reflector.NewNamespaced,
-		reflector.NewFallback, workers, generic.ConcurrencyModeAll)
+		reflector.NewFallback, reflectorConfig.NumWorkers, consts.CustomLiqo, generic.ConcurrencyModeAll)
 	reflector.Reflector = genericReflector
 	return reflector
 }

--- a/pkg/virtualKubelet/reflection/exposition/ingress_test.go
+++ b/pkg/virtualKubelet/reflection/exposition/ingress_test.go
@@ -27,10 +27,12 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/trace"
 
+	"github.com/liqotech/liqo/cmd/virtual-kubelet/root"
 	"github.com/liqotech/liqo/pkg/consts"
 	. "github.com/liqotech/liqo/pkg/utils/testutil"
 	"github.com/liqotech/liqo/pkg/virtualKubelet/forge"
 	"github.com/liqotech/liqo/pkg/virtualKubelet/reflection/exposition"
+	"github.com/liqotech/liqo/pkg/virtualKubelet/reflection/generic"
 	"github.com/liqotech/liqo/pkg/virtualKubelet/reflection/manager"
 	"github.com/liqotech/liqo/pkg/virtualKubelet/reflection/options"
 )
@@ -38,7 +40,11 @@ import (
 var _ = Describe("Ingress Reflection Tests", func() {
 	Describe("the NewIngressReflector function", func() {
 		It("should not return a nil reflector", func() {
-			Expect(exposition.NewIngressReflector(1)).ToNot(BeNil())
+			reflectorConfig := generic.ReflectorConfig{
+				NumWorkers: 1,
+				Type:       root.DefaultReflectorsTypes[generic.Ingress],
+			}
+			Expect(exposition.NewIngressReflector(&reflectorConfig)).ToNot(BeNil())
 		})
 	})
 
@@ -46,7 +52,8 @@ var _ = Describe("Ingress Reflection Tests", func() {
 		const IngressName = "name"
 
 		var (
-			reflector manager.NamespacedReflector
+			reflector      manager.NamespacedReflector
+			reflectionType consts.ReflectionType
 
 			local, remote netv1.Ingress
 			err           error
@@ -98,6 +105,7 @@ var _ = Describe("Ingress Reflection Tests", func() {
 		BeforeEach(func() {
 			local = netv1.Ingress{ObjectMeta: metav1.ObjectMeta{Name: IngressName, Namespace: LocalNamespace}}
 			remote = netv1.Ingress{ObjectMeta: metav1.ObjectMeta{Name: IngressName, Namespace: RemoteNamespace}}
+			reflectionType = root.DefaultReflectorsTypes[generic.Ingress]
 		})
 
 		AfterEach(func() {
@@ -114,6 +122,7 @@ var _ = Describe("Ingress Reflection Tests", func() {
 				WithRemote(RemoteNamespace, client, factory).
 				WithHandlerFactory(FakeEventHandler).
 				WithEventBroadcaster(record.NewBroadcaster()).
+				WithReflectionType(reflectionType).
 				WithForgingOpts(FakeForgingOpts()))
 
 			factory.Start(ctx.Done())
@@ -204,6 +213,36 @@ var _ = Describe("Ingress Reflection Tests", func() {
 
 			When("the remote object does not exist", WhenBodyRemoteShouldNotExist(false))
 			When("the remote object does exist", WhenBodyRemoteShouldNotExist(true))
+		})
+
+		When("the reflection type is AllowList", func() {
+			BeforeEach(func() {
+				reflectionType = consts.AllowList
+			})
+
+			When("the local object does exist, but does not have the allow annotation", func() {
+				BeforeEach(func() {
+					ForgeIngressSpec(&local)
+					CreateIngress(&local)
+				})
+
+				When("the remote object does not exist", WhenBodyRemoteShouldNotExist(false))
+				When("the remote object does exist", WhenBodyRemoteShouldNotExist(true))
+			})
+
+			When("the local object does exist, and does have the allow annotation", func() {
+				BeforeEach(func() {
+					local.SetAnnotations(map[string]string{consts.AllowReflectionAnnotationKey: "whatever"})
+					ForgeIngressSpec(&local)
+					CreateIngress(&local)
+				})
+
+				It("should succeed", func() { Expect(err).ToNot(HaveOccurred()) })
+				It("the remote object should be present", func() {
+					remoteAfter := GetIngress(RemoteNamespace)
+					Expect(remoteAfter).ToNot(BeNil())
+				})
+			})
 		})
 	})
 })

--- a/pkg/virtualKubelet/reflection/exposition/service.go
+++ b/pkg/virtualKubelet/reflection/exposition/service.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/utils/trace"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/liqotech/liqo/pkg/consts"
 	"github.com/liqotech/liqo/pkg/utils/virtualkubelet"
 	"github.com/liqotech/liqo/pkg/virtualKubelet/forge"
 	"github.com/liqotech/liqo/pkg/virtualKubelet/reflection/generic"
@@ -53,8 +54,9 @@ type NamespacedServiceReflector struct {
 }
 
 // NewServiceReflector returns a new ServiceReflector instance.
-func NewServiceReflector(workers uint) manager.Reflector {
-	return generic.NewReflector(ServiceReflectorName, NewNamespacedServiceReflector, generic.WithoutFallback(), workers, generic.ConcurrencyModeLeader)
+func NewServiceReflector(reflectorConfig *generic.ReflectorConfig) manager.Reflector {
+	return generic.NewReflector(ServiceReflectorName, NewNamespacedServiceReflector, generic.WithoutFallback(),
+		reflectorConfig.NumWorkers, reflectorConfig.Type, generic.ConcurrencyModeLeader)
 }
 
 // NewNamespacedServiceReflector returns a new NamespacedServiceReflector instance.
@@ -103,15 +105,26 @@ func (nsr *NamespacedServiceReflector) Handle(ctx context.Context, name string) 
 	}
 
 	// Abort the reflection if the local object has the "skip-reflection" annotation.
-	if !kerrors.IsNotFound(lerr) && nsr.ShouldSkipReflection(local) {
-		klog.Infof("Skipping reflection of local Service %q as marked with the skip annotation", nsr.LocalRef(name))
-		nsr.Event(local, corev1.EventTypeNormal, forge.EventReflectionDisabled, forge.EventObjectReflectionDisabledMsg())
-		if kerrors.IsNotFound(rerr) { // The remote object does not already exist, hence no further action is required.
-			return nil
+	if !kerrors.IsNotFound(lerr) {
+		skipReflection, err := nsr.ShouldSkipReflection(local)
+		if err != nil {
+			klog.Errorf("Failed to check whether local Service %q should be reflected: %v", nsr.LocalRef(name), err)
+			return err
 		}
+		if skipReflection {
+			if nsr.GetReflectionType() == consts.DenyList {
+				klog.Infof("Skipping reflection of local Service %q as marked with the skip annotation", nsr.LocalRef(name))
+			} else { // AllowList
+				klog.Infof("Skipping reflection of local Service %q as not marked with the allow annotation", nsr.LocalRef(name))
+			}
+			nsr.Event(local, corev1.EventTypeNormal, forge.EventReflectionDisabled, forge.EventObjectReflectionDisabledMsg(nsr.GetReflectionType()))
+			if kerrors.IsNotFound(rerr) { // The remote object does not already exist, hence no further action is required.
+				return nil
+			}
 
-		// Otherwise, let pretend the local object does not exist, so that the remote one gets deleted.
-		lerr = kerrors.NewNotFound(corev1.Resource("service"), local.GetName())
+			// Otherwise, let pretend the local object does not exist, so that the remote one gets deleted.
+			lerr = kerrors.NewNotFound(corev1.Resource("service"), local.GetName())
+		}
 	}
 
 	tracer.Step("Performed the sanity checks")

--- a/pkg/virtualKubelet/reflection/generic/namespaced_test.go
+++ b/pkg/virtualKubelet/reflection/generic/namespaced_test.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
 
+	"github.com/liqotech/liqo/pkg/consts"
 	. "github.com/liqotech/liqo/pkg/utils/testutil"
 	"github.com/liqotech/liqo/pkg/virtualKubelet/forge"
 	"github.com/liqotech/liqo/pkg/virtualKubelet/reflection/options"
@@ -41,21 +42,23 @@ var _ = Describe("NamespacedReflector tests", func() {
 
 	Context("the NewNamespacedReflector function", func() {
 		var (
-			nsrfl       NamespacedReflector
-			ready       bool
-			forgingOpts *forge.ForgingOpts
+			nsrfl          NamespacedReflector
+			ready          bool
+			forgingOpts    *forge.ForgingOpts
+			reflectionType consts.ReflectionType
 		)
 
 		BeforeEach(func() {
 			ready = false
 			forgingOpts = &forge.ForgingOpts{}
+			reflectionType = consts.CustomLiqo
 		})
 
 		JustBeforeEach(func() {
 			opts := options.NamespacedOpts{
 				LocalNamespace: localNamespace, RemoteNamespace: remoteNamespace,
 				Ready: func() bool { return ready }, EventBroadcaster: record.NewBroadcaster(),
-				ForgingOpts: forgingOpts,
+				ReflectionType: reflectionType, ForgingOpts: forgingOpts,
 			}
 			nsrfl = NewNamespacedReflector(&opts, name)
 		})
@@ -65,6 +68,7 @@ var _ = Describe("NamespacedReflector tests", func() {
 			Expect(nsrfl.local).To(BeIdenticalTo(localNamespace))
 			Expect(nsrfl.remote).To(BeIdenticalTo(remoteNamespace))
 			Expect(nsrfl.ready).ToNot(BeNil())
+			Expect(nsrfl.reflectionType).To(BeIdenticalTo(reflectionType))
 			Expect(nsrfl.ForgingOpts).To(BeIdenticalTo(forgingOpts))
 		})
 

--- a/pkg/virtualKubelet/reflection/generic/reflector.go
+++ b/pkg/virtualKubelet/reflection/generic/reflector.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/klog/v2"
 	"k8s.io/utils/trace"
 
+	"github.com/liqotech/liqo/pkg/consts"
 	traceutils "github.com/liqotech/liqo/pkg/utils/trace"
 	"github.com/liqotech/liqo/pkg/virtualKubelet/forge"
 	"github.com/liqotech/liqo/pkg/virtualKubelet/leaderelection"
@@ -66,6 +67,7 @@ type reflector struct {
 	fallbackFactory   FallbackReflectorFactoryFunc
 
 	concurrencyMode ConcurrencyMode
+	reflectionType  consts.ReflectionType
 }
 
 // String returns the name of the reflector.
@@ -83,20 +85,50 @@ const (
 	ConcurrencyModeAll ConcurrencyMode = "all"
 )
 
+// ResourceReflected represents a resource that can be reflected.
+type ResourceReflected string
+
+// List of all resources that can be reflected.
+const (
+	Pod                   ResourceReflected = "pod"
+	Service               ResourceReflected = "service"
+	EndpointSlice         ResourceReflected = "endpointslice"
+	Ingress               ResourceReflected = "ingress"
+	ConfigMap             ResourceReflected = "configmap"
+	Secret                ResourceReflected = "secret"
+	ServiceAccount        ResourceReflected = "serviceaccount"
+	PersistentVolumeClaim ResourceReflected = "persistentvolumeclaim"
+	Event                 ResourceReflected = "event"
+)
+
+// Reflectors is the list of all resources that can be reflected.
+var Reflectors = []ResourceReflected{Pod, Service, EndpointSlice, Ingress, ConfigMap, Secret, ServiceAccount, PersistentVolumeClaim, Event}
+
+// ReflectorsCustomizableType is the list of resources for which the reflection type can be customized.
+var ReflectorsCustomizableType = []ResourceReflected{Service, EndpointSlice, Ingress, ConfigMap, Secret, Event}
+
+// ReflectorConfig contains configuration parameters of the reflector.
+type ReflectorConfig struct {
+	// Number of workers for the reflector.
+	NumWorkers uint
+	// Type of reflection.
+	Type consts.ReflectionType
+}
+
 // NewReflector returns a new reflector to implement the reflection towards a remote clusters, of a dummy one if no workers are specified.
 func NewReflector(name string, namespaced NamespacedReflectorFactoryFunc, fallback FallbackReflectorFactoryFunc,
-	workers uint, concurrencyMode ConcurrencyMode) manager.Reflector {
+	workers uint, reflectionType consts.ReflectionType, concurrencyMode ConcurrencyMode) manager.Reflector {
 	if workers == 0 {
 		// Return a dummy reflector in case no workers are specified, to avoid starting the working queue and registering the infromers.
 		return &dummyreflector{name: name}
 	}
 
-	return newReflector(name, namespaced, fallback, workers, concurrencyMode)
+	return newReflector(name, namespaced, fallback, workers, reflectionType, concurrencyMode)
 }
 
 // newReflector returns a new reflector to implement the reflection towards a remote clusters.
 func newReflector(name string, namespaced NamespacedReflectorFactoryFunc, fallback FallbackReflectorFactoryFunc,
-	workers uint, concurrencyMode ConcurrencyMode) manager.Reflector {
+	workers uint, reflectionType consts.ReflectionType, concurrencyMode ConcurrencyMode) manager.Reflector {
 	return &reflector{
 		name:    name,
 		workers: workers,
@@ -109,12 +141,13 @@ func newReflector(name string, namespaced NamespacedReflectorFactoryFunc, fallba
 		fallbackFactory:   fallback,
 
 		concurrencyMode: concurrencyMode,
+		reflectionType:  reflectionType,
 	}
 }
 
 // Start starts the reflector.
 func (gr *reflector) Start(ctx context.Context, opts *options.ReflectorOpts) {
-	klog.Infof("Starting the %v reflector with %v workers", gr.name, gr.workers)
+	klog.Infof("Starting the %v reflector with %v workers (policy: %v)", gr.name, gr.workers, gr.reflectionType)
 	gr.fallback = gr.fallbackFactory(opts.WithHandlerFactory(gr.handlers))
 
 	for i := uint(0); i < gr.workers; i++ {
@@ -141,7 +174,9 @@ func (gr *reflector) StartNamespace(opts *options.NamespacedOpts) {
 		return
 	}
 
-	gr.reflectors[opts.LocalNamespace] = gr.namespacedFactory(opts.WithHandlerFactory(gr.handlers))
+	gr.reflectors[opts.LocalNamespace] = gr.namespacedFactory(opts.
+		WithHandlerFactory(gr.handlers).
+		WithReflectionType(gr.reflectionType))
 
 	// In case a fallback reflector exists, re-enqueue all the elements returned for the given namespace.
 	if gr.fallback != nil {

--- a/pkg/virtualKubelet/reflection/generic/reflector_test.go
+++ b/pkg/virtualKubelet/reflection/generic/reflector_test.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/cache"
 
+	"github.com/liqotech/liqo/pkg/consts"
 	reflectionfake "github.com/liqotech/liqo/pkg/virtualKubelet/reflection/generic/fake"
 	"github.com/liqotech/liqo/pkg/virtualKubelet/reflection/manager"
 	"github.com/liqotech/liqo/pkg/virtualKubelet/reflection/options"
@@ -64,7 +65,7 @@ var _ = Describe("Reflector tests", func() {
 
 		Context("a new reflector is created", func() {
 			JustBeforeEach(func() {
-				rfl = NewReflector(reflectorName, NewFakeNamespacedReflector, NewFakeFallbackReflector, workers, ConcurrencyModeAll)
+				rfl = NewReflector(reflectorName, NewFakeNamespacedReflector, NewFakeFallbackReflector, workers, consts.CustomLiqo, ConcurrencyModeAll)
 			})
 
 			When("no workers are specified", func() {
@@ -82,7 +83,7 @@ var _ = Describe("Reflector tests", func() {
 			BeforeEach(func() { workers = 10 })
 			JustBeforeEach(func() {
 				// Here, we use the internal function, to retrieve the real reflector also in case no workers are set.
-				rfl = newReflector(reflectorName, NewFakeNamespacedReflector, NewFakeFallbackReflector, workers, ConcurrencyModeAll)
+				rfl = newReflector(reflectorName, NewFakeNamespacedReflector, NewFakeFallbackReflector, workers, consts.CustomLiqo, ConcurrencyModeAll)
 			})
 			It("should return a non nil reflector", func() { Expect(rfl).ToNot(BeNil()) })
 			It("should correctly populate the reflector fields", func() {
@@ -95,6 +96,8 @@ var _ = Describe("Reflector tests", func() {
 				Expect(rfl.(*reflector).fallback).To(BeNil())
 				Expect(rfl.(*reflector).namespacedFactory).ToNot(BeNil())
 				Expect(rfl.(*reflector).fallbackFactory).ToNot(BeNil())
+				Expect(rfl.(*reflector).reflectionType).ToNot(BeNil())
+				Expect(rfl.(*reflector).concurrencyMode).ToNot(BeNil())
 			})
 
 			Context("the reflector is started", func() {

--- a/pkg/virtualKubelet/reflection/options/options.go
+++ b/pkg/virtualKubelet/reflection/options/options.go
@@ -26,6 +26,7 @@ import (
 
 	liqoclient "github.com/liqotech/liqo/pkg/client/clientset/versioned"
 	liqoinformers "github.com/liqotech/liqo/pkg/client/informers/externalversions"
+	"github.com/liqotech/liqo/pkg/consts"
 	"github.com/liqotech/liqo/pkg/virtualKubelet/forge"
 )
 
@@ -89,7 +90,8 @@ type NamespacedOpts struct {
 	Ready          func() bool
 	HandlerFactory func(Keyer, ...EventFilter) cache.ResourceEventHandler
 
-	ForgingOpts *forge.ForgingOpts
+	ForgingOpts    *forge.ForgingOpts
+	ReflectionType consts.ReflectionType
 }
 
 // NewNamespaced returns a new NamespacedOpts object.
@@ -148,6 +150,12 @@ func (ro *NamespacedOpts) WithEventBroadcaster(broadcaster record.EventBroadcast
 // WithForgingOpts configures the reflection options of the NamespacedOpts.
 func (ro *NamespacedOpts) WithForgingOpts(opts *forge.ForgingOpts) *NamespacedOpts {
 	ro.ForgingOpts = opts
+	return ro
+}
+
+// WithReflectionType configures the reflection type of the NamespacedOpts.
+func (ro *NamespacedOpts) WithReflectionType(reflectionType consts.ReflectionType) *NamespacedOpts {
+	ro.ReflectionType = reflectionType
 	return ro
 }
 

--- a/pkg/virtualKubelet/reflection/options/options_test.go
+++ b/pkg/virtualKubelet/reflection/options/options_test.go
@@ -29,6 +29,7 @@ import (
 	liqoclient "github.com/liqotech/liqo/pkg/client/clientset/versioned"
 	liqoclientfake "github.com/liqotech/liqo/pkg/client/clientset/versioned/fake"
 	liqoinformers "github.com/liqotech/liqo/pkg/client/informers/externalversions"
+	"github.com/liqotech/liqo/pkg/consts"
 	"github.com/liqotech/liqo/pkg/virtualKubelet/forge"
 	"github.com/liqotech/liqo/pkg/virtualKubelet/reflection/options"
 )
@@ -116,6 +117,7 @@ var _ = Describe("Options", func() {
 			Expect(opts.EventBroadcaster).To(BeNil())
 			Expect(opts.HandlerFactory).To(BeNil())
 			Expect(opts.Ready).To(BeNil())
+			Expect(opts.ReflectionType).To(BeEmpty())
 			Expect(opts.ForgingOpts).To(BeNil())
 		})
 	})
@@ -126,12 +128,13 @@ var _ = Describe("Options", func() {
 		var (
 			original, opts *options.NamespacedOpts
 
-			client      kubernetes.Interface
-			liqoClient  liqoclient.Interface
-			factory     informers.SharedInformerFactory
-			liqoFactory liqoinformers.SharedInformerFactory
-			broadcaster record.EventBroadcaster
-			forgingOpts *forge.ForgingOpts
+			client         kubernetes.Interface
+			liqoClient     liqoclient.Interface
+			factory        informers.SharedInformerFactory
+			liqoFactory    liqoinformers.SharedInformerFactory
+			broadcaster    record.EventBroadcaster
+			reflectionType consts.ReflectionType
+			forgingOpts    *forge.ForgingOpts
 		)
 
 		BeforeEach(func() {
@@ -140,6 +143,7 @@ var _ = Describe("Options", func() {
 			factory = informers.NewSharedInformerFactory(client, 10*time.Hour)
 			liqoFactory = liqoinformers.NewSharedInformerFactory(liqoClient, 10*time.Hour)
 			broadcaster = record.NewBroadcaster()
+			reflectionType = consts.CustomLiqo
 			forgingOpts = &forge.ForgingOpts{}
 		})
 
@@ -164,6 +168,7 @@ var _ = Describe("Options", func() {
 				Expect(opts.EventBroadcaster).To(BeNil())
 				Expect(opts.HandlerFactory).To(BeNil())
 				Expect(opts.Ready).To(BeNil())
+				Expect(opts.ReflectionType).To(BeEmpty())
 				Expect(opts.ForgingOpts).To(BeNil())
 			})
 		})
@@ -187,6 +192,7 @@ var _ = Describe("Options", func() {
 				Expect(opts.EventBroadcaster).To(BeNil())
 				Expect(opts.HandlerFactory).To(BeNil())
 				Expect(opts.Ready).To(BeNil())
+				Expect(opts.ReflectionType).To(BeEmpty())
 				Expect(opts.ForgingOpts).To(BeNil())
 			})
 		})
@@ -210,6 +216,7 @@ var _ = Describe("Options", func() {
 				Expect(opts.EventBroadcaster).To(BeNil())
 				Expect(opts.HandlerFactory).To(BeNil())
 				Expect(opts.Ready).To(BeNil())
+				Expect(opts.ReflectionType).To(BeEmpty())
 				Expect(opts.ForgingOpts).To(BeNil())
 			})
 		})
@@ -233,6 +240,7 @@ var _ = Describe("Options", func() {
 				Expect(opts.EventBroadcaster).To(BeNil())
 				Expect(opts.HandlerFactory).To(BeNil())
 				Expect(opts.Ready).To(BeNil())
+				Expect(opts.ReflectionType).To(BeEmpty())
 				Expect(opts.ForgingOpts).To(BeNil())
 			})
 		})
@@ -259,6 +267,7 @@ var _ = Describe("Options", func() {
 				Expect(opts.RemoteLiqoFactory).To(BeNil())
 				Expect(opts.EventBroadcaster).To(BeNil())
 				Expect(opts.Ready).To(BeNil())
+				Expect(opts.ReflectionType).To(BeEmpty())
 				Expect(opts.ForgingOpts).To(BeNil())
 			})
 		})
@@ -284,6 +293,7 @@ var _ = Describe("Options", func() {
 				Expect(opts.RemoteLiqoFactory).To(BeNil())
 				Expect(opts.EventBroadcaster).To(BeNil())
 				Expect(opts.HandlerFactory).To(BeNil())
+				Expect(opts.ReflectionType).To(BeEmpty())
 				Expect(opts.ForgingOpts).To(BeNil())
 			})
 		})
@@ -305,6 +315,31 @@ var _ = Describe("Options", func() {
 				Expect(opts.RemoteLiqoClient).To(BeNil())
 				Expect(opts.RemoteFactory).To(BeNil())
 				Expect(opts.RemoteLiqoFactory).To(BeNil())
+				Expect(opts.HandlerFactory).To(BeNil())
+				Expect(opts.Ready).To(BeNil())
+				Expect(opts.ReflectionType).To(BeEmpty())
+				Expect(opts.ForgingOpts).To(BeNil())
+			})
+		})
+
+		Describe("The WithReflectionType function", func() {
+			JustBeforeEach(func() { opts = original.WithReflectionType(reflectionType) })
+
+			It("should return a non-nil pointer", func() { Expect(opts).ToNot(BeNil()) })
+			It("should return the same pointer of the receiver", func() { Expect(opts).To(BeIdenticalTo(original)) })
+			It("should correctly set the reflection type value", func() { Expect(opts.ReflectionType).To(Equal(reflectionType)) })
+			It("should leave the other fields unset", func() {
+				Expect(opts.LocalNamespace).To(BeEmpty())
+				Expect(opts.RemoteNamespace).To(BeEmpty())
+				Expect(opts.LocalClient).To(BeNil())
+				Expect(opts.LocalFactory).To(BeNil())
+				Expect(opts.LocalLiqoClient).To(BeNil())
+				Expect(opts.LocalFactory).To(BeNil())
+				Expect(opts.RemoteClient).To(BeNil())
+				Expect(opts.RemoteLiqoClient).To(BeNil())
+				Expect(opts.RemoteFactory).To(BeNil())
+				Expect(opts.RemoteLiqoFactory).To(BeNil())
+				Expect(opts.EventBroadcaster).To(BeNil())
 				Expect(opts.HandlerFactory).To(BeNil())
 				Expect(opts.Ready).To(BeNil())
 				Expect(opts.ForgingOpts).To(BeNil())
@@ -331,6 +366,7 @@ var _ = Describe("Options", func() {
 				Expect(opts.HandlerFactory).To(BeNil())
 				Expect(opts.Ready).To(BeNil())
 				Expect(opts.EventBroadcaster).To(BeNil())
+				Expect(opts.ReflectionType).To(BeEmpty())
 			})
 		})
 	})

--- a/pkg/virtualKubelet/reflection/storage/persistentvolumeclaim.go
+++ b/pkg/virtualKubelet/reflection/storage/persistentvolumeclaim.go
@@ -68,11 +68,11 @@ type NamespacedPersistentVolumeClaimReflector struct {
 }
 
 // NewPersistentVolumeClaimReflector returns a new PersistentVolumeClaimReflector instance.
-func NewPersistentVolumeClaimReflector(workers uint,
-	virtualStorageClassName, remoteRealStorageClassName string, storageEnabled bool) manager.Reflector {
+func NewPersistentVolumeClaimReflector(virtualStorageClassName, remoteRealStorageClassName string,
+	storageEnabled bool, reflectorConfig *generic.ReflectorConfig) manager.Reflector {
 	return generic.NewReflector(PersistentVolumeClaimReflectorName,
 		NewNamespacedPersistentVolumeClaimReflector(virtualStorageClassName, remoteRealStorageClassName, storageEnabled),
-		generic.WithoutFallback(), workers, generic.ConcurrencyModeLeader)
+		generic.WithoutFallback(), reflectorConfig.NumWorkers, consts.CustomLiqo, generic.ConcurrencyModeLeader)
 }
 
 // NewNamespacedPersistentVolumeClaimReflector returns a function generating NamespacedPersistentVolumeClaimReflector instances.

--- a/pkg/virtualKubelet/reflection/workload/pod.go
+++ b/pkg/virtualKubelet/reflection/workload/pod.go
@@ -39,6 +39,7 @@ import (
 	"k8s.io/utils/trace"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/liqotech/liqo/pkg/consts"
 	"github.com/liqotech/liqo/pkg/liqonet/ipam"
 	"github.com/liqotech/liqo/pkg/utils/virtualkubelet"
 	"github.com/liqotech/liqo/pkg/virtualKubelet/forge"
@@ -116,16 +117,17 @@ func NewPodReflector(
 	remoteRESTConfig *rest.Config, /* required to establish the connection to implement `kubectl exec` */
 	remoteMetricsFactory MetricsFactory, /* required to retrieve the pod metrics from the remote cluster */
 	ipamclient ipam.IpamClient, /* required to translate the remote IP addresses to the corresponding local ones */
-	config *PodReflectorConfig,
-	workers uint) *PodReflector {
+	podReflectorconfig *PodReflectorConfig,
+	reflectorConfig *generic.ReflectorConfig) *PodReflector {
 	reflector := &PodReflector{
 		remoteRESTConfig:     remoteRESTConfig,
 		remoteMetricsFactory: remoteMetricsFactory,
 		ipamclient:           ipamclient,
-		config:               config,
+		config:               podReflectorconfig,
 	}
 
-	genericReflector := generic.NewReflector(PodReflectorName, reflector.NewNamespaced, reflector.NewFallback, workers, generic.ConcurrencyModeAll)
+	genericReflector := generic.NewReflector(PodReflectorName, reflector.NewNamespaced, reflector.NewFallback,
+		reflectorConfig.NumWorkers, consts.CustomLiqo, generic.ConcurrencyModeAll)
 	reflector.Reflector = genericReflector
 	return reflector
 }

--- a/pkg/virtualKubelet/reflection/workload/pod_test.go
+++ b/pkg/virtualKubelet/reflection/workload/pod_test.go
@@ -31,9 +31,11 @@ import (
 	metricsv1beta1 "k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1beta1"
 	"k8s.io/utils/trace"
 
+	"github.com/liqotech/liqo/cmd/virtual-kubelet/root"
 	fakeipam "github.com/liqotech/liqo/pkg/liqonet/ipam/fake"
 	. "github.com/liqotech/liqo/pkg/utils/testutil"
 	"github.com/liqotech/liqo/pkg/virtualKubelet/forge"
+	"github.com/liqotech/liqo/pkg/virtualKubelet/reflection/generic"
 	"github.com/liqotech/liqo/pkg/virtualKubelet/reflection/manager"
 	"github.com/liqotech/liqo/pkg/virtualKubelet/reflection/options"
 	"github.com/liqotech/liqo/pkg/virtualKubelet/reflection/workload"
@@ -42,7 +44,12 @@ import (
 var _ = Describe("Pod Reflection Tests", func() {
 	Describe("the NewPodReflector function", func() {
 		It("should not return a nil reflector", func() {
-			reflector := workload.NewPodReflector(nil, nil, nil, &workload.PodReflectorConfig{forge.APIServerSupportDisabled, false, "", ""}, 0)
+			reflectorConfig := generic.ReflectorConfig{
+				NumWorkers: 0,
+				Type:       root.DefaultReflectorsTypes[generic.Pod],
+			}
+			reflector := workload.NewPodReflector(nil, nil, nil,
+				&workload.PodReflectorConfig{forge.APIServerSupportDisabled, false, "", ""}, &reflectorConfig)
 			Expect(reflector).ToNot(BeNil())
 			Expect(reflector.Reflector).ToNot(BeNil())
 		})
@@ -59,7 +66,12 @@ var _ = Describe("Pod Reflection Tests", func() {
 		BeforeEach(func() {
 			ipam := fakeipam.NewIPAMClient("192.168.200.0/24", "192.168.201.0/24", true)
 			metricsFactory := func(string) metricsv1beta1.PodMetricsInterface { return nil }
-			reflector := workload.NewPodReflector(nil, metricsFactory, ipam, &workload.PodReflectorConfig{forge.APIServerSupportDisabled, false, "", ""}, 0)
+			reflectorConfig := generic.ReflectorConfig{
+				NumWorkers: 0,
+				Type:       root.DefaultReflectorsTypes[generic.Pod],
+			}
+			reflector := workload.NewPodReflector(nil, metricsFactory, ipam,
+				&workload.PodReflectorConfig{forge.APIServerSupportDisabled, false, "", ""}, &reflectorConfig)
 			kubernetesServiceIPGetter = reflector.KubernetesServiceIPGetter()
 		})
 
@@ -106,7 +118,12 @@ var _ = Describe("Pod Reflection Tests", func() {
 			client = fake.NewSimpleClientset(&local)
 			factory := informers.NewSharedInformerFactory(client, 10*time.Hour)
 
-			reflector = workload.NewPodReflector(nil, nil, nil, &workload.PodReflectorConfig{forge.APIServerSupportDisabled, false, "", ""}, 0)
+			reflectorConfig := generic.ReflectorConfig{
+				NumWorkers: 0,
+				Type:       root.DefaultReflectorsTypes[generic.Pod],
+			}
+			reflector = workload.NewPodReflector(nil, nil, nil,
+				&workload.PodReflectorConfig{forge.APIServerSupportDisabled, false, "", ""}, &reflectorConfig)
 
 			opts := options.New(client, factory.Core().V1().Pods()).
 				WithHandlerFactory(FakeEventHandler).

--- a/pkg/virtualKubelet/reflection/workload/podns_test.go
+++ b/pkg/virtualKubelet/reflection/workload/podns_test.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/utils/trace"
 
 	vkv1alpha1 "github.com/liqotech/liqo/apis/virtualkubelet/v1alpha1"
+	"github.com/liqotech/liqo/cmd/virtual-kubelet/root"
 	liqoclient "github.com/liqotech/liqo/pkg/client/clientset/versioned"
 	liqoclientfake "github.com/liqotech/liqo/pkg/client/clientset/versioned/fake"
 	liqoinformers "github.com/liqotech/liqo/pkg/client/informers/externalversions"
@@ -41,6 +42,7 @@ import (
 	fakeipam "github.com/liqotech/liqo/pkg/liqonet/ipam/fake"
 	. "github.com/liqotech/liqo/pkg/utils/testutil"
 	"github.com/liqotech/liqo/pkg/virtualKubelet/forge"
+	"github.com/liqotech/liqo/pkg/virtualKubelet/reflection/generic"
 	"github.com/liqotech/liqo/pkg/virtualKubelet/reflection/manager"
 	"github.com/liqotech/liqo/pkg/virtualKubelet/reflection/options"
 	"github.com/liqotech/liqo/pkg/virtualKubelet/reflection/workload"
@@ -72,7 +74,12 @@ var _ = Describe("Namespaced Pod Reflection Tests", func() {
 
 			broadcaster := record.NewBroadcaster()
 			metricsFactory := func(string) metricsv1beta1.PodMetricsInterface { return nil }
-			rfl := workload.NewPodReflector(nil, metricsFactory, ipam, &workload.PodReflectorConfig{forge.APIServerSupportTokenAPI, false, "", ""}, 0)
+			reflectorConfig := generic.ReflectorConfig{
+				NumWorkers: 0,
+				Type:       root.DefaultReflectorsTypes[generic.Pod],
+			}
+			rfl := workload.NewPodReflector(nil, metricsFactory, ipam,
+				&workload.PodReflectorConfig{forge.APIServerSupportTokenAPI, false, "", ""}, &reflectorConfig)
 			rfl.Start(ctx, options.New(client, factory.Core().V1().Pods()).WithEventBroadcaster(broadcaster))
 			reflector = rfl.NewNamespaced(options.NewNamespaced().
 				WithLocal(LocalNamespace, client, factory).WithLiqoLocal(liqoClient, liqoFactory).

--- a/pkg/vkMachinery/forge/forge.go
+++ b/pkg/vkMachinery/forge/forge.go
@@ -64,6 +64,9 @@ func forgeVKContainers(
 				getDefaultStorageClass(storageClasses).StorageClassName))
 	}
 
+	args = appendArgsReflectorsWorkers(args, opts.ReflectorsWorkers)
+	args = appendArgsReflectorsType(args, opts.ReflectorsType)
+
 	if len(opts.LabelsNotReflected) > 0 {
 		args = append(args, stringifyArgument(string(LabelsNotReflected), strings.Join(opts.LabelsNotReflected, ",")))
 	}
@@ -133,4 +136,20 @@ func forgeVKPodSpec(
 
 func stringifyArgument(key, value string) string {
 	return fmt.Sprintf("%s=%s", key, value)
+}
+
+func appendArgsReflectorsWorkers(args []string, reflectorsWorkers map[string]*uint) []string {
+	for resource, value := range reflectorsWorkers {
+		key := fmt.Sprintf("--%s-reflection-workers", resource)
+		args = append(args, stringifyArgument(key, strconv.Itoa(int(*value))))
+	}
+	return args
+}
+
+func appendArgsReflectorsType(args []string, reflectorsType map[string]*string) []string {
+	for resource, value := range reflectorsType {
+		key := fmt.Sprintf("--%s-reflection-type", resource)
+		args = append(args, stringifyArgument(key, *value))
+	}
+	return args
 }

--- a/pkg/vkMachinery/forge/type.go
+++ b/pkg/vkMachinery/forge/type.go
@@ -36,6 +36,8 @@ type VirtualKubeletOpts struct {
 	IpamEndpoint            string
 	MetricsEnabled          bool
 	MetricsAddress          string
+	ReflectorsWorkers       map[string]*uint
+	ReflectorsType          map[string]*string
 	LabelsNotReflected      []string
 	AnnotationsNotReflected []string
 }


### PR DESCRIPTION
# Description

This PR adds the possibility to configure a per-resource whitelist-based reflection mechanism.

Two different reflection mechanisms can be selected at install time:

- ***DenyList***: reflects all the resources available in the liqo-enabled namespaces, excluding the ones with the `liqo.io/skip-reflection` annotation.
- ***AllowList***: do not reflect any resource in the liqo-enabled namespaces, but the ones with the `liqo.io/allow-reflection` annotation.

You can configure the preferred reflection mechanism for each resource type through the Helm value `reflection.<resource>.type`.
***DenyList*** is the **default** reflection policy for all resources (*services*, *endpointslices*, *ingresses*, *configmaps*, *secrets*, *events*).
Note: the *pods*, *PVCs*, and *serviceaccounts* reflectors follow a **custom** Liqo logic and can't be customized.

Fixes #1855 

In addition:
- The number of workers for each reflector is customizable through the Helm value `reflection.<resource>.workers`. Set 0 to disable the reflection completely.
- Improved documentation about reflection.

# How Has This Been Tested?

- [x] locally (Kind)
- [x] unit tests
- [x] e2e tests
