### PR TITLE
Virtual Node: implementation of OffloadingPatch consumer-side

### DIFF
--- a/apis/virtualkubelet/v1alpha1/virtualnode_types.go
+++ b/apis/virtualkubelet/v1alpha1/virtualnode_types.go
@@ -35,7 +35,7 @@ type OffloadingPatch struct {
 	// Tolerations contains the tolerations to target the remote cluster.
 	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
 	// Affinity contains the affinity and anti-affinity rules to target the remote cluster.
-	Affinities *Affinity `json:"affinities,omitempty"`
+	Affinity *Affinity `json:"affinity,omitempty"`
 }
 
 // DeploymentTemplate contains the deployment template of the virtual node.

--- a/apis/virtualkubelet/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/virtualkubelet/v1alpha1/zz_generated.deepcopy.go
@@ -212,8 +212,8 @@ func (in *OffloadingPatch) DeepCopyInto(out *OffloadingPatch) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
-	if in.Affinities != nil {
-		in, out := &in.Affinities, &out.Affinities
+	if in.Affinity != nil {
+		in, out := &in.Affinity, &out.Affinity
 		*out = new(Affinity)
 		(*in).DeepCopyInto(*out)
 	}

--- a/deployments/liqo/crds/virtualkubelet.liqo.io_virtualnodes.yaml
+++ b/deployments/liqo/crds/virtualkubelet.liqo.io_virtualnodes.yaml
@@ -156,7 +156,7 @@ spec:
                 description: OffloadingPatch contains the information to target a
                   groups of node on the remote cluster.
                 properties:
-                  affinities:
+                  affinity:
                     description: Affinity contains the affinity and anti-affinity
                       rules to target the remote cluster.
                     properties:

--- a/pkg/utils/pod/pod.go
+++ b/pkg/utils/pod/pod.go
@@ -19,7 +19,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 // IsPodReady returns true if a pod is ready; false otherwise. It also returns a reason (as provided by Kubernetes).
@@ -60,7 +60,7 @@ func IsPodSpecEqual(previous, updated *corev1.PodSpec) bool {
 	// * spec.tolerations (only new entries can be added)
 	return AreContainersEqual(previous.Containers, updated.Containers) &&
 		AreContainersEqual(previous.InitContainers, updated.InitContainers) &&
-		pointer.Int64Equal(previous.ActiveDeadlineSeconds, updated.ActiveDeadlineSeconds) &&
+		ptr.Equal(previous.ActiveDeadlineSeconds, updated.ActiveDeadlineSeconds) &&
 		len(previous.Tolerations) == len(updated.Tolerations)
 }
 

--- a/pkg/virtualKubelet/forge/forge.go
+++ b/pkg/virtualKubelet/forge/forge.go
@@ -21,6 +21,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
+	virtualkubeletv1alpha1 "github.com/liqotech/liqo/apis/virtualkubelet/v1alpha1"
 )
 
 // ReflectionFieldManager -> The name associated with the fields modified by virtual kubelet reflection.
