### PR TITLE
[Auth] Create Kubeconfig secret from Identity

### DIFF
--- a/deployments/liqo/files/liqo-controller-manager-ClusterRole.yaml
+++ b/deployments/liqo/files/liqo-controller-manager-ClusterRole.yaml
@@ -50,6 +50,18 @@ rules:
 - apiGroups:
   - authentication.liqo.io
   resources:
+  - identities
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - authentication.liqo.io
+  resources:
   - tenants
   verbs:
   - create

--- a/pkg/consts/authentication.go
+++ b/pkg/consts/authentication.go
@@ -31,4 +31,7 @@ const (
 	NonceSecretField = "nonce"
 	// SignedNonceSecretField is the field key where the signed nonce is stored in the secret.
 	SignedNonceSecretField = "signedNonce"
+
+	// KubeconfigSecretField is the field key where the kubeconfig is stored in the secret.
+	KubeconfigSecretField = "kubeconfig"
 )

--- a/pkg/liqo-controller-manager/authentication/forge/kubeconfig.go
+++ b/pkg/liqo-controller-manager/authentication/forge/kubeconfig.go
@@ -1,0 +1,94 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package forge
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	"k8s.io/utils/ptr"
+
+	authv1alpha1 "github.com/liqotech/liqo/apis/authentication/v1alpha1"
+	"github.com/liqotech/liqo/pkg/consts"
+)
+
+// GenerateKubeconfigSecretName generates the name of the kubeconfig secret associated to an identity.
+func GenerateKubeconfigSecretName(identity *authv1alpha1.Identity) string {
+	return "kubeconfig-" + identity.Name
+}
+
+// KubeconfigSecret forges a new Secret object stroing the kubeconfig associated to the provided identity.
+func KubeconfigSecret(identity *authv1alpha1.Identity) *corev1.Secret {
+	return &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: corev1.SchemeGroupVersion.String(),
+			Kind:       "Secret",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      GenerateKubeconfigSecretName(identity),
+			Namespace: identity.Namespace,
+		},
+	}
+}
+
+// MutateKubeconfigSecret mutate a Secret object storing the kubeconfig associated to the provided identity.
+func MutateKubeconfigSecret(secret *corev1.Secret, identity *authv1alpha1.Identity, clientKey []byte, namespace *string) error {
+	kubeconfig, err := generateKubeconfiguration(identity.Name, identity.Spec.ClusterIdentity.ClusterName,
+		identity.Spec.AuthParams.APIServer, identity.Spec.AuthParams.CA, identity.Spec.AuthParams.SignedCRT, clientKey,
+		identity.Spec.AuthParams.ProxyURL, namespace)
+	if err != nil {
+		return err
+	}
+
+	secret.Data = map[string][]byte{
+		consts.KubeconfigSecretField: kubeconfig,
+	}
+
+	return nil
+}
+
+func generateKubeconfiguration(user, cluster, server string, ca, clientCertificate, clientKey []byte, proxyURL, namespace *string) ([]byte, error) {
+	clusters := make(map[string]*clientcmdapi.Cluster)
+	clusters[cluster] = &clientcmdapi.Cluster{
+		Server:                   server,
+		CertificateAuthorityData: ca,
+		ProxyURL:                 ptr.Deref(proxyURL, ""),
+	}
+
+	contexts := make(map[string]*clientcmdapi.Context)
+	contexts["default-context"] = &clientcmdapi.Context{
+		Cluster:   cluster,
+		Namespace: ptr.Deref(namespace, ""),
+		AuthInfo:  user,
+	}
+
+	authinfos := make(map[string]*clientcmdapi.AuthInfo)
+	authinfos[user] = &clientcmdapi.AuthInfo{
+		ClientKeyData:         clientKey,
+		ClientCertificateData: clientCertificate,
+	}
+
+	clientConfig := clientcmdapi.Config{
+		Kind:           "Config",
+		APIVersion:     "v1",
+		Clusters:       clusters,
+		Contexts:       contexts,
+		CurrentContext: "default-context",
+		AuthInfos:      authinfos,
+	}
+
+	return clientcmd.Write(clientConfig)
+}

--- a/pkg/liqo-controller-manager/authentication/identity-controller/doc.go
+++ b/pkg/liqo-controller-manager/authentication/identity-controller/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package identitycontroller contains the controller managing Identity resources.
+package identitycontroller

