### PR TITLE
Unit tests: envtest server new crds path

### DIFF
--- a/internal/auth-service/auth_service_suite_test.go
+++ b/internal/auth-service/auth_service_suite_test.go
@@ -60,7 +60,9 @@ var _ = BeforeSuite(func() {
 	_ = tMan.createToken()
 
 	var err error
-	cluster, _, err = testutil.NewTestCluster([]string{filepath.Join("..", "..", "deployments", "liqo", "crds")})
+	cluster, _, err = testutil.NewTestCluster([]string{
+		filepath.Join("..", "..", "deployments", "liqo", "charts", "liqo-crds", "crds"),
+	})
 	Expect(err).ToNot(HaveOccurred())
 
 	informerFactory := informers.NewSharedInformerFactoryWithOptions(cluster.GetClient(), 300*time.Second, informers.WithNamespace("default"))

--- a/internal/crdReplicator/crdReplicator_suite_test.go
+++ b/internal/crdReplicator/crdReplicator_suite_test.go
@@ -80,7 +80,9 @@ var _ = BeforeSuite(func() {
 	ctx, cancel = context.WithCancel(context.Background())
 
 	// The same cluster is used both as local and remote, using different namespaces.
-	clsrt, mgr, err := testutil.NewTestCluster([]string{filepath.Join("..", "..", "deployments", "liqo", "crds")})
+	clsrt, mgr, err := testutil.NewTestCluster([]string{
+		filepath.Join("..", "..", "deployments", "liqo", "charts", "liqo-crds", "crds"),
+	})
 	Expect(err).ToNot(HaveOccurred())
 	cluster = clsrt
 

--- a/internal/liqonet/network-manager/netcfgcreator/netcfgcreator_suite_test.go
+++ b/internal/liqonet/network-manager/netcfgcreator/netcfgcreator_suite_test.go
@@ -35,7 +35,9 @@ func TestForeignclusterwatcher(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	testutil.LogsToGinkgoWriter()
-	clstr, _, err := testutil.NewTestCluster([]string{filepath.Join("..", "..", "..", "..", "deployments", "liqo", "crds")})
+	clstr, _, err := testutil.NewTestCluster([]string{
+		filepath.Join("..", "..", "..", "..", "deployments", "liqo", "charts", "liqo-crds", "crds"),
+	})
 	Expect(err).ToNot(HaveOccurred())
 
 	testcluster = clstr

--- a/internal/liqonet/route-operator/overlayOperator_test.go
+++ b/internal/liqonet/route-operator/overlayOperator_test.go
@@ -393,7 +393,9 @@ func setupOverlayTestEnv() error {
 		return err
 	}
 	overlayEnvTest = &envtest.Environment{
-		CRDDirectoryPaths: []string{filepath.Join("..", "..", "..", "deployments", "liqo", "crds")},
+		CRDDirectoryPaths: []string{
+			filepath.Join("..", "..", "..", "deployments", "liqo", "charts", "liqo-crds", "crds"),
+		},
 	}
 	config, err := overlayEnvTest.Start()
 	if err != nil {

--- a/internal/liqonet/tunnel-operator/tunnel_operator_suite_test.go
+++ b/internal/liqonet/tunnel-operator/tunnel_operator_suite_test.go
@@ -120,7 +120,9 @@ var _ = BeforeSuite(func() {
 	err = netv1alpha1.AddToScheme(scheme.Scheme)
 	Expect(err).ShouldNot(HaveOccurred())
 	envTest = &envtest.Environment{
-		CRDDirectoryPaths: []string{filepath.Join("..", "..", "..", "deployments", "liqo", "crds")},
+		CRDDirectoryPaths: []string{
+			filepath.Join("..", "..", "..", "deployments", "liqo", "charts", "liqo-crds", "crds"),
+		},
 	}
 	config, err := envTest.Start()
 	Expect(err).ShouldNot(HaveOccurred())

--- a/pkg/identityManager/identityManager_suite_test.go
+++ b/pkg/identityManager/identityManager_suite_test.go
@@ -90,7 +90,9 @@ var _ = BeforeSuite(func() {
 	}, remoteCluster.ClusterID)
 
 	var err error
-	cluster, _, err = testutil.NewTestCluster([]string{filepath.Join("..", "..", "deployments", "liqo", "crds")})
+	cluster, _, err = testutil.NewTestCluster([]string{
+		filepath.Join("..", "..", "deployments", "liqo", "charts", "liqo-crds", "crds"),
+	})
 	Expect(err).ToNot(HaveOccurred())
 
 	client = cluster.GetClient()

--- a/pkg/liqo-controller-manager/foreign-cluster-operator/foreign-cluster-operator_test.go
+++ b/pkg/liqo-controller-manager/foreign-cluster-operator/foreign-cluster-operator_test.go
@@ -81,7 +81,9 @@ var _ = Describe("ForeignClusterOperator", func() {
 		ctx, cancel = context.WithCancel(context.Background())
 
 		var err error
-		cluster, mgr, err = testutil.NewTestCluster([]string{filepath.Join("..", "..", "..", "deployments", "liqo", "crds")})
+		cluster, mgr, err = testutil.NewTestCluster([]string{
+			filepath.Join("..", "..", "..", "deployments", "liqo", "charts", "liqo-crds", "crds")},
+		)
 		if err != nil {
 			By(err.Error())
 			os.Exit(1)

--- a/pkg/liqo-controller-manager/namespaceoffloading-controller/suite_test.go
+++ b/pkg/liqo-controller-manager/namespaceoffloading-controller/suite_test.go
@@ -131,7 +131,9 @@ var _ = BeforeSuite(func() {
 	testutil.LogsToGinkgoWriter()
 
 	homeClusterEnv = &envtest.Environment{
-		CRDDirectoryPaths: []string{filepath.Join("..", "..", "..", "deployments", "liqo", "crds")},
+		CRDDirectoryPaths: []string{
+			filepath.Join("..", "..", "..", "deployments", "liqo", "charts", "liqo-crds", "crds"),
+		},
 	}
 
 	var err error

--- a/pkg/liqo-controller-manager/resource-request-controller/suite_test.go
+++ b/pkg/liqo-controller-manager/resource-request-controller/suite_test.go
@@ -63,7 +63,7 @@ func createCluster() {
 	ctx, cancel = context.WithCancel(context.Background())
 	testEnv = &envtest.Environment{
 		CRDDirectoryPaths: []string{
-			filepath.Join("..", "..", "..", "deployments", "liqo", "crds"),
+			filepath.Join("..", "..", "..", "deployments", "liqo", "charts", "liqo-crds", "crds"),
 		},
 	}
 

--- a/pkg/liqo-controller-manager/resourceoffer-controller/resourceoffer_controller_test.go
+++ b/pkg/liqo-controller-manager/resourceoffer-controller/resourceoffer_controller_test.go
@@ -107,7 +107,9 @@ var _ = Describe("ResourceOffer Controller", func() {
 
 	BeforeEach(func() {
 		var err error
-		cluster, mgr, err = testutil.NewTestCluster([]string{filepath.Join("..", "..", "..", "deployments", "liqo", "crds")})
+		cluster, mgr, err = testutil.NewTestCluster([]string{
+			filepath.Join("..", "..", "..", "deployments", "liqo", "charts", "liqo-crds", "crds"),
+		})
 		if err != nil {
 			By(err.Error())
 			os.Exit(1)

--- a/pkg/liqo-controller-manager/shadowpod-controller/suite_test.go
+++ b/pkg/liqo-controller-manager/shadowpod-controller/suite_test.go
@@ -42,7 +42,9 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "deployments", "liqo", "crds")},
+		CRDDirectoryPaths: []string{
+			filepath.Join("..", "..", "..", "deployments", "liqo", "charts", "liqo-crds", "crds"),
+		},
 		ErrorIfCRDPathMissing: true,
 	}
 	cfg, err := testEnv.Start()

--- a/pkg/liqo-controller-manager/virtualnode-controller/suite_test.go
+++ b/pkg/liqo-controller-manager/virtualnode-controller/suite_test.go
@@ -92,7 +92,9 @@ func TestVirtualNode(t *testing.T) {
 var _ = BeforeSuite(func() {
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths: []string{filepath.Join("..", "..", "..", "deployments", "liqo", "crds")},
+		CRDDirectoryPaths: []string{
+			filepath.Join("..", "..", "..", "deployments", "liqo", "charts", "liqo-crds", "crds"),
+		},
 	}
 
 	ctx, cancel = context.WithCancel(context.Background())

--- a/pkg/tenantNamespace/tenantNamespace_suite_test.go
+++ b/pkg/tenantNamespace/tenantNamespace_suite_test.go
@@ -50,7 +50,9 @@ var _ = BeforeSuite(func() {
 	}
 
 	var err error
-	cluster, _, err = testutil.NewTestCluster([]string{filepath.Join("..", "..", "deployments", "liqo", "crds")})
+	cluster, _, err = testutil.NewTestCluster([]string{
+		filepath.Join("..", "..", "deployments", "liqo", "charts", "liqo-crds", "crds"),
+	})
 	Expect(err).ToNot(HaveOccurred())
 
 	namespaceManager = NewCachedManager(ctx, cluster.GetClient())

--- a/pkg/utils/authenticationtoken/authenticationtoken_test.go
+++ b/pkg/utils/authenticationtoken/authenticationtoken_test.go
@@ -50,7 +50,7 @@ func createCluster() {
 	ctx, cancel = context.WithCancel(context.Background())
 	testEnv = &envtest.Environment{
 		CRDDirectoryPaths: []string{
-			filepath.Join("..", "..", "..", "deployments", "liqo", "crds"),
+			filepath.Join("..", "..", "..", "deployments", "liqo", "charts", "liqo-crds", "crds"),
 		},
 	}
 

--- a/pkg/utils/csr/suite_test.go
+++ b/pkg/utils/csr/suite_test.go
@@ -40,7 +40,9 @@ var (
 var _ = BeforeSuite(func() {
 	ctx, cancel = context.WithCancel(context.Background())
 
-	cluster, _, err = testutil.NewTestCluster([]string{filepath.Join("..", "..", "..", "deployments", "liqo", "crds")})
+	cluster, _, err = testutil.NewTestCluster([]string{
+		filepath.Join("..", "..", "..", "deployments", "liqo", "charts", "liqo-crds", "crds"),
+	})
 	Expect(err).To(BeNil())
 })
 

--- a/pkg/virtualKubelet/liqoNodeProvider/nodeProvider_test.go
+++ b/pkg/virtualKubelet/liqoNodeProvider/nodeProvider_test.go
@@ -72,7 +72,9 @@ var _ = Describe("NodeProvider", func() {
 	BeforeEach(func() {
 		ctx, cancel = context.WithCancel(context.Background())
 
-		cluster, _, err = testutil.NewTestCluster([]string{filepath.Join("..", "..", "..", "deployments", "liqo", "crds")})
+		cluster, _, err = testutil.NewTestCluster([]string{
+			filepath.Join("..", "..", "..", "deployments", "liqo", "charts", "liqo-crds", "crds"),
+		})
 		Expect(err).To(BeNil())
 
 		client := kubernetes.NewForConfigOrDie(cluster.GetCfg())

--- a/test/integration/integration_suite_test.go
+++ b/test/integration/integration_suite_test.go
@@ -141,7 +141,9 @@ func initNatMappingController() error {
 		return err
 	}
 	envTest = &envtest.Environment{
-		CRDDirectoryPaths: []string{filepath.Join("..", "..", "deployments", "liqo", "crds")},
+		CRDDirectoryPaths: []string{
+			filepath.Join("..", "..", "deployments", "liqo", "charts", "liqo-crds", "crds"),
+		},
 	}
 	config, err := envTest.Start()
 	if err != nil {


### PR DESCRIPTION
# Description

This PR fixes the reference to the CRDs folder path in unit tests.