### PR TITLE
Liqoctl: get liqo version from controller-manager

### DIFF
--- a/pkg/liqoctl/status/handler.go
+++ b/pkg/liqoctl/status/handler.go
@@ -16,7 +16,6 @@ package status
 
 import (
 	"context"
-	"errors"
 
 	"github.com/pterm/pterm"
 
@@ -38,10 +37,10 @@ func (o *Options) Run(ctx context.Context) error {
 		return err
 	}
 
+	hasErrors := false
 	for i, checker := range o.Checkers {
 		checker.Collect(ctx)
-		text := ""
-		text = checker.Format()
+		text := checker.Format()
 
 		if !checker.Silent() || !checker.HasSucceeded() {
 			o.Printer.BoxSetTitle(checker.GetTitle())
@@ -49,13 +48,17 @@ func (o *Options) Run(ctx context.Context) error {
 		}
 
 		if !checker.HasSucceeded() {
-			return errors.New("some checks failed")
+			hasErrors = true
 		}
 		// Insert a new line between each checker.
 		if i != len(o.Checkers)-1 && !checker.Silent() {
 			pterm.Println()
 		}
 	}
+	if hasErrors {
+		o.Printer.Error.Println("some checks failed")
+	}
+
 	return nil
 }
 

--- a/pkg/liqoctl/status/local/localinfo.go
+++ b/pkg/liqoctl/status/local/localinfo.go
@@ -87,6 +87,13 @@ func (lic *LocalInfoChecker) Collect(ctx context.Context) {
 		}
 	}
 
+	configurationSection := lic.localInfoSection.AddSection("Configuration")
+	liqoVersion, err := liqogetters.GetLiqoVersion(ctx, lic.options.CRClient, lic.options.LiqoNamespace)
+	if err != nil {
+		lic.addCollectionError(fmt.Errorf("unable to get Liqo version: %w", err))
+	}
+	configurationSection.AddEntry("Version", liqoVersion)
+
 	networkSection := lic.localInfoSection.AddSection("Network")
 
 	if !lic.options.InternalNetworkEnabled {

--- a/pkg/liqoctl/status/local/localinfo_test.go
+++ b/pkg/liqoctl/status/local/localinfo_test.go
@@ -137,6 +137,9 @@ var _ = Describe("LocalInfo", func() {
 				Expect(text).To(ContainSubstring(v))
 			}
 		}
+		Expect(text).To(ContainSubstring(
+			pterm.Sprintf("Version: %s", testutil.FakeLiqoVersion),
+		))
 		if args.net.InternalNetworkEnabled {
 			Expect(text).To(ContainSubstring(
 				pterm.Sprintf("Pod CIDR: %s", testutil.PodCIDR),

--- a/pkg/liqoctl/version/handler.go
+++ b/pkg/liqoctl/version/handler.go
@@ -19,8 +19,8 @@ import (
 	"fmt"
 
 	"github.com/liqotech/liqo/pkg/liqoctl/factory"
-	"github.com/liqotech/liqo/pkg/liqoctl/install"
 	"github.com/liqotech/liqo/pkg/liqoctl/output"
+	liqogetters "github.com/liqotech/liqo/pkg/utils/getters"
 )
 
 var liqoctlVersion = "unknown"
@@ -40,28 +40,13 @@ func (o *Options) Run(ctx context.Context) error {
 		return nil
 	}
 
-	release, err := o.HelmClient().GetRelease(install.LiqoReleaseName)
+	version, err := liqogetters.GetLiqoVersion(ctx, o.CRClient, o.LiqoNamespace)
 	if err != nil {
-		o.Printer.Error.Printfln("Failed to retrieve release information from namespace %q: %v", o.LiqoNamespace, output.PrettyErr(err))
+		o.Printer.Error.Printfln("Failed to retrieve Liqo version: %v", output.PrettyErr(err))
 		return err
-	}
-
-	if release.Chart == nil || release.Chart.Metadata == nil {
-		o.Printer.Error.Println("Invalid release information")
-		return err
-	}
-
-	version := release.Chart.Metadata.AppVersion
-	if version == "" {
-		// Development version, fallback to the value specified as tag
-		tag, ok := release.Config["tag"]
-		if !ok {
-			o.Printer.Error.Println("Invalid release information")
-			return err
-		}
-		version = tag.(string)
 	}
 
 	fmt.Printf("Server version: %s\n", version)
+
 	return nil
 }

--- a/pkg/utils/testutil/consts.go
+++ b/pkg/utils/testutil/consts.go
@@ -39,6 +39,8 @@ const (
 	FakeNotReflectedLabelKey = "not-reflected-label"
 	// FakeNotReflectedAnnotKey is the key of the fake not reflected annotation used for testing.
 	FakeNotReflectedAnnotKey = "not-reflected-annot"
+	// FakeLiqoVersion is the version of Liqo used for testing.
+	FakeLiqoVersion = "fake-version"
 )
 
 var (

--- a/pkg/utils/testutil/liqo.go
+++ b/pkg/utils/testutil/liqo.go
@@ -89,7 +89,11 @@ func FakeControllerManagerDeployment(argsClusterLabels []string, networkEnabled 
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
-						{Args: containerArgs},
+						{
+							Args:  containerArgs,
+							Image: fmt.Sprintf("liqo-controller-manager:%s", FakeLiqoVersion),
+							Name:  "controller-manager",
+						},
 					},
 				},
 			},


### PR DESCRIPTION
# Description

This PR includes the following changes:
- adds a utility function to get the installed Liqo version (without using Helm client)
- use the new function in `liqoctl version` command
- added Liqo version in `liqoctl status` command
