### PR TITLE
[Auth] Various fixes

### DIFF
--- a/apis/authentication/v1alpha1/identity_types.go
+++ b/apis/authentication/v1alpha1/identity_types.go
@@ -43,8 +43,8 @@ type IdentityType string
 const (
 	// ControlPlaneIdentityType indicates an Identity of type ControlPlane.
 	ControlPlaneIdentityType IdentityType = "ControlPlane"
-	// VirtualNodeIdentityType indicates an Identity of type VirtualNode.
-	VirtualNodeIdentityType IdentityType = "VirtualNode"
+	// ResourceSliceIdentityType indicates an Identity of type ResourceSlice.
+	ResourceSliceIdentityType IdentityType = "ResourceSlice"
 )
 
 // IdentitySpec defines the desired state of Identity.
@@ -52,7 +52,7 @@ type IdentitySpec struct {
 	// ClusterIdentity is the identity of the provider cluster.
 	ClusterIdentity discoveryv1alpha1.ClusterIdentity `json:"clusterIdentity,omitempty"`
 	// Type is the type of the identity.
-	// +kubebuilder:validation:Enum=ControlPlane;VirtualNode
+	// +kubebuilder:validation:Enum=ControlPlane;ResourceSlice
 	Type IdentityType `json:"type,omitempty"`
 	// AuthParams contains the parameters to create an Identity to use in the provider cluster.
 	AuthParams AuthParams `json:"authParams,omitempty"`

--- a/deployments/liqo/crds/authentication.liqo.io_identities.yaml
+++ b/deployments/liqo/crds/authentication.liqo.io_identities.yaml
@@ -99,7 +99,7 @@ spec:
                 description: Type is the type of the identity.
                 enum:
                 - ControlPlane
-                - VirtualNode
+                - ResourceSlice
                 type: string
             type: object
           status:

--- a/pkg/identityManager/certificateIdentityProvider.go
+++ b/pkg/identityManager/certificateIdentityProvider.go
@@ -165,7 +165,7 @@ func (identityProvider *certificateIdentityProvider) ForgeAuthParams(resp *respo
 
 func remoteCertificateSecretName(options *SigningRequestOptions) string {
 	switch options.IdentityType {
-	case authv1alpha1.VirtualNodeIdentityType:
+	case authv1alpha1.ResourceSliceIdentityType:
 		return fmt.Sprintf("%s-%s", remoteCertificateSecret, options.Name)
 	default:
 		return remoteCertificateSecret

--- a/pkg/liqo-controller-manager/authentication/remoteresourceslice-controller/remoteresourceslice_controller.go
+++ b/pkg/liqo-controller-manager/authentication/remoteresourceslice-controller/remoteresourceslice_controller.go
@@ -134,7 +134,7 @@ func (r *RemoteResourceSliceReconciler) Reconcile(ctx context.Context, req ctrl.
 	resp, err := identitymanager.EnsureCertificate(ctx, r.identityProvider, &identitymanager.SigningRequestOptions{
 		Cluster:        resourceSlice.Spec.ConsumerClusterIdentity,
 		Namespace:      resourceSlice.Namespace,
-		IdentityType:   authv1alpha1.VirtualNodeIdentityType,
+		IdentityType:   authv1alpha1.ResourceSliceIdentityType,
 		Name:           resourceSlice.Name,
 		SigningRequest: resourceSlice.Spec.CSR,
 	})

--- a/pkg/liqo-controller-manager/authentication/tenant-controller/tenant_controller.go
+++ b/pkg/liqo-controller-manager/authentication/tenant-controller/tenant_controller.go
@@ -235,8 +235,12 @@ func checkCSR(csr, publicKey []byte, remoteClusterIdentity *discoveryv1alpha1.Cl
 		return err
 	}
 
-	if x509Csr.Subject.CommonName != authentication.CommonName(remoteClusterIdentity.ClusterID) {
+	if x509Csr.Subject.CommonName != authentication.CommonNameControlPlaneCSR(remoteClusterIdentity.ClusterID) {
 		return fmt.Errorf("invalid common name")
+	}
+
+	if x509Csr.Subject.Organization[0] != authentication.OrganizationControlPlaneCSR() {
+		return fmt.Errorf("invalid organization")
 	}
 
 	// if the pub key is 0-terminated, drop it

--- a/pkg/liqoctl/completion/completion.go
+++ b/pkg/liqoctl/completion/completion.go
@@ -27,6 +27,7 @@ import (
 	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
 	offloadingv1alpha1 "github.com/liqotech/liqo/apis/offloading/v1alpha1"
 	virtualkubeletv1alpha1 "github.com/liqotech/liqo/apis/virtualkubelet/v1alpha1"
+	"github.com/liqotech/liqo/pkg/discovery"
 	identitymanager "github.com/liqotech/liqo/pkg/identityManager"
 	"github.com/liqotech/liqo/pkg/liqoctl/factory"
 	utilsvirtualnode "github.com/liqotech/liqo/pkg/utils/virtualnode"
@@ -209,14 +210,16 @@ func ForeignClusters(ctx context.Context, f *factory.Factory, argsLimit int) FnT
 // ClusterIDs returns a function to autocomplete ForeignCluster cluster IDs.
 func ClusterIDs(ctx context.Context, f *factory.Factory, argsLimit int) FnType {
 	retriever := func(ctx context.Context, f *factory.Factory) ([]string, error) {
-		var foreignClusters discoveryv1alpha1.ForeignClusterList
-		if err := f.CRClient.List(ctx, &foreignClusters); err != nil {
+		var namespaces corev1.NamespaceList
+		if err := f.CRClient.List(ctx, &namespaces,
+			client.MatchingLabels{discovery.TenantNamespaceLabel: "true"},
+			client.HasLabels{discovery.ClusterIDLabel}); err != nil {
 			return nil, err
 		}
 
 		var ids []string
-		for i := range foreignClusters.Items {
-			ids = append(ids, foreignClusters.Items[i].Spec.ClusterIdentity.ClusterID)
+		for i := range namespaces.Items {
+			ids = append(ids, namespaces.Items[i].Labels[discovery.ClusterIDLabel])
 		}
 		return ids, nil
 	}

--- a/pkg/liqoctl/rest/tenant/generate.go
+++ b/pkg/liqoctl/rest/tenant/generate.go
@@ -131,7 +131,7 @@ func (o *Options) handleGenerate(ctx context.Context) error {
 
 	// Wait for the nonce to be signed.
 	waiter := wait.NewWaiterFromFactory(opts.Factory)
-	signedNonce, err := waiter.ForSignedNonce(ctx, o.remoteClusterIdentity.ClusterID)
+	signedNonce, err := waiter.ForSignedNonce(ctx, o.remoteClusterIdentity.ClusterID, true)
 	if err != nil {
 		opts.Printer.CheckErr(fmt.Errorf("unable to wait for nonce to be signed: %w", err))
 		return err
@@ -152,7 +152,7 @@ func (o *Options) handleGenerate(ctx context.Context) error {
 	}
 
 	// Generate a CSR for the remote cluster.
-	CSR, err := authentication.GenerateCSR(privateKey, authentication.CommonName(localClusterIdentity.ClusterID))
+	CSR, err := authentication.GenerateCSRForControlPlane(privateKey, localClusterIdentity.ClusterID)
 	if err != nil {
 		opts.Printer.CheckErr(fmt.Errorf("unable to generate CSR: %w", err))
 		return err


### PR DESCRIPTION
# Description

This PR includes the following fixes:

- standardize CSR commonName and organization depending on origin type (ControlPlane or ResourceSlice)
- Identity type renaming
- Fix liqoctl outputs
- Fix liqoctl clusterIDs completions
