### PR TITLE
Network: fwmark use all podcidr as src match

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -8,7 +8,6 @@ on:
       - network-general
       - network-external
       - network-internal
-      - frc/mangle
   repository_dispatch:
     types:
       - test-command

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/containernetworking/plugins v1.4.0
 	github.com/coreos/go-iptables v0.7.0
 	github.com/go-git/go-git/v5 v5.11.0
-	github.com/google/nftables v0.1.0
+	github.com/google/nftables v0.1.1-0.20240112203004-33ee8df9d8e2
 	github.com/google/uuid v1.6.0
 	github.com/goombaio/namegenerator v0.0.0-20181006234301-989e774b106e
 	github.com/grandcat/zeroconf v1.0.0
@@ -276,6 +276,5 @@ require (
 replace (
 	// Waitin for PR https://github.com/coreos/go-iptables/pull/110 to be merged
 	github.com/coreos/go-iptables => github.com/cheina97/go-iptables v0.0.0-20230824102241-61fc692e7548
-	github.com/google/nftables => github.com/cheina97/nftables v0.0.0-20231130113829-f658cd146651
 	github.com/grandcat/zeroconf => github.com/liqotech/zeroconf v1.0.1-0.20201020081245-6384f3f21ffb
 )

--- a/go.sum
+++ b/go.sum
@@ -173,8 +173,6 @@ github.com/chai2010/gettext-go v1.0.2 h1:1Lwwip6Q2QGsAdl/ZKPCwTe9fe0CjlUbqj5bFNS
 github.com/chai2010/gettext-go v1.0.2/go.mod h1:y+wnP2cHYaVj19NZhYKAwEMH2CI1gNHeQQ+5AjwawxA=
 github.com/cheina97/go-iptables v0.0.0-20230824102241-61fc692e7548 h1:tsUrWiCxLp1cI8TB7qDmHNezZavWgxghH+m+pW+04wA=
 github.com/cheina97/go-iptables v0.0.0-20230824102241-61fc692e7548/go.mod h1:Qe8Bv2Xik5FyTXwgIbLAnv2sWSBmvWdFETJConOQ//Q=
-github.com/cheina97/nftables v0.0.0-20231130113829-f658cd146651 h1:+fyNVmQQXROZWBvqhWREC96CWhUiQMHBlb/pzZf/36E=
-github.com/cheina97/nftables v0.0.0-20231130113829-f658cd146651/go.mod h1:FODgEv85GcCEyoUYZ27mPWQBSU1f67bzgNu2IITA9k8=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
@@ -410,6 +408,8 @@ github.com/google/gofuzz v1.1.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/
 github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
 github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
+github.com/google/nftables v0.1.1-0.20240112203004-33ee8df9d8e2 h1:G2RS+WwzoAixmpV1r6GxQL6XAjPBUiXo/71tNF1JvzE=
+github.com/google/nftables v0.1.1-0.20240112203004-33ee8df9d8e2/go.mod h1:KxupCGmcgEI3TVOAQE6vzfdSAHDQhDf4Cl5GpnneEzg=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/pprof v0.0.0-20190515194954-54271f7e092f/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/pprof v0.0.0-20191218002539-d4f498aebedc/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=

--- a/pkg/liqo-controller-manager/internal-network/route/pod_controller.go
+++ b/pkg/liqo-controller-manager/internal-network/route/pod_controller.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -92,6 +93,10 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 
 	op, err := enforceRoutePodPresence(ctx, r.Client, r.Scheme, r.Options, pod)
 	if err != nil {
+		if apierrors.IsNotFound(err) {
+			klog.Infof("there is no internalnode %s", pod.Spec.NodeName)
+			return ctrl.Result{RequeueAfter: time.Second}, nil
+		}
 		return ctrl.Result{}, err
 	}
 


### PR DESCRIPTION
# Description

This PR sets the first IP of the pod CIDR as the IP used to Masquerade the src of the packets incoming from a nodeport service.
