### PR TITLE
Network: disable legacy networking stack

### DIFF
--- a/deployments/liqo/README.md
+++ b/deployments/liqo/README.md
@@ -111,7 +111,6 @@
 | ipam.internal.pod.labels | object | `{}` | Labels for the IPAM pod. |
 | ipam.internal.pod.resources | object | `{"limits":{},"requests":{}}` | Resource requests and limits (https://kubernetes.io/docs/user-guide/compute-resources/) for the proxy pod. |
 | ipam.internal.replicas | int | `1` | The number of IPAM instances to run, which can be increased for active/passive high availability. |
-| ipam.legacy | bool | `false` |  |
 | ipam.podCIDR | string | `""` | The subnet used by the pods in your cluster, in CIDR notation (e.g., 10.0.0.0/16). |
 | ipam.reservedSubnets | list | `[]` | List of IP subnets that do not have to be used by Liqo. Liqo can perform automatic IP address remapping when a remote cluster is peering with you, e.g., in case IP address spaces (e.g., PodCIDR) overlaps. In order to prevent IP conflicting between locally used private subnets in your infrastructure and private subnets belonging to remote clusters you need tell liqo the subnets used in your cluster. E.g if your cluster nodes belong to the 192.168.2.0/24 subnet, then you should add that subnet to the reservedSubnets. PodCIDR and serviceCIDR used in the local cluster are automatically added to the reserved list. |
 | ipam.serviceCIDR | string | `""` | The subnet used by the services in you cluster, in CIDR notation (e.g., 172.16.0.0/16). |
@@ -144,6 +143,7 @@
 | networking.internal | bool | `true` | Use the default Liqo network manager. |
 | networking.iptables | object | `{"mode":"nf_tables"}` | Iptables configuration tuning. |
 | networking.iptables.mode | string | `"nf_tables"` | Select the iptables mode to use. Possible values are "legacy" and "nf_tables". |
+| networking.legacy | bool | `false` | Set to "false" to install the legacy networking stack. |
 | networking.mtu | int | `1340` | Set the MTU for the interfaces managed by liqo: vxlan, tunnel and veth interfaces. The value is used by the gateway and route operators. The default value is configured to ensure correct behavior regardless of the combination of the underlying environments (e.g., cloud providers). This guarantees improved compatibility at the cost of possible limited performance drops. |
 | networking.reflectIPs | bool | `true` | Reflect pod IPs and EnpointSlices to the remote clusters. |
 | networking.securityMode | string | `"FullPodToPod"` | Select the mode to enforce security on connectivity among clusters. Possible values are "FullPodToPod" and "IntraClusterTrafficSegregation"  |

--- a/deployments/liqo/templates/liqo-controller-manager-deployment.yaml
+++ b/deployments/liqo/templates/liqo-controller-manager-deployment.yaml
@@ -119,7 +119,7 @@ spec:
           {{- else if not .Values.networking.internal }}
           - --ipam-server=
           - --disable-internal-network
-          {{- else if .Values.ipam.legacy }}
+          {{- else if .Values.networking.legacy }}
           - --ipam-server={{ include "liqo.prefixedName" $netManagerConfig }}.{{ .Release.Namespace }}:6000
           {{- else }}
           - --ipam-server={{ include "liqo.prefixedName" $ipamConfig }}.{{ .Release.Namespace }}:6000

--- a/deployments/liqo/templates/liqo-ipam-deployment.yaml
+++ b/deployments/liqo/templates/liqo-ipam-deployment.yaml
@@ -1,4 +1,4 @@
-{{- if and (.Values.networking.internal) (not .Values.ipam.external.enabled) (not .Values.ipam.legacy ) }}
+{{- if and (.Values.networking.internal) (not .Values.ipam.external.enabled) (not .Values.networking.legacy ) }}
 
 {{- $ipamConfig := (merge (dict "name" "ipam" "module" "ipam" "version" .Values.ipam.internal.image.version) .) -}}
 {{- $ha := (gt .Values.ipam.internal.replicas 1.0) -}}

--- a/deployments/liqo/templates/liqo-ipam-rbac.yaml
+++ b/deployments/liqo/templates/liqo-ipam-rbac.yaml
@@ -1,7 +1,7 @@
 ---
 {{- $ipamConfig := (merge (dict "name" "ipam" "module" "ipam") .) -}}
 
-{{- if and (.Values.networking.internal) (not .Values.ipam.external.enabled) (not .Values.ipam.legacy ) }}
+{{- if and (.Values.networking.internal) (not .Values.ipam.external.enabled) (not .Values.networking.legacy ) }}
 
 apiVersion: v1
 kind: ServiceAccount

--- a/deployments/liqo/templates/liqo-ipam-service.yaml
+++ b/deployments/liqo/templates/liqo-ipam-service.yaml
@@ -1,4 +1,4 @@
-{{- if and (.Values.networking.internal) (not .Values.ipam.external.enabled) (not .Values.ipam.legacy ) }}
+{{- if and (.Values.networking.internal) (not .Values.ipam.external.enabled) (not .Values.networking.legacy ) }}
 
 {{- $ipamConfig := (merge (dict "name" "ipam" "module" "ipam") .) -}}
 {{- $ha := (gt .Values.ipam.internal.replicas 1.0) -}}

--- a/deployments/liqo/templates/liqo-legacy-gateway-deployment.yaml
+++ b/deployments/liqo/templates/liqo-legacy-gateway-deployment.yaml
@@ -1,7 +1,7 @@
 ---
 {{- $gatewayConfig := (merge (dict "name" "legacy-gateway" "module" "networking") .) -}}
 
-{{- if .Values.networking.internal }}
+{{- if and (.Values.networking.internal) (.Values.networking.legacy) }}
 
 apiVersion: apps/v1
 kind: Deployment

--- a/deployments/liqo/templates/liqo-legacy-gateway-rbac.yaml
+++ b/deployments/liqo/templates/liqo-legacy-gateway-rbac.yaml
@@ -1,7 +1,7 @@
 ---
 {{- $gatewayConfig := (merge (dict "name" "legacy-gateway" "module" "networking") .) -}}
 
-{{- if .Values.networking.internal }}
+{{- if and (.Values.networking.internal) (.Values.networking.legacy) }}
 
 apiVersion: v1
 kind: ServiceAccount

--- a/deployments/liqo/templates/liqo-legacy-gateway-service.yaml
+++ b/deployments/liqo/templates/liqo-legacy-gateway-service.yaml
@@ -1,7 +1,7 @@
 ---
 {{- $gatewayConfig := (merge (dict "name" "legacy-gateway" "module" "networking") .) -}}
 
-{{- if .Values.networking.internal }}
+{{- if and (.Values.networking.internal) (.Values.networking.legacy) }}
 
 apiVersion: v1
 kind: Service

--- a/deployments/liqo/templates/liqo-legacy-gateway-servicemonitor.yaml
+++ b/deployments/liqo/templates/liqo-legacy-gateway-servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.networking.internal }}
+{{- if and (.Values.networking.internal) (.Values.networking.legacy) }}
 
 ---
 {{- $gatewayMetricsConfig := (merge (dict "name" "legacy-gateway-metrics" "module" "networking") .) -}}

