### PR TITLE
External Network: ping disable

### DIFF
--- a/deployments/liqo/templates/liqo-wireguard-gateway-client-template.yaml
+++ b/deployments/liqo/templates/liqo-wireguard-gateway-client-template.yaml
@@ -41,6 +41,7 @@ spec:
                 - --mode=client
                 - --metrics-address=:8080
                 - --health-probe-bind-address=:8081
+                - --ping-enabled=true
                 - --ping-loss-threshold={{ .Values.networking.gateway.ping.lossThreshold }}
                 - --ping-interval={{ .Values.networking.gateway.ping.interval }}
                 - --ping-update-status-interval={{ .Values.networking.gateway.ping.updateStatusInterval }}

--- a/deployments/liqo/templates/liqo-wireguard-gateway-server-template.yaml
+++ b/deployments/liqo/templates/liqo-wireguard-gateway-server-template.yaml
@@ -55,9 +55,7 @@ spec:
                 - --mode=server
                 - --metrics-address=:8080
                 - --health-probe-bind-address=:8081
-                - --ping-loss-threshold=5
-                - --ping-interval=2s
-                - --ping-update-status-interval=10s
+                - --ping-enabled=true
                 - --ping-loss-threshold={{ .Values.networking.gateway.ping.lossThreshold }}
                 - --ping-interval={{ .Values.networking.gateway.ping.interval }}
                 - --ping-update-status-interval={{ .Values.networking.gateway.ping.updateStatusInterval }}

