### PR TITLE
Fix nat address and port override

### DIFF
--- a/deployments/liqo/README.md
+++ b/deployments/liqo/README.md
@@ -141,7 +141,7 @@
 | networkManager.pod.labels | object | `{}` | Labels for the networkManager pod. |
 | networkManager.pod.resources | object | `{"limits":{},"requests":{}}` | Resource requests and limits (https://kubernetes.io/docs/user-guide/compute-resources/) for the networkManager pod. |
 | networking.clientResources | list | `[{"apiVersion":"networking.liqo.io/v1alpha1","resource":"wggatewayclients"}]` | Set the list of resources that implement the GatewayClient |
-| networking.gatewayTemplates | object | `{"container":{"gateway":{"image":{"name":"ghcr.io/liqotech/gateway","version":""}},"geneve":{"image":{"name":"ghcr.io/liqotech/gateway/geneve","version":""}},"wireguard":{"image":{"name":"ghcr.io/liqotech/gateway/wireguard","version":""}}},"ping":{"interval":"2s","lossThreshold":5,"updateStatusInterval":"10s"},"replicas":1,"server":{"service":{"allocateLoadBalancerNodePorts":""}}}` | Set the options for the default gateway (server/client) templates. The default templates use a WireGuard implementation to connect the gateway of the clusters. These options are used to configure only the default templates and should not be considered if a custom template is used. |
+| networking.gatewayTemplates | object | `{"container":{"gateway":{"image":{"name":"ghcr.io/liqotech/gateway","version":""}},"geneve":{"image":{"name":"ghcr.io/liqotech/gateway/geneve","version":""}},"wireguard":{"image":{"name":"ghcr.io/liqotech/gateway/wireguard","version":""}}},"ping":{"interval":"2s","lossThreshold":5,"updateStatusInterval":"10s"},"replicas":1,"server":{"service":{"allocateLoadBalancerNodePorts":"","annotations":{}}}}` | Set the options for the default gateway (server/client) templates. The default templates use a WireGuard implementation to connect the gateway of the clusters. These options are used to configure only the default templates and should not be considered if a custom template is used. |
 | networking.gatewayTemplates.container.gateway.image.name | string | `"ghcr.io/liqotech/gateway"` | Image repository for the gateway container. |
 | networking.gatewayTemplates.container.gateway.image.version | string | `""` | Custom version for the gateway image. If not specified, the global tag is used. |
 | networking.gatewayTemplates.container.geneve.image.name | string | `"ghcr.io/liqotech/gateway/geneve"` | Image repository for the geneve container. |
@@ -153,9 +153,10 @@
 | networking.gatewayTemplates.ping.lossThreshold | int | `5` | Set the number of consecutive pings that must fail to consider the connection as lost |
 | networking.gatewayTemplates.ping.updateStatusInterval | string | `"10s"` | Set the interval at which the connection resource status is updated |
 | networking.gatewayTemplates.replicas | int | `1` | Set the number of replicas for the gateway deployments |
-| networking.gatewayTemplates.server | object | `{"service":{"allocateLoadBalancerNodePorts":""}}` | Set the options to configure the gateway server |
-| networking.gatewayTemplates.server.service | object | `{"allocateLoadBalancerNodePorts":""}` | Set the options to configure the server service |
+| networking.gatewayTemplates.server | object | `{"service":{"allocateLoadBalancerNodePorts":"","annotations":{}}}` | Set the options to configure the gateway server |
+| networking.gatewayTemplates.server.service | object | `{"allocateLoadBalancerNodePorts":"","annotations":{}}` | Set the options to configure the server service |
 | networking.gatewayTemplates.server.service.allocateLoadBalancerNodePorts | string | `""` | Set to "false" if you expose the gateway service as LoadBalancer and you do not want to create also a NodePort associated to it (Note: this setting is useful only on cloud providers that support this feature). |
+| networking.gatewayTemplates.server.service.annotations | object | `{}` | Annotations for the server service. |
 | networking.internal | bool | `true` | Use the default Liqo network manager. |
 | networking.iptables | object | `{"mode":"nf_tables"}` | Iptables configuration tuning. |
 | networking.iptables.mode | string | `"nf_tables"` | Select the iptables mode to use. Possible values are "legacy" and "nf_tables". |

--- a/deployments/liqo/templates/liqo-wireguard-gateway-server-template.yaml
+++ b/deployments/liqo/templates/liqo-wireguard-gateway-server-template.yaml
@@ -21,7 +21,11 @@ spec:
     spec:
       service:
         metadata:
-          {{- include "liqo.metadataTemplate" $templateConfig | nindent 12 }}
+          {{- include "liqo.metadataTemplate" $templateConfig | nindent 10 }}
+          {{- if .Values.networking.gatewayTemplates.server.service.annotations }}
+          annotations:
+            {{- toYaml .Values.networking.gatewayTemplates.server.service.annotations | nindent 12 }}
+          {{- end }}
         spec:
           selector:
             {{- include "liqo.labelsTemplate" $templateConfig | nindent 12 }}

--- a/deployments/liqo/values.yaml
+++ b/deployments/liqo/values.yaml
@@ -70,6 +70,14 @@ networking:
       service:
         # -- Set to "false" if you expose the gateway service as LoadBalancer and you do not want to create also a NodePort associated to it (Note: this setting is useful only on cloud providers that support this feature).
         allocateLoadBalancerNodePorts: ""
+        # -- Annotations for the server service.
+        annotations: {}
+          # -- Override the default address where your network gateway service is available.
+          # You should configure it if the network gateway is behind a reverse proxy or NAT.
+          # liqo.io/override-address: "10.43.12.182"
+          # -- Overrides the port where your network gateway service is available.
+          # You should configure it if the network gateway is behind a reverse proxy or NAT and is different from the listening port.
+          # liqo.io/override-port: "51820"
     container:
       gateway:
         image:

--- a/pkg/liqo-controller-manager/external-network/client-operator/client_controller.go
+++ b/pkg/liqo-controller-manager/external-network/client-operator/client_controller.go
@@ -170,13 +170,13 @@ func (r *ClientReconciler) EnsureGatewayClient(ctx context.Context, gwClient *ne
 			ClusterID:  remoteClusterID,
 		}
 
-		name, err := enutils.RenderTemplate(objectTemplateMetadata["name"], td)
+		name, err := enutils.RenderTemplate(objectTemplateMetadata["name"], td, true)
 		if err != nil {
 			return fmt.Errorf("unable to render the template name: %w", err)
 		}
 		objChild.SetName(name.(string))
 
-		namespace, err := enutils.RenderTemplate(objectTemplateMetadata["namespace"], td)
+		namespace, err := enutils.RenderTemplate(objectTemplateMetadata["namespace"], td, true)
 		if err != nil {
 			return fmt.Errorf("unable to render the template namespace: %w", err)
 		}
@@ -190,7 +190,7 @@ func (r *ClientReconciler) EnsureGatewayClient(ctx context.Context, gwClient *ne
 
 		var objectTemplateMetadataLabels interface{}
 		if objectTemplateMetadataLabels, ok = objectTemplateMetadata["labels"]; ok {
-			labels, err := enutils.RenderTemplate(objectTemplateMetadataLabels, td)
+			labels, err := enutils.RenderTemplate(objectTemplateMetadataLabels, td, true)
 			if err != nil {
 				return fmt.Errorf("unable to render the template labels: %w", err)
 			}
@@ -199,7 +199,7 @@ func (r *ClientReconciler) EnsureGatewayClient(ctx context.Context, gwClient *ne
 
 		var objectTemplateMetadataAnnotations interface{}
 		if objectTemplateMetadataAnnotations, ok = objectTemplateMetadata["annotations"]; ok {
-			annotations, err := enutils.RenderTemplate(objectTemplateMetadataAnnotations, td)
+			annotations, err := enutils.RenderTemplate(objectTemplateMetadataAnnotations, td, true)
 			if err != nil {
 				return fmt.Errorf("unable to render the template annotations: %w", err)
 			}
@@ -218,7 +218,7 @@ func (r *ClientReconciler) EnsureGatewayClient(ctx context.Context, gwClient *ne
 
 		objChild.SetLabels(labelsutils.Merge(objChild.GetLabels(), labelsutils.Set{consts.RemoteClusterID: remoteClusterID}))
 
-		spec, err := enutils.RenderTemplate(objectTemplateSpec, td)
+		spec, err := enutils.RenderTemplate(objectTemplateSpec, td, false)
 		if err != nil {
 			return fmt.Errorf("unable to render the template spec: %w", err)
 		}

--- a/pkg/liqo-controller-manager/external-network/server-operator/server_controller.go
+++ b/pkg/liqo-controller-manager/external-network/server-operator/server_controller.go
@@ -170,13 +170,13 @@ func (r *ServerReconciler) EnsureGatewayServer(ctx context.Context, gwServer *ne
 			ClusterID:  remoteClusterID,
 		}
 
-		name, err := enutils.RenderTemplate(objectTemplateMetadata["name"], td)
+		name, err := enutils.RenderTemplate(objectTemplateMetadata["name"], td, true)
 		if err != nil {
 			return fmt.Errorf("unable to render the template name: %w", err)
 		}
 		objChild.SetName(name.(string))
 
-		namespace, err := enutils.RenderTemplate(objectTemplateMetadata["namespace"], td)
+		namespace, err := enutils.RenderTemplate(objectTemplateMetadata["namespace"], td, true)
 		if err != nil {
 			return fmt.Errorf("unable to render the template namespace: %w", err)
 		}
@@ -190,7 +190,7 @@ func (r *ServerReconciler) EnsureGatewayServer(ctx context.Context, gwServer *ne
 
 		var objectTemplateMetadataLabels interface{}
 		if objectTemplateMetadataLabels, ok = objectTemplateMetadata["labels"]; ok {
-			labels, err := enutils.RenderTemplate(objectTemplateMetadataLabels, td)
+			labels, err := enutils.RenderTemplate(objectTemplateMetadataLabels, td, true)
 			if err != nil {
 				return fmt.Errorf("unable to render the template labels: %w", err)
 			}
@@ -199,7 +199,7 @@ func (r *ServerReconciler) EnsureGatewayServer(ctx context.Context, gwServer *ne
 
 		var objectTemplateMetadataAnnotations interface{}
 		if objectTemplateMetadataAnnotations, ok = objectTemplateMetadata["annotations"]; ok {
-			annotations, err := enutils.RenderTemplate(objectTemplateMetadataAnnotations, td)
+			annotations, err := enutils.RenderTemplate(objectTemplateMetadataAnnotations, td, true)
 			if err != nil {
 				return fmt.Errorf("unable to render the template annotations: %w", err)
 			}
@@ -218,7 +218,7 @@ func (r *ServerReconciler) EnsureGatewayServer(ctx context.Context, gwServer *ne
 
 		objChild.SetLabels(labelsutils.Merge(objChild.GetLabels(), labelsutils.Set{consts.RemoteClusterID: remoteClusterID}))
 
-		spec, err := enutils.RenderTemplate(objectTemplateSpec, td)
+		spec, err := enutils.RenderTemplate(objectTemplateSpec, td, false)
 		if err != nil {
 			return fmt.Errorf("unable to render the template spec: %w", err)
 		}

--- a/pkg/liqo-controller-manager/external-network/wireguard/wggatewayserver_controller.go
+++ b/pkg/liqo-controller-manager/external-network/wireguard/wggatewayserver_controller.go
@@ -384,6 +384,10 @@ func (r *WgGatewayServerReconciler) forgeEndpointStatusNodePort(ctx context.Cont
 		}
 	}
 
+	if err := checkServiceOverrides(service, &addresses, &port); err != nil {
+		return nil, nil, err
+	}
+
 	return &networkingv1alpha1.EndpointStatus{
 			Protocol:  protocol,
 			Port:      port,
@@ -432,6 +436,10 @@ func (r *WgGatewayServerReconciler) forgeEndpointStatusLoadBalancer(service *cor
 		if ip := service.Status.LoadBalancer.Ingress[i].IP; ip != "" {
 			addresses = append(addresses, ip)
 		}
+	}
+
+	if err := checkServiceOverrides(service, &addresses, &port); err != nil {
+		return nil, err
 	}
 
 	return &networkingv1alpha1.EndpointStatus{


### PR DESCRIPTION
# Description

This pr fixes overriding gateway services addresses and ports by setting annotations over them

In particular:
* `liqo.io/override-address` will override the address
* `liqo.io/override-port: "51820"` will override the port

This is particularly useful when exposing them behind a NAT or with a LoadBalancer external to Kubernetes

# How Has This Been Tested?

- [x] locally