--- a/deployments/liqo/templates/liqo-network-manager-deployment.yaml
+++ b/deployments/liqo/templates/liqo-network-manager-deployment.yaml
@@ -1,7 +1,7 @@
 ---
 {{- $netManagerConfig := (merge (dict "name" "network-manager" "module" "networking") .) -}}
 
-{{- if and (.Values.networking.internal) (.Values.ipam.legacy) }}
+{{- if and (.Values.networking.internal) (.Values.networking.legacy) }}
 
 apiVersion: apps/v1
 kind: Deployment

--- a/deployments/liqo/templates/liqo-network-manager-rbac.yaml
+++ b/deployments/liqo/templates/liqo-network-manager-rbac.yaml
@@ -1,7 +1,7 @@
 ---
 {{- $netManagerConfig := (merge (dict "name" "network-manager" "module" "networking") .) -}}
 
-{{- if and (.Values.networking.internal) (.Values.ipam.legacy) }}
+{{- if and (.Values.networking.internal) (.Values.networking.legacy) }}
 
 apiVersion: v1
 kind: ServiceAccount

--- a/deployments/liqo/templates/liqo-network-manager-service.yaml
+++ b/deployments/liqo/templates/liqo-network-manager-service.yaml
@@ -1,7 +1,7 @@
 ---
 {{- $netManagerConfig := (merge (dict "name" "network-manager" "module" "networking") .) -}}
 
-{{- if and (.Values.networking.internal) (.Values.ipam.legacy) }}
+{{- if and (.Values.networking.internal) (.Values.networking.legacy) }}
 
 apiVersion: v1
 kind: Service

--- a/deployments/liqo/templates/liqo-route-daemonset.yaml
+++ b/deployments/liqo/templates/liqo-route-daemonset.yaml
@@ -1,7 +1,7 @@
 ---
 {{- $routeConfig := (merge (dict "name" "route" "module" "networking") .) -}}
 
-{{- if .Values.networking.internal }}
+{{- if and (.Values.networking.internal) (.Values.networking.legacy) }}
 
 apiVersion: apps/v1
 kind: DaemonSet

--- a/deployments/liqo/templates/liqo-route-rbac.yaml
+++ b/deployments/liqo/templates/liqo-route-rbac.yaml
@@ -1,7 +1,7 @@
 ---
 {{- $routeConfig := (merge (dict "name" "route" "module" "networking") .) -}}
 
-{{- if .Values.networking.internal }}
+{{- if and (.Values.networking.internal) (.Values.networking.legacy) }}
 
 apiVersion: v1
 kind: ServiceAccount

--- a/deployments/liqo/values.yaml
+++ b/deployments/liqo/values.yaml
@@ -24,6 +24,8 @@ apiServer:
   trustedCA: false
 
 networking:
+  # -- Set to "false" to install the legacy networking stack.
+  legacy: false
   # -- Use the default Liqo network manager.
   internal: true
   # -- Reflect pod IPs and EnpointSlices to the remote clusters.
@@ -187,7 +189,6 @@ controllerManager:
     enableNodeFailureController: false
 
 ipam:
-  legacy: false
   external:
     # -- Use an external IPAM to allocate the IP addresses for the pods. Enabling it will disable the internal IPAM.
     enabled: false


### PR DESCRIPTION
# Description

This PR allows disabling the entire legacy networking stack with the Helm value `networking.legacy`. 
Set to `false` to install the legacy networking stack.
