### PR TITLE
Network: gw restart fix

### DIFF
--- a/pkg/utils/geneve/netlink.go
+++ b/pkg/utils/geneve/netlink.go
@@ -74,14 +74,11 @@ func CreateGeneveInterface(name string, local, remote net.IP, id uint32, enableA
 	} else {
 		geneveLink = link.(*netlink.Geneve)
 		if !geneveLink.Remote.Equal(remote) {
-			klog.Warningf("geneve link already exists with different remote IP (%s -> %s), deleting and recreating it",
+			klog.Warningf("geneve link already exists with different remote IP (%s -> %s), modifyng it",
 				geneveLink.Remote.String(), remote.String())
-			if err := netlink.LinkDel(geneveLink); err != nil {
-				return fmt.Errorf("cannot delete geneve link: %w", err)
-			}
 			geneveLink = ForgeGeneveInterface(name, remote, id)
-			if err := netlink.LinkAdd(geneveLink); err != nil {
-				return fmt.Errorf("cannot create geneve link: %w", err)
+			if err := netlink.LinkModify(geneveLink); err != nil {
+				return fmt.Errorf("cannot modify geneve link: %w", err)
 			}
 		}
 	}


### PR DESCRIPTION
# Description

This PR fixes a bug about gateway pod restart.

## The problem

When a gateway restarts, it changes its IP. This means that all the geneve tunnels inside of the fabric must reconfigure the remote IP. The first solution was deleting and recreating the interface. This is a problem because linux deletes all the routing configurations related to that interface.

## The solution

The solution is the netlink.LinkModify function. It implements the change of the netlink interfaces attributes (which is not supported by **iproute2**)