### PR TITLE
Fix nil pointer deference in pod Ready condition

### DIFF
--- a/pkg/virtualKubelet/reflection/workload/podns.go
+++ b/pkg/virtualKubelet/reflection/workload/podns.go
@@ -409,7 +409,15 @@ func (npr *NamespacedPodReflector) HandleStatus(ctx context.Context, local, remo
 	// in sync the endpointslice Ready condition with the associated pod Ready condition).
 	if podstatusctrl.HasRemoteUnavailableLabel(local) {
 		cond := pod.GetPodCondition(&po.Status, corev1.PodReady)
-		cond.Status = corev1.ConditionFalse
+		if cond == nil {
+			po.Status.Conditions = append(po.Status.Conditions, corev1.PodCondition{
+				Type:               corev1.PodReady,
+				Status:             corev1.ConditionFalse,
+				LastTransitionTime: metav1.NewTime(time.Now()),
+			})
+		} else {
+			cond.Status = corev1.ConditionFalse
+		}
 	}
 
 	// Do not attempt to perform an update if not necessary.


### PR DESCRIPTION
# Description

This PR fixes a _nil pointer dereference_ error occurring in the virtual kubelet when a local offloaded pod does not have the Ready condition set.

Fixes #2038

