### PR TITLE
External Network: liqoctl network reset and disconnect

### DIFF
--- a/pkg/liqoctl/completion/completion.go
+++ b/pkg/liqoctl/completion/completion.go
@@ -283,8 +283,8 @@ func PVCs(ctx context.Context, f *factory.Factory, argsLimit int) FnType {
 	return common(ctx, f, argsLimit, retriever)
 }
 
-// Gateway returns a function to autocomplete Gateway (server or client) names.
-func Gateway(ctx context.Context, f *factory.Factory, argsLimit int) FnType {
+// Gateways returns a function to autocomplete Gateway (server or client) names.
+func Gateways(ctx context.Context, f *factory.Factory, argsLimit int) FnType {
 	retriever := func(ctx context.Context, f *factory.Factory) ([]string, error) {
 		var names []string
 
@@ -302,6 +302,79 @@ func Gateway(ctx context.Context, f *factory.Factory, argsLimit int) FnType {
 		}
 		for i := range gwClients.Items {
 			names = append(names, gwClients.Items[i].Name)
+		}
+
+		return names, nil
+	}
+
+	return common(ctx, f, argsLimit, retriever)
+}
+
+// GatewayServers returns a function to autocomplete GatewayServers names.
+func GatewayServers(ctx context.Context, f *factory.Factory, argsLimit int) FnType {
+	retriever := func(ctx context.Context, f *factory.Factory) ([]string, error) {
+		var gwServers networkingv1alpha1.GatewayServerList
+		if err := f.CRClient.List(ctx, &gwServers, client.InNamespace(f.Namespace)); err != nil {
+			return nil, err
+		}
+
+		var names []string
+		for i := range gwServers.Items {
+			names = append(names, gwServers.Items[i].Name)
+		}
+		return names, nil
+	}
+
+	return common(ctx, f, argsLimit, retriever)
+}
+
+// GatewayClients returns a function to autocomplete GatewayClients names.
+func GatewayClients(ctx context.Context, f *factory.Factory, argsLimit int) FnType {
+	retriever := func(ctx context.Context, f *factory.Factory) ([]string, error) {
+		var gwClients networkingv1alpha1.GatewayClientList
+		if err := f.CRClient.List(ctx, &gwClients, client.InNamespace(f.Namespace)); err != nil {
+			return nil, err
+		}
+
+		var names []string
+		for i := range gwClients.Items {
+			names = append(names, gwClients.Items[i].Name)
+		}
+		return names, nil
+	}
+
+	return common(ctx, f, argsLimit, retriever)
+}
+
+// PublicKeys returns a function to autocomplete PublicKeys names.
+func PublicKeys(ctx context.Context, f *factory.Factory, argsLimit int) FnType {
+	retriever := func(ctx context.Context, f *factory.Factory) ([]string, error) {
+		var publicKeys networkingv1alpha1.PublicKeyList
+		if err := f.CRClient.List(ctx, &publicKeys, client.InNamespace(f.Namespace)); err != nil {
+			return nil, err
+		}
+
+		var names []string
+		for i := range publicKeys.Items {
+			names = append(names, publicKeys.Items[i].Name)
+		}
+		return names, nil
+	}
+
+	return common(ctx, f, argsLimit, retriever)
+}
+
+// Configurations returns a function to autocomplete Configurations names.
+func Configurations(ctx context.Context, f *factory.Factory, argsLimit int) FnType {
+	retriever := func(ctx context.Context, f *factory.Factory) ([]string, error) {
+		var configurations networkingv1alpha1.ConfigurationList
+		if err := f.CRClient.List(ctx, &configurations, client.InNamespace(f.Namespace)); err != nil {
+			return nil, err
+		}
+
+		var names []string
+		for i := range configurations.Items {
+			names = append(names, configurations.Items[i].Name)
 		}
 		return names, nil
 	}

--- a/pkg/liqoctl/rest/configuration/generate.go
+++ b/pkg/liqoctl/rest/configuration/generate.go
@@ -19,20 +19,12 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	networkingv1alpha1 "github.com/liqotech/liqo/apis/networking/v1alpha1"
-	liqoconsts "github.com/liqotech/liqo/pkg/consts"
 	"github.com/liqotech/liqo/pkg/liqoctl/completion"
 	"github.com/liqotech/liqo/pkg/liqoctl/output"
 	"github.com/liqotech/liqo/pkg/liqoctl/rest"
-	liqoutils "github.com/liqotech/liqo/pkg/utils"
 	"github.com/liqotech/liqo/pkg/utils/args"
-	liqogetters "github.com/liqotech/liqo/pkg/utils/getters"
 )
 
 const liqoctlGenerateConfigHelp = `Generate the local network configuration to be applied to other clusters.`
@@ -71,7 +63,7 @@ func (o *Options) Generate(ctx context.Context, options *rest.GenerateOptions) *
 func (o *Options) handleGenerate(ctx context.Context) error {
 	opts := o.generateOptions
 
-	conf, err := ForgeLocalConfiguration(ctx, opts.CRClient, opts.Namespace, opts.LiqoNamespace)
+	conf, err := ForgeConfigurationForRemoteCluster(ctx, opts.CRClient, opts.Namespace, opts.LiqoNamespace)
 	if err != nil {
 		opts.Printer.CheckErr(fmt.Errorf("unable to forge local configuration: %w", err))
 		return err
@@ -79,43 +71,4 @@ func (o *Options) handleGenerate(ctx context.Context) error {
 
 	opts.Printer.CheckErr(o.output(conf))
 	return nil
-}
-
-// ForgeLocalConfiguration creates a local configuration starting from the cluster identity and the IPAM storage.
-func ForgeLocalConfiguration(ctx context.Context, cl client.Client, namespace, liqoNamespace string) (*networkingv1alpha1.Configuration, error) {
-	clusterIdentity, err := liqoutils.GetClusterIdentityWithControllerClient(ctx, cl, liqoNamespace)
-	if err != nil {
-		return nil, fmt.Errorf("unable to get cluster identity: %w", err)
-	}
-
-	ipamStorage, err := liqogetters.GetIPAMStorageByLabel(ctx, cl, labels.NewSelector())
-	if err != nil {
-		return nil, fmt.Errorf("unable to get IPAM storage: %w", err)
-	}
-
-	cnf := &networkingv1alpha1.Configuration{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       networkingv1alpha1.ConfigurationKind,
-			APIVersion: networkingv1alpha1.GroupVersion.String(),
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name: clusterIdentity.ClusterName,
-			Labels: map[string]string{
-				liqoconsts.RemoteClusterID: clusterIdentity.ClusterID,
-			},
-		},
-		Spec: networkingv1alpha1.ConfigurationSpec{
-			Remote: networkingv1alpha1.ClusterConfig{
-				CIDR: networkingv1alpha1.ClusterConfigCIDR{
-					Pod:      networkingv1alpha1.CIDR(ipamStorage.Spec.PodCIDR),
-					External: networkingv1alpha1.CIDR(ipamStorage.Spec.ExternalCIDR),
-				},
-			},
-		},
-	}
-
-	if namespace != "" && namespace != corev1.NamespaceDefault {
-		cnf.Namespace = namespace
-	}
-	return cnf, nil
 }

--- a/pkg/liqoctl/rest/configuration/types.go
+++ b/pkg/liqoctl/rest/configuration/types.go
@@ -23,6 +23,7 @@ import (
 type Options struct {
 	createOptions   *rest.CreateOptions
 	generateOptions *rest.GenerateOptions
+	deleteOptions   *rest.DeleteOptions
 
 	RemoteClusterID string
 	PodCIDR         args.CIDR
@@ -42,5 +43,6 @@ func (o *Options) APIOptions() *rest.APIOptions {
 	return &rest.APIOptions{
 		EnableCreate:   true,
 		EnableGenerate: true,
+		EnableDelete:   true,
 	}
 }

--- a/pkg/liqoctl/rest/configuration/utils.go
+++ b/pkg/liqoctl/rest/configuration/utils.go
@@ -1,0 +1,91 @@
+// Copyright 2019-2023 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package configuration
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
+	networkingv1alpha1 "github.com/liqotech/liqo/apis/networking/v1alpha1"
+	liqoconsts "github.com/liqotech/liqo/pkg/consts"
+	liqoutils "github.com/liqotech/liqo/pkg/utils"
+	liqogetters "github.com/liqotech/liqo/pkg/utils/getters"
+)
+
+// ForgeConfigurationForRemoteCluster forges a configuration of the local cluster to be applied to a remote cluster.
+// It retrieves the local configuration settings starting from the cluster identity and the IPAM storage.
+func ForgeConfigurationForRemoteCluster(ctx context.Context, cl client.Client,
+	namespace, liqoNamespace string) (*networkingv1alpha1.Configuration, error) {
+	clusterIdentity, err := liqoutils.GetClusterIdentityWithControllerClient(ctx, cl, liqoNamespace)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get cluster identity: %w", err)
+	}
+
+	ipamStorage, err := liqogetters.GetIPAMStorageByLabel(ctx, cl, labels.NewSelector())
+	if err != nil {
+		return nil, fmt.Errorf("unable to get IPAM storage: %w", err)
+	}
+
+	cnf := &networkingv1alpha1.Configuration{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       networkingv1alpha1.ConfigurationKind,
+			APIVersion: networkingv1alpha1.GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: DefaultConfigurationName(&clusterIdentity),
+			Labels: map[string]string{
+				liqoconsts.RemoteClusterID: clusterIdentity.ClusterID,
+			},
+		},
+		Spec: networkingv1alpha1.ConfigurationSpec{
+			Remote: networkingv1alpha1.ClusterConfig{
+				CIDR: networkingv1alpha1.ClusterConfigCIDR{
+					Pod:      networkingv1alpha1.CIDR(ipamStorage.Spec.PodCIDR),
+					External: networkingv1alpha1.CIDR(ipamStorage.Spec.ExternalCIDR),
+				},
+			},
+		},
+	}
+
+	if namespace != "" && namespace != corev1.NamespaceDefault {
+		cnf.Namespace = namespace
+	}
+	return cnf, nil
+}
+
+// DefaultConfigurationName returns the default name for a Configuration.
+func DefaultConfigurationName(remoteClusterIdentity *discoveryv1alpha1.ClusterIdentity) string {
+	return remoteClusterIdentity.ClusterName
+}
+
+// IsConfigurationStatusSet check if a Configuration is ready by checking if its status is correctly set.
+func IsConfigurationStatusSet(ctx context.Context, cl client.Client, name, namespace string) (bool, error) {
+	conf := &networkingv1alpha1.Configuration{}
+	if err := cl.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, conf); err != nil {
+		return false, err
+	}
+
+	return conf.Status.Remote != nil &&
+			conf.Status.Remote.CIDR.Pod.String() != "" &&
+			conf.Status.Remote.CIDR.External.String() != "",
+		nil
+}

