### PR TITLE
Support getting aws credentials from existing secret instead of clear text in values file

### DIFF
--- a/deployments/liqo/templates/liqo-auth-deployment.yaml
+++ b/deployments/liqo/templates/liqo-auth-deployment.yaml
@@ -110,16 +110,28 @@ spec:
             {{- if .Values.awsConfig.accessKeyId }}
             - name: ACCESS_KEY_ID
               valueFrom:
+                {{- if .Values.awsConfig.accessKeyId.secretKeyRef }}
+                secretKeyRef:
+                  name: {{ .Values.awsConfig.accessKeyId.secretKeyRef.name }}
+                  key: {{ .Values.awsConfig.accessKeyId.secretKeyRef.key }}
+                {{- else }}
                 secretKeyRef:
                   name: {{ include "liqo.prefixedName" $awsConfig }}
                   key: ACCESS_KEY_ID
+                {{- end }}
             {{- end }}
             {{- if .Values.awsConfig.secretAccessKey }}
             - name: SECRET_ACCESS_KEY
               valueFrom:
+                {{- if .Values.awsConfig.secretAccessKey.secretKeyRef }}
+                secretKeyRef:
+                  name: {{ .Values.awsConfig.secretAccessKey.secretKeyRef.name }}
+                  key: {{ .Values.awsConfig.secretAccessKey.secretKeyRef.key }}
+                {{- else }}
                 secretKeyRef:
                   name: {{ include "liqo.prefixedName" $awsConfig }}
                   key: SECRET_ACCESS_KEY
+                {{- end }}
             {{- end }}
           resources: {{- toYaml .Values.auth.pod.resources | nindent 12 }}
           volumeMounts:

--- a/deployments/liqo/templates/liqo-aws-credentials.yaml
+++ b/deployments/liqo/templates/liqo-aws-credentials.yaml
@@ -2,6 +2,7 @@
 {{- $awsConfig := (merge (dict "name" "aws-config" "module" "aws-config") .) -}}
 
 {{- if and .Values.awsConfig.accessKeyId .Values.awsConfig.secretAccessKey }}
+{{- if not (or (.Values.awsConfig.accessKeyId.secretKeyRef) (.Values.awsConfig.secretAccessKey.secretKeyRef)) }}
 
 apiVersion: v1
 kind: Secret
@@ -13,4 +14,5 @@ data:
     ACCESS_KEY_ID: {{ .Values.awsConfig.accessKeyId | b64enc }}
     SECRET_ACCESS_KEY: {{ .Values.awsConfig.secretAccessKey | b64enc }}
 
+{{- end }}
 {{- end }}

--- a/deployments/liqo/values.yaml
+++ b/deployments/liqo/values.yaml
@@ -600,6 +600,18 @@ awsConfig:
   region: ""
   # -- Name of the EKS cluster.
   clusterName: ""
+# To use an existing secret instead of setting the secrets in values file:
+# awsConfig:
+#   accessKeyId:
+#     secretKeyRef:
+#       name: "your-secret-name"
+#       key: "your-secret-key"
+#   secretAccessKey
+#     secretKeyRef:
+#       name: "your-secret-name"
+#       key: "your-secret-key"
+#   region: "your-region"
+#   clusterName: "your-cluster-name"
 
 # OpenShift-specific configurations.
 openshiftConfig:


### PR DESCRIPTION
# Description

The changes add support in the Helm chart to use an existing secret for AWS credentials, instead of having the secrets as clear texts in values file

Fixes #(issue)

# How Has This Been Tested?

Tested with
```
helm template liqo deployments/liqo --version HEAD -f <values-file-path> --namespace liqo
```
