### PR TITLE
External Network: liqoctl network fixes

### DIFF
--- a/cmd/liqoctl/cmd/network.go
+++ b/cmd/liqoctl/cmd/network.go
@@ -118,8 +118,6 @@ func newNetworkConnectCommand(ctx context.Context, options *network.Options) *co
 		fmt.Sprintf("Service type of the Gateway Server. Default: %s", gatewayserver.DefaultServiceType))
 	cmd.Flags().Int32Var(&options.ServerPort, "server-port", gatewayserver.DefaultPort,
 		fmt.Sprintf("Port of the Gateway Server. Default: %d", gatewayserver.DefaultPort))
-	cmd.Flags().IntVar(&options.ServerMTU, "server-mtu", gatewayserver.DefaultMTU,
-		fmt.Sprintf("MTU of the Gateway Server. Default: %d", gatewayserver.DefaultMTU))
 
 	// Client flags
 	cmd.Flags().StringVar(&options.ClientGatewayType, "client-type", gatewayclient.DefaultGatewayType,
@@ -128,10 +126,10 @@ func newNetworkConnectCommand(ctx context.Context, options *network.Options) *co
 		"Name of the Gateway Client template")
 	cmd.Flags().StringVar(&options.ClientTemplateNamespace, "client-template-namespace", gatewayclient.DefaultTemplateNamespace,
 		"Namespace of the Gateway Client template")
-	cmd.Flags().IntVar(&options.ClientMTU, "client-mtu", gatewayclient.DefaultMTU,
-		fmt.Sprintf("MTU of the Gateway Client. Default: %d", gatewayclient.DefaultMTU))
 
 	// Common flags
+	cmd.Flags().IntVar(&options.MTU, "mtu", gatewayserver.DefaultMTU,
+		fmt.Sprintf("MTU of the Gateway server and client. Default: %d", gatewayserver.DefaultMTU))
 	cmd.Flags().BoolVar(&options.DisableSharingKeys, "disable-sharing-keys", false, "Disable the sharing of public keys between the two clusters")
 	cmd.Flags().BoolVar(&options.Proxy, "proxy", gatewayserver.DefaultProxy, "Enable proxy for the Gateway Server")
 

--- a/pkg/liqoctl/rest/configuration/types.go
+++ b/pkg/liqoctl/rest/configuration/types.go
@@ -24,10 +24,10 @@ type Options struct {
 	createOptions   *rest.CreateOptions
 	generateOptions *rest.GenerateOptions
 
-	ClusterID    string
-	PodCIDR      args.CIDR
-	ExternalCIDR args.CIDR
-	Wait         bool
+	RemoteClusterID string
+	PodCIDR         args.CIDR
+	ExternalCIDR    args.CIDR
+	Wait            bool
 }
 
 var _ rest.API = &Options{}

--- a/pkg/liqoctl/rest/gatewayclient/create.go
+++ b/pkg/liqoctl/rest/gatewayclient/create.go
@@ -40,7 +40,7 @@ The GatewayClient resource is used to define a Gateway Client for the external n
 
 Examples:
   $ {{ .Executable }} create gatewayclient my-gw-client \
