### PR TITLE
VirtualNode: namespacemap virtualnode selector

### DIFF
--- a/cmd/liqoctl/cmd/offload.go
+++ b/cmd/liqoctl/cmd/offload.go
@@ -128,6 +128,7 @@ func newOffloadNamespaceCommand(ctx context.Context, f *factory.Factory) *cobra.
 
 	f.Printer.CheckErr(cmd.RegisterFlagCompletionFunc("pod-offloading-strategy", completion.Enumeration(podOffloadingStrategy.Allowed)))
 	f.Printer.CheckErr(cmd.RegisterFlagCompletionFunc("namespace-mapping-strategy", completion.Enumeration(namespaceMappingStrategy.Allowed)))
+	f.Printer.CheckErr(cmd.RegisterFlagCompletionFunc("selector", completion.LabelsSelector(ctx, f, completion.NoLimit)))
 	f.Printer.CheckErr(cmd.RegisterFlagCompletionFunc("output", completion.Enumeration(outputFormat.Allowed)))
 
 	return cmd

--- a/deployments/liqo/files/liqo-controller-manager-ClusterRole.yaml
+++ b/deployments/liqo/files/liqo-controller-manager-ClusterRole.yaml
@@ -463,6 +463,16 @@ rules:
 - apiGroups:
   - virtualkubelet.liqo.io
   resources:
+  - virtualnode
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - virtualkubelet.liqo.io
+  resources:
   - virtualnodes
   verbs:
   - create

--- a/pkg/liqo-controller-manager/namespaceoffloading-controller/clusterselector.go
+++ b/pkg/liqo-controller-manager/namespaceoffloading-controller/clusterselector.go
@@ -31,6 +31,7 @@ import (
 	"github.com/liqotech/liqo/internal/crdReplicator/reflection"
 	liqoconst "github.com/liqotech/liqo/pkg/consts"
 	"github.com/liqotech/liqo/pkg/utils/getters"
+	virtualnodeutils "github.com/liqotech/liqo/pkg/utils/virtualnode"
 )
 
 func (r *NamespaceOffloadingReconciler) enforceClusterSelector(ctx context.Context, nsoff *offv1alpha1.NamespaceOffloading,
@@ -102,10 +103,10 @@ func matchVirtualNodeSelectorTerms(ctx context.Context, cl client.Client, virtua
 	if len(selector.NodeSelectorTerms) == 0 {
 		return true, nil
 	}
-
-	n, err := getters.GetNodeFromVirtualNode(ctx, cl, virtualNode)
+	var n *corev1.Node
+	n, err := virtualnodeutils.ForgeFakeNodeFromVirtualNode(ctx, cl, virtualNode)
 	if err != nil {
-		return false, fmt.Errorf("failed to retrieve node %s from VirtualNode %s: %w", n.Name, virtualNode.Name, err)
+		return false, fmt.Errorf("failed to forge fake node from VirtualNode: %w", err)
 	}
 	return k8shelper.MatchNodeSelectorTerms(n, selector)
 }

--- a/pkg/utils/getters/k8sGetters.go
+++ b/pkg/utils/getters/k8sGetters.go
@@ -271,9 +271,9 @@ func GetNodeFromVirtualNode(ctx context.Context, cl client.Client, virtualNode *
 			return &nodes.Items[i], nil
 		}
 	}
-	podRN := string(corev1.ResourcePods)
-	podGR := corev1.Resource(podRN)
-	return nil, kerrors.NewNotFound(podGR, nodename)
+	nodeRN := "nodes"
+	nodeGR := corev1.Resource(nodeRN)
+	return nil, kerrors.NewNotFound(nodeGR, nodename)
 }
 
 // GetTunnelEndpoint retrieves the tunnelEndpoint resource related to a cluster.

--- a/pkg/utils/virtualnode/doc.go
+++ b/pkg/utils/virtualnode/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2019-2023 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package virtualnode contains utils functions to manage virtual nodes.
+package virtualnode

--- a/pkg/utils/virtualnode/virtualnode.go
+++ b/pkg/utils/virtualnode/virtualnode.go
@@ -1,0 +1,63 @@
+// Copyright 2019-2023 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package virtualnode
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	virtualkubeletv1alpha1 "github.com/liqotech/liqo/apis/virtualkubelet/v1alpha1"
+	liqoconsts "github.com/liqotech/liqo/pkg/consts"
+	"github.com/liqotech/liqo/pkg/utils/getters"
+)
+
+// ForgeFakeNodeFromVirtualNode creates a fake node from a virtual node.
+func ForgeFakeNodeFromVirtualNode(ctx context.Context, cl client.Client, vn *virtualkubeletv1alpha1.VirtualNode) (*corev1.Node, error) {
+	l, err := GetLabelSelectors(ctx, cl, vn)
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve label selectors: %w", err)
+	}
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   vn.Name,
+			Labels: l,
+		},
+	}, nil
+}
+
+// GetLabelSelectors returns the labels that can be used to target a remote cluster.
+// If virtualnode spec.CreateNode is true, the labels are taken from the created node.
+// If virtualnode spec.CreateNode is false, the labels are taken from the virtual node spec.Labels and spec.Template .
+func GetLabelSelectors(ctx context.Context, cl client.Client, vn *virtualkubeletv1alpha1.VirtualNode) (labels.Set, error) {
+	n, err := getters.GetNodeFromVirtualNode(ctx, cl, vn)
+	switch {
+	case errors.IsNotFound(err):
+		return labels.Merge(vn.Spec.Labels, labels.Set{
+			liqoconsts.RemoteClusterID:       vn.Spec.ClusterIdentity.ClusterID,
+			liqoconsts.StorageAvailableLabel: strconv.FormatBool(len(vn.Spec.StorageClasses) == 0),
+		}), nil
+	case err != nil:
+		return nil, fmt.Errorf("failed to retrieve node %s from VirtualNode %s: %w", n.Name, vn.Name, err)
+	default:
+		return n.Labels, nil
+	}
+}


### PR DESCRIPTION
# Description

This PR adds support for node selector in namespace offloading, like before the introduction of the VIrtualNode API.
