### PR TITLE
Liqoctl: get cluster config

### DIFF
--- a/apis/core/v1beta1/foreigncluster_types.go
+++ b/apis/core/v1beta1/foreigncluster_types.go
@@ -26,7 +26,7 @@ type ClusterID string
 type ForeignClusterSpec struct {
 	// Foreign Cluster ID.
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="ClusterID field is immutable"
-	ClusterID ClusterID `json:"clusterID"`
+	ClusterID ClusterID `json:"clusterID" yaml:"clusterID"`
 }
 
 // RoleType represents the role of a ForeignCluster.

--- a/cmd/liqoctl/cmd/root.go
+++ b/cmd/liqoctl/cmd/root.go
@@ -36,6 +36,7 @@ import (
 	"github.com/liqotech/liqo/pkg/liqoctl/generate"
 	"github.com/liqotech/liqo/pkg/liqoctl/get"
 	"github.com/liqotech/liqo/pkg/liqoctl/rest"
+	"github.com/liqotech/liqo/pkg/liqoctl/rest/clusterconfig"
 	"github.com/liqotech/liqo/pkg/liqoctl/rest/configuration"
 	"github.com/liqotech/liqo/pkg/liqoctl/rest/gatewayclient"
 	"github.com/liqotech/liqo/pkg/liqoctl/rest/gatewayserver"
@@ -61,6 +62,7 @@ var liqoResources = []rest.APIProvider{
 	identity.Identity,
 	resourceslice.ResourceSlice,
 	kubeconfig.Kubeconfig,
+	clusterconfig.ClusterConfig,
 }
 
 func init() {

--- a/docs/advanced/peering/inter-cluster-network.md
+++ b/docs/advanced/peering/inter-cluster-network.md
@@ -230,8 +230,7 @@ spec:
 You can find *REMOTE_CLUSTER_ID* these parameters in the output of the
 
 ```bash
-kubectl get configmaps -n liqo liqo-clusterid-configmap \
-  --template {{.data.CLUSTER_ID}}
+liqoctl get cluster-config --cluster-id
 ```
 
 command in the remote cluster.

--- a/pkg/liqoctl/rest/clusterconfig/create.go
+++ b/pkg/liqoctl/rest/clusterconfig/create.go
@@ -1,0 +1,28 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clusterconfig
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+
+	"github.com/liqotech/liqo/pkg/liqoctl/rest"
+)
+
+// Create implements the create command.
+func (o *Options) Create(_ context.Context, _ *rest.CreateOptions) *cobra.Command {
+	panic("not implemented")
+}

--- a/pkg/liqoctl/rest/clusterconfig/delete.go
+++ b/pkg/liqoctl/rest/clusterconfig/delete.go
@@ -1,0 +1,28 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clusterconfig
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+
+	"github.com/liqotech/liqo/pkg/liqoctl/rest"
+)
+
+// Delete implements the delete command.
+func (o *Options) Delete(_ context.Context, _ *rest.DeleteOptions) *cobra.Command {
+	panic("not implemented")
+}

--- a/pkg/liqoctl/rest/clusterconfig/doc.go
+++ b/pkg/liqoctl/rest/clusterconfig/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package clusterconfig contains the logic to manage the cluster configuration.
+package clusterconfig

--- a/pkg/liqoctl/rest/clusterconfig/generate.go
+++ b/pkg/liqoctl/rest/clusterconfig/generate.go
@@ -1,0 +1,28 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clusterconfig
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+
+	"github.com/liqotech/liqo/pkg/liqoctl/rest"
+)
+
+// Generate implements the generate command.
+func (o *Options) Generate(_ context.Context, _ *rest.GenerateOptions) *cobra.Command {
+	panic("not implemented")
+}