--- a/pkg/liqoctl/rest/gatewayclient/types.go
+++ b/pkg/liqoctl/rest/gatewayclient/types.go
@@ -33,6 +33,7 @@ const (
 // Options encapsulates the arguments of the gatewayclient command.
 type Options struct {
 	createOptions *rest.CreateOptions
+	deleteOptions *rest.DeleteOptions
 
 	RemoteClusterID   string
 	GatewayType       string
@@ -56,6 +57,7 @@ func GatewayClient() rest.API {
 func (o *Options) APIOptions() *rest.APIOptions {
 	return &rest.APIOptions{
 		EnableCreate: true,
+		EnableDelete: true,
 	}
 }
 

--- a/pkg/liqoctl/rest/gatewayclient/utils.go
+++ b/pkg/liqoctl/rest/gatewayclient/utils.go
@@ -18,6 +18,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
 	networkingv1alpha1 "github.com/liqotech/liqo/apis/networking/v1alpha1"
 	liqoconsts "github.com/liqotech/liqo/pkg/consts"
 	enutils "github.com/liqotech/liqo/pkg/liqo-controller-manager/external-network/utils"
@@ -80,4 +81,9 @@ func MutateGatewayClient(gwClient *networkingv1alpha1.GatewayClient, o *ForgeOpt
 	}
 
 	return nil
+}
+
+// DefaultGatewayClientName returns the default name for a GatewayClient.
+func DefaultGatewayClientName(remoteClusterIdentity *discoveryv1alpha1.ClusterIdentity) string {
+	return remoteClusterIdentity.ClusterName
 }

--- a/pkg/liqoctl/rest/gatewayserver/delete.go
+++ b/pkg/liqoctl/rest/gatewayserver/delete.go
@@ -16,13 +16,64 @@ package gatewayserver
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	networkingv1alpha1 "github.com/liqotech/liqo/apis/networking/v1alpha1"
+	"github.com/liqotech/liqo/pkg/liqoctl/completion"
+	"github.com/liqotech/liqo/pkg/liqoctl/output"
 	"github.com/liqotech/liqo/pkg/liqoctl/rest"
 )
 
+const liqoctlDeleteGatewayServerLongHelp = `Delete a GatewayServer.
+
+Examples:
+  $ {{ .Executable }} delete gatewayserver my-gateway-server`
+
 // Delete deletes a GatewayServer.
-func (o *Options) Delete(_ context.Context, _ *rest.DeleteOptions) *cobra.Command {
-	panic("not implemented")
+func (o *Options) Delete(ctx context.Context, options *rest.DeleteOptions) *cobra.Command {
+	o.deleteOptions = options
+
+	cmd := &cobra.Command{
+		Use:     "gatewayserver",
+		Aliases: []string{"gatewayservers", "server", "servers", "gws"},
+		Short:   "Delete a GatewayServer",
+		Long:    liqoctlDeleteGatewayServerLongHelp,
+
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: completion.GatewayServers(ctx, o.deleteOptions.Factory, 1),
+
+		PreRun: func(cmd *cobra.Command, args []string) {
+			options.Name = args[0]
+			o.deleteOptions = options
+		},
+
+		Run: func(cmd *cobra.Command, args []string) {
+			output.ExitOnErr(o.handleDelete(ctx))
+		},
+	}
+
+	return cmd
+}
+
+func (o *Options) handleDelete(ctx context.Context) error {
+	opts := o.deleteOptions
+	s := opts.Printer.StartSpinner("Deleting GatewayServer")
+
+	gatewayServer := &networkingv1alpha1.GatewayServer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      opts.Name,
+			Namespace: opts.Namespace,
+		},
+	}
+	if err := o.deleteOptions.CRClient.Delete(ctx, gatewayServer); err != nil {
+		err = fmt.Errorf("unable to delete GatewayServer: %w", err)
+		s.Fail(err)
+		return err
+	}
+
+	s.Success("GatewayServer deleted")
+	return nil
 }

