### PR TITLE
AKS Private Link

### DIFF
--- a/docs/installation/install.md
+++ b/docs/installation/install.md
@@ -120,6 +120,8 @@ Alternatively, you can manually set a different name with the `--cluster-name` *
 ```{admonition} Note
 If you are running an [AKS private cluster](https://learn.microsoft.com/en-us/azure/aks/private-clusters), you may need to set the `--disable-api-server-sanity-check` *liqoctl* flag, since the API Server in your kubeconfig may be different from the one retrieved from the Azure APIs.
 
+If the private cluster uses private link, you can set the `--private-link` *liqoctl* flag to use the private FQDN for the API server.
+
 Additionally, since your API Server is not accessible from the public Internet, you shall leverage the [in-band peering approach](FeaturesPeeringInBandControlPlane) towards the clusters not attached to the same Azure Virtual Network.
 ```
 


### PR DESCRIPTION

# Description

Adding privateLink flag to liqoctl to better support private AKS clusters. AKS clusters that use private link have a generated fqdn stored on the AKS cluster object as privateFQDN in addition to a public FQDN which is likely blocked through Azure policies.

Fixes #(issue)

This has been tested locally to verify the correct fqdn property is used based on flag presence or absence.

- [x] Tested without using the flag --privateLink
- [x] Tested with using the flag --privateLink