@@ -72,12 +73,14 @@ func ApplyOptions() metav1.ApplyOptions {
 type ForgingOpts struct {
 	LabelsNotReflected      []string
 	AnnotationsNotReflected []string
+	OffloadingPatch         *virtualkubeletv1alpha1.OffloadingPatch
 }
 
 // NewForgingOpts returns a new ForgingOpts instance.
-func NewForgingOpts(labelsNotReflected, annotationsNotReflected []string) ForgingOpts {
+func NewForgingOpts(labelsNotReflected, annotationsNotReflected []string, offloadingPatch *virtualkubeletv1alpha1.OffloadingPatch) ForgingOpts {
 	return ForgingOpts{
 		LabelsNotReflected:      labelsNotReflected,
 		AnnotationsNotReflected: annotationsNotReflected,
+		OffloadingPatch:         offloadingPatch,
 	}
 }

--- a/pkg/virtualKubelet/provider/provider.go
+++ b/pkg/virtualKubelet/provider/provider.go
@@ -81,6 +81,8 @@ type InitConfig struct {
 
 	LabelsNotReflected      []string
 	AnnotationsNotReflected []string
+
+	OffloadingPatch *vkalpha1.OffloadingPatch
 }
 
 // LiqoProvider implements the virtual-kubelet provider interface and stores pods in memory.
@@ -134,7 +136,7 @@ func NewLiqoProvider(ctx context.Context, cfg *InitConfig, eb record.EventBroadc
 
 	podreflector := workload.NewPodReflector(cfg.RemoteConfig, remoteMetricsClient, ipamClient, &podReflectorConfig, cfg.ReflectorsConfigs[generic.Pod])
 	reflectionManager := manager.New(localClient, remoteClient, localLiqoClient, remoteLiqoClient,
-		cfg.InformerResyncPeriod, eb, cfg.LabelsNotReflected, cfg.AnnotationsNotReflected).
+		cfg.InformerResyncPeriod, eb, cfg.LabelsNotReflected, cfg.AnnotationsNotReflected, cfg.OffloadingPatch).
 		With(podreflector).
 		With(exposition.NewServiceReflector(cfg.ReflectorsConfigs[generic.Service], cfg.EnableLoadBalancer, cfg.RemoteRealLoadBalancerClassName)).
 		With(exposition.NewIngressReflector(cfg.ReflectorsConfigs[generic.Ingress], cfg.EnableIngress, cfg.RemoteRealIngressClassName)).

--- a/pkg/virtualKubelet/reflection/manager/manager.go
+++ b/pkg/virtualKubelet/reflection/manager/manager.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/klog/v2"
 	"k8s.io/utils/trace"
 
+	virtualkubeletv1alpha1 "github.com/liqotech/liqo/apis/virtualkubelet/v1alpha1"
 	liqoclient "github.com/liqotech/liqo/pkg/client/clientset/versioned"
 	liqoinformers "github.com/liqotech/liqo/pkg/client/informers/externalversions"
 	traceutils "github.com/liqotech/liqo/pkg/utils/trace"
@@ -61,7 +62,8 @@ type manager struct {
 
 // New returns a new manager to start the reflection towards a remote cluster.
 func New(local, remote kubernetes.Interface, localLiqo, remoteLiqo liqoclient.Interface, resync time.Duration,
-	eb record.EventBroadcaster, labelsNotReflected, annotationsNotReflected []string) Manager {
+	eb record.EventBroadcaster, labelsNotReflected, annotationsNotReflected []string,
+	offloadingPatch *virtualkubeletv1alpha1.OffloadingPatch) Manager {
 	// Configure the field selector to retrieve only the pods scheduled on the current virtual node.
 	localPodTweakListOptions := func(opts *metav1.ListOptions) {
 		opts.FieldSelector = fields.OneTermEqualSelector("spec.nodeName", forge.LiqoNodeName).String()
@@ -82,7 +84,7 @@ func New(local, remote kubernetes.Interface, localLiqo, remoteLiqo liqoclient.In
 		started: false,
 		stop:    make(map[string]context.CancelFunc),
 
-		forgingOpts: forge.NewForgingOpts(labelsNotReflected, annotationsNotReflected),
+		forgingOpts: forge.NewForgingOpts(labelsNotReflected, annotationsNotReflected, offloadingPatch),
 	}
 }
 

--- a/pkg/virtualKubelet/reflection/manager/manager_test.go
+++ b/pkg/virtualKubelet/reflection/manager/manager_test.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/record"
 
+	virtualkubeletv1alpha1 "github.com/liqotech/liqo/apis/virtualkubelet/v1alpha1"
 	liqoclient "github.com/liqotech/liqo/pkg/client/clientset/versioned"
 	liqoclientfake "github.com/liqotech/liqo/pkg/client/clientset/versioned/fake"
 	reflectionfake "github.com/liqotech/liqo/pkg/virtualKubelet/reflection/generic/fake"
@@ -44,6 +45,7 @@ var _ = Describe("Manager tests", func() {
 		broadcaster             record.EventBroadcaster
 		labelsNotReflected      []string
 		annotationsNotReflected []string
+		offloadingPatch         *virtualkubeletv1alpha1.OffloadingPatch
 
 		ctx    context.Context
 		cancel context.CancelFunc
@@ -60,7 +62,8 @@ var _ = Describe("Manager tests", func() {
 	AfterEach(func() { cancel() })
 
 	JustBeforeEach(func() {
-		mgr = New(localClient, remoteClient, localLiqoClient, remoteLiqoClient, 1*time.Hour, broadcaster, labelsNotReflected, annotationsNotReflected)
+		mgr = New(localClient, remoteClient, localLiqoClient, remoteLiqoClient, 1*time.Hour, broadcaster,
+			labelsNotReflected, annotationsNotReflected, offloadingPatch)
 	})
 
 	Context("a new manager is created", func() {
@@ -183,6 +186,6 @@ type fakeNamespaceHandler struct {
 }
 
 // Start is the fake Start method.
-func (nh *fakeNamespaceHandler) Start(ctx context.Context, mgr NamespaceStartStopper) {
+func (nh *fakeNamespaceHandler) Start(_ context.Context, _ NamespaceStartStopper) {
 	nh.StartCalled++
 }

--- a/pkg/vkMachinery/forge/forge.go
+++ b/pkg/vkMachinery/forge/forge.go
@@ -148,6 +148,14 @@ func forgeVKContainers(
 					Name:      "POD_NAME",
 					ValueFrom: &v1.EnvVarSource{FieldRef: &v1.ObjectFieldSelector{FieldPath: "metadata.name"}},
 				},
+				{
+					Name:      "POD_NAMESPACE",
+					ValueFrom: &v1.EnvVarSource{FieldRef: &v1.ObjectFieldSelector{FieldPath: "metadata.namespace"}},
+				},
+				{
+					Name:  "VIRTUALNODE_NAME",
+					Value: nodeName,
+				},
 			},
 			Ports: containerPorts,
 		},


### PR DESCRIPTION
# Description

This PR implements the support for the OffloadingPatch feature of the Virtual Node API. 
NodeSelectors, Affinities, and Tolerations defined in the virtual node are propagated to offloaded pods in the corresponding remote cluster.


# How Has This Been Tested?

- [x] Locally
- [x] Unit
- [x] e2e
