### PR TITLE
liqoctl: add incoming flag to peer and unpeer commands

### DIFF
--- a/cmd/liqoctl/cmd/peer.go
+++ b/cmd/liqoctl/cmd/peer.go
@@ -125,7 +125,7 @@ func newPeerCommand(ctx context.Context, f *factory.Factory) *cobra.Command {
 	}
 
 	cmd.PersistentFlags().DurationVar(&options.Timeout, "timeout", 120*time.Second, "Timeout for peering completion")
-
+	cmd.PersistentFlags().BoolVar(&options.Incoming, "incoming", false, "Allows incoming peering")
 	cmd.AddCommand(newPeerOutOfBandCommand(ctx, options))
 	cmd.AddCommand(newPeerInBandCommand(ctx, options))
 	return cmd
@@ -182,6 +182,7 @@ func newPeerInBandCommand(ctx context.Context, peerOptions *peer.Options) *cobra
 
 		Run: func(cmd *cobra.Command, args []string) {
 			options.Timeout = peerOptions.Timeout
+			options.Incoming = peerOptions.Incoming
 			output.ExitOnErr(options.Run(ctx))
 		},
 	}

--- a/cmd/liqoctl/cmd/unpeer.go
+++ b/cmd/liqoctl/cmd/unpeer.go
@@ -106,7 +106,7 @@ func newUnpeerCommand(ctx context.Context, f *factory.Factory) *cobra.Command {
 	}
 
 	cmd.PersistentFlags().DurationVar(&options.Timeout, "timeout", 120*time.Second, "Timeout for unpeering completion")
-
+	cmd.PersistentFlags().BoolVar(&options.Incoming, "incoming", false, "Dis-allowing peering")
 	cmd.AddCommand(newUnpeerOutOfBandCommand(ctx, options))
 	cmd.AddCommand(newUnpeerInBandCommand(ctx, options))
 	return cmd
@@ -158,6 +158,7 @@ func newUnpeerInBandCommand(ctx context.Context, unpeerOptions *unpeeroob.Option
 
 		Run: func(cmd *cobra.Command, args []string) {
 			options.Timeout = unpeerOptions.Timeout
+			options.Incoming = unpeerOptions.Incoming
 			output.ExitOnErr(options.Run(ctx))
 		},
 	}

--- a/pkg/liqoctl/peerib/handler.go
+++ b/pkg/liqoctl/peerib/handler.go
@@ -29,6 +29,7 @@ type Options struct {
 
 	Bidirectional bool
 	Timeout       time.Duration
+	Incoming      bool
 }
 
 // Run implements the peer in-band command.
