### PR TITLE
Select remote namespace name when offloading

### DIFF
--- a/apis/offloading/v1alpha1/namespaceoffloading_types.go
+++ b/apis/offloading/v1alpha1/namespaceoffloading_types.go
@@ -47,6 +47,9 @@ const (
 	// DefaultNameMappingStrategyType -> the remote namespace is assigned a default name which ensures uniqueness
 	// and avoids conflicts (localNamespaceName-localClusterID).
 	DefaultNameMappingStrategyType NamespaceMappingStrategyType = "DefaultName"
+	// SelectedNameMappingStrategyType -> the remote namespace is assigned a name chosen by the user.
+	// (the creation may fail in case of conflicts).
+	SelectedNameMappingStrategyType NamespaceMappingStrategyType = "SelectedName"
 )
 
 // PodOffloadingStrategyType represents different strategies to offload pods in this Namespace.
@@ -97,10 +100,14 @@ type NamespaceOffloadingSpec struct {
 	//  NamespaceMappingStrategy allows users to map local and remote namespace names according to two
 	//  different strategies: "DefaultName", which ensures uniqueness and prevents conflicts, and "EnforceSameName",
 	//  which enforces the same name at the cost of possible conflicts.
-	// +kubebuilder:validation:Enum="EnforceSameName";"DefaultName"
+	// +kubebuilder:validation:Enum="EnforceSameName";"DefaultName";"SelectedName"
 	// +kubebuilder:default="DefaultName"
 	// +kubebuilder:validation:Optional
 	NamespaceMappingStrategy NamespaceMappingStrategyType `json:"namespaceMappingStrategy"`
+
+	// RemoteNamespaceName allows users to choose a specific name for the remote namespace.
+	// This field is required if NamespaceMappingStrategy is set to "SelectedName". It is ignored otherwise.
+	RemoteNamespaceName string `json:"remoteNamespaceName,omitempty"`
 
 	// PodOffloadingStrategy allows users to configure how pods in this namespace are offloaded, according to three
 	// different strategies: "Local" (i.e. no pod offloading is performed), "Remote" (i.e. all pods are offloaded

--- a/cmd/liqoctl/cmd/offload.go
+++ b/cmd/liqoctl/cmd/offload.go
@@ -86,8 +86,11 @@ func newOffloadNamespaceCommand(ctx context.Context, f *factory.Factory) *cobra.
 
 	namespaceMappingStrategy := args.NewEnum([]string{
 		string(offloadingv1alpha1.EnforceSameNameMappingStrategyType),
-		string(offloadingv1alpha1.DefaultNameMappingStrategyType)},
+		string(offloadingv1alpha1.DefaultNameMappingStrategyType),
+		string(offloadingv1alpha1.SelectedNameMappingStrategyType)},
 		string(offloadingv1alpha1.DefaultNameMappingStrategyType))
+
+	var remoteNamespaceName = ""
 
 	outputFormat := args.NewEnum([]string{"json", "yaml"}, "")
 
@@ -104,6 +107,7 @@ func newOffloadNamespaceCommand(ctx context.Context, f *factory.Factory) *cobra.
 		PreRun: func(cmd *cobra.Command, args []string) {
 			options.PodOffloadingStrategy = offloadingv1alpha1.PodOffloadingStrategyType(podOffloadingStrategy.Value)
 			options.NamespaceMappingStrategy = offloadingv1alpha1.NamespaceMappingStrategyType(namespaceMappingStrategy.Value)
+			options.RemoteNamespaceName = remoteNamespaceName
 			options.OutputFormat = outputFormat.Value
 			options.Printer.CheckErr(options.ParseClusterSelectors(selectors))
 		},
@@ -117,8 +121,11 @@ func newOffloadNamespaceCommand(ctx context.Context, f *factory.Factory) *cobra.
 	cmd.Flags().Var(podOffloadingStrategy, "pod-offloading-strategy",
 		"The constraints regarding pods scheduling in this namespace, among Local, Remote and LocalAndRemote")
 	cmd.Flags().Var(namespaceMappingStrategy, "namespace-mapping-strategy",
-		"The naming strategy adopted for the creation of remote namespaces, among DefaultName and EnforceSameName")
+		"The naming strategy adopted for the creation of remote namespaces, among DefaultName, EnforceSameName and SelectedName")
 	cmd.Flags().DurationVar(&options.Timeout, "timeout", 20*time.Second, "The timeout for the offloading process")
