### PR TITLE
IPAMStorage namespaced

### DIFF
--- a/apis/net/v1alpha1/ipamstorage_types.go
+++ b/apis/net/v1alpha1/ipamstorage_types.go
@@ -83,7 +83,7 @@ type IpamSpec struct {
 }
 
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:scope=Cluster,categories=liqo
+// +kubebuilder:resource:scope=Namespaced,categories=liqo
 
 // IpamStorage is the Schema for the ipams API.
 type IpamStorage struct {

--- a/cmd/liqonet/network-manager.go
+++ b/cmd/liqonet/network-manager.go
@@ -83,7 +83,7 @@ func runNetworkManager(commonFlags *liqonetCommonFlags, managerFlags *networkMan
 	}
 	dynClient := dynamic.NewForConfigOrDie(mgr.GetConfig())
 
-	ipam, err := initializeIPAM(dynClient, managerFlags)
+	ipam, err := initializeIPAM(dynClient, podNamespace, managerFlags)
 	if err != nil {
 		klog.Errorf("Failed to initialize IPAM: %s", err)
 		os.Exit(1)
@@ -126,10 +126,10 @@ func runNetworkManager(commonFlags *liqonetCommonFlags, managerFlags *networkMan
 	}
 }
 
-func initializeIPAM(client dynamic.Interface, managerFlags *networkManagerFlags) (*liqonetIpam.IPAM, error) {
+func initializeIPAM(cl dynamic.Interface, namespace string, managerFlags *networkManagerFlags) (*liqonetIpam.IPAM, error) {
 	ipam := liqonetIpam.NewIPAM()
 
-	if err := ipam.Init(liqonetIpam.Pools, client, liqoconst.NetworkManagerIpamPort); err != nil {
+	if err := ipam.Init(liqonetIpam.Pools, cl, liqoconst.NetworkManagerIpamPort, namespace); err != nil {
 		return nil, err
 	}
 

--- a/deployments/liqo/crds/net.liqo.io_ipamstorages.yaml
+++ b/deployments/liqo/crds/net.liqo.io_ipamstorages.yaml
@@ -15,7 +15,7 @@ spec:
     listKind: IpamStorageList
     plural: ipamstorages
     singular: ipamstorage
-  scope: Cluster
+  scope: Namespaced
   versions:
   - name: v1alpha1
     schema:

--- a/internal/liqonet/route-operator/overlayOperator_test.go
+++ b/internal/liqonet/route-operator/overlayOperator_test.go
@@ -20,6 +20,7 @@ import (
 	"path/filepath"
 	"sync"
 	"syscall"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -132,7 +133,7 @@ var _ = Describe("OverlayOperator", func() {
 		Context("when the pod is the current one", func() {
 			It("should annotate the pod with the mac address of the vxlan device", func() {
 				// Set annotations to nil.
-				overlayTestPod.SetFinalizers(nil)
+				overlayTestPod.SetAnnotations(nil)
 				Eventually(func() error { return k8sClient.Create(context.TODO(), overlayTestPod) }).Should(BeNil())
 				newPod := &corev1.Pod{}
 				Eventually(func() error { return k8sClient.Get(context.TODO(), overlayReq.NamespacedName, newPod) }).Should(BeNil())
@@ -149,7 +150,7 @@ var _ = Describe("OverlayOperator", func() {
 						return fmt.Errorf(" error: annotated MAC %s is different than %s", newPod.GetAnnotations()[overlayAnnKey], ovc.vxlanDev.Link.HardwareAddr.String())
 					}
 					return nil
-				}).Should(BeNil())
+				}, 5*time.Second)
 			})
 		})
 

--- a/pkg/liqonet/ipam/ipam.go
+++ b/pkg/liqonet/ipam/ipam.go
@@ -104,10 +104,10 @@ var Pools = []string{
 const emptyCIDR = ""
 
 // Init uses the Ipam resource to retrieve and allocate reserved networks.
-func (liqoIPAM *IPAM) Init(pools []string, dynClient dynamic.Interface, listeningPort int) error {
+func (liqoIPAM *IPAM) Init(pools []string, dynClient dynamic.Interface, listeningPort int, namespace string) error {
 	var err error
 	// Set up storage
-	liqoIPAM.ipamStorage, err = NewIPAMStorage(dynClient)
+	liqoIPAM.ipamStorage, err = NewIPAMStorage(dynClient, namespace)
 	if err != nil {
 		return fmt.Errorf("cannot set up storage for ipam: %w", err)
 	}

--- a/pkg/liqonet/ipam/ipamStorage.go
+++ b/pkg/liqonet/ipam/ipamStorage.go
@@ -78,14 +78,17 @@ type IPAMStorage struct {
 
 	dynClient dynamic.Interface
 	storage   *netv1alpha1.IpamStorage
+
+	namespace string
 }
 
 // NewIPAMStorage inits the storage of the IPAM module,
 // retrieving an existing ipamStorage resource or creating a new one.
-func NewIPAMStorage(dynClient dynamic.Interface) (*IPAMStorage, error) {
+func NewIPAMStorage(dynClient dynamic.Interface, namespace string) (*IPAMStorage, error) {
 	klog.Infof("Init IPAM storage..")
 	ipamStorage := &IPAMStorage{}
 	ipamStorage.dynClient = dynClient
+	ipamStorage.namespace = namespace
 
 	klog.Infof("Looking for Ipam resource..")
 	ipam, err := ipamStorage.retrieveConfig()
@@ -282,7 +285,7 @@ func (ipamStorage *IPAMStorage) updateConfig(updateType string, data interface{}
 	b.Write(jsonData)
 	b.WriteString("}]")
 
-	unstr, err := ipamStorage.dynClient.Resource(netv1alpha1.IpamGroupVersionResource).Patch(context.Background(),
+	unstr, err := ipamStorage.dynClient.Resource(netv1alpha1.IpamGroupVersionResource).Namespace(ipamStorage.namespace).Patch(context.Background(),
 		ipamStorage.getConfigName(), types.JSONPatchType, b.Bytes(), metav1.PatchOptions{})
 	if err != nil {
 		klog.Error("Failed to patch the IPAM resource: %v", err)
@@ -348,7 +351,7 @@ func (ipamStorage *IPAMStorage) getConfigName() string {
 
 func (ipamStorage *IPAMStorage) retrieveConfig() (*netv1alpha1.IpamStorage, error) {
 	list, err := ipamStorage.dynClient.
-		Resource(netv1alpha1.IpamGroupVersionResource).
+		Resource(netv1alpha1.IpamGroupVersionResource).Namespace(ipamStorage.namespace).
 		List(context.Background(), metav1.ListOptions{
 			LabelSelector: fmt.Sprintf("%s=%s", consts.IpamStorageResourceLabelKey, consts.IpamStorageResourceLabelValue),
 		})
@@ -379,6 +382,7 @@ func (ipamStorage *IPAMStorage) createConfig() (*netv1alpha1.IpamStorage, error)
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: ipamNamePrefix,
+			Namespace:    ipamStorage.namespace,
 			Labels:       map[string]string{consts.IpamStorageResourceLabelKey: consts.IpamStorageResourceLabelValue},
 		},
 		Spec: netv1alpha1.IpamSpec{
@@ -394,7 +398,7 @@ func (ipamStorage *IPAMStorage) createConfig() (*netv1alpha1.IpamStorage, error)
 	unstr, err := runtime.DefaultUnstructuredConverter.ToUnstructured(ipam)
 	utilruntime.Must(err)
 
-	created, err := ipamStorage.dynClient.Resource(netv1alpha1.IpamGroupVersionResource).
+	created, err := ipamStorage.dynClient.Resource(netv1alpha1.IpamGroupVersionResource).Namespace(ipamStorage.namespace).
 		Create(context.Background(), &unstructured.Unstructured{Object: unstr}, metav1.CreateOptions{})
 	if err != nil {
 		klog.Errorf("cannot create ipam resource: %s", err.Error())

--- a/pkg/liqonet/ipam/ipam_test.go
+++ b/pkg/liqonet/ipam/ipam_test.go
@@ -51,6 +51,7 @@ const (
 	externalEndpointIP   = "10.0.50.6"
 	endpointIP           = "20.0.0.1"
 	invalidValue         = "invalid value"
+	namespace            = "test-namespace"
 )
 
 var (
@@ -135,7 +136,7 @@ var _ = Describe("Ipam", func() {
 		Expect(err).To(BeNil())
 		n, err := rand.Int(rand.Reader, big.NewInt(10000))
 		Expect(err).To(BeNil())
-		err = ipam.Init(Pools, dynClient, 2000+int(n.Int64()))
+		err = ipam.Init(Pools, dynClient, 2000+int(n.Int64()), namespace)
 		Expect(err).To(BeNil())
 	})
 	AfterEach(func() {
@@ -621,7 +622,7 @@ var _ = Describe("Ipam", func() {
 			ipam = NewIPAM()
 			n, err := rand.Int(rand.Reader, big.NewInt(2000))
 			Expect(err).To(BeNil())
-			err = ipam.Init(Pools, dynClient, 2000+int(n.Int64()))
+			err = ipam.Init(Pools, dynClient, 2000+int(n.Int64()), namespace)
 			Expect(err).To(BeNil())
 
 			// Another cluster asks for the same networks
@@ -1517,7 +1518,7 @@ var _ = Describe("Ipam", func() {
 				Expect(err).To(BeNil())
 
 				// Recreate the cached representation of the IPAM storage.
-				storage, err := NewIPAMStorage(dynClient)
+				storage, err := NewIPAMStorage(dynClient, namespace)
 				Expect(err).ToNot(HaveOccurred())
 				ipam.ipamStorage = storage
 
@@ -1762,7 +1763,7 @@ func getNatMappingResourcePerCluster(clusterID string) (*liqonetapi.NatMapping, 
 
 func getIpamStorageResource() (*liqonetapi.IpamStorage, error) {
 	ipamConfig := &liqonetapi.IpamStorage{}
-	list, err := dynClient.Resource(liqonetapi.IpamGroupVersionResource).List(
+	list, err := dynClient.Resource(liqonetapi.IpamGroupVersionResource).Namespace(namespace).List(
 		context.Background(),
 		v1.ListOptions{
 			LabelSelector: fmt.Sprintf("%s=%s",
@@ -1804,7 +1805,7 @@ func updateIpamStorageResource(ipamStorage *liqonetapi.IpamStorage) error {
 	if err != nil {
 		return err
 	}
-	_, err = dynClient.Resource(liqonetapi.IpamGroupVersionResource).Update(
+	_, err = dynClient.Resource(liqonetapi.IpamGroupVersionResource).Namespace(namespace).Update(
 		context.Background(),
 		&unstructured.Unstructured{Object: unstructuredResource},
 		v1.UpdateOptions{},


### PR DESCRIPTION
# Description

This PR moves the IPAMStorage inside the liqo namespace.
This allows IPAM to be deleted when Liqois uninstalled

# How Has This Been Tested?

- [x] Locally with KinD
