### PR TITLE
Override default Ingress tls secretName

### DIFF
--- a/deployments/liqo/README.md
+++ b/deployments/liqo/README.md
@@ -13,6 +13,7 @@
 | auth.ingress.enable | bool | `false` | Enable/disable the creation of the Ingress resource. |
 | auth.ingress.host | string | `""` | Set the hostname for your ingress. |
 | auth.ingress.port | int | `443` | Set port for your ingress. |
+| auth.ingress.tlsSecretName | string | `""` | Override default (ChartName-auth) tls secretName. |
 | auth.initContainer.imageName | string | `"ghcr.io/liqotech/cert-creator"` | Image repository for the init container of the auth pod. |
 | auth.pod.annotations | object | `{}` | Annotations for the auth pod. |
 | auth.pod.extraArgs | list | `[]` | Extra arguments for the auth pod. |

--- a/deployments/liqo/templates/liqo-auth-ingress.yaml
+++ b/deployments/liqo/templates/liqo-auth-ingress.yaml
@@ -38,7 +38,11 @@ spec:
     {{- if .Values.auth.ingress.host }}
     - hosts:
       - {{ .Values.auth.ingress.host }}
+      {{- if .Values.auth.ingress.tlsSecretName }}
+      secretName: {{ .Values.auth.ingress.tlsSecretName }}
+      {{- else }}
       secretName: {{ include "liqo.prefixedName" $authConfig }}
+      {{- end}}
     {{- else }}
     - hosts: []
     {{- end }}

--- a/deployments/liqo/values.yaml
+++ b/deployments/liqo/values.yaml
@@ -343,6 +343,8 @@ auth:
     class: ""
     # -- Set port for your ingress.
     port: 443
+    # -- Override default (ChartName-auth) tls secretName.
+    tlsSecretName: ""
   config:
     # -- Set to false to disable the authentication of discovered clusters.
     # Note: use it only for testing installations.


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
In our case we have Internal TLS certificate and created under different secret name under Liqo namespace. This PR changes will allow us to override default secret name generation from ChartName-auth with user provided secret name.

Fixes #(issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Locally