-  --cluster-id my-cluster-id \
+  --remote-cluster-id remote-cluster-id \
   --type networking.liqo.io/v1alpha1/wggatewayclients`
 
 // Create creates a GatewayClient.
@@ -70,7 +70,7 @@ func (o *Options) Create(ctx context.Context, options *rest.CreateOptions) *cobr
 	cmd.Flags().VarP(outputFormat, "output", "o",
 		"Output the resulting GatewayClient resource, instead of applying it. Supported formats: json, yaml")
 
-	cmd.Flags().StringVar(&o.ClusterID, "cluster-id", "", "The cluster ID of the remote cluster")
+	cmd.Flags().StringVar(&o.RemoteClusterID, "remote-cluster-id", "", "The cluster ID of the remote cluster")
 	cmd.Flags().StringVar(&o.GatewayType, "type", DefaultGatewayType, "Type of Gateway Client. Default: wireguard")
 	cmd.Flags().StringVar(&o.TemplateName, "template-name", DefaultTemplateName, "Name of the Gateway Client template")
 	cmd.Flags().StringVar(&o.TemplateNamespace, "template-namespace", DefaultTemplateNamespace, "Namespace of the Gateway Client template")
@@ -80,12 +80,12 @@ func (o *Options) Create(ctx context.Context, options *rest.CreateOptions) *cobr
 	cmd.Flags().StringVar(&o.Protocol, "protocol", DefaultProtocol, "Gateway Protocol")
 	cmd.Flags().BoolVar(&o.Wait, "wait", DefaultWait, "Wait for the Gateway Client to be ready")
 
-	runtime.Must(cmd.MarkFlagRequired("cluster-id"))
+	runtime.Must(cmd.MarkFlagRequired("remote-cluster-id"))
 	runtime.Must(cmd.MarkFlagRequired("addresses"))
 	runtime.Must(cmd.MarkFlagRequired("port"))
 
 	runtime.Must(cmd.RegisterFlagCompletionFunc("output", completion.Enumeration(outputFormat.Allowed)))
-	runtime.Must(cmd.RegisterFlagCompletionFunc("cluster-id", completion.ClusterIDs(ctx,
+	runtime.Must(cmd.RegisterFlagCompletionFunc("remote-cluster-id", completion.ClusterIDs(ctx,
 		o.createOptions.Factory, completion.NoLimit)))
 
 	return cmd

--- a/pkg/liqoctl/rest/gatewayclient/types.go
+++ b/pkg/liqoctl/rest/gatewayclient/types.go
@@ -34,7 +34,7 @@ const (
 type Options struct {
 	createOptions *rest.CreateOptions
 
-	ClusterID         string
+	RemoteClusterID   string
 	GatewayType       string
 	TemplateName      string
 	TemplateNamespace string
@@ -75,7 +75,7 @@ type ForgeOptions struct {
 func (o *Options) getForgeOptions() *ForgeOptions {
 	return &ForgeOptions{
 		KubeClient:        o.createOptions.KubeClient,
-		RemoteClusterID:   o.ClusterID,
+		RemoteClusterID:   o.RemoteClusterID,
 		GatewayType:       o.GatewayType,
 		TemplateName:      o.TemplateName,
 		TemplateNamespace: o.TemplateNamespace,

--- a/pkg/liqoctl/rest/gatewayserver/create.go
+++ b/pkg/liqoctl/rest/gatewayserver/create.go
@@ -40,7 +40,7 @@ The GatewayServer resource is used to define a Gateway Server for the external n
 
 Examples:
   $ {{ .Executable }} create gatewayserver my-gw-server \
-  --cluster-id my-cluster-id \
+  --remote-cluster-id remote-cluster-id \
   --type networking.liqo.io/v1alpha1/wggatewayservers --service-type LoadBalancer`
 
 // Create creates a GatewayServer.
@@ -70,7 +70,7 @@ func (o *Options) Create(ctx context.Context, options *rest.CreateOptions) *cobr
 	cmd.Flags().VarP(outputFormat, "output", "o",
 		"Output the resulting GatewayServer resource, instead of applying it. Supported formats: json, yaml")
 
-	cmd.Flags().StringVar(&o.ClusterID, "cluster-id", "", "The cluster ID of the remote cluster")
+	cmd.Flags().StringVar(&o.RemoteClusterID, "remote-cluster-id", "", "The cluster ID of the remote cluster")
 	cmd.Flags().StringVar(&o.GatewayType, "type", DefaultGatewayType,
 		"Type of Gateway Server. Leave empty to use default Liqo implementation of WireGuard")
 	cmd.Flags().StringVar(&o.TemplateName, "template-name", DefaultTemplateName, "Name of the Gateway Server template")
@@ -81,10 +81,10 @@ func (o *Options) Create(ctx context.Context, options *rest.CreateOptions) *cobr
 	cmd.Flags().BoolVar(&o.Proxy, "proxy", DefaultProxy, "Enable proxy for the Gateway Server")
 	cmd.Flags().BoolVar(&o.Wait, "wait", DefaultWait, "Wait for the Gateway Server to be ready")
 