+	cmd.Flags().StringVar(&remoteNamespaceName, "remote-namespace-name", "",
+		"The name of the remote namespace, required when using the SelectedName NamespaceMappingStrategy. "+
+			"Otherwise, it is ignored")
 
 	cmd.Flags().StringArrayVarP(&selectors, "selector", "l", []string{},
 		"The selector to filter the target clusters. Can be specified multiple times, defining alternative requirements (i.e., in logical OR)")

--- a/deployments/liqo/crds/offloading.liqo.io_namespaceoffloadings.yaml
+++ b/deployments/liqo/crds/offloading.liqo.io_namespaceoffloadings.yaml
@@ -152,6 +152,7 @@ spec:
                 enum:
                 - EnforceSameName
                 - DefaultName
+                - SelectedName
                 type: string
               podOffloadingStrategy:
                 default: LocalAndRemote
@@ -165,6 +166,11 @@ spec:
                 - Local
                 - Remote
                 - LocalAndRemote
+                type: string
+              remoteNamespaceName:
+                description: RemoteNamespaceName allows users to choose a specific
+                  name for the remote namespace. This field is required if NamespaceMappingStrategy
+                  is set to "SelectedName". It is ignored otherwise.
                 type: string
             type: object
           status:

--- a/docs/usage/namespace-offloading.md
+++ b/docs/usage/namespace-offloading.md
@@ -44,6 +44,8 @@ The accepted values are:
 * **EnforceSameName**: remote namespaces are named after the local cluster's namespace.
 This approach ensures **naming transparency**, which is required by certain applications, as well as guarantees that **cross-namespace DNS queries** referring to reflected services work out of the box (i.e., without adapting the target namespace name).
 Yet, it can lead to **conflicts** in case a namespace with the same name already exists inside the selected remote clusters, ultimately causing the remote namespace creation request to be rejected.
+* **SelectedName**: you can specify the name of the remote namespace through the `--remote-namespace-name` flag.
+This flag is ignored in case the *namespace mapping strategy* is set to *DefaultName* or *EnforceSameName*.
 
 ```{admonition} Note
 Once configured for a given namespace, the *namespace mapping strategy* is **immutable**, and any modification is prevented by a dedicated Liqo webhook.

--- a/pkg/liqoctl/offload/handler.go
+++ b/pkg/liqoctl/offload/handler.go
@@ -39,6 +39,7 @@ type Options struct {
 	Namespace                string
 	PodOffloadingStrategy    offloadingv1alpha1.PodOffloadingStrategyType
 	NamespaceMappingStrategy offloadingv1alpha1.NamespaceMappingStrategyType
+	RemoteNamespaceName      string
 	ClusterSelector          [][]metav1.LabelSelectorRequirement
 
 	OutputFormat string
@@ -87,6 +88,7 @@ func (o *Options) Run(ctx context.Context) error {
 		oldStrategy = nsoff.Spec.PodOffloadingStrategy
 		nsoff.Spec.PodOffloadingStrategy = o.PodOffloadingStrategy
 		nsoff.Spec.NamespaceMappingStrategy = o.NamespaceMappingStrategy
+		nsoff.Spec.RemoteNamespaceName = o.RemoteNamespaceName
 		nsoff.Spec.ClusterSelector = toNodeSelector(o.ClusterSelector)
 		return nil
 	})
@@ -132,6 +134,7 @@ func (o *Options) output() error {
 		Spec: offloadingv1alpha1.NamespaceOffloadingSpec{
 			PodOffloadingStrategy:    o.PodOffloadingStrategy,
 			NamespaceMappingStrategy: o.NamespaceMappingStrategy,
+			RemoteNamespaceName:      o.RemoteNamespaceName,
 			ClusterSelector:          toNodeSelector(o.ClusterSelector),
 		},
 	}


### PR DESCRIPTION
# Description

This PR allows selecting the name a namespace will assume in the other cluster after offloading.

Fixes #2307 

# How Has This Been Tested?

- [x] locally
