### PR TITLE
Controller client timeout

### DIFF
--- a/deployments/liqo/README.md
+++ b/deployments/liqo/README.md
@@ -27,9 +27,10 @@
 | awsConfig.clusterName | string | `""` | Name of the EKS cluster. |
 | awsConfig.region | string | `""` | AWS region where the clsuter is runnnig. |
 | awsConfig.secretAccessKey | string | `""` | SecretAccessKey for the Liqo user. |
-| common.affinity | object | `{}` | Affinity for all liqo services, excluding virtual kubelet deployment. |
-| common.nodeSelector | object | `{}` | NodeSelector for all liqo services, excluding virtual kubelet deployment. |
-| common.tolerations | list | `[]` | Tolerations for all liqo services, excluding virtual kubelet deployment. |
+| common.affinity | object | `{}` | Affinity for all liqo pods, excluding virtual kubelet. |
+| common.extraArgs | list | `[]` | Extra arguments for all liqo pods, excluding virtual kubelet. |
+| common.nodeSelector | object | `{}` | NodeSelector for all liqo pods, excluding virtual kubelet. |
+| common.tolerations | list | `[]` | Tolerations for all liqo pods, excluding virtual kubelet. |
 | controllerManager.config.enableNodeFailureController | bool | `false` | Ensure offloaded pods running on a failed node are evicted and rescheduled on a healthy node, preventing them to remain in a terminating state indefinitely. This feature can be useful in case of remote node failure to guarantee better service continuity and to have the expected pods workload on the remote cluster. However, enabling this feature could produce zombies in the worker node, in case the node returns Ready again without a restart. |
 | controllerManager.config.enableResourceEnforcement | bool | `false` | It enforces offerer-side that offloaded pods do not exceed offered resources (based on container limits). This feature is suggested to be enabled when consumer-side enforcement is not sufficient. It has the same tradeoffs of resource quotas (i.e, it requires all offloaded pods to have resource limits set). |
 | controllerManager.config.offerUpdateThresholdPercentage | string | `""` | Threshold (in percentage) of the variation of resources that triggers a ResourceOffer update. E.g., when the available resources grow/decrease by X, a new ResourceOffer is generated. |

--- a/deployments/liqo/templates/liqo-auth-deployment.yaml
+++ b/deployments/liqo/templates/liqo-auth-deployment.yaml
@@ -92,6 +92,9 @@ spec:
           {{- if .Values.awsConfig.clusterName }}
           - --aws-cluster-name={{ .Values.awsConfig.clusterName }}
           {{- end }}
+          {{- if .Values.common.extraArgs }}
+          {{- toYaml .Values.common.extraArgs | nindent 10 }}
+          {{- end }}
           {{- if .Values.auth.pod.extraArgs }}
           {{- toYaml .Values.auth.pod.extraArgs | nindent 10 }}
           {{- end }}

--- a/deployments/liqo/templates/liqo-controller-manager-deployment.yaml
+++ b/deployments/liqo/templates/liqo-controller-manager-deployment.yaml
@@ -148,6 +148,9 @@ spec:
           {{- $d := dict "commandName" "--node-extra-labels" "dictionary" .Values.virtualKubelet.virtualNode.extra.labels }}
           {{- include "liqo.concatenateMap" $d | nindent 10 }}
           {{- end }}
+          {{- if .Values.common.extraArgs }}
+          {{- toYaml .Values.common.extraArgs | nindent 10 }}
+          {{- end }}
           {{- if .Values.controllerManager.pod.extraArgs }}
           {{- toYaml .Values.controllerManager.pod.extraArgs | nindent 10 }}
           {{- end }}

--- a/deployments/liqo/templates/liqo-crd-replicator-deployment.yaml
+++ b/deployments/liqo/templates/liqo-crd-replicator-deployment.yaml
@@ -37,6 +37,9 @@ spec:
           args:
             - --cluster-id=$(CLUSTER_ID)
             - --cluster-name=$(CLUSTER_NAME)
+            {{- if .Values.common.extraArgs }}
+            {{- toYaml .Values.common.extraArgs | nindent 12 }}
+            {{- end }}
             {{- if .Values.crdReplicator.pod.extraArgs }}
             {{- toYaml .Values.crdReplicator.pod.extraArgs | nindent 12 }}
             {{- end }}

--- a/deployments/liqo/templates/liqo-discovery-deployment.yaml
+++ b/deployments/liqo/templates/liqo-discovery-deployment.yaml
@@ -40,6 +40,9 @@ spec:
           - --mdns-enable-advertisement={{ .Values.discovery.config.enableAdvertisement }}
           - --mdns-enable-discovery={{ .Values.discovery.config.enableDiscovery }}
           - --mdns-ttl={{ .Values.discovery.config.ttl }}s
+          {{- if .Values.common.extraArgs }}
+          {{- toYaml .Values.common.extraArgs | nindent 10 }}
+          {{- end }}
           {{- if .Values.discovery.pod.extraArgs }}
           {{- toYaml .Values.discovery.pod.extraArgs | nindent 10 }}
           {{- end }}

--- a/deployments/liqo/templates/liqo-gateway-deployment.yaml
+++ b/deployments/liqo/templates/liqo-gateway-deployment.yaml
@@ -51,6 +51,9 @@ spec:
           {{- if .Values.gateway.metrics.enabled }}
           - --metrics-bind-addr=:{{ .Values.gateway.metrics.port }}
           {{- end }}
