### PR TITLE
PublicKey API: plural fix

### DIFF
--- a/apis/networking/v1alpha1/publickey_types.go
+++ b/apis/networking/v1alpha1/publickey_types.go
@@ -23,7 +23,7 @@ import (
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
 // PublicKeyResource the name of the publickey resources.
-var PublicKeyResource = "publickeys"
+var PublicKeyResource = "publickeies"
 
 // PublicKeyKind is the kind name used to register the PublicKey CRD.
 var PublicKeyKind = "PublicKey"
@@ -40,8 +40,11 @@ type PublicKeySpec struct {
 	PublicKey []byte `json:"publicKey,omitempty"`
 }
 
+// publickeies is used for resource name pluralization because k8s api do not manage false friends.
+// Waiting for this fix https://github.com/kubernetes-sigs/kubebuilder/pull/3408
+
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:categories=liqo
+// +kubebuilder:resource:categories=liqo,path=publickeies
 
 // PublicKey contains a public key data required by some interconnection technologies.
 type PublicKey struct {

--- a/deployments/liqo/charts/liqo-crds/crds/networking.liqo.io_publickeies.yaml
+++ b/deployments/liqo/charts/liqo-crds/crds/networking.liqo.io_publickeies.yaml
@@ -1,0 +1,47 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.13.0
+  name: publickeies.networking.liqo.io
+spec:
+  group: networking.liqo.io
+  names:
+    categories:
+    - liqo
+    kind: PublicKey
+    listKind: PublicKeyList
+    plural: publickeies
+    singular: publickey
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: PublicKey contains a public key data required by some interconnection
+          technologies.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: PublicKeySpec defines the desired state of PublicKey.
+            properties:
+              publicKey:
+                description: PublicKey contains the public key.
+                format: byte
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true


### PR DESCRIPTION
# Description

This PR fixes the plural resource name generation of `PublicKey` API.

As explained [here](https://github.com/kubernetes/kube-state-metrics/pull/2065), kubebuilder and kubernetes uses 2 different ways to generate plural names.

This is a temporary workaround, waiting for this PR https://github.com/kubernetes-sigs/kubebuilder/pull/3408