### PR TITLE
Always reflect kube-root-ca.crt configmap in offloaded namespaces 

### DIFF
--- a/pkg/virtualKubelet/reflection/configuration/configmap_test.go
+++ b/pkg/virtualKubelet/reflection/configuration/configmap_test.go
@@ -240,10 +240,24 @@ var _ = Describe("ConfigMap Reflection", func() {
 				CreateConfigMap(&local)
 			})
 
-			It("should succeed", func() { Expect(err).ToNot(HaveOccurred()) })
-			It("the remapped remote object should be created", func() {
-				_, err = client.CoreV1().ConfigMaps(RemoteNamespace).Get(ctx, forge.RemoteConfigMapName(name), metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
+			When("the reflection type is DenyList", func() {
+				It("should succeed", func() { Expect(err).ToNot(HaveOccurred()) })
+				It("the remapped remote object should be created", func() {
+					_, err = client.CoreV1().ConfigMaps(RemoteNamespace).Get(ctx, forge.RemoteConfigMapName(name), metav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+				})
+			})
+
+			When("the reflection type is AllowList", func() {
+				BeforeEach(func() {
+					reflectionType = consts.AllowList
+				})
+
+				It("should succeed", func() { Expect(err).ToNot(HaveOccurred()) })
+				It("the remapped remote object should be created", func() {
+					_, err = client.CoreV1().ConfigMaps(RemoteNamespace).Get(ctx, forge.RemoteConfigMapName(name), metav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+				})
 			})
 		})
 	})


### PR DESCRIPTION
# Description

This PR modifies the kubelet to always reflect the _kube-root-ca.crt_ ConfigMap in offloaded namespaces. 
The ConfigMap must always be reflected for the offloaded pods to work, even if using a restricting policy as the `AllowList` .


# How Has This Been Tested?

- [x] locally
- [x] e2e tests
- [x] unit tests
