### PR TITLE
[Auth] Initialize cluster authentication keys

### DIFF
--- a/pkg/liqo-controller-manager/authentication/doc.go
+++ b/pkg/liqo-controller-manager/authentication/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package authentication contains the logic to authenticate foreign clusters.
+package authentication

--- a/pkg/liqo-controller-manager/authentication/keys.go
+++ b/pkg/liqo-controller-manager/authentication/keys.go
@@ -1,0 +1,74 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package authentication
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	// AuthKeysSecretName is the name of the secret containing the authentication keys.
+	AuthKeysSecretName = "authentication-keys"
+	// PrivateKeyField is the field key of the secret containing the private key.
+	PrivateKeyField = "privateKey"
+	// PublicKeyField is the field key of the secret containing the public key.
+	PublicKeyField = "publicKey"
+)
+
+// InitClusterKeys initializes the authentication keys for the cluster.
+// If the secret containing the keys does not exist, it generates a new pair of keys and stores them in a secret.
+func InitClusterKeys(ctx context.Context, cl client.Client, liqoNamespace string) error {
+	// Get secret if it exists
+	var secret corev1.Secret
+	err := cl.Get(ctx, client.ObjectKey{Name: AuthKeysSecretName, Namespace: liqoNamespace}, &secret)
+	switch {
+	case apierrors.IsNotFound(err):
+		// Forge a new pair of keys.
+		private, public, err := GenerateEd25519Keys()
+		if err != nil {
+			return fmt.Errorf("error while generating cluster authentication keys: %w", err)
+		}
+
+		// Store the keys in a secret.
+		secret = corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      AuthKeysSecretName,
+				Namespace: liqoNamespace,
+			},
+			Data: map[string][]byte{
+				PrivateKeyField: private,
+				PublicKeyField:  public,
+			},
+		}
+		if err := cl.Create(ctx, &secret); err != nil {
+			return fmt.Errorf("error while creating secret %s/%s: %w", liqoNamespace, AuthKeysSecretName, err)
+		}
+		klog.Infof("Created Secret (%s/%s) containing cluster authentication keys", liqoNamespace, AuthKeysSecretName)
+	case err != nil:
+		return fmt.Errorf("unable to get secret with cluster authentication keys: %w", err)
+	default:
+		// If secret already exists, do nothing.
+		klog.V(6).Infof("Secret %s/%s already created", liqoNamespace, AuthKeysSecretName)
+	}
+
+	return nil
+}

--- a/pkg/liqo-controller-manager/authentication/utils.go
+++ b/pkg/liqo-controller-manager/authentication/utils.go
@@ -1,0 +1,46 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package authentication
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+)
+
+// GenerateEd25519Keys returns a new pair of private and public keys in PEM format.
+// Keys are generated using the Ed25519 signature algorithm and encoded in PEM format.
+func GenerateEd25519Keys() (privateKey, publicKey []byte, err error) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to generate private key: %w", err)
+	}
+
+	privateKeyBytes, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to marshal private key: %w", err)
+	}
+	privateKeyPEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: privateKeyBytes})
+
+	publicKeyBytes, err := x509.MarshalPKIXPublicKey(pub)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to marshal public key: %w", err)
+	}
+	publicKeyPEM := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: publicKeyBytes})
+
+	return privateKeyPEM, publicKeyPEM, nil
+}


### PR DESCRIPTION
# Description

This PR handles the initialization of the cluster authentication keys when liqo is first installed.

It generates a pair of private and public keys using the Ed25519 signature algorithm. The keys are stored in a secret, encoded in PEM format.