### PR TITLE
Helm: Fix extraArgs

### DIFF
--- a/deployments/liqo/templates/liqo-metric-agent-deployment.yaml
+++ b/deployments/liqo/templates/liqo-metric-agent-deployment.yaml
@@ -69,6 +69,12 @@ spec:
           - --cert-path=/certs/cert.pem
           - --read-timeout={{ .Values.metricAgent.config.timeout.read }}
           - --write-timeout={{ .Values.metricAgent.config.timeout.write }}
+          {{- if .Values.common.extraArgs }}
+          {{- toYaml .Values.common.extraArgs | nindent 10 }}
+          {{- end }}
+          {{- if .Values.metricAgent.pod.extraArgs }}
+          {{- toYaml .Values.metricAgent.pod.extraArgs | nindent 10 }}
+          {{- end }}
           resources: {{- toYaml .Values.metricAgent.pod.resources | nindent 12 }}
           volumeMounts:
             - mountPath: '/certs'

--- a/deployments/liqo/templates/liqo-proxy-deployment.yaml
+++ b/deployments/liqo/templates/liqo-proxy-deployment.yaml
@@ -38,6 +38,15 @@ spec:
           - mountPath: /etc/envoy/envoy.yaml
             name: config-volume
             subPath: config
+          {{- if or .Values.common.extraArgs .Values.proxy.pod.extraArgs }}
+          args:
+          {{- if .Values.common.extraArgs }}
+          {{- toYaml .Values.common.extraArgs | nindent 10 }}
+          {{- end }}
+          {{- if .Values.proxy.pod.extraArgs }}
+          {{- toYaml .Values.proxy.pod.extraArgs | nindent 10 }}
+          {{- end }}
+          {{- end }}
       volumes:
       - name: config-volume
         configMap:

--- a/deployments/liqo/templates/liqo-telemetry-cronjob.yaml
+++ b/deployments/liqo/templates/liqo-telemetry-cronjob.yaml
@@ -50,6 +50,12 @@ spec:
               {{- $d := dict "commandName" "--cluster-labels" "dictionary" .Values.discovery.config.clusterLabels }}
               {{- include "liqo.concatenateMap" $d | nindent 14 }}
               {{- end }}
+              {{- if .Values.common.extraArgs }}
+              {{- toYaml .Values.common.extraArgs | nindent 14 }}
+              {{- end }}
+              {{- if .Values.telemetry.pod.extraArgs }}
+              {{- toYaml .Values.telemetry.pod.extraArgs | nindent 14 }}
+              {{- end }}
             resources: {{- toYaml .Values.telemetry.pod.resources | nindent 14 }}
           {{- if ((.Values.common).nodeSelector) }}
           nodeSelector:


### PR DESCRIPTION
# Description

ExtraArgs was not applied in the following two deployments and one cronjob, so fixed it so that it is applied correctly.

- deployments/liqo/templates/liqo-metric-agent-deployment.yaml
- deployments/liqo/templates/liqo-proxy-deployment.yaml
- deployments/liqo/templates/liqo-telemetry-cronjob.yaml