-	runtime.Must(cmd.MarkFlagRequired("cluster-id"))
+	runtime.Must(cmd.MarkFlagRequired("remote-cluster-id"))
 
 	runtime.Must(cmd.RegisterFlagCompletionFunc("output", completion.Enumeration(outputFormat.Allowed)))
-	runtime.Must(cmd.RegisterFlagCompletionFunc("cluster-id", completion.ClusterIDs(ctx,
+	runtime.Must(cmd.RegisterFlagCompletionFunc("remote-cluster-id", completion.ClusterIDs(ctx,
 		o.createOptions.Factory, completion.NoLimit)))
 	runtime.Must(cmd.RegisterFlagCompletionFunc("service-type", completion.Enumeration(o.ServiceType.Allowed)))
 

--- a/pkg/liqoctl/rest/gatewayserver/types.go
+++ b/pkg/liqoctl/rest/gatewayserver/types.go
@@ -38,7 +38,7 @@ const (
 type Options struct {
 	createOptions *liqorest.CreateOptions
 
-	ClusterID         string
+	RemoteClusterID   string
 	GatewayType       string
 	TemplateName      string
 	TemplateNamespace string
@@ -82,7 +82,7 @@ type ForgeOptions struct {
 func (o *Options) getForgeOptions() *ForgeOptions {
 	return &ForgeOptions{
 		KubeClient:        o.createOptions.KubeClient,
-		RemoteClusterID:   o.ClusterID,
+		RemoteClusterID:   o.RemoteClusterID,
 		GatewayType:       o.GatewayType,
 		TemplateName:      o.TemplateName,
 		TemplateNamespace: o.TemplateNamespace,

--- a/pkg/liqoctl/rest/publickey/create.go
+++ b/pkg/liqoctl/rest/publickey/create.go
@@ -36,7 +36,7 @@ const liqoctlCreatePublicKeyLongHelp = `Create a PublicKey.
 The PublicKey resource is used to define a PublicKey for the external network.
 
 Examples:
-  $ {{ .Executable }} create publickey my-public-key --cluster-id my-cluster-id --type server --gateway-name my-gateway`
+  $ {{ .Executable }} create publickey my-public-key --remote-cluster-id remote-cluster-id --type server --gateway-name my-gateway`
 
 // Create creates a PublicKey.
 func (o *Options) Create(ctx context.Context, options *rest.CreateOptions) *cobra.Command {
@@ -65,14 +65,14 @@ func (o *Options) Create(ctx context.Context, options *rest.CreateOptions) *cobr
 	cmd.Flags().VarP(outputFormat, "output", "o",
 		"Output the resulting PublicKey resource, instead of applying it. Supported formats: json, yaml")
 
-	cmd.Flags().StringVar(&o.ClusterID, "cluster-id", "", "The cluster ID of the remote cluster")
+	cmd.Flags().StringVar(&o.RemoteClusterID, "remote-cluster-id", "", "The cluster ID of the remote cluster")
 	cmd.Flags().BytesBase64Var(&o.PublicKey, "public-key", nil, "The public key to be used for the Gateway")
 
-	runtime.Must(cmd.MarkFlagRequired("cluster-id"))
+	runtime.Must(cmd.MarkFlagRequired("remote-cluster-id"))
 	runtime.Must(cmd.MarkFlagRequired("public-key"))
 
 	runtime.Must(cmd.RegisterFlagCompletionFunc("output", completion.Enumeration(outputFormat.Allowed)))
-	runtime.Must(cmd.RegisterFlagCompletionFunc("cluster-id", completion.ClusterIDs(ctx,
+	runtime.Must(cmd.RegisterFlagCompletionFunc("remote-cluster-id", completion.ClusterIDs(ctx,
 		o.createOptions.Factory, completion.NoLimit)))
 
 	return cmd
@@ -81,7 +81,7 @@ func (o *Options) Create(ctx context.Context, options *rest.CreateOptions) *cobr
 func (o *Options) handleCreate(ctx context.Context) error {
 	opts := o.createOptions
 
-	pubKey, err := ForgePublicKey(opts.Name, opts.Namespace, o.ClusterID, o.PublicKey)
+	pubKey, err := ForgePublicKey(opts.Name, opts.Namespace, o.RemoteClusterID, o.PublicKey)
 	if err != nil {
 		opts.Printer.CheckErr(err)
 		return err
@@ -95,7 +95,7 @@ func (o *Options) handleCreate(ctx context.Context) error {
 	s := opts.Printer.StartSpinner("Creating publickey")
 
 	_, err = controllerutil.CreateOrUpdate(ctx, opts.CRClient, pubKey, func() error {
-		return MutatePublicKey(pubKey, o.ClusterID, o.PublicKey)
+		return MutatePublicKey(pubKey, o.RemoteClusterID, o.PublicKey)
 	})
 	if err != nil {
 		s.Fail("Unable to create publickey: %v", output.PrettyErr(err))

--- a/pkg/liqoctl/rest/publickey/generate.go
+++ b/pkg/liqoctl/rest/publickey/generate.go
@@ -73,7 +73,7 @@ func (o *Options) handleGenerate(ctx context.Context) error {
 
 	pubKey, err := ForgePublicKeyForRemoteCluster(ctx, opts.CRClient, opts.LiqoNamespace, opts.Namespace, o.GatewayName, o.GatewayType.Value)
 	if err != nil {
-		opts.Printer.CheckErr(fmt.Errorf("unable to forge PublicKey for remote cluster %q: %w", o.ClusterID, err))
+		opts.Printer.CheckErr(fmt.Errorf("unable to forge PublicKey for remote cluster %q: %w", o.RemoteClusterID, err))
 		return err
 	}
 

--- a/pkg/liqoctl/rest/publickey/types.go
+++ b/pkg/liqoctl/rest/publickey/types.go
@@ -25,10 +25,10 @@ type Options struct {
 	createOptions   *rest.CreateOptions
 	generateOptions *rest.GenerateOptions
 
-	ClusterID   string
-	GatewayName string
-	GatewayType *argsutils.StringEnum
-	PublicKey   []byte
+	RemoteClusterID string
+	GatewayName     string
+	GatewayType     *argsutils.StringEnum
+	PublicKey       []byte
 }
 
 var _ rest.API = &Options{}

--- a/pkg/liqoctl/rest/virtualnode/create.go
+++ b/pkg/liqoctl/rest/virtualnode/create.go
@@ -42,8 +42,8 @@ const liqoctlCreateVirtualNodeLongHelp = `Create a VirtualNode.
 The VirtualNode resource is used to represent a remote cluster in the local cluster.
 
 Examples:
-  $ {{ .Executable }} create virtualnode my-cluster --cluster-id my-cluster-id \
-  --cluster-name my-cluster-name --kubeconfig-secret-name my-cluster-kubeconfig --namespace my-cluster`
+  $ {{ .Executable }} create virtualnode my-cluster --remote-cluster-id remote-cluster-id \
+  --remote-cluster-name remote-cluster-name --remote-kubeconfig-secret-name remote-cluster-kubeconfig --namespace my-cluster`
 
 // Create creates a VirtualNode.
 func (o *Options) Create(ctx context.Context, options *rest.CreateOptions) *cobra.Command {
@@ -73,11 +73,11 @@ func (o *Options) Create(ctx context.Context, options *rest.CreateOptions) *cobr
 		"Output the resulting VirtualNode resource, instead of applying it. Supported formats: json, yaml")
 
 	// TODO: check validity of both cluster-id and cluster-name
-	cmd.Flags().StringVar(&o.remoteClusterIdentity.ClusterID, "cluster-id", "", "The cluster ID of the remote cluster")
-	cmd.Flags().StringVar(&o.remoteClusterIdentity.ClusterName, "cluster-name", "", "The cluster name of the remote cluster")
+	cmd.Flags().StringVar(&o.remoteClusterIdentity.ClusterID, "remote-cluster-id", "", "The cluster ID of the remote cluster")
+	cmd.Flags().StringVar(&o.remoteClusterIdentity.ClusterName, "remote-cluster-name", "", "The cluster name of the remote cluster")
 	cmd.Flags().BoolVar(&o.createNode, "create-node",
 		true, "Create a node to target the remote cluster (and schedule on it)")
-	cmd.Flags().StringVar(&o.kubeconfigSecretName, "kubeconfig-secret-name",
+	cmd.Flags().StringVar(&o.kubeconfigSecretName, "remote-kubeconfig-secret-name",
 		"", "The name of the secret containing the kubeconfig of the remote cluster")
 	cmd.Flags().StringVar(&o.cpu, "cpu", "2", "The amount of CPU available in the virtual node")
 	cmd.Flags().StringVar(&o.memory, "memory", "4Gi", "The amount of memory available in the virtual node")
@@ -86,16 +86,16 @@ func (o *Options) Create(ctx context.Context, options *rest.CreateOptions) *cobr
 		[]string{}, "The storage classes offered by the remote cluster. The first one will be used as default")
 	cmd.Flags().StringToStringVar(&o.labels, "labels", map[string]string{}, "The labels to be added to the virtual node")
 
-	runtime.Must(cmd.MarkFlagRequired("cluster-id"))
-	runtime.Must(cmd.MarkFlagRequired("cluster-name"))
-	runtime.Must(cmd.MarkFlagRequired("kubeconfig-secret-name"))
+	runtime.Must(cmd.MarkFlagRequired("remote-cluster-id"))
+	runtime.Must(cmd.MarkFlagRequired("remote-cluster-name"))
+	runtime.Must(cmd.MarkFlagRequired("remote-kubeconfig-secret-name"))
 
 	runtime.Must(cmd.RegisterFlagCompletionFunc("output", completion.Enumeration(outputFormat.Allowed)))
-	runtime.Must(cmd.RegisterFlagCompletionFunc("cluster-id", completion.ClusterIDs(ctx,
+	runtime.Must(cmd.RegisterFlagCompletionFunc("remote-cluster-id", completion.ClusterIDs(ctx,
 		o.createOptions.Factory, completion.NoLimit)))
-	runtime.Must(cmd.RegisterFlagCompletionFunc("cluster-name", completion.ClusterNames(ctx,
+	runtime.Must(cmd.RegisterFlagCompletionFunc("remote-cluster-name", completion.ClusterNames(ctx,
 		o.createOptions.Factory, completion.NoLimit)))
-	runtime.Must(cmd.RegisterFlagCompletionFunc("kubeconfig-secret-name", completion.KubeconfigSecretNames(ctx,
+	runtime.Must(cmd.RegisterFlagCompletionFunc("remote-kubeconfig-secret-name", completion.KubeconfigSecretNames(ctx,
 		o.createOptions.Factory, completion.NoLimit)))
 
 	return cmd

--- a/pkg/utils/getters/k8sGetters.go
+++ b/pkg/utils/getters/k8sGetters.go
@@ -347,3 +347,13 @@ func ListPublicKeysByLabel(ctx context.Context, cl client.Client, ns string, lSe
 	}
 	return list, err
 }
+
+// ListConnectionsByLabel returns the Connection resource with the given labels.
+func ListConnectionsByLabel(ctx context.Context, cl client.Client, ns string, lSelector labels.Selector) (*networkingv1alpha1.ConnectionList, error) {
+	list := &networkingv1alpha1.ConnectionList{}
+	err := cl.List(ctx, list, &client.ListOptions{LabelSelector: lSelector}, client.InNamespace(ns))
+	if err != nil {
+		return nil, err
+	}
+	return list, err
+}


### PR DESCRIPTION
# Description

This PR fixes some bugs and adds features for the `liqoctl network` command.

- option to wait for the Connections to be `Established` when issuing the `network connect` command
- install external network resources on liqo-tenants namespaces, unless the user explicitly sets the namespaces
- set ownerRef to Gateway on PublicKeys
- same MTU between Client and Server
- refactor `clusterID` to `remoteClusterID` when necessary
