### PR TITLE
Updated wireguard-go to the latest commit

### DIFF
--- a/build/liqonet/Dockerfile
+++ b/build/liqonet/Dockerfile
@@ -1,11 +1,11 @@
 FROM golang:1.21.4 as goBuilder-wg
 
-ARG VERSION=0.0.20230223
-
+ARG VERSION=2e0774f246fb4fc1bd5cb44584d033038c89174e
 # change with "go install git.zx2c4.com/wireguard-go"
 # waiting for https://github.com/WireGuard/wireguard-go/pull/87 to be merged
-RUN git clone -b ${VERSION} https://git.zx2c4.com/wireguard-go
+RUN git clone https://git.zx2c4.com/wireguard-go
 WORKDIR /go/wireguard-go
+RUN git checkout $VERSION
 RUN CGO_ENABLED=0 make
 
 FROM golang:1.21.4 as goBuilder


### PR DESCRIPTION
# Description

Over the past year, the Tailscale team has made significant enhancements to the throughput achieved using `wireguard-go`. Details of these improvements can be found in their recent blog post [here](https://tailscale.com/blog/more-throughput).

Regrettably, these advancements have not yet been integrated into a stable release but are currently available only as commits in the repository. Notably, the latest changes were introduced in October 2023.

In this pull request, I have updated the version used by Liqo to include the latest commit available for `wireguard-go`. This update aims to integrate the recent improvements made by the Tailscale team.

