### PR TITLE
WireGuard templates examples

### DIFF
--- a/docs/usage/inter-cluster-network.md
+++ b/docs/usage/inter-cluster-network.md
@@ -368,3 +368,27 @@ liqoctl --kubeconfig $KUBE_CLIENT generate publickey --gateway-type client --gat
 kubectl --kubeconfig $KUBE_SERVER apply -f publickey-client.yaml
 kubectl --kubeconfig $KUBE_CLIENT apply -f publickey-server.yaml
 ```
+
+## Custom templates
+
+Gateway resources (i.e., `GatewayServer` and `GatewayClient`) contain a reference to the template CR implementing the inter-cluster network technology.
+
+The default technology used by Liqo is an implementation of a WireGuard VPN tunnel to connect the gateway client and gateway server of the two peered clusters.
+The template is referenced in the spec of the API, as shown here:
+
+```yaml
+spec:
+  serverTemplateRef:
+    apiVersion: networking.liqo.io/v1alpha1
+    kind: WgGatewayServerTemplate
+    name: wireguard-server
+    namespace: liqo
+```
+
+This allows the user to reference custom-made templates, giving also the possibility to implement custom technologies different from WireGuard.
+
+The `examples/networking` folder contains a bunch of template manifests, showing possible customizations to the default WireGuard template.
+
+```{admonition} Tip
+A field with a value in the form of `'{{ EXAMPLE }}'` will be templated automatically by the Gateway operator with the value(s) from the `GatewayServer`/`GatewayClient` resource.  
+```

--- a/examples/networking/wireguard-client-default.yaml
+++ b/examples/networking/wireguard-client-default.yaml
@@ -1,0 +1,102 @@
+apiVersion: networking.liqo.io/v1alpha1
+kind: WgGatewayClientTemplate
+metadata:
+  name: wireguard-client
+  # namespace: liqo # or custom namespace
+spec:
+  objectKind:
+    apiVersion: networking.liqo.io/v1alpha1
+    kind: WgGatewayClient
+  template:
+    metadata:
+      labels:
+        networking.liqo.io/component: gateway
+      name: '{{ .Name }}'
+      namespace: '{{ .Namespace }}'
+    spec:
+      deployment:
+        metadata:
+          labels:
+            networking.liqo.io/component: gateway
+          name: '{{ .Name }}'
+          namespace: '{{ .Namespace }}'
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app.kubernetes.io/name: '{{ .Name }}'
+              networking.liqo.io/component: gateway
+          template:
+            metadata:
+              labels:
+                app.kubernetes.io/name: '{{ .Name }}'
+                networking.liqo.io/component: gateway
+              name: '{{ .Name }}'
+              namespace: '{{ .Namespace }}'
+            spec:
+              containers:
+              - args:
+                - --name={{ .Name }}
+                - --namespace={{ .Namespace }}
+                - --remote-cluster-id={{ .ClusterID }}
+                - --gateway-uid={{ .GatewayUID }}
+                - --mode=client
+                - --metrics-address=:8080
+                - --health-probe-bind-address=:8081
+                - --ping-enabled=true
+                - --ping-loss-threshold=5
+                - --ping-interval=2s
+                - --ping-update-status-interval=10s
+                image: ghcr.io/liqotech/gateway:<VERSION>
+                imagePullPolicy: IfNotPresent
+                name: gateway
+                securityContext:
+                  capabilities:
+                    add:
+                    - NET_ADMIN
+                    - NET_RAW
+                  privileged: true
+              - args:
+                - --name={{ .Name }}
+                - --namespace={{ .Namespace }}
+                - --remote-cluster-id={{ .ClusterID }}
+                - --gateway-uid={{ .GatewayUID }}
+                - --mode=client
+                - --mtu={{ .Spec.MTU }}
+                - --endpoint-address={{ index .Spec.Endpoint.Addresses 0 }}
+                - --endpoint-port={{ .Spec.Endpoint.Port }}
+                - --metrics-address=:8082
+                - --health-probe-bind-address=:8083
+                image: ghcr.io/liqotech/gateway/wireguard:<VERSION>
+                imagePullPolicy: IfNotPresent
+                name: wireguard
+                securityContext:
+                  capabilities:
+                    add:
+                    - NET_ADMIN
+                    - NET_RAW
+              - args:
+                - --name={{ .Name }}
+                - --namespace={{ .Namespace }}
+                - --remote-cluster-id={{ .ClusterID }}
+                - --node-name=$(NODE_NAME)
+                - --gateway-uid={{ .GatewayUID }}
+                - --mode=server
+                - --metrics-address=:8084
+                - --health-probe-bind-address=:8085
+                - --enable-arp=true
+                env:
+                - name: NODE_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: spec.nodeName
+                image: ghcr.io/liqotech/gateway/geneve:<VERSION>
+                imagePullPolicy: IfNotPresent
+                name: geneve
+                securityContext:
+                  capabilities:
+                    add:
+                    - NET_ADMIN
+                    - NET_RAW
+              serviceAccount: '{{ .Name }}'
+              serviceAccountName: '{{ .Name }}'

--- a/examples/networking/wireguard-client-high-availability.yaml
+++ b/examples/networking/wireguard-client-high-availability.yaml
@@ -1,0 +1,110 @@
+apiVersion: networking.liqo.io/v1alpha1
+kind: WgGatewayClientTemplate
+metadata:
+  name: wireguard-client-high-availability
+  # namespace: liqo # or custom namespace
+spec:
+  objectKind:
+    apiVersion: networking.liqo.io/v1alpha1
+    kind: WgGatewayClient
+  template:
+    metadata:
+      labels:
+        networking.liqo.io/component: gateway
+      name: '{{ .Name }}'
+      namespace: '{{ .Namespace }}'
+    spec:
+      deployment:
+        metadata:
+          labels:
+            networking.liqo.io/component: gateway
+          name: '{{ .Name }}'
+          namespace: '{{ .Namespace }}'
+        spec:
+          replicas: 2
+          selector:
+            matchLabels:
+              app.kubernetes.io/name: '{{ .Name }}'
+              networking.liqo.io/component: gateway
+          template:
+            metadata:
+              labels:
+                app.kubernetes.io/name: '{{ .Name }}'
+                networking.liqo.io/component: gateway
+              name: '{{ .Name }}'
+              namespace: '{{ .Namespace }}'
+            spec:
+              affinity:
+                podAntiAffinity:
+                  requiredDuringSchedulingIgnoredDuringExecution:
+                  - labelSelector:
+                      matchLabels:
+                        app.kubernetes.io/name: '{{ .Name }}'
+                        networking.liqo.io/component: gateway
+                    topologyKey: "kubernetes.io/hostname"
+              containers:
+              - args:
+                - --name={{ .Name }}
+                - --namespace={{ .Namespace }}
+                - --remote-cluster-id={{ .ClusterID }}
+                - --gateway-uid={{ .GatewayUID }}
+                - --mode=client
+                - --metrics-address=:8080
+                - --health-probe-bind-address=:8081
+                - --ping-enabled=true
+                - --ping-loss-threshold=5
+                - --ping-interval=2s
+                - --ping-update-status-interval=10s
+                image: ghcr.io/liqotech/gateway:<VERSION>
+                imagePullPolicy: IfNotPresent
+                name: gateway
+                securityContext:
+                  capabilities:
+                    add:
+                    - NET_ADMIN
+                    - NET_RAW
+                  privileged: true
+              - args:
+                - --name={{ .Name }}
+                - --namespace={{ .Namespace }}
+                - --remote-cluster-id={{ .ClusterID }}
+                - --gateway-uid={{ .GatewayUID }}
+                - --mode=client
+                - --mtu={{ .Spec.MTU }}
+                - --endpoint-address={{ index .Spec.Endpoint.Addresses 0 }}
+                - --endpoint-port={{ .Spec.Endpoint.Port }}
+                - --metrics-address=:8082
+                - --health-probe-bind-address=:8083
+                image: ghcr.io/liqotech/gateway/wireguard:<VERSION>
+                imagePullPolicy: IfNotPresent
+                name: wireguard
+                securityContext:
+                  capabilities:
+                    add:
+                    - NET_ADMIN
+                    - NET_RAW
+              - args:
+                - --name={{ .Name }}
+                - --namespace={{ .Namespace }}
+                - --remote-cluster-id={{ .ClusterID }}
+                - --node-name=$(NODE_NAME)
+                - --gateway-uid={{ .GatewayUID }}
+                - --mode=server
+                - --metrics-address=:8084
+                - --health-probe-bind-address=:8085
+                - --enable-arp=true
+                env:
+                - name: NODE_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: spec.nodeName
+                image: ghcr.io/liqotech/gateway/geneve:<VERSION>
+                imagePullPolicy: IfNotPresent
+                name: geneve
+                securityContext:
+                  capabilities:
+                    add:
+                    - NET_ADMIN
+                    - NET_RAW
+              serviceAccount: '{{ .Name }}'
+              serviceAccountName: '{{ .Name }}'

--- a/examples/networking/wireguard-client-pingdisabled.yaml
+++ b/examples/networking/wireguard-client-pingdisabled.yaml
@@ -1,0 +1,99 @@
+apiVersion: networking.liqo.io/v1alpha1
+kind: WgGatewayClientTemplate
+metadata:
+  name: wireguard-client-pingdisabled
+  # namespace: liqo # or custom namespace
+spec:
+  objectKind:
+    apiVersion: networking.liqo.io/v1alpha1
+    kind: WgGatewayClient
+  template:
+    metadata:
+      labels:
+        networking.liqo.io/component: gateway
+      name: '{{ .Name }}'
+      namespace: '{{ .Namespace }}'
+    spec:
+      deployment:
+        metadata:
+          labels:
+            networking.liqo.io/component: gateway
+          name: '{{ .Name }}'
+          namespace: '{{ .Namespace }}'
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app.kubernetes.io/name: '{{ .Name }}'
+              networking.liqo.io/component: gateway
+          template:
+            metadata:
+              labels:
+                app.kubernetes.io/name: '{{ .Name }}'
+                networking.liqo.io/component: gateway
+              name: '{{ .Name }}'
+              namespace: '{{ .Namespace }}'
+            spec:
+              containers:
+              - args:
+                - --name={{ .Name }}
+                - --namespace={{ .Namespace }}
+                - --remote-cluster-id={{ .ClusterID }}
+                - --gateway-uid={{ .GatewayUID }}
+                - --mode=client
+                - --metrics-address=:8080
+                - --health-probe-bind-address=:8081
+                - --ping-enabled=false
+                image: ghcr.io/liqotech/gateway:<VERSION>
+                imagePullPolicy: IfNotPresent
+                name: gateway
+                securityContext:
+                  capabilities:
+                    add:
+                    - NET_ADMIN
+                    - NET_RAW
+                  privileged: true
+              - args:
+                - --name={{ .Name }}
+                - --namespace={{ .Namespace }}
+                - --remote-cluster-id={{ .ClusterID }}
+                - --gateway-uid={{ .GatewayUID }}
+                - --mode=client
+                - --mtu={{ .Spec.MTU }}
+                - --endpoint-address={{ index .Spec.Endpoint.Addresses 0 }}
+                - --endpoint-port={{ .Spec.Endpoint.Port }}
+                - --metrics-address=:8082
+                - --health-probe-bind-address=:8083
+                image: ghcr.io/liqotech/gateway/wireguard:<VERSION>
+                imagePullPolicy: IfNotPresent
+                name: wireguard
+                securityContext:
+                  capabilities:
+                    add:
+                    - NET_ADMIN
+                    - NET_RAW
+              - args:
+                - --name={{ .Name }}
+                - --namespace={{ .Namespace }}
+                - --remote-cluster-id={{ .ClusterID }}
+                - --node-name=$(NODE_NAME)
+                - --gateway-uid={{ .GatewayUID }}
+                - --mode=server
+                - --metrics-address=:8084
+                - --health-probe-bind-address=:8085
+                - --enable-arp=true
+                env:
+                - name: NODE_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: spec.nodeName
+                image: ghcr.io/liqotech/gateway/geneve:<VERSION>
+                imagePullPolicy: IfNotPresent
+                name: geneve
+                securityContext:
+                  capabilities:
+                    add:
+                    - NET_ADMIN
+                    - NET_RAW
+              serviceAccount: '{{ .Name }}'
+              serviceAccountName: '{{ .Name }}'

--- a/examples/networking/wireguard-client-selector.yaml
+++ b/examples/networking/wireguard-client-selector.yaml
@@ -1,0 +1,111 @@
+apiVersion: networking.liqo.io/v1alpha1
+kind: WgGatewayClientTemplate
+metadata:
+  name: wireguard-client-selector
+  # namespace: liqo # or custom namespace
+spec:
+  objectKind:
+    apiVersion: networking.liqo.io/v1alpha1
+    kind: WgGatewayClient
+  template:
+    metadata:
+      labels:
+        networking.liqo.io/component: gateway
+      name: '{{ .Name }}'
+      namespace: '{{ .Namespace }}'
+    spec:
+      deployment:
+        metadata:
+          labels:
+            networking.liqo.io/component: gateway
+          name: '{{ .Name }}'
+          namespace: '{{ .Namespace }}'
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app.kubernetes.io/name: '{{ .Name }}'
+              networking.liqo.io/component: gateway
+          template:
+            metadata:
+              labels:
+                app.kubernetes.io/name: '{{ .Name }}'
+                networking.liqo.io/component: gateway
+              name: '{{ .Name }}'
+              namespace: '{{ .Namespace }}'
+            spec:
+              affinity:
+                nodeAffinity:
+                  requiredDuringSchedulingIgnoredDuringExecution:
+                    nodeSelectorTerms:
+                    - matchExpressions:
+                      - key: nodeType
+                        operator: In
+                        values:
+                        - cpu-optimized
+              containers:
+              - args:
+                - --name={{ .Name }}
+                - --namespace={{ .Namespace }}
+                - --remote-cluster-id={{ .ClusterID }}
+                - --gateway-uid={{ .GatewayUID }}
+                - --mode=client
+                - --metrics-address=:8080
+                - --health-probe-bind-address=:8081
+                - --ping-enabled=true
+                - --ping-loss-threshold=5
+                - --ping-interval=2s
+                - --ping-update-status-interval=10s
+                image: ghcr.io/liqotech/gateway:<VERSION>
+                imagePullPolicy: IfNotPresent
+                name: gateway
+                securityContext:
+                  capabilities:
+                    add:
+                    - NET_ADMIN
+                    - NET_RAW
+                  privileged: true
+              - args:
+                - --name={{ .Name }}
+                - --namespace={{ .Namespace }}
+                - --remote-cluster-id={{ .ClusterID }}
+                - --gateway-uid={{ .GatewayUID }}
+                - --mode=client
+                - --mtu={{ .Spec.MTU }}
+                - --endpoint-address={{ index .Spec.Endpoint.Addresses 0 }}
+                - --endpoint-port={{ .Spec.Endpoint.Port }}
+                - --metrics-address=:8082
+                - --health-probe-bind-address=:8083
+                image: ghcr.io/liqotech/gateway/wireguard:<VERSION>
+                imagePullPolicy: IfNotPresent
+                name: wireguard
+                securityContext:
+                  capabilities:
+                    add:
+                    - NET_ADMIN
+                    - NET_RAW
+              - args:
+                - --name={{ .Name }}
+                - --namespace={{ .Namespace }}
+                - --remote-cluster-id={{ .ClusterID }}
+                - --node-name=$(NODE_NAME)
+                - --gateway-uid={{ .GatewayUID }}
+                - --mode=server
+                - --metrics-address=:8084
+                - --health-probe-bind-address=:8085
+                - --enable-arp=true
+                env:
+                - name: NODE_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: spec.nodeName
+                image: ghcr.io/liqotech/gateway/geneve:<VERSION>
+                imagePullPolicy: IfNotPresent
+                name: geneve
+                securityContext:
+                  capabilities:
+                    add:
+                    - NET_ADMIN
+                    - NET_RAW
+              serviceAccount: '{{ .Name }}'
+              serviceAccountName: '{{ .Name }}'

--- a/examples/networking/wireguard-server-default.yaml
+++ b/examples/networking/wireguard-server-default.yaml
@@ -1,0 +1,116 @@
+apiVersion: networking.liqo.io/v1alpha1
+kind: WgGatewayServerTemplate
+metadata:
+  name: wireguard-server
+  # namespace: liqo # or custom namespace
+spec:
+  objectKind:
+    apiVersion: networking.liqo.io/v1alpha1
+    kind: WgGatewayServer
+  template:
+    metadata:
+      labels:
+        networking.liqo.io/component: gateway
+      name: '{{ .Name }}'
+      namespace: '{{ .Namespace }}'
+    spec:
+      deployment:
+        metadata:
+          labels:
+            networking.liqo.io/component: gateway
+          name: '{{ .Name }}'
+          namespace: '{{ .Namespace }}'
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app.kubernetes.io/name: '{{ .Name }}'
+              networking.liqo.io/component: gateway
+          template:
+            metadata:
+              labels:
+                app.kubernetes.io/name: '{{ .Name }}'
+                networking.liqo.io/component: gateway
+              name: '{{ .Name }}'
+              namespace: '{{ .Namespace }}'
+            spec:
+              containers:
+              - args:
+                - --name={{ .Name }}
+                - --namespace={{ .Namespace }}
+                - --remote-cluster-id={{ .ClusterID }}
+                - --gateway-uid={{ .GatewayUID }}
+                - --mode=server
+                - --metrics-address=:8080
+                - --health-probe-bind-address=:8081
+                - --ping-enabled=true
+                - --ping-loss-threshold=5
+                - --ping-interval=2s
+                - --ping-update-status-interval=10s
+                image: ghcr.io/liqotech/gateway:<VERSION>
+                imagePullPolicy: IfNotPresent
+                name: gateway
+                securityContext:
+                  capabilities:
+                    add:
+                    - NET_ADMIN
+                    - NET_RAW
+                  privileged: true
+              - args:
+                - --name={{ .Name }}
+                - --namespace={{ .Namespace }}
+                - --remote-cluster-id={{ .ClusterID }}
+                - --gateway-uid={{ .GatewayUID }}
+                - --mode=server
+                - --mtu={{ .Spec.MTU }}
+                - --listen-port={{ .Spec.Endpoint.Port }}
+                - --metrics-address=:8082
+                - --health-probe-bind-address=:8083
+                image: ghcr.io/liqotech/gateway/wireguard:<VERSION>
+                imagePullPolicy: IfNotPresent
+                name: wireguard
+                securityContext:
+                  capabilities:
+                    add:
+                    - NET_ADMIN
+                    - NET_RAW
+              - args:
+                - --name={{ .Name }}
+                - --namespace={{ .Namespace }}
+                - --remote-cluster-id={{ .ClusterID }}
+                - --node-name=$(NODE_NAME)
+                - --gateway-uid={{ .GatewayUID }}
+                - --mode=server
+                - --metrics-address=:8084
+                - --health-probe-bind-address=:8085
+                - --enable-arp=true
+                env:
+                - name: NODE_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: spec.nodeName
+                image: ghcr.io/liqotech/gateway/geneve:<VERSION>
+                imagePullPolicy: IfNotPresent
+                name: geneve
+                securityContext:
+                  capabilities:
+                    add:
+                    - NET_ADMIN
+                    - NET_RAW
+              serviceAccount: '{{ .Name }}'
+              serviceAccountName: '{{ .Name }}'
+      service:
+        metadata:
+          labels:
+            networking.liqo.io/component: gateway
+          name: '{{ .Name }}'
+          namespace: '{{ .Namespace }}'
+        spec:
+          ports:
+          - port: '{{ .Spec.Endpoint.Port }}'
+            protocol: UDP
+            targetPort: '{{ .Spec.Endpoint.Port }}'
+          selector:
+            app.kubernetes.io/name: '{{ .Name }}'
+            networking.liqo.io/component: gateway
+          type: '{{ .Spec.Endpoint.ServiceType }}'

--- a/examples/networking/wireguard-server-high-availability.yaml
+++ b/examples/networking/wireguard-server-high-availability.yaml
@@ -1,0 +1,124 @@
+apiVersion: networking.liqo.io/v1alpha1
+kind: WgGatewayServerTemplate
+metadata:
+  name: wireguard-server-high-availability
+  # namespace: liqo # or custom namespace
+spec:
+  objectKind:
+    apiVersion: networking.liqo.io/v1alpha1
+    kind: WgGatewayServer
+  template:
+    metadata:
+      labels:
+        networking.liqo.io/component: gateway
+      name: '{{ .Name }}'
+      namespace: '{{ .Namespace }}'
+    spec:
+      deployment:
+        metadata:
+          labels:
+            networking.liqo.io/component: gateway
+          name: '{{ .Name }}'
+          namespace: '{{ .Namespace }}'
+        spec:
+          replicas: 2
+          selector:
+            matchLabels:
+              app.kubernetes.io/name: '{{ .Name }}'
+              networking.liqo.io/component: gateway
+          template:
+            metadata:
+              labels:
+                app.kubernetes.io/name: '{{ .Name }}'
+                networking.liqo.io/component: gateway
+              name: '{{ .Name }}'
+              namespace: '{{ .Namespace }}'
+            spec:
+              affinity:
+                podAntiAffinity:
+                  requiredDuringSchedulingIgnoredDuringExecution:
+                  - labelSelector:
+                      matchLabels:
+                        app.kubernetes.io/name: '{{ .Name }}'
+                        networking.liqo.io/component: gateway
+                    topologyKey: "kubernetes.io/hostname"
+              containers:
+              - args:
+                - --name={{ .Name }}
+                - --namespace={{ .Namespace }}
+                - --remote-cluster-id={{ .ClusterID }}
+                - --gateway-uid={{ .GatewayUID }}
+                - --mode=server
+                - --metrics-address=:8080
+                - --health-probe-bind-address=:8081
+                - --ping-enabled=true
+                - --ping-loss-threshold=5
+                - --ping-interval=2s
+                - --ping-update-status-interval=10s
+                image: ghcr.io/liqotech/gateway:<VERSION>
+                imagePullPolicy: IfNotPresent
+                name: gateway
+                securityContext:
+                  capabilities:
+                    add:
+                    - NET_ADMIN
+                    - NET_RAW
+                  privileged: true
+              - args:
+                - --name={{ .Name }}
+                - --namespace={{ .Namespace }}
+                - --remote-cluster-id={{ .ClusterID }}
+                - --gateway-uid={{ .GatewayUID }}
+                - --mode=server
+                - --mtu={{ .Spec.MTU }}
+                - --listen-port={{ .Spec.Endpoint.Port }}
+                - --metrics-address=:8082
+                - --health-probe-bind-address=:8083
+                image: ghcr.io/liqotech/gateway/wireguard:<VERSION>
+                imagePullPolicy: IfNotPresent
+                name: wireguard
+                securityContext:
+                  capabilities:
+                    add:
+                    - NET_ADMIN
+                    - NET_RAW
+              - args:
+                - --name={{ .Name }}
+                - --namespace={{ .Namespace }}
+                - --remote-cluster-id={{ .ClusterID }}
+                - --node-name=$(NODE_NAME)
+                - --gateway-uid={{ .GatewayUID }}
+                - --mode=server
+                - --metrics-address=:8084
+                - --health-probe-bind-address=:8085
+                - --enable-arp=true
+                env:
+                - name: NODE_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: spec.nodeName
+                image: ghcr.io/liqotech/gateway/geneve:<VERSION>
+                imagePullPolicy: IfNotPresent
+                name: geneve
+                securityContext:
+                  capabilities:
+                    add:
+                    - NET_ADMIN
+                    - NET_RAW
+              serviceAccount: '{{ .Name }}'
+              serviceAccountName: '{{ .Name }}'
+      service:
+        metadata:
+          labels:
+            networking.liqo.io/component: gateway
+          name: '{{ .Name }}'
+          namespace: '{{ .Namespace }}'
+        spec:
+          ports:
+          - port: '{{ .Spec.Endpoint.Port }}'
+            protocol: UDP
+            targetPort: '{{ .Spec.Endpoint.Port }}'
+          selector:
+            app.kubernetes.io/name: '{{ .Name }}'
+            networking.liqo.io/component: gateway
+          type: '{{ .Spec.Endpoint.ServiceType }}'

--- a/examples/networking/wireguard-server-nat.yaml
+++ b/examples/networking/wireguard-server-nat.yaml
@@ -1,0 +1,119 @@
+apiVersion: networking.liqo.io/v1alpha1
+kind: WgGatewayServerTemplate
+metadata:
+  name: wireguard-server-nat
+  # namespace: liqo # or custom namespace
+spec:
+  objectKind:
+    apiVersion: networking.liqo.io/v1alpha1
+    kind: WgGatewayServer
+  template:
+    metadata:
+      labels:
+        networking.liqo.io/component: gateway
+      name: '{{ .Name }}'
+      namespace: '{{ .Namespace }}'
+    spec:
+      deployment:
+        metadata:
+          labels:
+            networking.liqo.io/component: gateway
+          name: '{{ .Name }}'
+          namespace: '{{ .Namespace }}'
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app.kubernetes.io/name: '{{ .Name }}'
+              networking.liqo.io/component: gateway
+          template:
+            metadata:
+              labels:
+                app.kubernetes.io/name: '{{ .Name }}'
+                networking.liqo.io/component: gateway
+              name: '{{ .Name }}'
+              namespace: '{{ .Namespace }}'
+            spec:
+              containers:
+              - args:
+                - --name={{ .Name }}
+                - --namespace={{ .Namespace }}
+                - --remote-cluster-id={{ .ClusterID }}
+                - --gateway-uid={{ .GatewayUID }}
+                - --mode=server
+                - --metrics-address=:8080
+                - --health-probe-bind-address=:8081
+                - --ping-enabled=true
+                - --ping-loss-threshold=5
+                - --ping-interval=2s
+                - --ping-update-status-interval=10s
+                image: ghcr.io/liqotech/gateway:<VERSION>
+                imagePullPolicy: IfNotPresent
+                name: gateway
+                securityContext:
+                  capabilities:
+                    add:
+                    - NET_ADMIN
+                    - NET_RAW
+                  privileged: true
+              - args:
+                - --name={{ .Name }}
+                - --namespace={{ .Namespace }}
+                - --remote-cluster-id={{ .ClusterID }}
+                - --gateway-uid={{ .GatewayUID }}
+                - --mode=server
+                - --mtu={{ .Spec.MTU }}
+                - --listen-port={{ .Spec.Endpoint.Port }}
+                - --metrics-address=:8082
+                - --health-probe-bind-address=:8083
+                image: ghcr.io/liqotech/gateway/wireguard:<VERSION>
+                imagePullPolicy: IfNotPresent
+                name: wireguard
+                securityContext:
+                  capabilities:
+                    add:
+                    - NET_ADMIN
+                    - NET_RAW
+              - args:
+                - --name={{ .Name }}
+                - --namespace={{ .Namespace }}
+                - --remote-cluster-id={{ .ClusterID }}
+                - --node-name=$(NODE_NAME)
+                - --gateway-uid={{ .GatewayUID }}
+                - --mode=server
+                - --metrics-address=:8084
+                - --health-probe-bind-address=:8085
+                - --enable-arp=true
+                env:
+                - name: NODE_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: spec.nodeName
+                image: ghcr.io/liqotech/gateway/geneve:<VERSION>
+                imagePullPolicy: IfNotPresent
+                name: geneve
+                securityContext:
+                  capabilities:
+                    add:
+                    - NET_ADMIN
+                    - NET_RAW
+              serviceAccount: '{{ .Name }}'
+              serviceAccountName: '{{ .Name }}'
+      service:
+        metadata:
+          annotations:
+            liqo.io/override-address: 10.43.12.182
+            liqo.io/override-port: "51820"
+          labels:
+            networking.liqo.io/component: gateway
+          name: '{{ .Name }}'
+          namespace: '{{ .Namespace }}'
+        spec:
+          ports:
+          - port: '{{ .Spec.Endpoint.Port }}'
+            protocol: UDP
+            targetPort: '{{ .Spec.Endpoint.Port }}'
+          selector:
+            app.kubernetes.io/name: '{{ .Name }}'
+            networking.liqo.io/component: gateway
+          type: '{{ .Spec.Endpoint.ServiceType }}'

--- a/examples/networking/wireguard-server-overridetargetport.yaml
+++ b/examples/networking/wireguard-server-overridetargetport.yaml
@@ -1,0 +1,116 @@
+apiVersion: networking.liqo.io/v1alpha1
+kind: WgGatewayServerTemplate
+metadata:
+  name: wireguard-server-overridetargetport
+  # namespace: liqo # or custom namespace
+spec:
+  objectKind:
+    apiVersion: networking.liqo.io/v1alpha1
+    kind: WgGatewayServer
+  template:
+    metadata:
+      labels:
+        networking.liqo.io/component: gateway
+      name: '{{ .Name }}'
+      namespace: '{{ .Namespace }}'
+    spec:
+      deployment:
+        metadata:
+          labels:
+            networking.liqo.io/component: gateway
+          name: '{{ .Name }}'
+          namespace: '{{ .Namespace }}'
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app.kubernetes.io/name: '{{ .Name }}'
+              networking.liqo.io/component: gateway
+          template:
+            metadata:
+              labels:
+                app.kubernetes.io/name: '{{ .Name }}'
+                networking.liqo.io/component: gateway
+              name: '{{ .Name }}'
+              namespace: '{{ .Namespace }}'
+            spec:
+              containers:
+              - args:
+                - --name={{ .Name }}
+                - --namespace={{ .Namespace }}
+                - --remote-cluster-id={{ .ClusterID }}
+                - --gateway-uid={{ .GatewayUID }}
+                - --mode=server
+                - --metrics-address=:8080
+                - --health-probe-bind-address=:8081
+                - --ping-enabled=true
+                - --ping-loss-threshold=5
+                - --ping-interval=2s
+                - --ping-update-status-interval=10s
+                image: ghcr.io/liqotech/gateway:<VERSION>
+                imagePullPolicy: IfNotPresent
+                name: gateway
+                securityContext:
+                  capabilities:
+                    add:
+                    - NET_ADMIN
+                    - NET_RAW
+                  privileged: true
+              - args:
+                - --name={{ .Name }}
+                - --namespace={{ .Namespace }}
+                - --remote-cluster-id={{ .ClusterID }}
+                - --gateway-uid={{ .GatewayUID }}
+                - --mode=server
+                - --mtu={{ .Spec.MTU }}
+                - --listen-port=30000
+                - --metrics-address=:8082
+                - --health-probe-bind-address=:8083
+                image: ghcr.io/liqotech/gateway/wireguard:<VERSION>
+                imagePullPolicy: IfNotPresent
+                name: wireguard
+                securityContext:
+                  capabilities:
+                    add:
+                    - NET_ADMIN
+                    - NET_RAW
+              - args:
+                - --name={{ .Name }}
+                - --namespace={{ .Namespace }}
+                - --remote-cluster-id={{ .ClusterID }}
+                - --node-name=$(NODE_NAME)
+                - --gateway-uid={{ .GatewayUID }}
+                - --mode=server
+                - --metrics-address=:8084
+                - --health-probe-bind-address=:8085
+                - --enable-arp=true
+                env:
+                - name: NODE_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: spec.nodeName
+                image: ghcr.io/liqotech/gateway/geneve:<VERSION>
+                imagePullPolicy: IfNotPresent
+                name: geneve
+                securityContext:
+                  capabilities:
+                    add:
+                    - NET_ADMIN
+                    - NET_RAW
+              serviceAccount: '{{ .Name }}'
+              serviceAccountName: '{{ .Name }}'
+      service:
+        metadata:
+          labels:
+            networking.liqo.io/component: gateway
+          name: '{{ .Name }}'
+          namespace: '{{ .Namespace }}'
+        spec:
+          ports:
+          - port: '{{ .Spec.Endpoint.Port }}'
+            protocol: UDP
+            targetPort: 30000
+          selector:
+            app.kubernetes.io/name: '{{ .Name }}'
+            networking.liqo.io/component: gateway
+          type: '{{ .Spec.Endpoint.ServiceType }}'

--- a/examples/networking/wireguard-server-pingdisabled.yaml
+++ b/examples/networking/wireguard-server-pingdisabled.yaml
@@ -1,0 +1,113 @@
+apiVersion: networking.liqo.io/v1alpha1
+kind: WgGatewayServerTemplate
+metadata:
+  name: wireguard-server-pingdisabled
+  # namespace: liqo # or custom namespace
+spec:
+  objectKind:
+    apiVersion: networking.liqo.io/v1alpha1
+    kind: WgGatewayServer
+  template:
+    metadata:
+      labels:
+        networking.liqo.io/component: gateway
+      name: '{{ .Name }}'
+      namespace: '{{ .Namespace }}'
+    spec:
+      deployment:
+        metadata:
+          labels:
+            networking.liqo.io/component: gateway
+          name: '{{ .Name }}'
+          namespace: '{{ .Namespace }}'
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app.kubernetes.io/name: '{{ .Name }}'
+              networking.liqo.io/component: gateway
+          template:
+            metadata:
+              labels:
+                app.kubernetes.io/name: '{{ .Name }}'
+                networking.liqo.io/component: gateway
+              name: '{{ .Name }}'
+              namespace: '{{ .Namespace }}'
+            spec:
+              containers:
+              - args:
+                - --name={{ .Name }}
+                - --namespace={{ .Namespace }}
+                - --remote-cluster-id={{ .ClusterID }}
+                - --gateway-uid={{ .GatewayUID }}
+                - --mode=server
+                - --metrics-address=:8080
+                - --health-probe-bind-address=:8081
+                - --ping-enabled=false
+                image: ghcr.io/liqotech/gateway:<VERSION>
+                imagePullPolicy: IfNotPresent
+                name: gateway
+                securityContext:
+                  capabilities:
+                    add:
+                    - NET_ADMIN
+                    - NET_RAW
+                  privileged: true
+              - args:
+                - --name={{ .Name }}
+                - --namespace={{ .Namespace }}
+                - --remote-cluster-id={{ .ClusterID }}
+                - --gateway-uid={{ .GatewayUID }}
+                - --mode=server
+                - --mtu={{ .Spec.MTU }}
+                - --listen-port={{ .Spec.Endpoint.Port }}
+                - --metrics-address=:8082
+                - --health-probe-bind-address=:8083
+                image: ghcr.io/liqotech/gateway/wireguard:<VERSION>
+                imagePullPolicy: IfNotPresent
+                name: wireguard
+                securityContext:
+                  capabilities:
+                    add:
+                    - NET_ADMIN
+                    - NET_RAW
+              - args:
+                - --name={{ .Name }}
+                - --namespace={{ .Namespace }}
+                - --remote-cluster-id={{ .ClusterID }}
+                - --node-name=$(NODE_NAME)
+                - --gateway-uid={{ .GatewayUID }}
+                - --mode=server
+                - --metrics-address=:8084
+                - --health-probe-bind-address=:8085
+                - --enable-arp=true
+                env:
+                - name: NODE_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: spec.nodeName
+                image: ghcr.io/liqotech/gateway/geneve:<VERSION>
+                imagePullPolicy: IfNotPresent
+                name: geneve
+                securityContext:
+                  capabilities:
+                    add:
+                    - NET_ADMIN
+                    - NET_RAW
+              serviceAccount: '{{ .Name }}'
+              serviceAccountName: '{{ .Name }}'
+      service:
+        metadata:
+          labels:
+            networking.liqo.io/component: gateway
+          name: '{{ .Name }}'
+          namespace: '{{ .Namespace }}'
+        spec:
+          ports:
+          - port: '{{ .Spec.Endpoint.Port }}'
+            protocol: UDP
+            targetPort: '{{ .Spec.Endpoint.Port }}'
+          selector:
+            app.kubernetes.io/name: '{{ .Name }}'
+            networking.liqo.io/component: gateway
+          type: '{{ .Spec.Endpoint.ServiceType }}'

--- a/examples/networking/wireguard-server-selector.yaml
+++ b/examples/networking/wireguard-server-selector.yaml
@@ -1,0 +1,125 @@
+apiVersion: networking.liqo.io/v1alpha1
+kind: WgGatewayServerTemplate
+metadata:
+  name: wireguard-server-selector
+  # namespace: liqo # or custom namespace
+spec:
+  objectKind:
+    apiVersion: networking.liqo.io/v1alpha1
+    kind: WgGatewayServer
+  template:
+    metadata:
+      labels:
+        networking.liqo.io/component: gateway
+      name: '{{ .Name }}'
+      namespace: '{{ .Namespace }}'
+    spec:
+      deployment:
+        metadata:
+          labels:
+            networking.liqo.io/component: gateway
+          name: '{{ .Name }}'
+          namespace: '{{ .Namespace }}'
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app.kubernetes.io/name: '{{ .Name }}'
+              networking.liqo.io/component: gateway
+          template:
+            metadata:
+              labels:
+                app.kubernetes.io/name: '{{ .Name }}'
+                networking.liqo.io/component: gateway
+              name: '{{ .Name }}'
+              namespace: '{{ .Namespace }}'
+            spec:
+              affinity:
+                nodeAffinity:
+                  requiredDuringSchedulingIgnoredDuringExecution:
+                    nodeSelectorTerms:
+                    - matchExpressions:
+                      - key: nodeType
+                        operator: In
+                        values:
+                        - cpu-optimized
+              containers:
+              - args:
+                - --name={{ .Name }}
+                - --namespace={{ .Namespace }}
+                - --remote-cluster-id={{ .ClusterID }}
+                - --gateway-uid={{ .GatewayUID }}
+                - --mode=server
+                - --metrics-address=:8080
+                - --health-probe-bind-address=:8081
+                - --ping-enabled=true
+                - --ping-loss-threshold=5
+                - --ping-interval=2s
+                - --ping-update-status-interval=10s
+                image: ghcr.io/liqotech/gateway:<VERSION>
+                imagePullPolicy: IfNotPresent
+                name: gateway
+                securityContext:
+                  capabilities:
+                    add:
+                    - NET_ADMIN
+                    - NET_RAW
+                  privileged: true
+              - args:
+                - --name={{ .Name }}
+                - --namespace={{ .Namespace }}
+                - --remote-cluster-id={{ .ClusterID }}
+                - --gateway-uid={{ .GatewayUID }}
+                - --mode=server
+                - --mtu={{ .Spec.MTU }}
+                - --listen-port={{ .Spec.Endpoint.Port }}
+                - --metrics-address=:8082
+                - --health-probe-bind-address=:8083
+                image: ghcr.io/liqotech/gateway/wireguard:<VERSION>
+                imagePullPolicy: IfNotPresent
+                name: wireguard
+                securityContext:
+                  capabilities:
+                    add:
+                    - NET_ADMIN
+                    - NET_RAW
+              - args:
+                - --name={{ .Name }}
+                - --namespace={{ .Namespace }}
+                - --remote-cluster-id={{ .ClusterID }}
+                - --node-name=$(NODE_NAME)
+                - --gateway-uid={{ .GatewayUID }}
+                - --mode=server
+                - --metrics-address=:8084
+                - --health-probe-bind-address=:8085
+                - --enable-arp=true
+                env:
+                - name: NODE_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: spec.nodeName
+                image: ghcr.io/liqotech/gateway/geneve:<VERSION>
+                imagePullPolicy: IfNotPresent
+                name: geneve
+                securityContext:
+                  capabilities:
+                    add:
+                    - NET_ADMIN
+                    - NET_RAW
+              serviceAccount: '{{ .Name }}'
+              serviceAccountName: '{{ .Name }}'
+      service:
+        metadata:
+          labels:
+            networking.liqo.io/component: gateway
+          name: '{{ .Name }}'
+          namespace: '{{ .Namespace }}'
+        spec:
+          ports:
+          - port: '{{ .Spec.Endpoint.Port }}'
+            protocol: UDP
+            targetPort: '{{ .Spec.Endpoint.Port }}'
+          selector:
+            app.kubernetes.io/name: '{{ .Name }}'
+            networking.liqo.io/component: gateway
+          type: '{{ .Spec.Endpoint.ServiceType }}'


### PR DESCRIPTION
# Description

This PR adds a folder with examples of custom gateway server/client templates.
It also adds a description in the docs on how to reference a custom template.