+          {{- if .Values.common.extraArgs }}
+          {{- toYaml .Values.common.extraArgs | nindent 10 }}
+          {{- end }}
           {{- if .Values.gateway.pod.extraArgs }}
           {{- toYaml .Values.gateway.pod.extraArgs | nindent 10 }}
           {{- end }}

--- a/deployments/liqo/templates/liqo-network-manager-deployment.yaml
+++ b/deployments/liqo/templates/liqo-network-manager-deployment.yaml
@@ -50,6 +50,9 @@ spec:
             {{- $d := dict "commandName" "--manager.additional-pools" "list" .Values.networkManager.config.additionalPools }}
             {{- include "liqo.concatenateList" $d | nindent 12 }}
             {{- end }}
+            {{- if .Values.common.extraArgs }}
+            {{- toYaml .Values.common.extraArgs | nindent 12 }}
+            {{- end }}
             {{- if .Values.networkManager.pod.extraArgs }}
             {{- toYaml .Values.networkManager.pod.extraArgs | nindent 12 }}
             {{- end }}

--- a/deployments/liqo/templates/liqo-route-daemonset.yaml
+++ b/deployments/liqo/templates/liqo-route-daemonset.yaml
@@ -44,6 +44,9 @@ spec:
           args:
           - --run-as=liqo-route
           - --route.vxlan-mtu={{ .Values.networking.mtu }}
+          {{- if .Values.common.extraArgs }}
+          {{- toYaml .Values.common.extraArgs | nindent 10 }}
+          {{- end }}
           {{- if .Values.route.pod.extraArgs }}
           {{- toYaml .Values.route.pod.extraArgs | nindent 10 }}
           {{- end }}

--- a/deployments/liqo/templates/pre-delete-job.yaml
+++ b/deployments/liqo/templates/pre-delete-job.yaml
@@ -32,9 +32,14 @@ spec:
         securityContext:
           {{- include "liqo.containerSecurityContext" . | nindent 10 }}
         command: ["/usr/bin/uninstaller"]
-        {{- if .Values.uninstaller.pod.extraArgs }}
+        {{- if or .Values.uninstaller.pod.extraArgs .Values.common.extraArgs }}
         args:
+          {{- if .Values.common.extraArgs }}
+          {{- toYaml .Values.common.extraArgs | nindent 10 }}
+          {{- end }}
+          {{- if .Values.uninstaller.pod.extraArgs }}
           {{- toYaml .Values.uninstaller.pod.extraArgs | nindent 10 }}
+          {{- end }}
         {{- end }}
         env:
           - name: POD_NAMESPACE

--- a/deployments/liqo/values.yaml
+++ b/deployments/liqo/values.yaml
@@ -8,12 +8,14 @@ tag: ""
 pullPolicy: "IfNotPresent"
 
 common:
-  # -- NodeSelector for all liqo services, excluding virtual kubelet deployment.
+  # -- NodeSelector for all liqo pods, excluding virtual kubelet.
   nodeSelector: {}
-  # -- Tolerations for all liqo services, excluding virtual kubelet deployment.
+  # -- Tolerations for all liqo pods, excluding virtual kubelet.
   tolerations: []
-  # -- Affinity for all liqo services, excluding virtual kubelet deployment.
+  # -- Affinity for all liqo pods, excluding virtual kubelet.
   affinity: {}
+  # -- Extra arguments for all liqo pods, excluding virtual kubelet.
+  extraArgs: []
 
 apiServer:
   # -- The address that must be used to contact your API server, it needs to be reachable from the clusters that you will peer with (defaults to your master IP).

--- a/pkg/utils/restcfg/ratelimiting_test.go
+++ b/pkg/utils/restcfg/ratelimiting_test.go
@@ -34,8 +34,9 @@ var _ = Describe("The rate limiting utility functions", func() {
 	)
 
 	const (
-		qps   = 67
-		burst = 89
+		timeout = 10
+		qps     = 67
+		burst   = 89
 	)
 
 	Describe("the SetRateLimiter function", func() {
@@ -69,9 +70,10 @@ var _ = Describe("The rate limiting utility functions", func() {
 
 	Describe("the SetRateLimiterWithCustomParameters function", func() {
 		Context("configuring the rate limiting parameters", func() {
-			JustBeforeEach(func() { output = restcfg.SetRateLimiterWithCustomParameters(&cfg, qps, burst) })
+			JustBeforeEach(func() { output = restcfg.SetRateLimiterWithCustomParameters(&cfg, timeout, qps, burst) })
 
 			It("should return a pointer to the original object", func() { Expect(output).To(BeIdenticalTo(&cfg)) })
+			It("should set the desired timeout value", func() { Expect(cfg.Timeout).To(BeNumerically("==", timeout)) })
 			It("should set the desired QPS value", func() { Expect(cfg.QPS).To(BeNumerically("==", qps)) })
 			It("should set the desired burst value", func() { Expect(cfg.Burst).To(BeNumerically("==", burst)) })
 		})


### PR DESCRIPTION
# Description

This PR introduces the possibility of setting the timeout of the controllers' client from helm values **extra-args**.
It also inserts the possibility to specify **common extra-args** that will be applied to all the Liqo pods.
