### PR TITLE
Add Prometheus scraping in Helm chart

### DIFF
--- a/deployments/liqo/README.md
+++ b/deployments/liqo/README.md
@@ -44,6 +44,13 @@
 | controllerManager.config.resourcePluginAddress | string | `""` | The address of an external resource plugin service (see https://github.com/liqotech/liqo-resource-plugins for additional information), overriding the default resource computation logic based on the percentage of available resources. Leave it empty to use the standard local resource monitor. |
 | controllerManager.config.resourceSharingPercentage | int | `30` | Percentage of available cluster resources that you are willing to share with foreign clusters. |
 | controllerManager.imageName | string | `"ghcr.io/liqotech/liqo-controller-manager"` | Image repository for the controller-manager pod. |
+| controllerManager.metrics.service | object | `{"annotations":{},"labels":{}}` | Service used to expose metrics. |
+| controllerManager.metrics.service.annotations | object | `{}` | Annotations for the metrics service. |
+| controllerManager.metrics.service.labels | object | `{}` | Labels for the metrics service. |
+| controllerManager.metrics.serviceMonitor.enabled | bool | `false` | Enable/Disable a Prometheus servicemonitor. Turn on this flag when the Prometheus Operator runs in your cluster |
+| controllerManager.metrics.serviceMonitor.interval | string | `""` | Customize service monitor requests interval. If empty, Prometheus uses the global scrape interval (https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#endpoint). |
+| controllerManager.metrics.serviceMonitor.labels | object | `{}` | Labels for the gateway servicemonitor. |
+| controllerManager.metrics.serviceMonitor.scrapeTimeout | string | `""` | Customize service monitor scrape timeout. If empty, Prometheus uses the global scrape timeout (https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#endpoint). |
 | controllerManager.pod.annotations | object | `{}` | Annotations for the controller-manager pod. |
 | controllerManager.pod.extraArgs | list | `[]` | Extra arguments for the controller-manager pod. |
 | controllerManager.pod.labels | object | `{}` | Labels for the controller-manager pod. |
@@ -51,6 +58,10 @@
 | controllerManager.pod.resources | object | `{"limits":{},"requests":{}}` | Resource requests and limits (https://kubernetes.io/docs/user-guide/compute-resources/) for the controller-manager pod. |
 | controllerManager.replicas | int | `1` | The number of controller-manager instances to run, which can be increased for active/passive high availability. |
 | crdReplicator.imageName | string | `"ghcr.io/liqotech/crd-replicator"` | Image repository for the crdReplicator pod. |
+| crdReplicator.metrics.podMonitor.enabled | bool | `false` | Enable/Disable the creation of a Prometheus podmonitor. Turn on this flag when the Prometheus Operator runs in your cluster |
+| crdReplicator.metrics.podMonitor.interval | string | `""` | Setup pod monitor requests interval. If empty, Prometheus uses the global scrape interval (https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#endpoint). |
+| crdReplicator.metrics.podMonitor.labels | object | `{}` | Labels for the crdReplicator podmonitor. |
+| crdReplicator.metrics.podMonitor.scrapeTimeout | string | `""` | Setup pod monitor scrape timeout. If empty, Prometheus uses the global scrape timeout (https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#endpoint). |
 | crdReplicator.pod.annotations | object | `{}` | Annotations for the crdReplicator pod. |
 | crdReplicator.pod.extraArgs | list | `[]` | Extra arguments for the crdReplicator pod. |
 | crdReplicator.pod.labels | object | `{}` | Labels for the crdReplicator pod. |

--- a/deployments/liqo/templates/liqo-controller-manager-deployment.yaml
+++ b/deployments/liqo/templates/liqo-controller-manager-deployment.yaml
@@ -215,6 +215,9 @@ spec:
         - name: healthz
           containerPort: 8081
           protocol: TCP
+        - name: metrics
+          containerPort: 8080
+          protocol: TCP
         readinessProbe:
           httpGet:
             path: /readyz

--- a/deployments/liqo/templates/liqo-controller-manager-service.yaml
+++ b/deployments/liqo/templates/liqo-controller-manager-service.yaml
@@ -13,3 +13,29 @@ spec:
   ports:
   - port: {{ .Values.webhook.port }}
     targetPort: webhook
+
+---
+{{- $ctrlManagerMetricsConfig := (merge (dict "name" "controller-manager-metrics" "module" "controller-manager") .) -}}
+
+{{- if .Values.controllerManager.metrics.serviceMonitor.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "liqo.prefixedName" $ctrlManagerMetricsConfig }}
+  annotations:
+    {{- if .Values.controllerManager.metrics.service.annotations }}
+      {{- toYaml .Values.controllerManager.metrics.service.annotations | nindent 4 }}
+    {{- end}}
+  labels:
+    {{- include "liqo.labels" $ctrlManagerMetricsConfig | nindent 4 }}
+    {{- if .Values.controllerManager.metrics.service.labels }}
+      {{- toYaml .Values.controllerManager.metrics.service.labels | nindent 4 }}
+    {{- end}}
+spec:
+  selector:
+    {{- include "liqo.selectorLabels" $ctrlManagerConfig | nindent 4 }}
+  ports:
+  - name: metrics
+    port: 8080
+    targetPort: metrics
+{{- end }}

--- a/deployments/liqo/templates/liqo-controller-manager-servicemonitor.yaml
+++ b/deployments/liqo/templates/liqo-controller-manager-servicemonitor.yaml
@@ -1,0 +1,22 @@
+{{- $ctrlManagerMetricsConfig := (merge (dict "name" "controller-manager-metrics" "module" "controller-manager") .) -}}
+
+{{- if .Values.controllerManager.metrics.serviceMonitor.enabled }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "liqo.prefixedName" $ctrlManagerMetricsConfig }}
+  labels:
+    {{- include "liqo.labels" $ctrlManagerMetricsConfig | nindent 4 }}
+    {{- if .Values.controllerManager.metrics.serviceMonitor.labels }}
+      {{- toYaml .Values.controllerManager.metrics.serviceMonitor.labels | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "liqo.labels" $ctrlManagerMetricsConfig | nindent 6 }}
+  endpoints:
+  - port: metrics
+    interval: {{ .Values.controllerManager.metrics.serviceMonitor.interval }}
+    scrapeTimeout: {{ .Values.controllerManager.metrics.serviceMonitor.scrapeTimeout }}
+{{- end }}

--- a/deployments/liqo/templates/liqo-crd-replicator-deployment.yaml
+++ b/deployments/liqo/templates/liqo-crd-replicator-deployment.yaml
@@ -54,6 +54,10 @@ spec:
                   name: {{ include "liqo.clusterIdConfig" . }}
                   key: CLUSTER_NAME
           resources: {{- toYaml .Values.crdReplicator.pod.resources | nindent 12 }}
+          ports:
+          - name: metrics
+            containerPort: 8080
+            protocol: TCP
       {{- if ((.Values.common).nodeSelector) }}
       nodeSelector:
       {{- toYaml .Values.common.nodeSelector | nindent 8 }}

--- a/deployments/liqo/templates/liqo-crd-replicator-podmonitor.yaml
+++ b/deployments/liqo/templates/liqo-crd-replicator-podmonitor.yaml
@@ -1,0 +1,23 @@
+{{- $crdReplicatorConfig := (merge (dict "name" "crd-replicator" "module" "dispatcher") .) -}}
+{{- if .Values.crdReplicator.metrics.podMonitor.enabled }}
+
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ include "liqo.prefixedName" $crdReplicatorConfig }}
+  labels:
+    {{- include "liqo.labels" $crdReplicatorConfig | nindent 4 }}
+    {{- if .Values.crdReplicator.metrics.podMonitor.labels }}
+      {{- toYaml .Values.crdReplicator.metrics.podMonitor.labels | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "liqo.selectorLabels" $crdReplicatorConfig | nindent 6 }}
+  podMetricsEndpoints:
+  - port: metrics
+    interval: {{ .Values.crdReplicator.metrics.podMonitor.interval }}
+    scrapeTimeout: {{ .Values.crdReplicator.metrics.podMonitor.scrapeTimeout }}
+{{- end }}
+

--- a/deployments/liqo/values.yaml
+++ b/deployments/liqo/values.yaml
@@ -142,6 +142,25 @@ controllerManager:
     # This feature can be useful in case of remote node failure to guarantee better service continuity and to have the expected pods workload on the remote cluster.
     # However, enabling this feature could produce zombies in the worker node, in case the node returns Ready again without a restart.
     enableNodeFailureController: false
+  metrics:
+    # -- Service used to expose metrics.
+    service:
+      # -- Labels for the metrics service.
+      labels: {}
+      # -- Annotations for the metrics service.
+      annotations: {}
+    serviceMonitor:
+      # -- Enable/Disable a Prometheus servicemonitor. Turn on this flag when the Prometheus Operator
+      # runs in your cluster
+      enabled: false
+      # -- Customize service monitor requests interval. If empty, Prometheus uses the global scrape interval
+      # (https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#endpoint).
+      interval: ""
+      # -- Customize service monitor scrape timeout. If empty, Prometheus uses the global scrape timeout
+      # (https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#endpoint).
+      scrapeTimeout: ""
+      # -- Labels for the gateway servicemonitor.
+      labels: {}
 
 route:
   pod:
@@ -292,6 +311,19 @@ crdReplicator:
     priorityClassName: ""
   # -- Image repository for the crdReplicator pod.
   imageName: "ghcr.io/liqotech/crd-replicator"
+  metrics:
+    podMonitor:
+      # -- Enable/Disable the creation of a Prometheus podmonitor. Turn on this flag when the Prometheus Operator
+      # runs in your cluster
+      enabled: false
+      # -- Setup pod monitor requests interval. If empty, Prometheus uses the global scrape interval
+      # (https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#endpoint).
+      interval: ""
+      # -- Setup pod monitor scrape timeout. If empty, Prometheus uses the global scrape timeout
+      # (https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#endpoint).
+      scrapeTimeout: ""
+      # -- Labels for the crdReplicator podmonitor.
+      labels: {}
 
 discovery:
   pod:


### PR DESCRIPTION
# Description

Adding scraping using ServiceMonitor to the Controller Manager and PodMonitor to the CRD Replicator

Motivation is having the ability to scrape the controllers metrics in order of creating alerts on failed reconciles etc.

# How Has This Been Tested?

- [x] Test A
  Installed with default values -> only change is the addition of the `metrics` port on the relevant Deployment(s)
- [x] Test B
  Installed with relevant PodMonitor/ServiceMonitor enabled -> metrics are visible in Prometheus
