### PR TITLE
External Network: Wireguard MTU

### DIFF
--- a/pkg/liqoctl/rest/gatewayclient/types.go
+++ b/pkg/liqoctl/rest/gatewayclient/types.go
@@ -25,7 +25,7 @@ const (
 	DefaultGatewayType       = "networking.liqo.io/v1alpha1/wggatewayclienttemplates"
 	DefaultTemplateName      = "wireguard-client"
 	DefaultTemplateNamespace = "liqo"
-	DefaultMTU               = 1450
+	DefaultMTU               = 1340
 	DefaultProtocol          = "UDP"
 	DefaultWait              = false
 )

--- a/pkg/liqoctl/rest/gatewayserver/types.go
+++ b/pkg/liqoctl/rest/gatewayserver/types.go
@@ -28,7 +28,7 @@ const (
 	DefaultTemplateName      = "wireguard-server"
 	DefaultTemplateNamespace = "liqo"
 	DefaultServiceType       = corev1.ServiceTypeLoadBalancer
-	DefaultMTU               = 1450
+	DefaultMTU               = 1340
 	DefaultPort              = 51820
 	DefaultProxy             = false
 	DefaultWait              = false


### PR DESCRIPTION
# Description

This PR set up the wireguard default MTU. 

https://docs.tigera.io/calico/latest/networking/configuring/mtu#:~:text=Recommended%20MTU%20for%20overlay%20networking&text=WireGuard%20sets%20the%20Don't,network%20to%20avoid%20dropped%20packets.