### PR TITLE
Network: refactoring template namespaces

### DIFF
--- a/cmd/liqoctl/cmd/network.go
+++ b/cmd/liqoctl/cmd/network.go
@@ -104,7 +104,7 @@ func newNetworkInitCommand(ctx context.Context, options *network.Options) *cobra
 			err := options.RunInit(ctx)
 			if err != nil {
 				options.LocalFactory.Printer.CheckErr(
-					fmt.Errorf("`network init` failed: issue `network reset` to cleanup the environment"))
+					fmt.Errorf("`network init` failed (error: %w). Issue `network reset` to cleanup the environment", err))
 			}
 			output.ExitOnErr(err)
 		},
@@ -143,7 +143,7 @@ func newNetworkConnectCommand(ctx context.Context, options *network.Options) *co
 			err := options.RunConnect(ctx)
 			if err != nil {
 				options.LocalFactory.Printer.CheckErr(
-					fmt.Errorf("`network connect` failed: issue `network disconnect` to cleanup the environment"))
+					fmt.Errorf("`network connect` failed (error: %w). Issue `network disconnect` to cleanup the environment", err))
 			}
 			output.ExitOnErr(err)
 		},
@@ -154,7 +154,7 @@ func newNetworkConnectCommand(ctx context.Context, options *network.Options) *co
 		"Type of Gateway Server. Leave empty to use default Liqo implementation of WireGuard")
 	cmd.Flags().StringVar(&options.ServerTemplateName, "server-template-name", gatewayserver.DefaultTemplateName,
 		"Name of the Gateway Server template")
-	cmd.Flags().StringVar(&options.ServerTemplateNamespace, "server-template-namespace", gatewayserver.DefaultTemplateNamespace,
+	cmd.Flags().StringVar(&options.ServerTemplateNamespace, "server-template-namespace", "",
 		"Namespace of the Gateway Server template")
 	cmd.Flags().Var(options.ServerServiceType, "server-service-type",
 		fmt.Sprintf("Service type of the Gateway Server. Default: %s", gatewayserver.DefaultServiceType))
@@ -170,7 +170,7 @@ func newNetworkConnectCommand(ctx context.Context, options *network.Options) *co
 		"Type of Gateway Client. Leave empty to use default Liqo implementation of WireGuard")
 	cmd.Flags().StringVar(&options.ClientTemplateName, "client-template-name", gatewayclient.DefaultTemplateName,
 		"Name of the Gateway Client template")
