### PR TITLE
fix dependabot docker updater

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,21 @@ updates:
       interval: "daily"
 
   - package-ecosystem: "docker"
-    directory: "/build/*"
+    directory: "/build/cert-creator"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "docker"
+    directory: "/build/common"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "docker"
+    directory: "/build/liqo-test"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "docker"
+    directory: "/build/liqonet"
     schedule:
       interval: "daily"


### PR DESCRIPTION
# Description

This PR fixes the Dependabot Docker updater to use all the Dockerfiles in the build directory
