### PR TITLE
Network: Fabric IPAM init fix

### DIFF
--- a/pkg/liqo-controller-manager/internal-network/client-controller/client_controller.go
+++ b/pkg/liqo-controller-manager/internal-network/client-controller/client_controller.go
@@ -69,10 +69,6 @@ func (r *ClientReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("unable to initialize the IPAM: %w", err)
 	}
-	if ipam == nil {
-		klog.Info("IPAM not ready")
-		return ctrl.Result{Requeue: true}, nil
-	}
 
 	remoteClusterID, ok := gwClient.Labels[consts.RemoteClusterID]
 	if !ok {

--- a/pkg/liqo-controller-manager/internal-network/fabricipam/singleton.go
+++ b/pkg/liqo-controller-manager/internal-network/fabricipam/singleton.go
@@ -16,6 +16,7 @@ package fabricipam
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	"k8s.io/apimachinery/pkg/labels"
@@ -46,7 +47,7 @@ func Get(ctx context.Context, cl client.Client) (*IPAM, error) {
 		return nil, err
 	}
 	if network.Status.CIDR.String() == "" {
-		return nil, nil
+		return nil, fmt.Errorf("network %s has not been remapped yet", consts.NetworkTypeInternalCIDR)
 	}
 
 	fabricIPAM, err = newIPAM(network.Status.CIDR.String())

--- a/pkg/liqo-controller-manager/internal-network/node-controller/node_controller.go
+++ b/pkg/liqo-controller-manager/internal-network/node-controller/node_controller.go
@@ -69,10 +69,6 @@ func (r *NodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res c
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("unable to initialize the IPAM: %w", err)
 	}
-	if ipam == nil {
-		klog.Infof("IPAM not ready")
-		return ctrl.Result{}, nil
-	}
 
 	internalNode := &networkingv1alpha1.InternalNode{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/liqo-controller-manager/internal-network/server-controller/server_controller.go
+++ b/pkg/liqo-controller-manager/internal-network/server-controller/server_controller.go
@@ -69,10 +69,6 @@ func (r *ServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("unable to initialize the IPAM: %w", err)
 	}
-	if ipam == nil {
-		klog.Infof("IPAM not ready")
-		return ctrl.Result{}, nil
-	}
 
 	remoteClusterID, ok := gwServer.Labels[consts.RemoteClusterID]
 	if !ok {


### PR DESCRIPTION
# Description

This PR fixes a bug in fabric IPAM initialization. If the internal-cidr network has not been remapped yet, the Init function returns an error and the controller requeue the resource.
