### PR TITLE
Helm-docs ignore CRDs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ generate: generate-controller generate-groups rbacs manifests fmt
 
 #generate helm documentation
 docs: helm-docs
-	$(HELM_DOCS) -t deployments/liqo/README.gotmpl deployments/liqo
+	$(HELM_DOCS) -t deployments/liqo/README.gotmpl -i deployments/liqo/.helmdocsignore -c deployments/liqo
 
 #run all tests
 test: unit e2e

--- a/deployments/liqo/.helmdocsignore
+++ b/deployments/liqo/.helmdocsignore
@@ -1,0 +1,1 @@
+deployments/liqo/charts

--- a/deployments/liqo/charts/liqo-crds/values.yaml
+++ b/deployments/liqo/charts/liqo-crds/values.yaml
@@ -1,0 +1,1 @@
+# This file is intentionally empty, since the CRDs do not need to be custoized.


### PR DESCRIPTION
# Description

This PR adds a `.helmdocsignore` to exclude CRDs sub chart from docs generation.
