### PR TITLE
Liqo Gateway & Auth Service Loadbalancer Static IP

### DIFF
--- a/deployments/liqo/README.md
+++ b/deployments/liqo/README.md
@@ -19,8 +19,10 @@
 | auth.pod.extraArgs | list | `[]` | Extra arguments for the auth pod. |
 | auth.pod.labels | object | `{}` | Labels for the auth pod. |
 | auth.pod.resources | object | `{"limits":{},"requests":{}}` | Resource requests and limits (https://kubernetes.io/docs/user-guide/compute-resources/) for the auth pod. |
+| auth.service.allocateLoadBalancerNodePorts | string | `""` | Set to false if you expose the auth service as LoadBalancer and you do not want to create also a NodePort associated to it (Note: this setting is useful only on cloud providers that support this feature). |
 | auth.service.annotations | object | `{}` | Annotations for the auth service. |
 | auth.service.labels | object | `{}` | Labels for the auth service. |
+| auth.service.loadBalancerIP | string | `""` | Override the IP here if service type is LoadBalancer and you want to use a specific IP address, e.g., because you want a static LB. |
 | auth.service.port | int | `443` | Port used by the Authentication Service. |
 | auth.service.type | string | `"LoadBalancer"` | Kubernetes service used to expose the Authentication Service. If you are exposing this service with an Ingress, you can change it to ClusterIP; if your cluster does not support LoadBalancer services, consider to switch it to NodePort. See https://doc.liqo.io/installation/ for more details. |
 | auth.tls | bool | `true` | Enable TLS for the Authentication Service Pod (using a self-signed certificate). If you are exposing this service with an Ingress, consider to disable it or add the appropriate annotations to the Ingress resource. |
@@ -81,8 +83,10 @@
 | gateway.pod.labels | object | `{}` | Labels for the network gateway pod. |
 | gateway.pod.resources | object | `{"limits":{},"requests":{}}` | Resource requests and limits (https://kubernetes.io/docs/user-guide/compute-resources/) for the network gateway pod. |
 | gateway.replicas | int | `1` | The number of gateway instances to run. The gateway component supports active/passive high availability. Make sure that there are enough nodes to accommodate the replicas, because such pod has to run in the host network, hence no more than one replica can be scheduled on a given node. |
+| gateway.service.allocateLoadBalancerNodePorts | string | `""` | Set to false if you expose the gateway service as LoadBalancer and you do not want to create also a NodePort associated to it (Note: this setting is useful only on cloud providers that support this feature). |
 | gateway.service.annotations | object | `{}` | Annotations for the network gateway service. |
 | gateway.service.labels | object | `{}` | Labels for the network gateway service. |
+| gateway.service.loadBalancerIP | string | `""` | Override the IP here if service type is LoadBalancer and you want to use a specific IP address, e.g., because you want a static LB. |
 | gateway.service.type | string | `"LoadBalancer"` | Kubernetes service to be used to expose the network gateway pod. If you plan to use liqo over the Internet, consider to change this field to "LoadBalancer". Instead, if your nodes are directly reachable from the cluster you are peering to, you may change it to "NodePort". |
 | metricAgent.enable | bool | `true` | Enable/Disable the virtual kubelet metric agent. This component aggregates all the kubelet-related metrics (e.g., CPU, RAM, etc) collected on the nodes that are used by a remote cluster peered with you, then exporting  the resulting values as a property of the virtual kubelet running on the remote cluster. |
 | metricAgent.imageName | string | `"ghcr.io/liqotech/metric-agent"` | Image repository for the metricAgent pod. |

--- a/deployments/liqo/templates/liqo-auth-service.yaml
+++ b/deployments/liqo/templates/liqo-auth-service.yaml
@@ -40,3 +40,9 @@ spec:
       port: {{ .Values.auth.service.port }}
       targetPort: 8443
       {{- end }}
+  {{- if and (eq .Values.auth.service.type "LoadBalancer") (.Values.auth.service.loadBalancerIP) }}
+  loadBalancerIP: .Values.auth.service.loadBalancerIP
+  {{- end }}
+  {{- if and (eq .Values.auth.service.type "LoadBalancer") (.Values.auth.service.allocateLoadBalancerNodePorts) }}
+  allocateLoadBalancerNodePorts: .Values.auth.service.allocateLoadBalancerNodePorts
+  {{- end }}

--- a/deployments/liqo/templates/liqo-gateway-service.yaml
+++ b/deployments/liqo/templates/liqo-gateway-service.yaml
@@ -30,6 +30,12 @@ spec:
       port: {{ .Values.gateway.config.listeningPort }}
       targetPort: wireguard
       protocol: UDP
+  {{- if and (eq .Values.gateway.service.type "LoadBalancer") (.Values.gateway.service.loadBalancerIP) }}
+  loadBalancerIP: .Values.gateway.service.loadBalancerIP
+  {{- end }}
+  {{- if and (eq .Values.gateway.service.type "LoadBalancer") (.Values.gateway.service.allocateLoadBalancerNodePorts) }}
+  allocateLoadBalancerNodePorts: .Values.gateway.service.allocateLoadBalancerNodePorts
+  {{- end }}
   selector:
     {{- include "liqo.gatewaySelector" $gatewayConfig | nindent 4 }}
 

--- a/deployments/liqo/values.yaml
+++ b/deployments/liqo/values.yaml
@@ -172,6 +172,10 @@ gateway:
     annotations: {}
     # -- Labels for the network gateway service.
     labels: {}
+    # -- Override the IP here if service type is LoadBalancer and you want to use a specific IP address, e.g., because you want a static LB.
+    loadBalancerIP: ""
+    # -- Set to false if you expose the gateway service as LoadBalancer and you do not want to create also a NodePort associated to it (Note: this setting is useful only on cloud providers that support this feature).
+    allocateLoadBalancerNodePorts: ""
   config:
     # -- Override the default address where your network gateway service is available.
     # You should configure it if the network gateway is behind a reverse proxy or NAT.
@@ -329,6 +333,10 @@ auth:
     annotations: {}
     # -- Port used by the Authentication Service.
     port: 443
+    # -- Override the IP here if service type is LoadBalancer and you want to use a specific IP address, e.g., because you want a static LB.
+    loadBalancerIP: ""
+    # -- Set to false if you expose the auth service as LoadBalancer and you do not want to create also a NodePort associated to it (Note: this setting is useful only on cloud providers that support this feature).
+    allocateLoadBalancerNodePorts: ""
   # -- Enable TLS for the Authentication Service Pod (using a self-signed certificate).
   # If you are exposing this service with an Ingress, consider to disable it or add the appropriate annotations to the Ingress resource.
   tls: true


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

When exposing Liqo Gateway & Auth service as `LoadBalancer` currently it's only possible to change the `type` to `LoadBalancer`, but in some cloud provided we are able to create Static LoadBalancer and use IP in `loadBalancerIP` field. This PR will allow user to set custom LoadBalancer IP.

Fixes #(issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Helm template and install
