### PR TITLE
AKS vnet resource group

### DIFF
--- a/docs/installation/install.md
+++ b/docs/installation/install.md
@@ -127,6 +127,12 @@ Additionally, since your API Server is not accessible from the public Internet, 
 By default, the **AKS** provider exposes *liqo-auth* and *liqo-gateway* with **LoadBalancer** services.
 To change this behavior, check the [network flags](NetworkFlags).
 ```
+
+```{admonition} Virtual Network Resource Group
+By default, it is assumed the Virtual Network Resource for the AKS Subnet is located in the same Resource Group
+as the AKS Resource. If that is not the case, you will need to use the `--vnet-resource-group-name` flag to provide the 
+correct Resource Group name where the Virtual Network Resource is located.
+```
 ````
 
 ````{tab-item} EKS


### PR DESCRIPTION
Adding optional flag for vnet resource group for scenarios when the vnet is in a different resource group from the AKS resource

# Description

The virtual network is not always in the same resource group as the AKS resource and subsequently this needs to be exposed as a param to the CLI

Fixes #(issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Executed CLI using param and verified param was used
- [x] Executed CLI without param and verified param defaulted to resource-group-name
