### PR TITLE
liqo-route: mac annotation fix

### DIFF
--- a/cmd/liqonet/route-operator.go
+++ b/cmd/liqonet/route-operator.go
@@ -72,6 +72,11 @@ func runRouteOperator(commonFlags *liqonetCommonFlags, routeFlags *routeOperator
 		klog.Errorf("unable to get podIP: %v", err)
 		os.Exit(1)
 	}
+	podName, err := liqonetutils.GetPodName()
+	if err != nil {
+		klog.Errorf("unable to get pod name: %v", err)
+		os.Exit(1)
+	}
 	nodeName, err := liqonetutils.GetNodeName()
 	if err != nil {
 		klog.Errorf("unable to get node name: %v", err)
@@ -170,7 +175,7 @@ func runRouteOperator(commonFlags *liqonetCommonFlags, routeFlags *routeOperator
 		klog.Errorf("unable to start go routine that configures firewall rules for the route controller: %v", err)
 		os.Exit(1)
 	}
-	overlayController, err := routeoperator.NewOverlayController(podIP.String(), vxlanDevice, mutex, nodeMap, overlayMgr.GetClient())
+	overlayController, err := routeoperator.NewOverlayController(podName, vxlanDevice, mutex, nodeMap, overlayMgr.GetClient())
 	if err != nil {
 		klog.Errorf("an error occurred while creating overlay controller: %v", err)
 		os.Exit(3)

--- a/internal/liqonet/route-operator/overlayOperator_test.go
+++ b/internal/liqonet/route-operator/overlayOperator_test.go
@@ -38,13 +38,14 @@ import (
 )
 
 var (
-	overlayPodIP     = "10.0.0.1"
-	overlayAnnKey    = vxlanMACAddressKey
-	overlayAnnValue  = "45:d0:ae:c9:d6:40"
-	overlayPeerIP    = "10.11.1.1"
-	overlayPeerMAC   = "4e:d0:ae:c9:d6:30"
-	overlayNamespace = "overlay-namespace"
-	overlayPodName   = "overlay-test-pod"
+	overlayPodIP        = "10.0.0.1"
+	overlayAnnKey       = vxlanMACAddressKey
+	overlayAnnValue     = "45:d0:ae:c9:d6:40"
+	overlayPeerIP       = "10.11.1.1"
+	overlayPeerMAC      = "4e:d0:ae:c9:d6:30"
+	overlayNamespace    = "overlay-namespace"
+	overlayPodName      = "overlay-test-pod"
+	overlayPodNameWrong = "overlay-test-pod-wrong"
 
 	overlayTestPod          *corev1.Pod
 	overlayReq              ctrl.Request
@@ -93,7 +94,7 @@ var _ = Describe("OverlayOperator", func() {
 		}
 		// Create dummy overlay operator.
 		ovc = &OverlayController{
-			podIP:      overlayPodIP,
+			podName:    overlayPodName,
 			vxlanPeers: make(map[string]*overlay.Neighbor),
 			vxlanDev:   vxlanDevice,
 			Client:     k8sClient,
@@ -339,20 +340,21 @@ var _ = Describe("OverlayOperator", func() {
 		})
 
 		Context("when object is a pod", func() {
-			It("and has same ip, should return true", func() {
+			It("and has same name, should return true", func() {
 				// Add ip address to the test pod.
-				overlayTestPod.Status.PodIP = overlayPodIP
 				ok := ovc.podFilter(overlayTestPod)
 				Expect(ok).Should(BeTrue())
 			})
 
-			It("has not the same ip and has not been annotated, should return false", func() {
+			It("has not the same name and has not been annotated, should return false", func() {
 				overlayTestPod.SetAnnotations(nil)
+				overlayTestPod.Name = overlayPodNameWrong
 				ok := ovc.podFilter(overlayTestPod)
 				Expect(ok).Should(BeFalse())
 			})
 
-			It("has not the same ip and has  been annotated, should return true", func() {
+			It("has not the same name and has  been annotated, should return true", func() {
+				overlayTestPod.Name = overlayPodNameWrong
 				ok := ovc.podFilter(overlayTestPod)
 				Expect(ok).Should(BeTrue())
 			})

--- a/pkg/liqonet/utils/utils.go
+++ b/pkg/liqonet/utils/utils.go
@@ -64,6 +64,15 @@ func MapIPToNetwork(newNetwork, oldIP string) (newIP string, err error) {
 	return
 }
 
+// GetPodName returns the pod name.
+func GetPodName() (string, error) {
+	podName, isSet := os.LookupEnv("POD_NAME")
+	if !isSet || podName == "" {
+		return "", errors.New("pod name is not yet set")
+	}
+	return podName, nil
+}
+
 // GetPodIP returns the pod IP address.
 func GetPodIP() (net.IP, error) {
 	ipAddress, isSet := os.LookupEnv("POD_IP")


### PR DESCRIPTION
# Description

This PR changes the method used to understand if a reconciled pod is the pod where the controller is running.

Previously we checked that the reconciled pod IP and the pod where the IP is running have the same IP. In some rare cases, this creates problems, in fact, if a node is deleted and another node is created with the same IP, it's possible that the controller gets an event that refer to a zombie pod. 

Using the podName instead of the IP solves this problem.