--- a/internal/liqonet/tunnel-operator/tunnel-operator.go
+++ b/internal/liqonet/tunnel-operator/tunnel-operator.go
@@ -89,7 +89,7 @@ type TunnelController struct {
 func NewTunnelController(ctx context.Context, wg *sync.WaitGroup,
 	podIP, namespace string, er record.EventRecorder, k8sClient k8s.Interface, cl client.Client,
 	readyClustersMutex *sync.Mutex, readyClusters map[string]struct{}, gatewayNetns, hostNetns ns.NetNS, mtu, port int,
-	updateStatusInterval time.Duration, securityMode liqoconst.SecurityModeType) (*TunnelController, error) {
+	updateStatusInterval time.Duration, securityMode liqoconst.SecurityModeType, connCheckOpts *conncheck.Options) (*TunnelController, error) {
 	tunnelEndpointFinalizer := liqoconst.LiqoGatewayOperatorName + "." + liqoconst.FinalizersSuffix
 	tc := &TunnelController{
 		Client:               cl,
@@ -146,7 +146,7 @@ func NewTunnelController(ctx context.Context, wg *sync.WaitGroup,
 			return fmt.Errorf("unable to enforce tunnel IP: %w", err)
 		}
 
-		wg.Connchecker, err = conncheck.NewConnChecker()
+		wg.Connchecker, err = conncheck.NewConnChecker(connCheckOpts)
 		if err != nil {
 			return fmt.Errorf("failed to create connchecker: %w", err)
 		}

--- a/pkg/gateway/connection/conncheck/options.go
+++ b/pkg/gateway/connection/conncheck/options.go
@@ -16,16 +16,19 @@ package conncheck
 
 import "time"
 
-const (
-	port     = 12345
-	buffSize = 1024
-)
-
-var (
+// Options contains the options for the wireguard interface.
+type Options struct {
+	// PingPort is the port used for the ping check.
+	PingPort int
+	// PingBufferSize is the size of the buffer used for the ping check.
+	PingBufferSize uint
 	// PingLossThreshold is the number of lost packets after which the connection check is considered as failed.
 	PingLossThreshold uint
 	// PingInterval is the interval at which the ping is sent.
 	PingInterval time.Duration
-	// PingUpdateStatusInterval is the interval at which the status is updated.
-	PingUpdateStatusInterval time.Duration
-)
+}
+
+// NewOptions returns a new Options struct.
+func NewOptions() *Options {
+	return &Options{}
+}

--- a/pkg/gateway/connection/conncheck/sender.go
+++ b/pkg/gateway/connection/conncheck/sender.go
@@ -34,7 +34,7 @@ type Sender struct {
 }
 
 // NewSender creates a new conncheck sender.
-func NewSender(ctx context.Context, clusterID string, cancel func(), conn *net.UDPConn, ip string) (*Sender, error) {
+func NewSender(ctx context.Context, opts *Options, clusterID string, cancel func(), conn *net.UDPConn, ip string) (*Sender, error) {
 	pip := net.ParseIP(ip)
 	if pip == nil {
 		return nil, fmt.Errorf("conncheck sender: invalid IP address %s", ip)
@@ -44,7 +44,7 @@ func NewSender(ctx context.Context, clusterID string, cancel func(), conn *net.U
 		clusterID: clusterID,
 		cancel:    cancel,
 		conn:      conn,
-		raddr:     net.UDPAddr{IP: pip, Port: port},
+		raddr:     net.UDPAddr{IP: pip, Port: opts.PingPort},
 	}, nil
 }
 

--- a/pkg/gateway/connection/k8s.go
+++ b/pkg/gateway/connection/k8s.go
@@ -24,15 +24,14 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	networkingv1alpha1 "github.com/liqotech/liqo/apis/networking/v1alpha1"
-	"github.com/liqotech/liqo/pkg/gateway/connection/conncheck"
 	timeutils "github.com/liqotech/liqo/pkg/utils/time"
 )
 
 // UpdateConnectionStatus updates the status of a connection.
-func UpdateConnectionStatus(ctx context.Context, cl client.Client, connection *networkingv1alpha1.Connection,
+func UpdateConnectionStatus(ctx context.Context, cl client.Client, opts *Options, connection *networkingv1alpha1.Connection,
 	value networkingv1alpha1.ConnectionStatusValue, latency time.Duration, timestamp time.Time) error {
 	if connection.Status.Value != value ||
-		timestamp.Sub(connection.Status.Latency.Timestamp.Time) > conncheck.PingUpdateStatusInterval {
+		timestamp.Sub(connection.Status.Latency.Timestamp.Time) > opts.PingUpdateStatusInterval {
 		if connection.Status.Value != value {
 			klog.Infof("changing connection %q status to %q",
 				client.ObjectKeyFromObject(connection).String(), value)

--- a/pkg/gateway/connection/options.go
+++ b/pkg/gateway/connection/options.go
@@ -1,0 +1,45 @@
+// Copyright 2019-2023 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connection
+
+import (
+	"time"
+
+	"github.com/liqotech/liqo/pkg/gateway"
+	"github.com/liqotech/liqo/pkg/gateway/connection/conncheck"
+)
+
+// Options contains the options for the wireguard interface.
+type Options struct {
+	// EnableConnectionController enables the connection controller.
+	EnableConnectionController bool
+	// GwOptions contains the options for the wireguard interface.
+	GwOptions *gateway.Options
+	// ConnCheckOptions contains the options for the connchecker.
+	ConnCheckOptions *conncheck.Options
+	// PingEnabled enables the ping check.
+	PingEnabled bool
+	// PingUpdateStatusInterval is the interval at which the status is updated.
+	PingUpdateStatusInterval time.Duration
+}
+
+// NewOptions returns a new Options struct.
+func NewOptions(gwOptions *gateway.Options,
+	conncheckOptions *conncheck.Options) *Options {
+	return &Options{
+		GwOptions:        gwOptions,
+		ConnCheckOptions: conncheckOptions,
+	}
+}


### PR DESCRIPTION
# Description

This PR gives the possibility to disable the ping from the gateway container's flags.
In case the ping is disabled the connection will be always true.

A flag to disable the connection controller is added. This should be useful in case the check of the connection is performed by the tunnel technology, instead of the connection controller. 