--- a/pkg/liqoctl/rest/gatewayserver/types.go
+++ b/pkg/liqoctl/rest/gatewayserver/types.go
@@ -18,7 +18,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 
-	liqorest "github.com/liqotech/liqo/pkg/liqoctl/rest"
+	"github.com/liqotech/liqo/pkg/liqoctl/rest"
 	argsutils "github.com/liqotech/liqo/pkg/utils/args"
 )
 
@@ -36,7 +36,8 @@ const (
 
 // Options encapsulates the arguments of the gatewayserver command.
 type Options struct {
-	createOptions *liqorest.CreateOptions
+	createOptions *rest.CreateOptions
+	deleteOptions *rest.DeleteOptions
 
 	RemoteClusterID   string
 	GatewayType       string
@@ -49,10 +50,10 @@ type Options struct {
 	Wait              bool
 }
 
-var _ liqorest.API = &Options{}
+var _ rest.API = &Options{}
 
 // GatewayServer returns the rest API for the gatewayserver command.
-func GatewayServer() liqorest.API {
+func GatewayServer() rest.API {
 	return &Options{
 		ServiceType: argsutils.NewEnum(
 			[]string{string(corev1.ServiceTypeLoadBalancer), string(corev1.ServiceTypeNodePort)}, string(DefaultServiceType)),
@@ -60,9 +61,10 @@ func GatewayServer() liqorest.API {
 }
 
 // APIOptions returns the APIOptions for the gatewayserver API.
-func (o *Options) APIOptions() *liqorest.APIOptions {
-	return &liqorest.APIOptions{
+func (o *Options) APIOptions() *rest.APIOptions {
+	return &rest.APIOptions{
 		EnableCreate: true,
+		EnableDelete: true,
 	}
 }
 

--- a/pkg/liqoctl/rest/gatewayserver/utils.go
+++ b/pkg/liqoctl/rest/gatewayserver/utils.go
@@ -18,6 +18,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
 	networkingv1alpha1 "github.com/liqotech/liqo/apis/networking/v1alpha1"
 	liqoconsts "github.com/liqotech/liqo/pkg/consts"
 	enutils "github.com/liqotech/liqo/pkg/liqo-controller-manager/external-network/utils"
@@ -77,4 +78,9 @@ func MutateGatewayServer(gwServer *networkingv1alpha1.GatewayServer, o *ForgeOpt
 	}
 
 	return nil
+}
+
+// DefaultGatewayServerName returns the default name for a GatewayServer.
+func DefaultGatewayServerName(remoteClusterIdentity *discoveryv1alpha1.ClusterIdentity) string {
+	return remoteClusterIdentity.ClusterName
 }

--- a/pkg/liqoctl/rest/publickey/delete.go
+++ b/pkg/liqoctl/rest/publickey/delete.go
@@ -16,13 +16,64 @@ package publickey
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	networkingv1alpha1 "github.com/liqotech/liqo/apis/networking/v1alpha1"
+	"github.com/liqotech/liqo/pkg/liqoctl/completion"
+	"github.com/liqotech/liqo/pkg/liqoctl/output"
 	"github.com/liqotech/liqo/pkg/liqoctl/rest"
 )
 
+const liqoctlDeletePublicKeyLongHelp = `Delete a PublicKey.
+
+Examples:
+  $ {{ .Executable }} delete publickey my-public-key`
+
 // Delete deletes a PublicKey.
-func (o *Options) Delete(_ context.Context, _ *rest.DeleteOptions) *cobra.Command {
-	panic("not implemented")
+func (o *Options) Delete(ctx context.Context, options *rest.DeleteOptions) *cobra.Command {
+	o.deleteOptions = options
+
+	cmd := &cobra.Command{
+		Use:     "publickey",
+		Aliases: []string{"publickeys", "publickeies"},
+		Short:   "Delete a PublicKey",
+		Long:    liqoctlDeletePublicKeyLongHelp,
+
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: completion.PublicKeys(ctx, o.deleteOptions.Factory, 1),
+
+		PreRun: func(cmd *cobra.Command, args []string) {
+			options.Name = args[0]
+			o.deleteOptions = options
+		},
+
+		Run: func(cmd *cobra.Command, args []string) {
+			output.ExitOnErr(o.handleDelete(ctx))
+		},
+	}
+
+	return cmd
+}
+
+func (o *Options) handleDelete(ctx context.Context) error {
+	opts := o.deleteOptions
+	s := opts.Printer.StartSpinner("Deleting PublicKey")
+
+	publicKey := &networkingv1alpha1.PublicKey{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      opts.Name,
+			Namespace: opts.Namespace,
+		},
+	}
+	if err := o.deleteOptions.CRClient.Delete(ctx, publicKey); err != nil {
+		err = fmt.Errorf("unable to delete PublicKey: %w", err)
+		s.Fail(err)
+		return err
+	}
+
+	s.Success("PublicKey deleted")
+	return nil
 }

--- a/pkg/liqoctl/rest/publickey/generate.go
+++ b/pkg/liqoctl/rest/publickey/generate.go
@@ -63,7 +63,7 @@ func (o *Options) Generate(ctx context.Context, options *rest.GenerateOptions) *
 
 	runtime.Must(cmd.RegisterFlagCompletionFunc("output", completion.Enumeration(outputFormat.Allowed)))
 	runtime.Must(cmd.RegisterFlagCompletionFunc("gateway-type", completion.Enumeration(o.GatewayType.Allowed)))
-	runtime.Must(cmd.RegisterFlagCompletionFunc("gateway-name", completion.Gateway(ctx, o.generateOptions.Factory, completion.NoLimit)))
+	runtime.Must(cmd.RegisterFlagCompletionFunc("gateway-name", completion.Gateways(ctx, o.generateOptions.Factory, completion.NoLimit)))
 
 	return cmd
 }

--- a/pkg/liqoctl/rest/publickey/types.go
+++ b/pkg/liqoctl/rest/publickey/types.go
@@ -24,6 +24,7 @@ import (
 type Options struct {
 	createOptions   *rest.CreateOptions
 	generateOptions *rest.GenerateOptions
+	deleteOptions   *rest.DeleteOptions
 
 	RemoteClusterID string
 	GatewayName     string
@@ -45,5 +46,6 @@ func (o *Options) APIOptions() *rest.APIOptions {
 	return &rest.APIOptions{
 		EnableCreate:   true,
 		EnableGenerate: true,
+		EnableDelete:   true,
 	}
 }

--- a/pkg/liqoctl/rest/publickey/utils.go
+++ b/pkg/liqoctl/rest/publickey/utils.go
@@ -22,6 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
 	networkingv1alpha1 "github.com/liqotech/liqo/apis/networking/v1alpha1"
 	"github.com/liqotech/liqo/pkg/consts"
 	liqoutils "github.com/liqotech/liqo/pkg/utils"
@@ -93,7 +94,7 @@ func ForgePublicKeyForRemoteCluster(ctx context.Context, cl client.Client,
 			APIVersion: networkingv1alpha1.GroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: clusterIdentity.ClusterName,
+			Name: DefaultPublicKeyName(&clusterIdentity),
 			Labels: map[string]string{
 				consts.RemoteClusterID:      clusterIdentity.ClusterID,
 				consts.GatewayResourceLabel: consts.GatewayResourceLabelValue,
@@ -139,4 +140,9 @@ func GetGatewaySecretReference(ctx context.Context, cl client.Client, namespace,
 	default:
 		return nil, fmt.Errorf("unable to forge PublicKey: invalid gateway type %q", gatewayType)
 	}
+}
+
+// DefaultPublicKeyName returns the default name of a PublicKey.
+func DefaultPublicKeyName(remoteClusterIdentity *discoveryv1alpha1.ClusterIdentity) string {
+	return remoteClusterIdentity.ClusterName
 }


### PR DESCRIPTION
# Description

This PR implements the liqoctl network reset and disconnect commands, and the REST Delete method for Configurations, PublicKeys, GatewayServers, GatewayClients

In addition:
- prevent running `liqoctl network connect` without issuing `liqoctl network init` first