### PR TITLE
Update fake IPAMClient

### DIFF
--- a/pkg/liqoctl/uninstall/handler.go
+++ b/pkg/liqoctl/uninstall/handler.go
@@ -32,6 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
+	ipamv1alpha1 "github.com/liqotech/liqo/apis/ipam/v1alpha1"
 	netv1alpha1 "github.com/liqotech/liqo/apis/net/v1alpha1"
 	offv1alpha1 "github.com/liqotech/liqo/apis/offloading/v1alpha1"
 	sharingv1alpha1 "github.com/liqotech/liqo/apis/sharing/v1alpha1"
@@ -49,6 +50,7 @@ var liqoGroupVersions = []schema.GroupVersion{
 	offv1alpha1.GroupVersion,
 	sharingv1alpha1.GroupVersion,
 	virtualKubeletv1alpha1.SchemeGroupVersion,
+	ipamv1alpha1.GroupVersion,
 }
 
 // Options encapsulates the arguments of the uninstall command.

--- a/pkg/liqonet/ipam/fake/ipam.go
+++ b/pkg/liqonet/ipam/fake/ipam.go
@@ -24,6 +24,8 @@ import (
 	liqonetutils "github.com/liqotech/liqo/pkg/liqonet/utils"
 )
 
+var _ ipam.IpamClient = &IPAMClient{}
+
 // IPAMClient provides a mock implementation of the IPAMClient interface for testing purposes.
 type IPAMClient struct {
 	localRemappedPodCIDR  string
@@ -102,4 +104,14 @@ func (mock *IPAMClient) GetHomePodIP(_ context.Context, req *ipam.GetHomePodIPRe
 func (mock *IPAMClient) BelongsToPodCIDR(context.Context, *ipam.BelongsRequest,
 	...grpc.CallOption) (*ipam.BelongsResponse, error) {
 	return &ipam.BelongsResponse{Belongs: true}, nil
+}
+
+// MapNetworkCIDR mocks the corresponding IPAMClient function.
+func (mock *IPAMClient) MapNetworkCIDR(_ context.Context, req *ipam.MapCIDRRequest, _ ...grpc.CallOption) (*ipam.MapCIDRResponse, error) {
+	return &ipam.MapCIDRResponse{Cidr: req.GetCidr()}, nil
+}
+
+// UnmapNetworkCIDR mocks the corresponding IPAMClient function.
+func (mock *IPAMClient) UnmapNetworkCIDR(_ context.Context, _ *ipam.UnmapCIDRRequest, _ ...grpc.CallOption) (*ipam.UnmapCIDRResponse, error) {
+	return &ipam.UnmapCIDRResponse{}, nil
 }


### PR DESCRIPTION
# Description

This PR updates the fake IPAMClient with the new methods.
In addition, it fixes the Uninstall e2e test.