### PR TITLE
Network: set gateway server Service type with liqoctl flag --service-type

### DIFF
--- a/pkg/liqoctl/install/handler.go
+++ b/pkg/liqoctl/install/handler.go
@@ -418,6 +418,17 @@ func (o *Options) postProviderValues() map[string]interface{} {
 				"type": o.ExtServiceType.Value,
 			},
 		}
+		values["peering"] = map[string]interface{}{
+			"networking": map[string]interface{}{
+				"gateway": map[string]interface{}{
+					"server": map[string]interface{}{
+						"service": map[string]interface{}{
+							"type": o.ExtServiceType.Value,
+						},
+					},
+				},
+			},
+		}
 	}
 	return values
 }


### PR DESCRIPTION
# Description

This PR updates liqoctl to set the GatewayServer Service type when the flag `--service-type` is set