--- a/pkg/liqo-controller-manager/authentication/identity-controller/identity_controller.go
+++ b/pkg/liqo-controller-manager/authentication/identity-controller/identity_controller.go
@@ -1,0 +1,136 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package identitycontroller
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+	klog "k8s.io/klog/v2"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	authv1alpha1 "github.com/liqotech/liqo/apis/authentication/v1alpha1"
+	"github.com/liqotech/liqo/pkg/liqo-controller-manager/authentication"
+	"github.com/liqotech/liqo/pkg/liqo-controller-manager/authentication/forge"
+)
+
+// NewIdentityReconciler returns a new IdentityReconciler.
+func NewIdentityReconciler(cl client.Client, s *runtime.Scheme, recorder record.EventRecorder, liqoNamespace string) *IdentityReconciler {
+	return &IdentityReconciler{
+		Client: cl,
+		Scheme: s,
+
+		eventRecorder: recorder,
+
+		liqoNamespace: liqoNamespace,
+	}
+}
+
+// IdentityReconciler reconciles an Identity object.
+type IdentityReconciler struct {
+	client.Client
+	*runtime.Scheme
+
+	eventRecorder record.EventRecorder
+
+	liqoNamespace string
+}
+
+// cluster-role
+// +kubebuilder:rbac:groups=authentication.liqo.io,resources=identities,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;create;update;patch;delete
+
+// Reconcile Identitiy resources and ensure the secret containing the associated kubeconfig.
+func (r *IdentityReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	var identity authv1alpha1.Identity
+	if err := r.Get(ctx, req.NamespacedName, &identity); err != nil {
+		if errors.IsNotFound(err) {
+			klog.V(4).Infof("identity %q not found", req.NamespacedName)
+			return ctrl.Result{}, nil
+		}
+		klog.Errorf("unable to get identity %q: %v", req.NamespacedName, err)
+		return ctrl.Result{}, err
+	}
+
+	// Ensure the kubeconfig secret.
+	secret, err := r.ensureKubeconfigSecret(ctx, &identity)
+	if err != nil {
+		klog.Errorf("unable to ensure kubeconfig secret for identity %q: %v", req.NamespacedName, err)
+		return ctrl.Result{}, err
+	}
+
+	// Update the identity status to reference the kubeconfig secret.
+	r.handleIdentityStatus(&identity, secret.Name)
+	if err := r.Status().Update(ctx, &identity); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *IdentityReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&authv1alpha1.Identity{}).
+		Owns(&corev1.Secret{}).
+		Complete(r)
+}
+
+func (r *IdentityReconciler) ensureKubeconfigSecret(ctx context.Context, identity *authv1alpha1.Identity) (*corev1.Secret, error) {
+	// Get the private Key encoded in PEM format.
+	privateKey, _, err := authentication.GetClusterKeysPEM(ctx, r.Client, r.liqoNamespace)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get cluster keys: %w", err)
+	}
+
+	// If it's an identity used for the CRD Replicator (type: ControlPlane) we set the remote namespace as default
+	// for the kubeconfig.
+	var namespace *string
+	if identity.Spec.Type == authv1alpha1.ControlPlaneIdentityType {
+		namespace = identity.Spec.Namespace
+	}
+
+	// Create or update the secret containing the kubeconfig.
+	kubeconfigSecret := forge.KubeconfigSecret(identity)
+	op, err := controllerutil.CreateOrUpdate(ctx, r.Client, kubeconfigSecret, func() error {
+		if err := forge.MutateKubeconfigSecret(kubeconfigSecret, identity, privateKey, namespace); err != nil {
+			return err
+		}
+		return controllerutil.SetOwnerReference(identity, kubeconfigSecret, r.Scheme)
+	})
+	if err != nil {
+		return nil, fmt.Errorf("unable to create or update kubeconfig secret: %w", err)
+	}
+
+	if op != controllerutil.OperationResultNone {
+		klog.Infof("kubeconfig secret %q %s", client.ObjectKeyFromObject(kubeconfigSecret), op)
+		r.eventRecorder.Event(kubeconfigSecret, "Normal", "KubeconfigEnsured", "Kubeconfig secret ensured")
+	}
+
+	return kubeconfigSecret, nil
+}
+
+// handleIdentityStatus updates the identity status to reference the kubeconfig secret.
+func (r *IdentityReconciler) handleIdentityStatus(identity *authv1alpha1.Identity, secretName string) {
+	identity.Status.KubeconfigSecretRef = &corev1.LocalObjectReference{
+		Name: secretName,
+	}
+}

--- a/pkg/liqo-controller-manager/authentication/keys.go
+++ b/pkg/liqo-controller-manager/authentication/keys.go
@@ -142,3 +142,25 @@ func GetClusterKeys(ctx context.Context, cl client.Client, liqoNamespace string)
 
 	return priv.(ed25519.PrivateKey), pub.(ed25519.PublicKey), nil
 }
+
+// GetClusterKeysPEM retrieves the private and public keys of the cluster from the secret and encoded in PEM format.
+func GetClusterKeysPEM(ctx context.Context, cl client.Client, liqoNamespace string) (privateKey, publicKey []byte, err error) {
+	var secret corev1.Secret
+	if err = cl.Get(ctx, client.ObjectKey{Name: consts.AuthKeysSecretName, Namespace: liqoNamespace}, &secret); err != nil {
+		return nil, nil, fmt.Errorf("unable to get secret with cluster authentication keys: %w", err)
+	}
+
+	// Get the private key from the secret.
+	privateKey, found := secret.Data[consts.PrivateKeyField]
+	if !found {
+		return nil, nil, fmt.Errorf("private key not found in secret %s/%s", liqoNamespace, consts.AuthKeysSecretName)
+	}
+
+	// Get the public key from the secret.
+	publicKey, found = secret.Data[consts.PublicKeyField]
+	if !found {
+		return nil, nil, fmt.Errorf("public key not found in secret %s/%s", liqoNamespace, consts.AuthKeysSecretName)
+	}
+
+	return privateKey, publicKey, nil
+}


### PR DESCRIPTION
# Description

This PR implements a controller that reconciles Identity resources and creates a secret containing its associated `kubeconfig`.
