### PR TITLE
[Network] Use a single manager with all pods cached in controller-manager

### DIFF
--- a/pkg/consts/externalnetwork.go
+++ b/pkg/consts/externalnetwork.go
@@ -15,11 +15,6 @@
 package consts
 
 const (
-	// ExternalNetworkLabel is the label added to all components that belong to the external network.
-	ExternalNetworkLabel = "networking.liqo.io/external-network"
-	// ExternalNetworkLabelValue is the value of the label added to components that belong to the external network.
-	ExternalNetworkLabelValue = "true"
-
 	// GatewayResourceLabel is the label added to a gateway resource.
 	GatewayResourceLabel = "networking.liqo.io/gateway-resource"
 	// GatewayResourceLabelValue is the value of the label added to a gateway resource.

--- a/pkg/liqo-controller-manager/podstatus-controller/podstatus_controller_test.go
+++ b/pkg/liqo-controller-manager/podstatus-controller/podstatus_controller_test.go
@@ -46,15 +46,14 @@ var _ = Describe("PodStatusController", func() {
 	)
 
 	var (
-		ctx                 context.Context
-		err                 error
-		buffer              *bytes.Buffer
-		fakeClient          client.WithWatch
-		fakeClientBuilder   *fake.ClientBuilder
-		fakeLocalPodsClient client.WithWatch
-		localPod            *corev1.Pod
-		localPod2           *corev1.Pod
-		liqoNode2           *corev1.Node
+		ctx               context.Context
+		err               error
+		buffer            *bytes.Buffer
+		fakeClient        client.WithWatch
+		fakeClientBuilder *fake.ClientBuilder
+		localPod          *corev1.Pod
+		localPod2         *corev1.Pod
+		liqoNode2         *corev1.Node
 
 		reqLiqoNode = ctrl.Request{NamespacedName: types.NamespacedName{Name: liqoNodeName}}
 
@@ -144,9 +143,8 @@ var _ = Describe("PodStatusController", func() {
 
 	JustBeforeEach(func() {
 		r := &PodStatusReconciler{
-			Client:          fakeClient,
-			Scheme:          scheme.Scheme,
-			LocalPodsClient: fakeLocalPodsClient,
+			Client: fakeClient,
+			Scheme: scheme.Scheme,
 		}
 		_, err = r.Reconcile(ctx, reqLiqoNode)
 		Expect(err).NotTo(HaveOccurred())
@@ -160,14 +158,14 @@ var _ = Describe("PodStatusController", func() {
 
 		When("remote unavailable label not present", func() {
 			BeforeEach(func() {
-				fakeLocalPodsClient = fakeClientBuilder.WithObjects(localPod, localPod2).Build()
+				fakeClient = fakeClientBuilder.WithObjects(localPod, localPod2).Build()
 			})
 
 			It("should add remote unavailable label to local offloaded pods", func() {
 				localPodAfter := corev1.Pod{}
 				localPod2After := corev1.Pod{}
-				Expect(fakeLocalPodsClient.Get(ctx, reqLocalPod.NamespacedName, &localPodAfter)).To(Succeed())
-				Expect(fakeLocalPodsClient.Get(ctx, reqLocalPod2.NamespacedName, &localPod2After)).To(Succeed())
+				Expect(fakeClient.Get(ctx, reqLocalPod.NamespacedName, &localPodAfter)).To(Succeed())
+				Expect(fakeClient.Get(ctx, reqLocalPod2.NamespacedName, &localPod2After)).To(Succeed())
 				Expect(localPodAfter.Labels).To(HaveKeyWithValue(consts.RemoteUnavailableKey, consts.RemoteUnavailableValue))
 				Expect(localPod2After.Labels).ToNot(HaveKeyWithValue(consts.RemoteUnavailableKey, consts.RemoteUnavailableValue))
 			})
@@ -176,14 +174,14 @@ var _ = Describe("PodStatusController", func() {
 		When("remote unavailable label present", func() {
 			BeforeEach(func() {
 				localPod.Labels = labels.Merge(localPod.Labels, labels.Set{consts.RemoteUnavailableKey: consts.RemoteUnavailableValue})
-				fakeLocalPodsClient = fakeClientBuilder.WithObjects(localPod, localPod2).Build()
+				fakeClient = fakeClientBuilder.WithObjects(localPod, localPod2).Build()
 			})
 
 			It("should keep remote unavailable label to local offloaded pods", func() {
 				localPodAfter := corev1.Pod{}
 				localPod2After := corev1.Pod{}
-				Expect(fakeLocalPodsClient.Get(ctx, reqLocalPod.NamespacedName, &localPodAfter)).To(Succeed())
-				Expect(fakeLocalPodsClient.Get(ctx, reqLocalPod2.NamespacedName, &localPod2After)).To(Succeed())
+				Expect(fakeClient.Get(ctx, reqLocalPod.NamespacedName, &localPodAfter)).To(Succeed())
+				Expect(fakeClient.Get(ctx, reqLocalPod2.NamespacedName, &localPod2After)).To(Succeed())
 				Expect(localPodAfter.Labels).To(HaveKeyWithValue(consts.RemoteUnavailableKey, consts.RemoteUnavailableValue))
 				Expect(localPod2After.Labels).ToNot(HaveKeyWithValue(consts.RemoteUnavailableKey, consts.RemoteUnavailableValue))
 			})
@@ -197,14 +195,14 @@ var _ = Describe("PodStatusController", func() {
 
 		When("remote unavailable label not present", func() {
 			BeforeEach(func() {
-				fakeLocalPodsClient = fakeClientBuilder.WithObjects(localPod, localPod2).Build()
+				fakeClient = fakeClientBuilder.WithObjects(localPod, localPod2).Build()
 			})
 
 			It("should not add remote unavailable label to local offloaded pods", func() {
 				localPodAfter := corev1.Pod{}
 				localPod2After := corev1.Pod{}
-				Expect(fakeLocalPodsClient.Get(ctx, reqLocalPod.NamespacedName, &localPodAfter)).To(Succeed())
-				Expect(fakeLocalPodsClient.Get(ctx, reqLocalPod2.NamespacedName, &localPod2After)).To(Succeed())
+				Expect(fakeClient.Get(ctx, reqLocalPod.NamespacedName, &localPodAfter)).To(Succeed())
+				Expect(fakeClient.Get(ctx, reqLocalPod2.NamespacedName, &localPod2After)).To(Succeed())
 				Expect(localPodAfter.Labels).ToNot(HaveKeyWithValue(consts.RemoteUnavailableKey, consts.RemoteUnavailableValue))
 				Expect(localPod2After.Labels).ToNot(HaveKeyWithValue(consts.RemoteUnavailableKey, consts.RemoteUnavailableValue))
 			})
@@ -213,14 +211,14 @@ var _ = Describe("PodStatusController", func() {
 		When("remote unavailable label present", func() {
 			BeforeEach(func() {
 				localPod.Labels = labels.Merge(localPod.Labels, labels.Set{consts.RemoteUnavailableKey: consts.RemoteUnavailableValue})
-				fakeLocalPodsClient = fakeClientBuilder.WithObjects(localPod, localPod2).Build()
+				fakeClient = fakeClientBuilder.WithObjects(localPod, localPod2).Build()
 			})
 
 			It("should remove remote unavailable label to local offloaded pods", func() {
 				localPod := corev1.Pod{}
 				localPod2 := corev1.Pod{}
-				Expect(fakeLocalPodsClient.Get(ctx, reqLocalPod.NamespacedName, &localPod)).To(Succeed())
-				Expect(fakeLocalPodsClient.Get(ctx, reqLocalPod2.NamespacedName, &localPod2)).To(Succeed())
+				Expect(fakeClient.Get(ctx, reqLocalPod.NamespacedName, &localPod)).To(Succeed())
+				Expect(fakeClient.Get(ctx, reqLocalPod2.NamespacedName, &localPod2)).To(Succeed())
 				Expect(localPod.Labels).ToNot(HaveKeyWithValue(consts.RemoteUnavailableKey, consts.RemoteUnavailableValue))
 				Expect(localPod2.Labels).ToNot(HaveKeyWithValue(consts.RemoteUnavailableKey, consts.RemoteUnavailableValue))
 			})

--- a/pkg/liqo-controller-manager/virtualnode-controller/deletion-routine.go
+++ b/pkg/liqo-controller-manager/virtualnode-controller/deletion-routine.go
@@ -149,7 +149,7 @@ func (dr *DeletionRoutine) handle(ctx context.Context, key string) (err error) {
 			// We need to ensure that the current pods will no recreate the node after deleting it.
 			var found bool
 			if found, err = vkutils.CheckVirtualKubeletFlagsConsistence(
-				ctx, dr.vnr.ClientVK, vn, dr.vnr.VirtualKubeletOptions, createNodeFalseFlag); err != nil || !found {
+				ctx, dr.vnr.Client, vn, dr.vnr.VirtualKubeletOptions, createNodeFalseFlag); err != nil || !found {
 				if err == nil {
 					err = fmt.Errorf("virtual kubelet pods are still running with arg %s", createNodeFalseFlag.String())
 					return err
@@ -196,7 +196,7 @@ func (dr *DeletionRoutine) deleteNode(ctx context.Context, node *corev1.Node, vn
 
 	klog.Infof("Node %s cordoned", node.Name)
 
-	if err := client.IgnoreNotFound(drainNode(ctx, dr.vnr.ClientLocal, vn)); err != nil {
+	if err := client.IgnoreNotFound(drainNode(ctx, dr.vnr.Client, vn)); err != nil {
 		return fmt.Errorf("error draining node: %w", err)
 	}
 

--- a/pkg/liqo-controller-manager/virtualnode-controller/suite_test.go
+++ b/pkg/liqo-controller-manager/virtualnode-controller/suite_test.go
@@ -127,8 +127,6 @@ var _ = BeforeSuite(func() {
 
 	vnr, err := NewVirtualNodeReconciler(ctx,
 		k8sClient,
-		k8sClient,
-		k8sClient,
 		scheme.Scheme,
 		k8sManager.GetEventRecorderFor("virtualnode-controller"),
 		&localIdentity,

--- a/pkg/liqo-controller-manager/virtualnode-controller/virtualkubelet.go
+++ b/pkg/liqo-controller-manager/virtualnode-controller/virtualkubelet.go
@@ -166,7 +166,7 @@ func (r *VirtualNodeReconciler) ensureVirtualKubeletDeploymentAbsence(
 		}
 	}
 
-	if err := vkutils.CheckVirtualKubeletPodAbsence(ctx, r.ClientVK, virtualNode, r.VirtualKubeletOptions); err != nil {
+	if err := vkutils.CheckVirtualKubeletPodAbsence(ctx, r.Client, virtualNode, r.VirtualKubeletOptions); err != nil {
 		return err
 	}
 

--- a/pkg/liqo-controller-manager/virtualnode-controller/virtualnode_controller.go
+++ b/pkg/liqo-controller-manager/virtualnode-controller/virtualnode_controller.go
@@ -50,10 +50,6 @@ const (
 // VirtualNodeReconciler manage NamespaceMap lifecycle.
 type VirtualNodeReconciler struct {
 	client.Client
-	// Client used to list local pods
-	ClientLocal client.Client
-	// Client used to list virtual-kubelet pods
-	ClientVK              client.Client
 	Scheme                *runtime.Scheme
 	HomeClusterIdentity   *discoveryv1alpha1.ClusterIdentity
 	VirtualKubeletOptions *vkforge.VirtualKubeletOpts
@@ -64,14 +60,12 @@ type VirtualNodeReconciler struct {
 // NewVirtualNodeReconciler returns a new VirtualNodeReconciler.
 func NewVirtualNodeReconciler(
 	ctx context.Context,
-	cl client.Client, cll client.Client, clvk client.Client,
+	cl client.Client,
 	s *runtime.Scheme, er record.EventRecorder,
 	hci *discoveryv1alpha1.ClusterIdentity, vko *vkforge.VirtualKubeletOpts,
 ) (*VirtualNodeReconciler, error) {
 	vnr := &VirtualNodeReconciler{
 		Client:                cl,
-		ClientLocal:           cll,
-		ClientVK:              clvk,
 		Scheme:                s,
 		HomeClusterIdentity:   hci,
 		VirtualKubeletOptions: vko,


### PR DESCRIPTION
# Description

This PR deletes all the auxiliary managers of the controller-manager and replaces them with a single unified manager where all pods are cached. 
Reason: the new network requires caching of all pods for the internal network to work correctly, so the managers with specific pods in cache are not useful anymore.