@@ -134,6 +135,20 @@ func (o *Options) Run(ctx context.Context) error {
 	if err := cluster2.EnforceForeignCluster(ctx, cluster1.GetClusterID(), cluster1.GetAuthToken(),
 		cluster1.GetAuthURL(), cluster1.GetProxyURL()); err != nil {
 		return err
+	}
+
+	// Allowing Incoming peering when the flag is set
+	if o.Incoming {
+		// Setting the foreign cluster incoming flag in cluster 1 for cluster 2
+		if err := cluster1.EnforceIncomingPeeringFlag(ctx, cluster2.GetClusterID(), true); err != nil {
+			return err
+		}
+
+		// Setting the foreign cluster incoming flag in cluster 2 for cluster 1
+		if err := cluster2.EnforceIncomingPeeringFlag(ctx, cluster1.GetClusterID(), o.Bidirectional); err != nil {
+			return err
+		}
+		return nil
 	}
 
 	// Setting the foreign cluster outgoing flag in cluster 1 for cluster 2

--- a/pkg/liqoctl/peeroob/handler.go
+++ b/pkg/liqoctl/peeroob/handler.go
@@ -108,9 +108,14 @@ func (o *Options) enforceForeignCluster(ctx context.Context) (*discoveryv1alpha1
 
 		fc.Spec.ForeignAuthURL = o.ClusterAuthURL
 		fc.Spec.ForeignProxyURL = ""
-		fc.Spec.OutgoingPeeringEnabled = discoveryv1alpha1.PeeringEnabledYes
-		if fc.Spec.IncomingPeeringEnabled == "" {
-			fc.Spec.IncomingPeeringEnabled = discoveryv1alpha1.PeeringEnabledAuto
+
+		if o.Incoming {
+			fc.Spec.IncomingPeeringEnabled = discoveryv1alpha1.PeeringEnabledYes
+		} else {
+			fc.Spec.OutgoingPeeringEnabled = discoveryv1alpha1.PeeringEnabledYes
+			if fc.Spec.IncomingPeeringEnabled == "" {
+				fc.Spec.IncomingPeeringEnabled = discoveryv1alpha1.PeeringEnabledAuto
+			}
 		}
 		if fc.Spec.InsecureSkipTLSVerify == nil {
 			fc.Spec.InsecureSkipTLSVerify = pointer.BoolPtr(true)

--- a/pkg/liqoctl/wait/wait.go
+++ b/pkg/liqoctl/wait/wait.go
@@ -76,6 +76,20 @@ func (w *Waiter) ForOutgoingUnpeering(ctx context.Context, remoteClusterID *disc
 	return nil
 }
 
+// ForIncomingUnpeering waits until the status on the foreiglcusters resource states that the incoming peering has been successfully
+// set to None or the timeout expires.
+func (w *Waiter) ForIncomingUnpeering(ctx context.Context, remoteClusterID *discoveryv1alpha1.ClusterIdentity) error {
+	remName := remoteClusterID.ClusterName
+	s := w.Printer.StartSpinner(fmt.Sprintf("Disabling incoming peering to the remote cluster %q", remName))
+	err := fcutils.PollForEvent(ctx, w.CRClient, remoteClusterID, fcutils.IsIncomingPeeringNo, 1*time.Second)
+	if client.IgnoreNotFound(err) != nil {
+		s.Fail(fmt.Sprintf("Failed disabling incoming peering to the remote cluster %q: %s", remName, output.PrettyErr(err)))
+		return err
+	}
+	s.Success(fmt.Sprintf("Successfully disabled incoming peering to the remote cluster %q", remName))
+	return nil
+}
+
 // ForAuth waits until the authentication has been established with the remote cluster or the timeout expires.
 func (w *Waiter) ForAuth(ctx context.Context, remoteClusterID *discoveryv1alpha1.ClusterIdentity) error {
 	remName := remoteClusterID.ClusterName
@@ -113,6 +127,20 @@ func (w *Waiter) ForOutgoingPeering(ctx context.Context, remoteClusterID *discov
 		return err
 	}
 	s.Success(fmt.Sprintf("Outgoing peering activated to the remote cluster %q", remName))
+	return nil
+}
+
+// ForIncomingPeering waits until the status on the foreiglcusters resource states that the incoming peering has been successfully
+// set to Yes or the timeout expires.
+func (w *Waiter) ForIncomingPeering(ctx context.Context, remoteClusterID *discoveryv1alpha1.ClusterIdentity) error {
+	remName := remoteClusterID.ClusterName
+	s := w.Printer.StartSpinner(fmt.Sprintf("Activating incoming peering to the remote cluster %q", remName))
+	err := fcutils.PollForEvent(ctx, w.CRClient, remoteClusterID, fcutils.IsIncomingPeeringYes, 1*time.Second)
+	if err != nil {
+		s.Fail(fmt.Sprintf("Failed activating outgoing peering to the remote cluster %q: %s", remName, output.PrettyErr(err)))
+		return err
+	}
+	s.Success(fmt.Sprintf("Incoming peering activated to the remote cluster %q", remName))
 	return nil
 }
 

--- a/pkg/utils/foreignCluster/peeringStatus.go
+++ b/pkg/utils/foreignCluster/peeringStatus.go
@@ -55,6 +55,16 @@ func IsIncomingPeeringNone(foreignCluster *discoveryv1alpha1.ForeignCluster) boo
 	return curPhase == discoveryv1alpha1.PeeringConditionStatusNone
 }
 
+// IsIncomingPeeringYes checks if the incoming peering is set to Yes.
+func IsIncomingPeeringYes(foreignCluster *discoveryv1alpha1.ForeignCluster) bool {
+	return foreignCluster.Spec.IncomingPeeringEnabled == discoveryv1alpha1.PeeringEnabledYes
+}
+
+// IsIncomingPeeringNo checks if the incoming peering is set to No.
+func IsIncomingPeeringNo(foreignCluster *discoveryv1alpha1.ForeignCluster) bool {
+	return foreignCluster.Spec.IncomingPeeringEnabled == discoveryv1alpha1.PeeringEnabledNo
+}
+
 // IsOutgoingPeeringNone checks if the outgoing peering is set to none.
 func IsOutgoingPeeringNone(foreignCluster *discoveryv1alpha1.ForeignCluster) bool {
 	curPhase := peeringconditionsutils.GetStatus(foreignCluster, discoveryv1alpha1.OutgoingPeeringCondition)


### PR DESCRIPTION
# Description

The pull request adds an incoming flag in the peer and unpeer commands. 
User will be able to explicitly set the incoming flag while executing the commands.

Passing --incoming in peer commands sets the ForeignCluster resource .spec.incomingPeeringEnabled to Yes.
Passing --incoming in unpeer commands sets the ForeignCluster resource .spec.incomingPeeringEnabled to No.

Fixes #957 

# How Has This Been Tested?

- locally
