### PR TITLE
Network: firewall controller webhook uniqe table name

### DIFF
--- a/pkg/liqo-controller-manager/webhooks/firewallconfiguration/firewallconfiguration.go
+++ b/pkg/liqo-controller-manager/webhooks/firewallconfiguration/firewallconfiguration.go
@@ -90,10 +90,7 @@ func (w *webhookMutate) Handle(_ context.Context, req admission.Request) admissi
 		return admission.Errored(http.StatusBadRequest, err)
 	}
 
-	table := firewallConfiguration.Spec.Table
-	chains := table.Chains
-
-	generateRuleNames(chains)
+	generateRuleNames(firewallConfiguration.Spec.Table.Chains)
 
 	return w.CreatePatchResponse(&req, firewallConfiguration)
 }


### PR DESCRIPTION
# Description

This PR fixes a bug in webhook validation for firewall configuration table names

It depends on #2174 
