### PR TITLE
Support priorityClassName in Helm chart

### DIFF
--- a/deployments/liqo/README.md
+++ b/deployments/liqo/README.md
@@ -18,6 +18,7 @@
 | auth.pod.annotations | object | `{}` | Annotations for the auth pod. |
 | auth.pod.extraArgs | list | `[]` | Extra arguments for the auth pod. |
 | auth.pod.labels | object | `{}` | Labels for the auth pod. |
+| auth.pod.priorityClassName | string | `""` | PriorityClassName (https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#pod-priority) for the auth pod. |
 | auth.pod.resources | object | `{"limits":{},"requests":{}}` | Resource requests and limits (https://kubernetes.io/docs/user-guide/compute-resources/) for the auth pod. |
 | auth.service.annotations | object | `{}` | Annotations for the auth service. |
 | auth.service.labels | object | `{}` | Labels for the auth service. |
@@ -46,12 +47,14 @@
 | controllerManager.pod.annotations | object | `{}` | Annotations for the controller-manager pod. |
 | controllerManager.pod.extraArgs | list | `[]` | Extra arguments for the controller-manager pod. |
 | controllerManager.pod.labels | object | `{}` | Labels for the controller-manager pod. |
+| controllerManager.pod.priorityClassName | string | `""` | PriorityClassName (https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#pod-priority) for the controller-manager pod. |
 | controllerManager.pod.resources | object | `{"limits":{},"requests":{}}` | Resource requests and limits (https://kubernetes.io/docs/user-guide/compute-resources/) for the controller-manager pod. |
 | controllerManager.replicas | int | `1` | The number of controller-manager instances to run, which can be increased for active/passive high availability. |
 | crdReplicator.imageName | string | `"ghcr.io/liqotech/crd-replicator"` | Image repository for the crdReplicator pod. |
 | crdReplicator.pod.annotations | object | `{}` | Annotations for the crdReplicator pod. |
 | crdReplicator.pod.extraArgs | list | `[]` | Extra arguments for the crdReplicator pod. |
 | crdReplicator.pod.labels | object | `{}` | Labels for the crdReplicator pod. |
+| crdReplicator.pod.priorityClassName | string | `""` | PriorityClassName (https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#pod-priority) for the crdReplicator pod. |
 | crdReplicator.pod.resources | object | `{"limits":{},"requests":{}}` | Resource requests and limits (https://kubernetes.io/docs/user-guide/compute-resources/) for the crdReplicator pod. |
 | discovery.config.autojoin | bool | `true` | Automatically join discovered clusters. |
 | discovery.config.clusterIDOverride | string | `""` | Specify an unique ID (must be a valid uuidv4) for your cluster, instead of letting helm generate it automatically at install time. You can generate it using the command: `uuidgen` This field is needed when using tools such as ArgoCD, since the helm lookup function is not supported and a new value would be generated at each deployment. |
@@ -65,6 +68,7 @@
 | discovery.pod.annotations | object | `{}` | Annotation for the discovery pod. |
 | discovery.pod.extraArgs | list | `[]` | Extra arguments for the discovery pod. |
 | discovery.pod.labels | object | `{}` | Labels for the discovery pod. |
+| discovery.pod.priorityClassName | string | `""` | PriorityClassName (https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#pod-priority) for the discovery pod. |
 | discovery.pod.resources | object | `{"limits":{},"requests":{}}` | Resource requests and limits (https://kubernetes.io/docs/user-guide/compute-resources/) for the discovery pod. |
 | fullnameOverride | string | `""` | Override the standard full name used by Helm and associated to Kubernetes/Liqo resources. |
 | gateway.config.addressOverride | string | `""` | Override the default address where your network gateway service is available. You should configure it if the network gateway is behind a reverse proxy or NAT. |
@@ -84,6 +88,7 @@
 | gateway.pod.annotations | object | `{}` | Annotations for the network gateway pod. |
 | gateway.pod.extraArgs | list | `[]` | Extra arguments for the network gateway pod. |
 | gateway.pod.labels | object | `{}` | Labels for the network gateway pod. |
+| gateway.pod.priorityClassName | string | `""` | PriorityClassName (https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#pod-priority) for the network gateway pod. |
 | gateway.pod.resources | object | `{"limits":{},"requests":{}}` | Resource requests and limits (https://kubernetes.io/docs/user-guide/compute-resources/) for the network gateway pod. |
 | gateway.replicas | int | `1` | The number of gateway instances to run. The gateway component supports active/passive high availability. Make sure that there are enough nodes to accommodate the replicas, because such pod has to run in the host network, hence no more than one replica can be scheduled on a given node. |
 | gateway.service.annotations | object | `{}` | Annotations for the network gateway service. |
@@ -101,6 +106,7 @@
 | metricAgent.pod.annotations | object | `{}` | Annotations for the metricAgent pod. |
 | metricAgent.pod.extraArgs | list | `[]` | Extra arguments for the metricAgent pod. |
 | metricAgent.pod.labels | object | `{}` | Labels for the metricAgent pod. |
+| metricAgent.pod.priorityClassName | string | `""` | PriorityClassName (https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#pod-priority) for the metricAgent pod. |
 | metricAgent.pod.resources | object | `{"limits":{},"requests":{}}` | Resource requests and limits (https://kubernetes.io/docs/user-guide/compute-resources/) for the metricAgent pod. |
 | nameOverride | string | `""` | Override the standard name used by Helm and associated to Kubernetes/Liqo resources. |
 | networkManager.config.additionalPools | list | `[]` | Set of additional network pools to perform the automatic address mapping in Liqo. Network pools are used to map a cluster network into another one in order to prevent conflicts. Default set of network pools is: [10.0.0.0/8, 192.168.0.0/16, 172.16.0.0/12] |
@@ -113,6 +119,7 @@
 | networkManager.pod.annotations | object | `{}` | Annotations for the networkManager pod. |
 | networkManager.pod.extraArgs | list | `[]` | Extra arguments for the networkManager pod. |
 | networkManager.pod.labels | object | `{}` | Labels for the networkManager pod. |
+| networkManager.pod.priorityClassName | string | `""` | PriorityClassName (https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#pod-priority) for the networkManager pod. |
 | networkManager.pod.resources | object | `{"limits":{},"requests":{}}` | Resource requests and limits (https://kubernetes.io/docs/user-guide/compute-resources/) for the networkManager pod. |
 | networking.internal | bool | `true` | Use the default Liqo network manager. |
 | networking.iptables | object | `{"mode":"nf_tables"}` | Iptables configuration tuning. |
@@ -136,6 +143,7 @@
 | proxy.pod.annotations | object | `{}` | Annotations for the proxy pod. |
 | proxy.pod.extraArgs | list | `[]` | Extra arguments for the proxy pod. |
 | proxy.pod.labels | object | `{}` | Labels for the proxy pod. |
+| proxy.pod.priorityClassName | string | `""` | PriorityClassName (https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#pod-priority) for the proxy pod. |
 | proxy.pod.resources | object | `{"limits":{},"requests":{}}` | Resource requests and limits (https://kubernetes.io/docs/user-guide/compute-resources/) for the proxy pod. |
 | proxy.service.annotations | object | `{}` |  |
 | proxy.service.type | string | `"ClusterIP"` |  |
@@ -162,6 +170,7 @@
 | route.pod.annotations | object | `{}` | Annotations for the route pod. |
 | route.pod.extraArgs | list | `[]` | Extra arguments for the route pod. |
 | route.pod.labels | object | `{}` | Labels for the route pod. |
+| route.pod.priorityClassName | string | `""` | PriorityClassName (https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#pod-priority) for the route pod. |
 | route.pod.resources | object | `{"limits":{},"requests":{}}` | Resource requests and limits (https://kubernetes.io/docs/user-guide/compute-resources/) for the route pod. |
 | route.tolerations | list | `[]` | Extra tolerations for the route daemonset. |
 | storage.enable | bool | `true` | Enable/Disable the liqo virtual storage class on the local cluster. You will be able to offload your persistent volumes, while other clusters will be able to schedule their persistent workloads on the current cluster. |

--- a/deployments/liqo/templates/liqo-auth-deployment.yaml
+++ b/deployments/liqo/templates/liqo-auth-deployment.yaml
@@ -140,3 +140,6 @@ spec:
       affinity:
       {{- toYaml .Values.common.affinity | nindent 8 }}
       {{- end }}
+      {{- if .Values.auth.pod.priorityClassName }}
+      priorityClassName: {{ .Values.auth.pod.priorityClassName }}
+      {{- end }}

--- a/deployments/liqo/templates/liqo-controller-manager-deployment.yaml
+++ b/deployments/liqo/templates/liqo-controller-manager-deployment.yaml
@@ -236,3 +236,6 @@ spec:
       affinity:
       {{- toYaml .Values.common.affinity | nindent 8 }}
       {{- end }}
+      {{- if .Values.controllerManager.pod.priorityClassName }}
+      priorityClassName: {{ .Values.controllerManager.pod.priorityClassName }}
+      {{- end }}

--- a/deployments/liqo/templates/liqo-crd-replicator-deployment.yaml
+++ b/deployments/liqo/templates/liqo-crd-replicator-deployment.yaml
@@ -66,4 +66,7 @@ spec:
       affinity:
       {{- toYaml .Values.common.affinity | nindent 8 }}
       {{- end }}
+      {{- if .Values.crdReplicator.pod.priorityClassName }}
+      priorityClassName: {{ .Values.crdReplicator.pod.priorityClassName }}
+      {{- end }}
 ---

--- a/deployments/liqo/templates/liqo-discovery-deployment.yaml
+++ b/deployments/liqo/templates/liqo-discovery-deployment.yaml
@@ -75,4 +75,7 @@ spec:
       affinity:
       {{- toYaml .Values.common.affinity | nindent 8 }}
       {{- end }}
+      {{- if .Values.discovery.pod.priorityClassName }}
+      priorityClassName: {{ .Values.discovery.pod.priorityClassName }}
+      {{- end }}
 {{- end }}

--- a/deployments/liqo/templates/liqo-gateway-deployment.yaml
+++ b/deployments/liqo/templates/liqo-gateway-deployment.yaml
@@ -95,4 +95,7 @@ spec:
       affinity:
       {{- toYaml .Values.common.affinity | nindent 8 }}
       {{- end }}
+      {{- if .Values.gateway.pod.priorityClassName }}
+      priorityClassName: {{ .Values.gateway.pod.priorityClassName }}
+      {{- end }}
 {{- end }}

--- a/deployments/liqo/templates/liqo-metric-agent-deployment.yaml
+++ b/deployments/liqo/templates/liqo-metric-agent-deployment.yaml
@@ -94,4 +94,7 @@ spec:
       affinity:
       {{- toYaml .Values.common.affinity | nindent 8 }}
       {{- end }}
+      {{- if .Values.metricAgent.pod.priorityClassName }}
+      priorityClassName: {{ .Values.metricAgent.pod.priorityClassName }}
+      {{- end }}
 {{- end }}

--- a/deployments/liqo/templates/liqo-network-manager-deployment.yaml
+++ b/deployments/liqo/templates/liqo-network-manager-deployment.yaml
@@ -76,4 +76,7 @@ spec:
       affinity:
       {{- toYaml .Values.common.affinity | nindent 8 }}
       {{- end }}
+      {{- if .Values.networkManager.pod.priorityClassName }}
+      priorityClassName: {{ .Values.networkManager.pod.priorityClassName }}
+      {{- end }}
 {{- end }}

--- a/deployments/liqo/templates/liqo-proxy-deployment.yaml
+++ b/deployments/liqo/templates/liqo-proxy-deployment.yaml
@@ -63,3 +63,6 @@ spec:
       affinity:
       {{- toYaml .Values.common.affinity | nindent 8 }}
       {{- end }}
+      {{- if .Values.proxy.pod.priorityClassName }}
+      priorityClassName: {{ .Values.proxy.pod.priorityClassName }}
+      {{- end }}

--- a/deployments/liqo/templates/liqo-route-daemonset.yaml
+++ b/deployments/liqo/templates/liqo-route-daemonset.yaml
@@ -81,5 +81,8 @@ spec:
             path: /run/xtables.lock
             type: FileOrCreate
           name: xtables-lock
+      {{- if .Values.route.pod.priorityClassName }}
+      priorityClassName: {{ .Values.route.pod.priorityClassName }}
+      {{- end }}
 
 {{- end }}

--- a/deployments/liqo/values.yaml
+++ b/deployments/liqo/values.yaml
@@ -123,6 +123,8 @@ controllerManager:
     resources:
       limits: {}
       requests: {}
+    # -- PriorityClassName (https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#pod-priority) for the controller-manager pod.
+    priorityClassName: ""
   # -- Image repository for the controller-manager pod.
   imageName: "ghcr.io/liqotech/liqo-controller-manager"
   config:
@@ -153,6 +155,8 @@ route:
     resources:
       limits: {}
       requests: {}
+    # -- PriorityClassName (https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#pod-priority) for the route pod.
+    priorityClassName: ""
   # -- Image repository for the route pod.
   imageName: "ghcr.io/liqotech/liqonet"
   # -- Extra tolerations for the route daemonset.
@@ -175,6 +179,8 @@ gateway:
     resources:
       limits: {}
       requests: {}
+    # -- PriorityClassName (https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#pod-priority) for the network gateway pod.
+    priorityClassName: ""
   # -- Image repository for the network gateway pod.
   imageName: "ghcr.io/liqotech/liqonet"
   service:
@@ -250,6 +256,8 @@ networkManager:
     resources:
       limits: {}
       requests: {}
+    # -- PriorityClassName (https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#pod-priority) for the networkManager pod.
+    priorityClassName: ""
   # -- Image repository for the networkManager pod.
   imageName: "ghcr.io/liqotech/liqonet"
   config:
@@ -280,6 +288,8 @@ crdReplicator:
     resources:
       limits: {}
       requests: {}
+    # -- PriorityClassName (https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#pod-priority) for the crdReplicator pod.
+    priorityClassName: ""
   # -- Image repository for the crdReplicator pod.
   imageName: "ghcr.io/liqotech/crd-replicator"
 
@@ -295,6 +305,8 @@ discovery:
     resources:
       limits: {}
       requests: {}
+    # -- PriorityClassName (https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#pod-priority) for the discovery pod.
+    priorityClassName: ""
   # -- Image repository for the discovery pod.
   imageName: "ghcr.io/liqotech/discovery"
   config:
@@ -336,6 +348,8 @@ auth:
     resources:
       limits: {}
       requests: {}
+    # -- PriorityClassName (https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#pod-priority) for the auth pod.
+    priorityClassName: ""
   # -- Image repository for the auth pod.
   imageName: "ghcr.io/liqotech/auth-service"
   initContainer:
@@ -409,6 +423,8 @@ metricAgent:
     resources:
       limits: {}
       requests: {}
+    # -- PriorityClassName (https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#pod-priority) for the metricAgent pod.
+    priorityClassName: ""
   # -- Image repository for the metricAgent pod.
   imageName: "ghcr.io/liqotech/metric-agent"
   initContainer:
@@ -511,6 +527,8 @@ proxy:
     resources:
       limits: {}
       requests: {}
+    # -- PriorityClassName (https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#pod-priority) for the proxy pod.
+    priorityClassName: ""
   # -- Image repository for the proxy pod.
   imageName: "ghcr.io/liqotech/proxy"
   service:


### PR DESCRIPTION
# Description

This PR adds support for defining [priorityClassName](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#pod-priority) on some of the pods

It is especially useful for the `liqo-route` as in real case scenarios it is not being schedule to some of the worker nodes and it breaks the network for anything which is running there. When assigning a high (enough) priority to `liqo-route` it is always scheduled to all of the worker nodes

# How Has This Been Tested?

- [x] Test A
Installed with default values -> no priorityClassName exists on any of the pods
- [x] Test B
Assigned priorityClassName values to all relevant workloads and the workloads are running with priorityClassName