### PR TITLE
fix: ServiceMonitor PodMonitor scrape config null values

### DIFF
--- a/deployments/liqo/templates/liqo-controller-manager-servicemonitor.yaml
+++ b/deployments/liqo/templates/liqo-controller-manager-servicemonitor.yaml
@@ -17,6 +17,10 @@ spec:
       {{- include "liqo.labels" $ctrlManagerMetricsConfig | nindent 6 }}
   endpoints:
   - port: metrics
-    interval: {{ .Values.controllerManager.metrics.serviceMonitor.interval }}
-    scrapeTimeout: {{ .Values.controllerManager.metrics.serviceMonitor.scrapeTimeout }}
+    {{- with .Values.controllerManager.metrics.serviceMonitor.interval }}
+    interval: {{ . }}
+    {{- end }}
+    {{- with .Values.controllerManager.metrics.serviceMonitor.scrapeTimeout }}
+    scrapeTimeout: {{ . }}
+    {{- end }}
 {{- end }}

--- a/deployments/liqo/templates/liqo-crd-replicator-podmonitor.yaml
+++ b/deployments/liqo/templates/liqo-crd-replicator-podmonitor.yaml
@@ -17,7 +17,11 @@ spec:
       {{- include "liqo.selectorLabels" $crdReplicatorConfig | nindent 6 }}
   podMetricsEndpoints:
   - port: metrics
-    interval: {{ .Values.crdReplicator.metrics.podMonitor.interval }}
-    scrapeTimeout: {{ .Values.crdReplicator.metrics.podMonitor.scrapeTimeout }}
+    {{- with .Values.crdReplicator.metrics.podMonitor.interval }}
+    interval: {{ . }}
+    {{- end }}
+    {{- with .Values.crdReplicator.metrics.podMonitor.scrapeTimeout }}
+    scrapeTimeout: {{ . }}
+    {{- end }}
 {{- end }}
 

--- a/deployments/liqo/templates/liqo-gateway-servicemonitor.yaml
+++ b/deployments/liqo/templates/liqo-gateway-servicemonitor.yaml
@@ -18,8 +18,12 @@ spec:
       {{- include "liqo.labels" $gatewayMetricsConfig | nindent 6 }}
   endpoints:
   - port: metrics
-    interval: {{ .Values.gateway.metrics.serviceMonitor.interval }}
-    scrapeTimeout: {{ .Values.gateway.metrics.serviceMonitor.scrapeTimeout }}
+    {{- with .Values.gateway.metrics.serviceMonitor.interval }}
+    interval: {{ . }}
+    {{- end }}
+    {{- with .Values.gateway.metrics.serviceMonitor.scrapeTimeout }}
+    scrapeTimeout: {{ . }}
+    {{- end }}
 {{- end }}
 
 {{- end }}

--- a/deployments/liqo/templates/liqo-virtualkubelet-podmonitor.yaml
+++ b/deployments/liqo/templates/liqo-virtualkubelet-podmonitor.yaml
@@ -19,7 +19,11 @@ spec:
       app.kubernetes.io/component: "virtual-kubelet"
   podMetricsEndpoints:
   - port: metrics
-    interval: {{ .Values.virtualKubelet.metrics.podMonitor.interval }}
-    scrapeTimeout: {{ .Values.virtualKubelet.metrics.podMonitor.scrapeTimeout }}
+    {{- with .Values.virtualKubelet.metrics.podMonitor.interval }}
+    interval: {{ . }}
+    {{- end }}
+    {{- with .Values.virtualKubelet.metrics.podMonitor.scrapeTimeout }}
+    scrapeTimeout: {{ . }}
+    {{- end }}
 {{- end }}
 


### PR DESCRIPTION
# Description

When using liqo's ServiceMonitors and PodMonitors with ArgoCD we encounter unresolvable diff with `null` values.
ArgoCD failed to sync this resources. 

# How Has This Been Tested?

Deployed new version -> ArgoCD does not show wrong diff.


<img width="1420" alt="image" src="https://github.com/liqotech/liqo/assets/11005895/20725a4e-84db-45b8-b8bf-dd314c73e760">

