### PR TITLE
Customize image name and version on new networking containers

### DIFF
--- a/deployments/liqo/README.md
+++ b/deployments/liqo/README.md
@@ -71,7 +71,8 @@
 | discovery.pod.extraArgs | list | `[]` | Extra arguments for the discovery pod. |
 | discovery.pod.labels | object | `{}` | Labels for the discovery pod. |
 | discovery.pod.resources | object | `{"limits":{},"requests":{}}` | Resource requests and limits (https://kubernetes.io/docs/user-guide/compute-resources/) for the discovery pod. |
-| fabric.imageName | string | `"ghcr.io/liqotech/fabric"` | Image repository for the fabric pod. |
+| fabric.image.name | string | `"ghcr.io/liqotech/fabric"` | Image repository for the fabric pod. |
+| fabric.image.version | string | `""` | Custom version for the fabric image. If not specified, the global tag is used. |
 | fabric.pod.annotations | object | `{}` | Annotations for the fabric pod. |
 | fabric.pod.extraArgs | list | `[]` | Extra arguments for the fabric pod. |
 | fabric.pod.labels | object | `{}` | Labels for the fabric pod. |
@@ -137,15 +138,21 @@
 | networkManager.pod.labels | object | `{}` | Labels for the networkManager pod. |
 | networkManager.pod.resources | object | `{"limits":{},"requests":{}}` | Resource requests and limits (https://kubernetes.io/docs/user-guide/compute-resources/) for the networkManager pod. |
 | networking.clientResources | list | `[{"apiVersion":"networking.liqo.io/v1alpha1","resource":"wggatewayclients"}]` | Set the list of resources that implement the GatewayClient |
-| networking.gateway | object | `{"ping":{"interval":"2s","lossThreshold":5,"updateStatusInterval":"10s"},"replicas":1,"server":{"service":{"allocateLoadBalancerNodePorts":""}}}` | Set the options for gateway templates |
-| networking.gateway.ping | object | `{"interval":"2s","lossThreshold":5,"updateStatusInterval":"10s"}` | Set the options to configure the gateway ping used to check connection |
-| networking.gateway.ping.interval | string | `"2s"` | Set the interval between two consecutive pings |
-| networking.gateway.ping.lossThreshold | int | `5` | Set the number of consecutive pings that must fail to consider the connection as lost |
-| networking.gateway.ping.updateStatusInterval | string | `"10s"` | Set the interval at which the connection resource status is updated |
-| networking.gateway.replicas | int | `1` | Set the number of replicas for the gateway deployments |
-| networking.gateway.server | object | `{"service":{"allocateLoadBalancerNodePorts":""}}` | Set the options to configure the gateway server |
-| networking.gateway.server.service | object | `{"allocateLoadBalancerNodePorts":""}` | Set the options to configure the server service |
-| networking.gateway.server.service.allocateLoadBalancerNodePorts | string | `""` | Set to "false" if you expose the gateway service as LoadBalancer and you do not want to create also a NodePort associated to it (Note: this setting is useful only on cloud providers that support this feature). |
+| networking.gatewayTemplates | object | `{"container":{"gateway":{"image":{"name":"ghcr.io/liqotech/gateway","version":""}},"geneve":{"image":{"name":"ghcr.io/liqotech/gateway/geneve","version":""}},"wireguard":{"image":{"name":"ghcr.io/liqotech/gateway/wireguard","version":""}}},"ping":{"interval":"2s","lossThreshold":5,"updateStatusInterval":"10s"},"replicas":1,"server":{"service":{"allocateLoadBalancerNodePorts":""}}}` | Set the options for the default gateway (server/client) templates. The default templates use a WireGuard implementation to connect the gateway of the clusters. These options are used to configure only the default templates and should not be considered if a custom template is used. |
+| networking.gatewayTemplates.container.gateway.image.name | string | `"ghcr.io/liqotech/gateway"` | Image repository for the gateway container. |
+| networking.gatewayTemplates.container.gateway.image.version | string | `""` | Custom version for the gateway image. If not specified, the global tag is used. |
+| networking.gatewayTemplates.container.geneve.image.name | string | `"ghcr.io/liqotech/gateway/geneve"` | Image repository for the geneve container. |
+| networking.gatewayTemplates.container.geneve.image.version | string | `""` | Custom version for the geneve image. If not specified, the global tag is used. |
+| networking.gatewayTemplates.container.wireguard.image.name | string | `"ghcr.io/liqotech/gateway/wireguard"` | Image repository for the wireguard container. |
+| networking.gatewayTemplates.container.wireguard.image.version | string | `""` | Custom version for the wireguard image. If not specified, the global tag is used. |
+| networking.gatewayTemplates.ping | object | `{"interval":"2s","lossThreshold":5,"updateStatusInterval":"10s"}` | Set the options to configure the gateway ping used to check connection |
+| networking.gatewayTemplates.ping.interval | string | `"2s"` | Set the interval between two consecutive pings |
+| networking.gatewayTemplates.ping.lossThreshold | int | `5` | Set the number of consecutive pings that must fail to consider the connection as lost |
+| networking.gatewayTemplates.ping.updateStatusInterval | string | `"10s"` | Set the interval at which the connection resource status is updated |
+| networking.gatewayTemplates.replicas | int | `1` | Set the number of replicas for the gateway deployments |
+| networking.gatewayTemplates.server | object | `{"service":{"allocateLoadBalancerNodePorts":""}}` | Set the options to configure the gateway server |
+| networking.gatewayTemplates.server.service | object | `{"allocateLoadBalancerNodePorts":""}` | Set the options to configure the server service |
+| networking.gatewayTemplates.server.service.allocateLoadBalancerNodePorts | string | `""` | Set to "false" if you expose the gateway service as LoadBalancer and you do not want to create also a NodePort associated to it (Note: this setting is useful only on cloud providers that support this feature). |
 | networking.internal | bool | `true` | Use the default Liqo network manager. |
 | networking.iptables | object | `{"mode":"nf_tables"}` | Iptables configuration tuning. |
 | networking.iptables.mode | string | `"nf_tables"` | Select the iptables mode to use. Possible values are "legacy" and "nf_tables". |

--- a/deployments/liqo/templates/liqo-fabric-daemonset.yaml
+++ b/deployments/liqo/templates/liqo-fabric-daemonset.yaml
@@ -1,5 +1,5 @@
 ---
-{{- $fabricConfig := (merge (dict "name" "fabric" "module" "networking") .) -}}
+{{- $fabricConfig := (merge (dict "name" "fabric" "module" "networking" "version" .Values.fabric.image.version ) .) -}}
 
 {{- if .Values.networking.internal }}
 
@@ -37,7 +37,7 @@ spec:
         {{- end }}
       serviceAccountName: {{ include "liqo.prefixedName" $fabricConfig }}
       containers:
-        - image: {{ .Values.fabric.imageName }}{{ include "liqo.suffix" $fabricConfig }}:{{ include "liqo.version" $fabricConfig }}
+        - image: {{ .Values.fabric.image.name }}{{ include "liqo.suffix" $fabricConfig }}:{{ include "liqo.version" $fabricConfig }}
           imagePullPolicy: {{ .Values.pullPolicy }}
           name: {{ $fabricConfig.name }}
           command: ["/usr/bin/liqo-fabric"]

--- a/deployments/liqo/templates/liqo-wireguard-gateway-client-template.yaml
+++ b/deployments/liqo/templates/liqo-wireguard-gateway-client-template.yaml
@@ -1,4 +1,7 @@
 {{- $templateConfig := (merge (dict "name" "wireguard-client" "module" "networking") .) -}}
+{{- $gatewayConfig := (merge (dict "name" "gateway" "module" "networking" "version" .Values.networking.gatewayTemplates.container.gateway.image.version) .) -}}
+{{- $wireguardConfig := (merge (dict "name" "gateway-wireguard" "module" "networking" "version" .Values.networking.gatewayTemplates.container.wireguard.image.version) .) -}}
+{{- $geneveConfig := (merge (dict "name" "gateway-geneve" "module" "networking" "version" .Values.networking.gatewayTemplates.container.geneve.image.version) .) -}}
 
 {{- if .Values.networking.internal }}
 
@@ -20,7 +23,7 @@ spec:
         metadata:
           {{- include "liqo.metadataTemplate" $templateConfig | nindent 10 }}
         spec:
-          replicas: {{ .Values.networking.gateway.replicas }}
+          replicas: {{ .Values.networking.gatewayTemplates.replicas }}
           selector:
             matchLabels:
               {{- include "liqo.labelsTemplate" $templateConfig | nindent 14 }}
@@ -32,7 +35,7 @@ spec:
               serviceAccountName: "{{"{{ .Name }}"}}"
               containers:
               - name: gateway
-                image: ghcr.io/liqotech/gateway{{ include "liqo.suffix" $templateConfig }}:{{ include "liqo.version" $templateConfig }}
+                image: {{ .Values.networking.gatewayTemplates.container.gateway.image.name }}{{ include "liqo.suffix" $gatewayConfig }}:{{ include "liqo.version" $gatewayConfig }}
                 imagePullPolicy: {{ .Values.pullPolicy }}
                 args:
                 - --name={{"{{ .Name }}"}}
@@ -43,10 +46,10 @@ spec:
                 - --metrics-address=:8080
                 - --health-probe-bind-address=:8081
                 - --ping-enabled=true
-                - --ping-loss-threshold={{ .Values.networking.gateway.ping.lossThreshold }}
-                - --ping-interval={{ .Values.networking.gateway.ping.interval }}
-                - --ping-update-status-interval={{ .Values.networking.gateway.ping.updateStatusInterval }}
-                {{- if gt .Values.networking.gateway.replicas 1.0 }}
+                - --ping-loss-threshold={{ .Values.networking.gatewayTemplates.ping.lossThreshold }}
+                - --ping-interval={{ .Values.networking.gatewayTemplates.ping.interval }}
+                - --ping-update-status-interval={{ .Values.networking.gatewayTemplates.ping.updateStatusInterval }}
+                {{- if gt .Values.networking.gatewayTemplates.replicas 1.0 }}
                 - --leader-election=true
                 {{- end }}
                 securityContext:
@@ -55,7 +58,7 @@ spec:
                     - NET_ADMIN
                     - NET_RAW
               - name: wireguard
-                image: ghcr.io/liqotech/gateway/wireguard{{ include "liqo.suffix" $templateConfig }}:{{ include "liqo.version" $templateConfig }}
+                image: {{ .Values.networking.gatewayTemplates.container.wireguard.image.name }}{{ include "liqo.suffix" $wireguardConfig }}:{{ include "liqo.version" $wireguardConfig }}
                 imagePullPolicy: {{ .Values.pullPolicy }}
                 args:
                 - --name={{"{{ .Name }}"}}
@@ -74,12 +77,13 @@ spec:
                     - NET_ADMIN
                     - NET_RAW
               - name: geneve
-                image: ghcr.io/liqotech/gateway/geneve{{ include "liqo.suffix" $templateConfig }}:{{ include "liqo.version" $templateConfig }}
+                image: {{ .Values.networking.gatewayTemplates.container.geneve.image.name }}{{ include "liqo.suffix" $geneveConfig }}:{{ include "liqo.version" $geneveConfig }}
                 imagePullPolicy: {{ .Values.pullPolicy }}
                 args:
                 - --name={{"{{ .Name }}"}}
                 - --namespace={{"{{ .Namespace }}"}}
                 - --remote-cluster-id={{"{{ .ClusterID }}"}}
+                - --gateway-uid={{"{{ .GatewayUID }}"}}
                 - --mode=server
                 - --metrics-address=:8084
                 - --health-probe-bind-address=:8085

--- a/deployments/liqo/templates/liqo-wireguard-gateway-server-template.yaml
+++ b/deployments/liqo/templates/liqo-wireguard-gateway-server-template.yaml
@@ -1,4 +1,7 @@
 {{- $templateConfig := (merge (dict "name" "wireguard-server" "module" "networking") .) -}}
+{{- $gatewayConfig := (merge (dict "name" "gateway" "module" "networking" "version" .Values.networking.gatewayTemplates.container.gateway.image.version) .) -}}
+{{- $wireguardConfig := (merge (dict "name" "gateway-wireguard" "module" "networking" "version" .Values.networking.gatewayTemplates.container.wireguard.image.version) .) -}}
+{{- $geneveConfig := (merge (dict "name" "gateway-geneve" "module" "networking" "version" .Values.networking.gatewayTemplates.container.geneve.image.version) .) -}}
 
 {{- if .Values.networking.internal }}
 
@@ -27,14 +30,14 @@ spec:
           - port: "{{"{{ .Spec.Endpoint.Port }}"}}"
             protocol: UDP
             targetPort: "{{"{{ .Spec.Endpoint.Port }}"}}"
-          {{- if .Values.networking.gateway.server.service.allocateLoadBalancerNodePorts }}
-          allocateLoadBalancerNodePorts: {{ .Values.networking.gateway.server.service.allocateLoadBalancerNodePorts }}
+          {{- if .Values.networking.gatewayTemplates.server.service.allocateLoadBalancerNodePorts }}
+          allocateLoadBalancerNodePorts: {{ .Values.networking.gatewayTemplates.server.service.allocateLoadBalancerNodePorts }}
           {{- end }}
       deployment:
         metadata:
           {{- include "liqo.metadataTemplate" $templateConfig | nindent 10 }}
         spec:
-          replicas: {{ .Values.networking.gateway.replicas }}
+          replicas: {{ .Values.networking.gatewayTemplates.replicas }}
           selector:
             matchLabels:
               {{- include "liqo.labelsTemplate" $templateConfig | nindent 14 }}
@@ -46,7 +49,7 @@ spec:
               serviceAccountName: "{{"{{ .Name }}"}}"
               containers:
               - name: gateway
-                image: ghcr.io/liqotech/gateway{{ include "liqo.suffix" $templateConfig }}:{{ include "liqo.version" $templateConfig }}
+                image: {{ .Values.networking.gatewayTemplates.container.gateway.image.name }}{{ include "liqo.suffix" $gatewayConfig }}:{{ include "liqo.version" $gatewayConfig }}
                 imagePullPolicy: {{ .Values.pullPolicy }}
                 args:
                 - --name={{"{{ .Name }}"}}
@@ -57,10 +60,10 @@ spec:
                 - --metrics-address=:8080
                 - --health-probe-bind-address=:8081
                 - --ping-enabled=true
-                - --ping-loss-threshold={{ .Values.networking.gateway.ping.lossThreshold }}
-                - --ping-interval={{ .Values.networking.gateway.ping.interval }}
-                - --ping-update-status-interval={{ .Values.networking.gateway.ping.updateStatusInterval }}
-                {{- if gt .Values.networking.gateway.replicas 1.0 }}
+                - --ping-loss-threshold={{ .Values.networking.gatewayTemplates.ping.lossThreshold }}
+                - --ping-interval={{ .Values.networking.gatewayTemplates.ping.interval }}
+                - --ping-update-status-interval={{ .Values.networking.gatewayTemplates.ping.updateStatusInterval }}
+                {{- if gt .Values.networking.gatewayTemplates.replicas 1.0 }}
                 - --leader-election=true
                 {{- end }}
                 securityContext:
@@ -69,7 +72,7 @@ spec:
                     - NET_ADMIN
                     - NET_RAW
               - name: wireguard
-                image: ghcr.io/liqotech/gateway/wireguard{{ include "liqo.suffix" $templateConfig }}:{{ include "liqo.version" $templateConfig }}
+                image: {{ .Values.networking.gatewayTemplates.container.wireguard.image.name }}{{ include "liqo.suffix" $wireguardConfig }}:{{ include "liqo.version" $wireguardConfig }}
                 imagePullPolicy: {{ .Values.pullPolicy }}
                 args:
                 - --name={{"{{ .Name }}"}}
@@ -87,12 +90,13 @@ spec:
                     - NET_ADMIN
                     - NET_RAW
               - name: geneve
-                image: ghcr.io/liqotech/gateway/geneve{{ include "liqo.suffix" $templateConfig }}:{{ include "liqo.version" $templateConfig }}
+                image: {{ .Values.networking.gatewayTemplates.container.geneve.image.name }}{{ include "liqo.suffix" $geneveConfig }}:{{ include "liqo.version" $geneveConfig }}
                 imagePullPolicy: {{ .Values.pullPolicy }}
                 args:
                 - --name={{"{{ .Name }}"}}
                 - --namespace={{"{{ .Namespace }}"}}
                 - --remote-cluster-id={{"{{ .ClusterID }}"}}
+                - --gateway-uid={{"{{ .GatewayUID }}"}}
                 - --mode=server
                 - --metrics-address=:8084
                 - --health-probe-bind-address=:8085

--- a/deployments/liqo/values.yaml
+++ b/deployments/liqo/values.yaml
@@ -49,8 +49,11 @@ networking:
   clientResources:
     - apiVersion: networking.liqo.io/v1alpha1
       resource: wggatewayclients
-  # -- Set the options for gateway templates
-  gateway:
+  # -- Set the options for the default gateway (server/client) templates.
+  # The default templates use a WireGuard implementation to connect the gateway of the clusters.
+  # These options are used to configure only the default templates and should not be considered
+  # if a custom template is used.
+  gatewayTemplates:
     # -- Set the number of replicas for the gateway deployments
     replicas: 1
     # -- Set the options to configure the gateway ping used to check connection
@@ -67,6 +70,25 @@ networking:
       service:
         # -- Set to "false" if you expose the gateway service as LoadBalancer and you do not want to create also a NodePort associated to it (Note: this setting is useful only on cloud providers that support this feature).
         allocateLoadBalancerNodePorts: ""
+    container:
+      gateway:
+        image:
+          # -- Image repository for the gateway container.
+          name: "ghcr.io/liqotech/gateway"
+          # -- Custom version for the gateway image. If not specified, the global tag is used.
+          version: ""
+      wireguard:
+        image:
+          # -- Image repository for the wireguard container.
+          name: "ghcr.io/liqotech/gateway/wireguard"
+          # -- Custom version for the wireguard image. If not specified, the global tag is used.
+          version: ""
+      geneve:
+        image:
+          # -- Image repository for the geneve container.
+          name: "ghcr.io/liqotech/gateway/geneve"
+          # -- Custom version for the geneve image. If not specified, the global tag is used.
+          version: ""
 
 peering:
   # -- Set the default configuration for the networking resources created during the peering process
@@ -261,8 +283,11 @@ fabric:
     resources:
       limits: {}
       requests: {}
-  # -- Image repository for the fabric pod.
-  imageName: "ghcr.io/liqotech/fabric"
+  image:
+    # -- Image repository for the fabric pod.
+    name: "ghcr.io/liqotech/fabric"
+    # -- Custom version for the fabric image. If not specified, the global tag is used.
+    version: ""
   # -- Extra tolerations for the fabric daemonset.
   tolerations: []
 

--- a/pkg/utils/geneve/k8s.go
+++ b/pkg/utils/geneve/k8s.go
@@ -43,9 +43,9 @@ func GetGeneveTunnelID(ctx context.Context, cl client.Client,
 		return 0, fmt.Errorf("no geneve tunnel found for internalfabric %s and internalnode %s",
 			internalFabricName, internalNodeName)
 	case 1:
+		return list.Items[0].Spec.ID, nil
+	default:
 		return 0, fmt.Errorf("multiple geneve tunnels found for internalfabric %s and internalnode %s",
 			internalFabricName, internalNodeName)
-	default:
-		return list.Items[0].Spec.ID, nil
 	}
 }


### PR DESCRIPTION
# Description

This PR allows to customize image name and version on new networking containers (gateway, wireguard, geneve, fabric)