-	cmd.Flags().StringVar(&options.ClientTemplateNamespace, "client-template-namespace", gatewayclient.DefaultTemplateNamespace,
+	cmd.Flags().StringVar(&options.ClientTemplateNamespace, "client-template-namespace", "",
 		"Namespace of the Gateway Client template")
 
 	// Common flags

--- a/pkg/liqoctl/network/handler.go
+++ b/pkg/liqoctl/network/handler.go
@@ -298,6 +298,10 @@ func (o *Options) RunDisconnect(ctx context.Context) error {
 }
 
 func (o *Options) newGatewayServerForgeOptions(kubeClient kubernetes.Interface, remoteClusterID string) *gatewayserver.ForgeOptions {
+	if o.ServerTemplateNamespace == "" {
+		o.ServerTemplateNamespace = o.LocalFactory.LiqoNamespace
+	}
+
 	return &gatewayserver.ForgeOptions{
 		KubeClient:        kubeClient,
 		RemoteClusterID:   remoteClusterID,
@@ -315,6 +319,10 @@ func (o *Options) newGatewayServerForgeOptions(kubeClient kubernetes.Interface, 
 
 func (o *Options) newGatewayClientForgeOptions(kubeClient kubernetes.Interface, remoteClusterID string,
 	serverEndpoint *networkingv1alpha1.EndpointStatus) *gatewayclient.ForgeOptions {
+	if o.ClientTemplateNamespace == "" {
+		o.ClientTemplateNamespace = o.RemoteFactory.LiqoNamespace
+	}
+
 	return &gatewayclient.ForgeOptions{
 		KubeClient:        kubeClient,
 		RemoteClusterID:   remoteClusterID,

--- a/pkg/liqoctl/rest/gatewayclient/create.go
+++ b/pkg/liqoctl/rest/gatewayclient/create.go
@@ -73,7 +73,7 @@ func (o *Options) Create(ctx context.Context, options *rest.CreateOptions) *cobr
 	cmd.Flags().StringVar(&o.RemoteClusterID, "remote-cluster-id", "", "The cluster ID of the remote cluster")
 	cmd.Flags().StringVar(&o.GatewayType, "type", DefaultGatewayType, "Type of Gateway Client. Default: wireguard")
 	cmd.Flags().StringVar(&o.TemplateName, "template-name", DefaultTemplateName, "Name of the Gateway Client template")
-	cmd.Flags().StringVar(&o.TemplateNamespace, "template-namespace", DefaultTemplateNamespace, "Namespace of the Gateway Client template")
+	cmd.Flags().StringVar(&o.TemplateNamespace, "template-namespace", "", "Namespace of the Gateway Client template")
 	cmd.Flags().IntVar(&o.MTU, "mtu", DefaultMTU, "MTU of Gateway Client")
 	cmd.Flags().StringSliceVar(&o.Addresses, "addresses", []string{}, "Addresses of Gateway Server")
 	cmd.Flags().Int32Var(&o.Port, "port", 0, "Port of Gateway Server")

--- a/pkg/liqoctl/rest/gatewayclient/types.go
+++ b/pkg/liqoctl/rest/gatewayclient/types.go
@@ -22,12 +22,11 @@ import (
 
 // Default values for the gatewayclient command.
 const (
-	DefaultGatewayType       = "networking.liqo.io/v1alpha1/wggatewayclienttemplates"
-	DefaultTemplateName      = "wireguard-client"
-	DefaultTemplateNamespace = "liqo"
-	DefaultMTU               = 1340
-	DefaultProtocol          = "UDP"
-	DefaultWait              = false
+	DefaultGatewayType  = "networking.liqo.io/v1alpha1/wggatewayclienttemplates"
+	DefaultTemplateName = "wireguard-client"
+	DefaultMTU          = 1340
+	DefaultProtocol     = "UDP"
+	DefaultWait         = false
 )
 
 // Options encapsulates the arguments of the gatewayclient command.
@@ -75,6 +74,10 @@ type ForgeOptions struct {
 }
 
 func (o *Options) getForgeOptions() *ForgeOptions {
+	if o.TemplateNamespace == "" {
+		o.TemplateNamespace = o.createOptions.LiqoNamespace
+	}
+
 	return &ForgeOptions{
 		KubeClient:        o.createOptions.KubeClient,
 		RemoteClusterID:   o.RemoteClusterID,

--- a/pkg/liqoctl/rest/gatewayserver/create.go
+++ b/pkg/liqoctl/rest/gatewayserver/create.go
@@ -74,7 +74,7 @@ func (o *Options) Create(ctx context.Context, options *rest.CreateOptions) *cobr
 	cmd.Flags().StringVar(&o.GatewayType, "type", DefaultGatewayType,
 		"Type of Gateway Server. Leave empty to use default Liqo implementation of WireGuard")
 	cmd.Flags().StringVar(&o.TemplateName, "template-name", DefaultTemplateName, "Name of the Gateway Server template")
-	cmd.Flags().StringVar(&o.TemplateNamespace, "template-namespace", DefaultTemplateNamespace, "Namespace of the Gateway Server template")
+	cmd.Flags().StringVar(&o.TemplateNamespace, "template-namespace", "", "Namespace of the Gateway Server template")
 	cmd.Flags().Var(o.ServiceType, "service-type", fmt.Sprintf("Service type of Gateway Server. Default: %s", DefaultServiceType))
 	cmd.Flags().IntVar(&o.MTU, "mtu", DefaultMTU, "MTU of Gateway Server")
 	cmd.Flags().Int32Var(&o.Port, "port", DefaultPort, "Port of Gateway Server")

--- a/pkg/liqoctl/rest/gatewayserver/types.go
+++ b/pkg/liqoctl/rest/gatewayserver/types.go
@@ -25,14 +25,13 @@ import (
 
 // Default values for the gatewayserver command.
 const (
-	DefaultGatewayType       = "networking.liqo.io/v1alpha1/wggatewayservertemplates"
-	DefaultTemplateName      = "wireguard-server"
-	DefaultTemplateNamespace = "liqo"
-	DefaultServiceType       = corev1.ServiceTypeLoadBalancer
-	DefaultMTU               = 1340
-	DefaultPort              = 51820
-	DefaultProxy             = false
-	DefaultWait              = false
+	DefaultGatewayType  = "networking.liqo.io/v1alpha1/wggatewayservertemplates"
+	DefaultTemplateName = "wireguard-server"
+	DefaultServiceType  = corev1.ServiceTypeLoadBalancer
+	DefaultMTU          = 1340
+	DefaultPort         = 51820
+	DefaultProxy        = false
+	DefaultWait         = false
 )
 
 // Options encapsulates the arguments of the gatewayserver command.
@@ -87,6 +86,10 @@ type ForgeOptions struct {
 }
 
 func (o *Options) getForgeOptions() *ForgeOptions {
+	if o.TemplateNamespace == "" {
+		o.TemplateNamespace = o.createOptions.LiqoNamespace
+	}
+
 	return &ForgeOptions{
 		KubeClient:        o.createOptions.KubeClient,
 		RemoteClusterID:   o.RemoteClusterID,


### PR DESCRIPTION
# Description

This PR fixes a bug where the namespace of the wireguard templates where hardcoded to the default `liqo` namespace instead of using the actual liqo namespace provided by the `--liqo-namespace` (and `--remote-liqo-namespace`) flag.