### PR TITLE
Docs: add warning for api server when security mode is enabled

### DIFF
--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -9,3 +9,7 @@
     font-size: 0.85rem !important;
     line-height: unset !important;
 }
+
+.mb {
+    margin-bottom: 1.5rem !important;
+}

--- a/docs/usage/security-modes.md
+++ b/docs/usage/security-modes.md
@@ -47,6 +47,7 @@ Considering two clusters (C1 and C2) in which the former has started a peering t
 ```{figure} /_static/images/usage/security-modes/security-modes-schema.drawio.svg
 ---
 align: center
+class: mb
 ---
 
 ```
@@ -54,6 +55,7 @@ align: center
 ```{figure} /_static/images/usage/security-modes/matrix-full-p2p.drawio.svg
 ---
 align: center
+class: mb
 ---
 
 ```
@@ -71,6 +73,7 @@ Using the same rules and conventions already presented for the previous case (_f
 ```{figure} /_static/images/usage/security-modes/security-modes-schema.drawio.svg
 ---
 align: center
+class: mb
 ---
 
 ```
@@ -78,8 +81,17 @@ align: center
 ```{figure} /_static/images/usage/security-modes/matrix-traffic-segregation.drawio.svg
 ---
 align: center
+class: mb
 ---
 
+```
+
+``` {warning} Warning
+Currently, when this feature is enabled, your offloaded pods will not be able to reach the local cluster's API Server.
+This is due to the fact that the API Server is not exposed as a service, but it is directly reachable through the remapped cluster's IP address.
+This limitation will be removed in future.
+
+For the same reason, the [in-band](FeaturesPeeringInBandControlPlane) peer will not work in this mode.
 ```
 
 ## Selection of the security mode


### PR DESCRIPTION
# Description

This pr adds a warning in the documentation to warn users that the remote API server support is not available when the security mode feature is enabled.