--- a/pkg/liqoctl/rest/clusterconfig/get.go
+++ b/pkg/liqoctl/rest/clusterconfig/get.go
@@ -1,0 +1,81 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clusterconfig
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/util/runtime"
+
+	"github.com/liqotech/liqo/pkg/liqoctl/completion"
+	"github.com/liqotech/liqo/pkg/liqoctl/output"
+	"github.com/liqotech/liqo/pkg/liqoctl/rest"
+	liqoutils "github.com/liqotech/liqo/pkg/utils"
+	"github.com/liqotech/liqo/pkg/utils/args"
+)
+
+// Get implements the get command.
+func (o *Options) Get(ctx context.Context, options *rest.GetOptions) *cobra.Command {
+	outputFormat := args.NewEnum([]string{"json", "yaml"}, "json")
+
+	o.getOptions = options
+
+	cmd := &cobra.Command{
+		Use:     "cluster-config",
+		Aliases: []string{"cc"},
+		Short:   "Get the cluster configuration",
+		Long:    "Get the cluster configuration",
+		Args:    cobra.NoArgs,
+
+		PreRun: func(_ *cobra.Command, _ []string) {
+			options.OutputFormat = outputFormat.Value
+			o.getOptions = options
+		},
+
+		Run: func(_ *cobra.Command, _ []string) {
+			output.ExitOnErr(o.handleGet(ctx))
+		},
+	}
+
+	cmd.Flags().VarP(outputFormat, "output", "o",
+		"Output the resulting resource. Supported formats: json, yaml")
+
+	cmd.Flags().BoolVar(&o.onlyClusterID, "cluster-id", false, "Print only the cluster ID")
+
+	runtime.Must(cmd.RegisterFlagCompletionFunc("output", completion.Enumeration(outputFormat.Allowed)))
+
+	return cmd
+}
+
+func (o *Options) handleGet(ctx context.Context) error {
+	localClusterID, err := liqoutils.GetClusterIDWithControllerClient(ctx, o.getOptions.CRClient, o.getOptions.LiqoNamespace)
+	if err != nil {
+		return err
+	}
+
+	clusterConfig := ClusterConfigType{
+		ClusterID: localClusterID,
+	}
+
+	switch {
+	case o.onlyClusterID:
+		fmt.Print(clusterConfig.ClusterID)
+		return nil
+	default:
+		return o.output(&clusterConfig)
+	}
+}

--- a/pkg/liqoctl/rest/clusterconfig/types.go
+++ b/pkg/liqoctl/rest/clusterconfig/types.go
@@ -1,0 +1,71 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clusterconfig
+
+import (
+	"fmt"
+
+	liqov1beta1 "github.com/liqotech/liqo/apis/core/v1beta1"
+	"github.com/liqotech/liqo/pkg/liqoctl/rest"
+)
+
+// ClusterConfigType is the type of the cluster configuration.
+// This is the object that will be printed to the user.
+//
+//nolint:revive // It is a standard name.
+type ClusterConfigType struct {
+	ClusterID liqov1beta1.ClusterID `json:"clusterID" yaml:"clusterID"`
+}
+
+// Options encapsulates the arguments of the configuration command.
+type Options struct {
+	getOptions *rest.GetOptions
+
+	onlyClusterID bool
+}
+
+var _ rest.API = &Options{}
+
+// ClusterConfig returns the rest API for the cluster configuration command.
+func ClusterConfig() rest.API {
+	return &Options{}
+}
+
+// APIOptions returns the APIOptions for the cluster configuration API.
+func (o *Options) APIOptions() *rest.APIOptions {
+	return &rest.APIOptions{
+		EnableGet: true,
+	}
+}
+
+// output implements the logic to output the cluster configuration.
+func (o *Options) output(cc *ClusterConfigType) error {
+	var outputFormat string
+	switch {
+	case o.getOptions != nil:
+		outputFormat = o.getOptions.OutputFormat
+	default:
+		return fmt.Errorf("unable to determine output format")
+	}
+
+	switch outputFormat {
+	case "yaml":
+		return rest.OutputYAML(cc)
+	case "json":
+		return rest.OutputJSON(cc)
+	default:
+		return fmt.Errorf("unknown output format: %s", outputFormat)
+	}
+}

--- a/pkg/liqoctl/rest/clusterconfig/update.go
+++ b/pkg/liqoctl/rest/clusterconfig/update.go
@@ -1,0 +1,28 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clusterconfig
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+
+	"github.com/liqotech/liqo/pkg/liqoctl/rest"
+)
+
+// Update implements the update command.
+func (o *Options) Update(_ context.Context, _ *rest.UpdateOptions) *cobra.Command {
+	panic("not implemented")
+}


### PR DESCRIPTION
# Description

This pr adds the possibility to retrieve information about the local cluster (e.g., cluster-id) with liqoctl.

You can retrieve:

* a `json` or `yaml` containing all gathered information
* a string containing the clusterID with the `--cluster-id` flag