### PR TITLE
[Network] Renamed flag to enable/disable the Networking module

### DIFF
--- a/apis/discovery/v1alpha1/foreigncluster_types.go
+++ b/apis/discovery/v1alpha1/foreigncluster_types.go
@@ -46,8 +46,8 @@ const (
 	PeeringConditionStatusError PeeringConditionStatusType = "Error"
 	// PeeringConditionStatusSuccess indicates that the condition is successful.
 	PeeringConditionStatusSuccess PeeringConditionStatusType = "Success"
-	// PeeringConditionStatusExternal indicates that the condition is managed by an external component.
-	PeeringConditionStatusExternal PeeringConditionStatusType = "External"
+	// PeeringConditionStatusDisabled indicates that the condition is disabled or managed by an external component.
+	PeeringConditionStatusDisabled PeeringConditionStatusType = "Disabled"
 )
 
 // PeeringType defines the type of peering to be established.
@@ -175,7 +175,7 @@ type PeeringCondition struct {
 	//nolint:lll // ignore long lines given by Kubebuilder marker annotations
 	Type PeeringConditionType `json:"type"`
 	// Status of the condition.
-	// +kubebuilder:validation:Enum="None";"Pending";"Established";"Disconnecting";"Denied";"EmptyDenied";"Error";"Success";"External"
+	// +kubebuilder:validation:Enum="None";"Pending";"Established";"Disconnecting";"Denied";"EmptyDenied";"Error";"Success";"Disabled"
 	// +kubebuilder:default="None"
 	Status PeeringConditionStatusType `json:"status"`
 	// LastTransitionTime -> timestamp for when the condition last transitioned from one status to another.

--- a/cmd/liqo-controller-manager/main.go
+++ b/cmd/liqo-controller-manager/main.go
@@ -134,7 +134,7 @@ func main() {
 	var gatewayServerResources argsutils.StringList
 	var gatewayClientResources argsutils.StringList
 
-	disableInternalNetwork := flag.Bool("disable-internal-network", false, "Disable the creation of the internal network")
+	networkingEnabled := flag.Bool("networking-enabled", true, "Enable/disable the networking module")
 
 	webhookPort := flag.Uint("webhook-port", 9443, "The port the webhook server binds to")
 	metricsAddr := flag.String("metrics-address", ":8080", "The address the metric endpoint binds to")
@@ -355,10 +355,10 @@ func main() {
 		Scheme:        mgr.GetScheme(),
 		LiqoNamespace: *liqoNamespace,
 
-		ResyncPeriod:           *resyncPeriod,
-		HomeCluster:            clusterIdentity,
-		AutoJoin:               *autoJoin,
-		DisableInternalNetwork: *disableInternalNetwork,
+		ResyncPeriod:      *resyncPeriod,
+		HomeCluster:       clusterIdentity,
+		AutoJoin:          *autoJoin,
+		NetworkingEnabled: *networkingEnabled,
 
 		NamespaceManager:  namespaceManager,
 		IdentityManager:   idManager,
@@ -537,7 +537,7 @@ func main() {
 		ipamClient = ipam.NewIpamClient(connection)
 	}
 
-	if !*disableInternalNetwork {
+	if *networkingEnabled {
 		opts := &modules.NetworkingOption{
 			DynClient:  dynClient,
 			Factory:    factory,

--- a/deployments/liqo/README.md
+++ b/deployments/liqo/README.md
@@ -160,6 +160,7 @@
 | networkManager.pod.priorityClassName | string | `""` | PriorityClassName (https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#pod-priority) for the networkManager pod. |
 | networkManager.pod.resources | object | `{"limits":{},"requests":{}}` | Resource requests and limits (https://kubernetes.io/docs/user-guide/compute-resources/) for the networkManager pod. |
 | networking.clientResources | list | `[{"apiVersion":"networking.liqo.io/v1alpha1","resource":"wggatewayclients"}]` | Set the list of resources that implement the GatewayClient |
+| networking.enabled | bool | `true` | Use the default Liqo networking module. |
 | networking.gatewayTemplates | object | `{"container":{"gateway":{"image":{"name":"ghcr.io/liqotech/gateway","version":""}},"geneve":{"image":{"name":"ghcr.io/liqotech/gateway/geneve","version":""}},"wireguard":{"image":{"name":"ghcr.io/liqotech/gateway/wireguard","version":""}}},"ping":{"interval":"2s","lossThreshold":5,"updateStatusInterval":"10s"},"replicas":1,"server":{"service":{"allocateLoadBalancerNodePorts":"","annotations":{"service.beta.kubernetes.io/aws-load-balancer-type":"nlb"}}}}` | Set the options for the default gateway (server/client) templates. The default templates use a WireGuard implementation to connect the gateway of the clusters. These options are used to configure only the default templates and should not be considered if a custom template is used. |
 | networking.gatewayTemplates.container.gateway.image.name | string | `"ghcr.io/liqotech/gateway"` | Image repository for the gateway container. |
 | networking.gatewayTemplates.container.gateway.image.version | string | `""` | Custom version for the gateway image. If not specified, the global tag is used. |
@@ -176,10 +177,9 @@
 | networking.gatewayTemplates.server.service | object | `{"allocateLoadBalancerNodePorts":"","annotations":{"service.beta.kubernetes.io/aws-load-balancer-type":"nlb"}}` | Set the options to configure the server service |
 | networking.gatewayTemplates.server.service.allocateLoadBalancerNodePorts | string | `""` | Set to "false" if you expose the gateway service as LoadBalancer and you do not want to create also a NodePort associated to it (Note: this setting is useful only on cloud providers that support this feature). |
 | networking.gatewayTemplates.server.service.annotations | object | `{"service.beta.kubernetes.io/aws-load-balancer-type":"nlb"}` | Annotations for the server service. |
-| networking.internal | bool | `true` | Use the default Liqo network manager. |
 | networking.iptables | object | `{"mode":"nf_tables"}` | Iptables configuration tuning. |
 | networking.iptables.mode | string | `"nf_tables"` | Select the iptables mode to use. Possible values are "legacy" and "nf_tables". |
-| networking.legacy | bool | `false` | Set to "false" to install the legacy networking stack. |
+| networking.legacy | bool | `false` | Set to "true" to install the legacy networking stack. |
 | networking.mtu | int | `1340` | Set the MTU for the interfaces managed by liqo: vxlan, tunnel and veth interfaces. The value is used by the gateway and route operators. The default value is configured to ensure correct behavior regardless of the combination of the underlying environments (e.g., cloud providers). This guarantees improved compatibility at the cost of possible limited performance drops. |
 | networking.reflectIPs | bool | `true` | Reflect pod IPs and EnpointSlices to the remote clusters. |
 | networking.securityMode | string | `"FullPodToPod"` | Select the mode to enforce security on connectivity among clusters. Possible values are "FullPodToPod" and "IntraClusterTrafficSegregation"  |
@@ -229,7 +229,7 @@
 | reflection.service.type | string | `"DenyList"` | The type of reflection used for the services reflector. Ammitted values: "DenyList", "AllowList". |
 | reflection.service.workers | int | `3` | The number of workers used for the services reflector. Set 0 to disable the reflection of services. |
 | reflection.serviceaccount.workers | int | `3` | The number of workers used for the serviceaccounts reflector. Set 0 to disable the reflection of serviceaccounts. |
-| reflection.skip.annotations | list | `["cloud.google.com/neg","cloud.google.com/neg-status","kubernetes.digitalocean.com/load-balancer-id","ingress.kubernetes.io/backends","ingress.kubernetes.io/forwarding-rule","ingress.kubernetes.io/target-proxy","ingress.kubernetes.io/url-map","metallb.universe.tf/address-pool","metallb.universe.tf/ip-allocated-from-pool","metallb.universe.tf/loadBalancerIPs"]` | List of annotations that must not be reflected on remote clusters. |
+| reflection.skip.annotations | list | `["cloud.google.com/neg","cloud.google.com/neg-status","kubernetes.digitalocean.com/load-balancer-id","ingress.kubernetes.io/backends","ingress.kubernetes.io/forwarding-rule","ingress.kubernetes.io/target-proxy","ingress.kubernetes.io/url-map","metallb.universe.tf/address-pool","metallb.universe.tf/ip-allocated-from-pool","metallb.universe.tf/loadBalancerIPs","loadbalancer.openstack.org/load-balancer-id"]` | List of annotations that must not be reflected on remote clusters. |
 | reflection.skip.labels | list | `[]` | List of labels that must not be reflected on remote clusters. |
 | route.imageName | string | `"ghcr.io/liqotech/liqonet"` | Image repository for the route pod. |
 | route.pod.annotations | object | `{}` | Annotations for the route pod. |

--- a/deployments/liqo/charts/liqo-crds/crds/discovery.liqo.io_foreignclusters.yaml
+++ b/deployments/liqo/charts/liqo-crds/crds/discovery.liqo.io_foreignclusters.yaml
@@ -172,7 +172,7 @@ spec:
                       - EmptyDenied
                       - Error
                       - Success
-                      - External
+                      - Disabled
                       type: string
                     type:
                       description: Type of the peering condition.

--- a/deployments/liqo/templates/liqo-controller-manager-deployment.yaml
+++ b/deployments/liqo/templates/liqo-controller-manager-deployment.yaml
@@ -10,8 +10,8 @@
 {{- if not (or (has "--enable-apiserver-support" $vkargs ) (has "--enable-apiserver-support=true" $vkargs ) (has "--enable-apiserver-support=false" $vkargs )) }}
 {{- $vkargs = append $vkargs "--enable-apiserver-support=true" }}
 {{- end }}
-{{- /* Configure the appropriate flags if the internal networking is disabled, if not overridden by the user */ -}}
-{{- if not .Values.networking.internal }}
+{{- /* Configure the appropriate flags if the networking module is disabled, if not overridden by the user */ -}}
+{{- if not .Values.networking.enabled }}
 {{- if not (or (has "--node-check-network" $vkargs ) (has "--node-check-network=true" $vkargs ) (has "--node-check-network=false" $vkargs )) }}
 {{- $vkargs = append $vkargs "--node-check-network=false" }}
 {{- end }}
@@ -120,9 +120,9 @@ spec:
           - --podcidr={{ .Values.ipam.podCIDR }}
           {{- if .Values.ipam.external.enabled }}
           - --ipam-server={{ .Values.ipam.external.url }}
-          {{- else if not .Values.networking.internal }}
+          {{- else if not .Values.networking.enabled }}
           - --ipam-server=
-          - --disable-internal-network
+          - --networking-enabled=false
           {{- else if .Values.networking.legacy }}
           - --ipam-server={{ include "liqo.prefixedName" $netManagerConfig }}.{{ .Release.Namespace }}:6000
           {{- else }}

--- a/deployments/liqo/templates/liqo-fabric-daemonset.yaml
+++ b/deployments/liqo/templates/liqo-fabric-daemonset.yaml
@@ -1,7 +1,7 @@
 ---
 {{- $fabricConfig := (merge (dict "name" "fabric" "module" "networking" "version" .Values.fabric.image.version ) .) -}}
 
-{{- if .Values.networking.internal }}
+{{- if .Values.networking.enabled }}
 
 apiVersion: apps/v1
 kind: DaemonSet

--- a/deployments/liqo/templates/liqo-fabric-rbac.yaml
+++ b/deployments/liqo/templates/liqo-fabric-rbac.yaml
@@ -1,6 +1,6 @@
 {{- $fabricConfig := (merge (dict "name" "fabric" "module" "networking") .) -}}
 
-{{- if .Values.networking.internal }}
+{{- if .Values.networking.enabled }}
 
 apiVersion: v1
 kind: ServiceAccount

--- a/deployments/liqo/templates/liqo-gateway-rbac.yaml
+++ b/deployments/liqo/templates/liqo-gateway-rbac.yaml
@@ -1,7 +1,7 @@
 ---
 {{- $gatewayConfig := (merge (dict "name" "gateway" "module" "networking") .) -}}
 
-{{- if .Values.networking.internal }}
+{{- if .Values.networking.enabled }}
 
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/deployments/liqo/templates/liqo-ipam-deployment.yaml
+++ b/deployments/liqo/templates/liqo-ipam-deployment.yaml
@@ -1,4 +1,4 @@
-{{- if and (.Values.networking.internal) (not .Values.ipam.external.enabled) (not .Values.networking.legacy ) }}
+{{- if and (.Values.networking.enabled) (not .Values.ipam.external.enabled) (not .Values.networking.legacy ) }}
 
 {{- $ipamConfig := (merge (dict "name" "ipam" "module" "ipam" "version" .Values.ipam.internal.image.version) .) -}}
 {{- $ha := (gt .Values.ipam.internal.replicas 1.0) -}}

--- a/deployments/liqo/templates/liqo-ipam-rbac.yaml
+++ b/deployments/liqo/templates/liqo-ipam-rbac.yaml
@@ -1,7 +1,7 @@
 ---
 {{- $ipamConfig := (merge (dict "name" "ipam" "module" "ipam") .) -}}
 
-{{- if and (.Values.networking.internal) (not .Values.ipam.external.enabled) (not .Values.networking.legacy ) }}
+{{- if and (.Values.networking.enabled) (not .Values.ipam.external.enabled) (not .Values.networking.legacy ) }}
 
 apiVersion: v1
 kind: ServiceAccount

--- a/deployments/liqo/templates/liqo-ipam-service.yaml
+++ b/deployments/liqo/templates/liqo-ipam-service.yaml
@@ -1,4 +1,4 @@
-{{- if and (.Values.networking.internal) (not .Values.ipam.external.enabled) (not .Values.networking.legacy ) }}
+{{- if and (.Values.networking.enabled) (not .Values.ipam.external.enabled) (not .Values.networking.legacy ) }}
 
 {{- $ipamConfig := (merge (dict "name" "ipam" "module" "ipam") .) -}}
 {{- $ha := (gt .Values.ipam.internal.replicas 1.0) -}}

--- a/deployments/liqo/templates/liqo-legacy-gateway-deployment.yaml
+++ b/deployments/liqo/templates/liqo-legacy-gateway-deployment.yaml
@@ -1,7 +1,7 @@
 ---
 {{- $gatewayConfig := (merge (dict "name" "legacy-gateway" "module" "networking") .) -}}
 
-{{- if and (.Values.networking.internal) (.Values.networking.legacy) }}
+{{- if and (.Values.networking.enabled) (.Values.networking.legacy) }}
 
 apiVersion: apps/v1
 kind: Deployment

--- a/deployments/liqo/templates/liqo-legacy-gateway-rbac.yaml
+++ b/deployments/liqo/templates/liqo-legacy-gateway-rbac.yaml
@@ -1,7 +1,7 @@
 ---
 {{- $gatewayConfig := (merge (dict "name" "legacy-gateway" "module" "networking") .) -}}
 
-{{- if and (.Values.networking.internal) (.Values.networking.legacy) }}
+{{- if and (.Values.networking.enabled) (.Values.networking.legacy) }}
 
 apiVersion: v1
 kind: ServiceAccount

--- a/deployments/liqo/templates/liqo-legacy-gateway-service.yaml
+++ b/deployments/liqo/templates/liqo-legacy-gateway-service.yaml
@@ -1,7 +1,7 @@
 ---
 {{- $gatewayConfig := (merge (dict "name" "legacy-gateway" "module" "networking") .) -}}
 
-{{- if and (.Values.networking.internal) (.Values.networking.legacy) }}
+{{- if and (.Values.networking.enabled) (.Values.networking.legacy) }}
 
 apiVersion: v1
 kind: Service

--- a/deployments/liqo/templates/liqo-legacy-gateway-servicemonitor.yaml
+++ b/deployments/liqo/templates/liqo-legacy-gateway-servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if and (.Values.networking.internal) (.Values.networking.legacy) }}
+{{- if and (.Values.networking.enabled) (.Values.networking.legacy) }}
 
 ---
 {{- $gatewayMetricsConfig := (merge (dict "name" "legacy-gateway-metrics" "module" "networking") .) -}}

--- a/deployments/liqo/templates/liqo-network-manager-deployment.yaml
+++ b/deployments/liqo/templates/liqo-network-manager-deployment.yaml
@@ -1,7 +1,7 @@
 ---
 {{- $netManagerConfig := (merge (dict "name" "network-manager" "module" "networking") .) -}}
 
-{{- if and (.Values.networking.internal) (.Values.networking.legacy) }}
+{{- if and (.Values.networking.enabled) (.Values.networking.legacy) }}
 
 apiVersion: apps/v1
 kind: Deployment

--- a/deployments/liqo/templates/liqo-network-manager-rbac.yaml
+++ b/deployments/liqo/templates/liqo-network-manager-rbac.yaml
@@ -1,7 +1,7 @@
 ---
 {{- $netManagerConfig := (merge (dict "name" "network-manager" "module" "networking") .) -}}
 
-{{- if and (.Values.networking.internal) (.Values.networking.legacy) }}
+{{- if and (.Values.networking.enabled) (.Values.networking.legacy) }}
 
 apiVersion: v1
 kind: ServiceAccount

--- a/deployments/liqo/templates/liqo-network-manager-service.yaml
+++ b/deployments/liqo/templates/liqo-network-manager-service.yaml
@@ -1,7 +1,7 @@
 ---
 {{- $netManagerConfig := (merge (dict "name" "network-manager" "module" "networking") .) -}}
 
-{{- if and (.Values.networking.internal) (.Values.networking.legacy) }}
+{{- if and (.Values.networking.enabled) (.Values.networking.legacy) }}
 
 apiVersion: v1
 kind: Service

--- a/deployments/liqo/templates/liqo-route-daemonset.yaml
+++ b/deployments/liqo/templates/liqo-route-daemonset.yaml
@@ -1,7 +1,7 @@
 ---
 {{- $routeConfig := (merge (dict "name" "route" "module" "networking") .) -}}
 
-{{- if and (.Values.networking.internal) (.Values.networking.legacy) }}
+{{- if and (.Values.networking.enabled) (.Values.networking.legacy) }}
 
 apiVersion: apps/v1
 kind: DaemonSet

--- a/deployments/liqo/templates/liqo-route-rbac.yaml
+++ b/deployments/liqo/templates/liqo-route-rbac.yaml
@@ -1,7 +1,7 @@
 ---
 {{- $routeConfig := (merge (dict "name" "route" "module" "networking") .) -}}
 
-{{- if and (.Values.networking.internal) (.Values.networking.legacy) }}
+{{- if and (.Values.networking.enabled) (.Values.networking.legacy) }}
 
 apiVersion: v1
 kind: ServiceAccount

--- a/deployments/liqo/templates/liqo-wireguard-gateway-client-template.yaml
+++ b/deployments/liqo/templates/liqo-wireguard-gateway-client-template.yaml
@@ -3,7 +3,7 @@
 {{- $wireguardConfig := (merge (dict "name" "gateway-wireguard" "module" "networking" "version" .Values.networking.gatewayTemplates.container.wireguard.image.version) .) -}}
 {{- $geneveConfig := (merge (dict "name" "gateway-geneve" "module" "networking" "version" .Values.networking.gatewayTemplates.container.geneve.image.version) .) -}}
 
-{{- if .Values.networking.internal }}
+{{- if .Values.networking.enabled }}
 
 apiVersion: networking.liqo.io/v1alpha1
 kind: WgGatewayClientTemplate

--- a/deployments/liqo/templates/liqo-wireguard-gateway-server-template.yaml
+++ b/deployments/liqo/templates/liqo-wireguard-gateway-server-template.yaml
@@ -3,7 +3,7 @@
 {{- $wireguardConfig := (merge (dict "name" "gateway-wireguard" "module" "networking" "version" .Values.networking.gatewayTemplates.container.wireguard.image.version) .) -}}
 {{- $geneveConfig := (merge (dict "name" "gateway-geneve" "module" "networking" "version" .Values.networking.gatewayTemplates.container.geneve.image.version) .) -}}
 
-{{- if .Values.networking.internal }}
+{{- if .Values.networking.enabled }}
 
 apiVersion: networking.liqo.io/v1alpha1
 kind: WgGatewayServerTemplate

--- a/deployments/liqo/values.yaml
+++ b/deployments/liqo/values.yaml
@@ -24,10 +24,10 @@ apiServer:
   trustedCA: false
 
 networking:
-  # -- Set to "false" to install the legacy networking stack.
+  # -- Set to "true" to install the legacy networking stack.
   legacy: false
-  # -- Use the default Liqo network manager.
-  internal: true
+  # -- Use the default Liqo networking module.
+  enabled: true
   # -- Reflect pod IPs and EnpointSlices to the remote clusters.
   reflectIPs: true
   # -- Iptables configuration tuning.
@@ -131,6 +131,7 @@ reflection:
       metallb.universe.tf/address-pool,
       metallb.universe.tf/ip-allocated-from-pool,
       metallb.universe.tf/loadBalancerIPs,
+      loadbalancer.openstack.org/load-balancer-id,
     ]
   pod:
     # -- The number of workers used for the pods reflector. Set 0 to disable the reflection of pods.

--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -34,7 +34,7 @@ subtrees:
       - file: usage/reflection.md
       - file: usage/stateful-applications.md
       - file: usage/prometheus-metrics.md
-      - file: usage/external-network.md
+      - file: usage/disable-networking.md
       - file: usage/inter-cluster-network.md
       - file: usage/service-continuity.md
       - file: usage/security-modes.md

--- a/docs/index.md
+++ b/docs/index.md
@@ -162,7 +162,7 @@ Explore the details about which and how native resources are **reflected** to re
 [](usage/reflection.md) ·
 [](usage/stateful-applications.md)
 [](usage/prometheus-metrics.md)
-[](usage/external-network.md)
+[](usage/disable-networking.md)
 [](usage/service-continuity)
 ```
 ````

--- a/docs/usage/disable-networking.md
+++ b/docs/usage/disable-networking.md
@@ -1,33 +1,33 @@
-# External Network
+# Disable Networking Module
 
-Since Liqo v0.8.0, it is possible to enable [**resource reflection**](/usage/reflection) and [**namespace offloading**](/usage/namespace-offloading) without the need to establish network connectivity between the clusters.
-This feature is called **External Network**. In this section, we will see how to enable/disable this feature and how to use it.
+Since Liqo v0.8.0, it is possible to enable [**resource reflection**](/usage/reflection) and [**namespace offloading**](/usage/namespace-offloading) without the need to use the default Liqo networking module to establish network connectivity between the clusters.
+In this section, we will see how to enable/disable this module and how to use this feature.
 
 ## Overview
 
-The *External Network* feature allows resource reflection and namespaces offloading without requiring network connectivity between clusters.
+Turning off the networking module feature allows resource reflection and namespaces offloading without requiring network connectivity between clusters.
 
 This feature is useful in scenarios where the offloaded application **does not need to perform cross-cluster communication** but only needs to access local resources.
 For example, a batch processing application does not need to communicate with other clusters, but it needs to access a database external to the cluster.
 In this case, a network interconnection between clusters is not required and may lead to unnecessary **security issues** and **interdependencies** between clusters.
 
 Another use case is when the clusters and the pods running on them are **already connected to the same network**.
-In this case, you may leverage the *External Network* feature to enable resource reflection and namespaces offloading without having to establish another network connection between the clusters.
+In this case, you may enable resource reflection and namespaces offloading without having to establish another network connection between the clusters.
 
-## Enable/Disable the External Network
+## Enable/Disable the Networking module
 
-This feature is **disabled** by default, and can be configured with **two** different **feature flags** at install time (see the [reference](/installation/install.md)):
+The networking module is **enabled** by default and can be disabled or configured with **two** different **feature flags** at install time (see the [reference](/installation/install.md)):
 
-* `--set networking.internal=false` to disable the internal network
+* `--set networking.enabled=false` to disable the networking module
 * `--set networking.reflectIPs=false` to disable the reflection of the IP addresses
 
-### networking.internal=false
+### networking.enabled=false
 
 This flag disables the internal network.
 When this flag is set to `false`, the Liqo network controllers are not deployed on the cluster.
 The Liqo Network Manager is responsible for creating the `gatewayserver` and `gatewayclient` resources, which are used to establish the network connectivity between the clusters.
 
-When the internal network is disabled, the Liqo Network Fabric is not enabled and **no parameter negotiation or IP remapping is performed**.
+When the networking is disabled, the Liqo Network Fabric is not enabled and **no parameter negotiation or IP remapping is performed**.
 The IP addresses of the remote pods are reflected as they are.
 
 ```{admonition} Note

--- a/pkg/liqo-controller-manager/foreign-cluster-operator/foreign-cluster-controller.go
+++ b/pkg/liqo-controller-manager/foreign-cluster-operator/foreign-cluster-controller.go
@@ -98,10 +98,10 @@ type ForeignClusterReconciler struct {
 
 	LiqoNamespace string
 
-	ResyncPeriod           time.Duration
-	HomeCluster            discoveryv1alpha1.ClusterIdentity
-	AutoJoin               bool
-	DisableInternalNetwork bool
+	ResyncPeriod      time.Duration
+	HomeCluster       discoveryv1alpha1.ClusterIdentity
+	AutoJoin          bool
+	NetworkingEnabled bool
 
 	NamespaceManager tenantnamespace.Manager
 	IdentityManager  identitymanager.IdentityManager
@@ -362,7 +362,7 @@ func (r *ForeignClusterReconciler) peerNamespaced(ctx context.Context,
 		discoveryv1alpha1.OutgoingPeeringCondition, status, reason, message)
 
 	// Ensure the ExternalNetwork presence
-	if !r.DisableInternalNetwork {
+	if r.NetworkingEnabled {
 		if err = r.ensureExternalNetwork(ctx, foreignCluster); err != nil {
 			klog.Error(err)
 			return err
@@ -558,9 +558,9 @@ func ensureStatusForConnection(foreignCluster *discoveryv1alpha1.ForeignCluster,
 
 func (r *ForeignClusterReconciler) checkConnection(ctx context.Context,
 	foreignCluster *discoveryv1alpha1.ForeignCluster) error {
-	if r.DisableInternalNetwork {
+	if !r.NetworkingEnabled {
 		peeringconditionsutils.EnsureStatus(foreignCluster,
-			discoveryv1alpha1.NetworkStatusCondition, discoveryv1alpha1.PeeringConditionStatusExternal,
+			discoveryv1alpha1.NetworkStatusCondition, discoveryv1alpha1.PeeringConditionStatusDisabled,
 			externalNetworkReason, externalNetworkMessage)
 		return nil
 	}

--- a/pkg/liqo-controller-manager/shadowendpointslice-controller/mapping.go
+++ b/pkg/liqo-controller-manager/shadowendpointslice-controller/mapping.go
@@ -25,11 +25,10 @@ import (
 )
 
 // MapEndpointsWithConfiguration maps the endpoints of the shadowendpointslice.
-func MapEndpointsWithConfiguration(ctx context.Context, cl client.Client,
-	clusterID string, endpoints []discoveryv1.Endpoint) ([]discoveryv1.Endpoint, error) {
+func MapEndpointsWithConfiguration(ctx context.Context, cl client.Client, clusterID string, endpoints []discoveryv1.Endpoint) error {
 	cfg, err := getters.GetConfigurationByClusterID(ctx, cl, clusterID)
 	if err != nil {
-		return endpoints, err
+		return err
 	}
 
 	var (
@@ -42,24 +41,24 @@ func MapEndpointsWithConfiguration(ctx context.Context, cl client.Client,
 
 	_, podnet, err = net.ParseCIDR(cfg.Spec.Remote.CIDR.Pod.String())
 	if err != nil {
-		return endpoints, err
+		return err
 	}
 	if podNeedsRemap {
 		_, podnetMapped, err = net.ParseCIDR(cfg.Status.Remote.CIDR.Pod.String())
 		if err != nil {
-			return endpoints, err
+			return err
 		}
 		podNetMaskLen, _ = podnetMapped.Mask.Size()
 	}
 
 	_, extnet, err = net.ParseCIDR(cfg.Spec.Remote.CIDR.External.String())
 	if err != nil {
-		return endpoints, err
+		return err
 	}
 	if extNeedsRemap {
 		_, extnetMapped, err = net.ParseCIDR(cfg.Status.Remote.CIDR.External.String())
 		if err != nil {
-			return endpoints, err
+			return err
 		}
 		extNetMaskLen, _ = extnetMapped.Mask.Size()
 	}
@@ -76,7 +75,8 @@ func MapEndpointsWithConfiguration(ctx context.Context, cl client.Client,
 			}
 		}
 	}
-	return endpoints, nil
+
+	return nil
 }
 
 // remapMask remaps the mask of the address.

--- a/pkg/liqoctl/inband/cluster.go
+++ b/pkg/liqoctl/inband/cluster.go
@@ -137,7 +137,7 @@ func (c *Cluster) Init(ctx context.Context) error {
 		s.Fail(fmt.Sprintf("an error occurred while retrieving Liqo controller manager deployment args: %v", output.PrettyErr(err)))
 		return err
 	}
-	if hasExternalNetworkFlag(clusterArgs) {
+	if hasNetworkingDisabled(clusterArgs) {
 		err = fmt.Errorf("cluster network is not managed by Liqo, cannot perform in-band peering")
 		s.Fail(err)
 		return err
@@ -934,9 +934,9 @@ func (c *Cluster) DisablePeering(ctx context.Context, remoteClusterID *discovery
 	return nil
 }
 
-func hasExternalNetworkFlag(flags []string) bool {
+func hasNetworkingDisabled(flags []string) bool {
 	for _, flag := range flags {
-		if flag == "--disable-internal-network" || flag == "--disable-internal-network=true" {
+		if flag == "--networking-enabled=false" {
 			return true
 		}
 	}

--- a/pkg/liqoctl/status/handler.go
+++ b/pkg/liqoctl/status/handler.go
@@ -28,12 +28,12 @@ type Options struct {
 	Verbose  bool
 	Checkers []Checker
 	*factory.Factory
-	InternalNetworkEnabled bool
+	NetworkingEnabled bool
 }
 
 // Run implements the logic of the status command.
 func (o *Options) Run(ctx context.Context) error {
-	if err := o.SetInternalNetworkEnabled(ctx); err != nil {
+	if err := o.SetNetworkingEnabled(ctx); err != nil {
 		return err
 	}
 
@@ -62,18 +62,18 @@ func (o *Options) Run(ctx context.Context) error {
 	return nil
 }
 
-// SetInternalNetworkEnabled sets the internal network enabled flag.
-func (o *Options) SetInternalNetworkEnabled(ctx context.Context) error {
+// SetNetworkingEnabled sets the internal network enabled flag.
+func (o *Options) SetNetworkingEnabled(ctx context.Context) error {
 	var ctrlargs []string
 	ctrlargs, err := liqoctlutil.RetrieveLiqoControllerManagerDeploymentArgs(ctx, o.CRClient, o.LiqoNamespace)
 	if err != nil {
 		return err
 	}
-	_, err = liqoctlutil.ExtractValuesFromArgumentList("--disable-internal-network", ctrlargs)
-	if err != nil {
-		o.InternalNetworkEnabled = true
+	value, err := liqoctlutil.ExtractValuesFromArgumentList("--networking-enabled", ctrlargs)
+	if err != nil || value == "true" {
+		o.NetworkingEnabled = true
 	} else {
-		o.InternalNetworkEnabled = false
+		o.NetworkingEnabled = false
 	}
 	return nil
 }

--- a/pkg/liqoctl/status/local/localinfo.go
+++ b/pkg/liqoctl/status/local/localinfo.go
@@ -137,8 +137,8 @@ func (lic *LocalInfoChecker) addClusterIdentitySection(ctx context.Context) {
 func (lic *LocalInfoChecker) addNetworkSection(ctx context.Context) {
 	networkSection := lic.localInfoSection.AddSection("Network")
 
-	if !lic.options.InternalNetworkEnabled {
-		networkSection.AddEntry("Status", string(discoveryv1alpha1.PeeringConditionStatusExternal))
+	if !lic.options.NetworkingEnabled {
+		networkSection.AddEntry("Status", string(discoveryv1alpha1.PeeringConditionStatusDisabled))
 	} else {
 		podCIDR, err := ipamutils.GetPodCIDR(ctx, lic.options.CRClient)
 		if err != nil {

--- a/pkg/liqoctl/status/local/localinfo_test.go
+++ b/pkg/liqoctl/status/local/localinfo_test.go
@@ -38,8 +38,8 @@ import (
 )
 
 type TestArgsNet struct {
-	InternalNetworkEnabled, apiServerOverride bool
-	endpointServiceType                       corev1.ServiceType
+	networkingEnabled, apiServerOverride bool
+	endpointServiceType                  corev1.ServiceType
 }
 
 type TestArgs struct {
@@ -95,9 +95,9 @@ var _ = Describe("LocalInfo", func() {
 
 		var fakectrlman *appv1.Deployment
 		if args.clusterLabels {
-			fakectrlman = testutil.FakeControllerManagerDeployment(argsClusterLabels, args.net.InternalNetworkEnabled)
+			fakectrlman = testutil.FakeControllerManagerDeployment(argsClusterLabels, args.net.networkingEnabled)
 		} else {
-			fakectrlman = testutil.FakeControllerManagerDeployment(nil, args.net.InternalNetworkEnabled)
+			fakectrlman = testutil.FakeControllerManagerDeployment(nil, args.net.networkingEnabled)
 		}
 		objects = append(objects, fakectrlman)
 
@@ -109,7 +109,7 @@ var _ = Describe("LocalInfo", func() {
 		objects = append(objects,
 			testutil.FakeLiqoAuthService(args.net.endpointServiceType),
 		)
-		if args.net.InternalNetworkEnabled {
+		if args.net.networkingEnabled {
 			objects = append(objects,
 				testutil.FakeNetworkPodCIDR(),
 				testutil.FakeNetworkServiceCIDR(),
@@ -122,7 +122,7 @@ var _ = Describe("LocalInfo", func() {
 		}
 
 		clientBuilder.WithObjects(objects...)
-		options.InternalNetworkEnabled = args.net.InternalNetworkEnabled
+		options.NetworkingEnabled = args.net.networkingEnabled
 		options.CRClient = clientBuilder.Build()
 		options.LiqoNamespace = liqoconsts.DefaultLiqoNamespace
 		options.Verbose = args.verbose
@@ -148,7 +148,7 @@ var _ = Describe("LocalInfo", func() {
 		Expect(text).To(ContainSubstring(
 			pterm.Sprintf("Version: %s", testutil.FakeLiqoVersion),
 		))
-		if args.net.InternalNetworkEnabled {
+		if args.net.networkingEnabled {
 			Expect(text).To(ContainSubstring(
 				pterm.Sprintf("Pod CIDR: %s", testutil.PodCIDR),
 			))
@@ -167,7 +167,7 @@ var _ = Describe("LocalInfo", func() {
 				Expect(text).To(ContainSubstring(v))
 			}
 		} else {
-			Expect(text).To(ContainSubstring(pterm.Sprintf("Status: %s", discoveryv1alpha1.PeeringConditionStatusExternal)))
+			Expect(text).To(ContainSubstring(pterm.Sprintf("Status: %s", discoveryv1alpha1.PeeringConditionStatusDisabled)))
 		}
 		Expect(text).To(ContainSubstring(
 			pterm.Sprintf("Authentication: https://%s:%d", testutil.EndpointIP, testutil.AuthenticationPort),
@@ -185,101 +185,101 @@ var _ = Describe("LocalInfo", func() {
 	},
 		Entry("Standard case with NodePort",
 			TestArgs{false, TestArgsNet{
-				InternalNetworkEnabled: true,
-				apiServerOverride:      false,
-				endpointServiceType:    corev1.ServiceTypeNodePort,
+				networkingEnabled:   true,
+				apiServerOverride:   false,
+				endpointServiceType: corev1.ServiceTypeNodePort,
 			}, true}),
 		Entry("Standard case with LoadBalancer",
 			TestArgs{false, TestArgsNet{
-				InternalNetworkEnabled: true,
-				apiServerOverride:      false,
-				endpointServiceType:    corev1.ServiceTypeLoadBalancer,
+				networkingEnabled:   true,
+				apiServerOverride:   false,
+				endpointServiceType: corev1.ServiceTypeLoadBalancer,
 			}, true}),
 		Entry("Cluster Labels with NodePort",
 			TestArgs{true, TestArgsNet{
-				InternalNetworkEnabled: true,
-				apiServerOverride:      false,
-				endpointServiceType:    corev1.ServiceTypeNodePort,
+				networkingEnabled:   true,
+				apiServerOverride:   false,
+				endpointServiceType: corev1.ServiceTypeNodePort,
 			}, true}),
 
 		Entry("Cluster Labels with LoadBalancer",
 			TestArgs{true, TestArgsNet{
-				InternalNetworkEnabled: true,
-				apiServerOverride:      false,
-				endpointServiceType:    corev1.ServiceTypeLoadBalancer,
+				networkingEnabled:   true,
+				apiServerOverride:   false,
+				endpointServiceType: corev1.ServiceTypeLoadBalancer,
 			}, true}),
 		Entry("API Server Override with NodePort",
 			TestArgs{false, TestArgsNet{
-				InternalNetworkEnabled: true,
-				apiServerOverride:      true,
-				endpointServiceType:    corev1.ServiceTypeNodePort,
+				networkingEnabled:   true,
+				apiServerOverride:   true,
+				endpointServiceType: corev1.ServiceTypeNodePort,
 			}, true}),
 		Entry("API Server Override with LoadBalancer",
 			TestArgs{false, TestArgsNet{
-				InternalNetworkEnabled: true,
-				apiServerOverride:      true,
-				endpointServiceType:    corev1.ServiceTypeLoadBalancer,
+				networkingEnabled:   true,
+				apiServerOverride:   true,
+				endpointServiceType: corev1.ServiceTypeLoadBalancer,
 			}, true}),
 		Entry("Cluster Labels and API Server Override with NodePort",
 			TestArgs{true, TestArgsNet{
-				InternalNetworkEnabled: true,
-				apiServerOverride:      true,
-				endpointServiceType:    corev1.ServiceTypeNodePort,
+				networkingEnabled:   true,
+				apiServerOverride:   true,
+				endpointServiceType: corev1.ServiceTypeNodePort,
 			}, true}),
 		Entry("Cluster Labels and API Server Override with LoadBalancer",
 			TestArgs{true, TestArgsNet{
-				InternalNetworkEnabled: true,
-				apiServerOverride:      true,
-				endpointServiceType:    corev1.ServiceTypeLoadBalancer,
+				networkingEnabled:   true,
+				apiServerOverride:   true,
+				endpointServiceType: corev1.ServiceTypeLoadBalancer,
 			}, true}),
 		Entry("Standard case with NodePort (Internal network Disabled)",
 			TestArgs{false, TestArgsNet{
-				InternalNetworkEnabled: false,
-				apiServerOverride:      false,
-				endpointServiceType:    corev1.ServiceTypeNodePort,
+				networkingEnabled:   false,
+				apiServerOverride:   false,
+				endpointServiceType: corev1.ServiceTypeNodePort,
 			}, true}),
 		Entry("Standard case with LoadBalancer (Internal network Disabled)",
 			TestArgs{false, TestArgsNet{
-				InternalNetworkEnabled: false,
-				apiServerOverride:      false,
-				endpointServiceType:    corev1.ServiceTypeLoadBalancer,
+				networkingEnabled:   false,
+				apiServerOverride:   false,
+				endpointServiceType: corev1.ServiceTypeLoadBalancer,
 			}, true}),
 		Entry("Cluster Labels with NodePort (Internal network Disabled)",
 			TestArgs{true, TestArgsNet{
-				InternalNetworkEnabled: false,
-				apiServerOverride:      false,
-				endpointServiceType:    corev1.ServiceTypeNodePort,
+				networkingEnabled:   false,
+				apiServerOverride:   false,
+				endpointServiceType: corev1.ServiceTypeNodePort,
 			}, true}),
 
 		Entry("Cluster Labels with LoadBalancer (Internal network Disabled)",
 			TestArgs{true, TestArgsNet{
-				InternalNetworkEnabled: false,
-				apiServerOverride:      false,
-				endpointServiceType:    corev1.ServiceTypeLoadBalancer,
+				networkingEnabled:   false,
+				apiServerOverride:   false,
+				endpointServiceType: corev1.ServiceTypeLoadBalancer,
 			}, true}),
 		Entry("API Server Override with NodePort (Internal network Disabled)",
 			TestArgs{false, TestArgsNet{
-				InternalNetworkEnabled: false,
-				apiServerOverride:      true,
-				endpointServiceType:    corev1.ServiceTypeNodePort,
+				networkingEnabled:   false,
+				apiServerOverride:   true,
+				endpointServiceType: corev1.ServiceTypeNodePort,
 			}, true}),
 		Entry("API Server Override with LoadBalancer (Internal network Disabled)",
 			TestArgs{false, TestArgsNet{
-				InternalNetworkEnabled: false,
-				apiServerOverride:      true,
-				endpointServiceType:    corev1.ServiceTypeLoadBalancer,
+				networkingEnabled:   false,
+				apiServerOverride:   true,
+				endpointServiceType: corev1.ServiceTypeLoadBalancer,
 			}, true}),
 		Entry("Cluster Labels and API Server Override with NodePort (Internal network Disabled)",
 			TestArgs{true, TestArgsNet{
-				InternalNetworkEnabled: false,
-				apiServerOverride:      true,
-				endpointServiceType:    corev1.ServiceTypeNodePort,
+				networkingEnabled:   false,
+				apiServerOverride:   true,
+				endpointServiceType: corev1.ServiceTypeNodePort,
 			}, true}),
 		Entry("Cluster Labels and API Server Override with LoadBalancer (Internal network Disabled)",
 			TestArgs{true, TestArgsNet{
-				InternalNetworkEnabled: false,
-				apiServerOverride:      true,
-				endpointServiceType:    corev1.ServiceTypeLoadBalancer,
+				networkingEnabled:   false,
+				apiServerOverride:   true,
+				endpointServiceType: corev1.ServiceTypeLoadBalancer,
 			}, true}),
 	)
 })

--- a/pkg/liqoctl/status/local/pods.go
+++ b/pkg/liqoctl/status/local/pods.go
@@ -198,7 +198,7 @@ func (pc *PodChecker) Silent() bool {
 // collected at the pod level.
 func (pc *PodChecker) Collect(ctx context.Context) {
 	pc.deployments = slices.Clone(liqoDeployments)
-	if pc.options.InternalNetworkEnabled {
+	if pc.options.NetworkingEnabled {
 		pc.deployments = append(pc.deployments, liqoDeploymentsNetwork...)
 		pc.daemonSets = append(pc.daemonSets, liqoDaemonSetsNetwork...)
 	}

--- a/pkg/liqoctl/status/local/pods_test.go
+++ b/pkg/liqoctl/status/local/pods_test.go
@@ -162,7 +162,7 @@ var _ = Describe("Pods", func() {
 		BeforeEach(func() {
 			options.LiqoNamespace = namespace
 			options.Printer = printer
-			options.InternalNetworkEnabled = true
+			options.NetworkingEnabled = true
 			pod = &v1.Pod{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "Pod",
@@ -222,14 +222,14 @@ var _ = Describe("Pods", func() {
 
 		Describe("Collect() function", func() {
 			Context("collecting deployment apps", func() {
-				DescribeTable("Validating deployments and daemonsets to check are initialized correctly", func(internalNetworkEnabled bool) {
+				DescribeTable("Validating deployments and daemonsets to check are initialized correctly", func(NetworkingEnabled bool) {
 					podC.options.KubeClient = fake.NewSimpleClientset()
-					podC.options.InternalNetworkEnabled = internalNetworkEnabled
+					podC.options.NetworkingEnabled = NetworkingEnabled
 					podC.Collect(ctx)
-					if internalNetworkEnabled {
+					if NetworkingEnabled {
 						Expect(podC.daemonSets[1:]).To(Equal(liqoDaemonSetsNetwork))
 					}
-					if internalNetworkEnabled {
+					if NetworkingEnabled {
 						Expect(podC.deployments).To(Equal(append(liqoDeployments, liqoDeploymentsNetwork...)))
 					} else {
 						Expect(podC.deployments).To(Equal(liqoDeployments))

--- a/pkg/liqoctl/status/peer/peerinfo.go
+++ b/pkg/liqoctl/status/peer/peerinfo.go
@@ -163,7 +163,7 @@ func (pic *PeerInfoChecker) addNetworkSection(ctx context.Context, rootSection o
 	networkSection := rootSection.AddSection("Network")
 	networkStatus := peeringconditionsutils.GetStatus(foreignCluster, discoveryv1alpha1.NetworkStatusCondition)
 	networkSection.AddEntry("Status", string(networkStatus))
-	if !pic.options.InternalNetworkEnabled {
+	if !pic.options.NetworkingEnabled {
 		return
 	}
 	if pic.options.Verbose {

--- a/pkg/liqoctl/status/peer/peerinfo_test.go
+++ b/pkg/liqoctl/status/peer/peerinfo_test.go
@@ -43,7 +43,7 @@ type TestArgsPeer struct {
 }
 
 type TestArgsNet struct {
-	internalNetworkEnabled bool
+	networkingEnabled bool
 }
 
 type TestArgs struct {
@@ -127,7 +127,7 @@ var _ = Describe("PeerInfo", func() {
 			incomingEnabled = discoveryv1alpha1.PeeringEnabledNo
 			outgoingConditionStatus = discoveryv1alpha1.PeeringConditionStatusNone
 			incomingConditionStatus = discoveryv1alpha1.PeeringConditionStatusNone
-			networkConditionStatus = discoveryv1alpha1.PeeringConditionStatusExternal
+			networkConditionStatus = discoveryv1alpha1.PeeringConditionStatusDisabled
 
 			if args.peer.outgoingPeeringEnabled {
 				outgoingEnabled = discoveryv1alpha1.PeeringEnabledYes
@@ -143,7 +143,7 @@ var _ = Describe("PeerInfo", func() {
 			var conn *networkingv1alpha1.Connection
 			var gwServer *networkingv1alpha1.GatewayServer
 			var gwClient *networkingv1alpha1.GatewayClient
-			if args.net.internalNetworkEnabled {
+			if args.net.networkingEnabled {
 				networkConditionStatus = discoveryv1alpha1.PeeringConditionStatusEstablished
 				conf = testutil.FakeConfiguration(remoteClusterID, podCIDR, extCIDR,
 					remotePodCIDR, remoteExtCIDR, remoteRemappedPodCIDR, remoteRemappedExtCIDR)
@@ -159,7 +159,7 @@ var _ = Describe("PeerInfo", func() {
 			)
 
 			clientBuilder.WithObjects(objects...)
-			options.InternalNetworkEnabled = args.net.internalNetworkEnabled
+			options.NetworkingEnabled = args.net.networkingEnabled
 			options.Verbose = args.verbose
 			options.LiqoNamespace = liqoconsts.DefaultLiqoNamespace
 			options.CRClient = clientBuilder.Build()
@@ -209,7 +209,7 @@ var _ = Describe("PeerInfo", func() {
 			}
 
 			// Network
-			if args.net.internalNetworkEnabled {
+			if args.net.networkingEnabled {
 				Expect(text).To(ContainSubstring(
 					pterm.Sprintf("Network Status: %s", discoveryv1alpha1.PeeringConditionStatusEstablished),
 				))
@@ -219,7 +219,7 @@ var _ = Describe("PeerInfo", func() {
 
 			} else {
 				Expect(text).To(ContainSubstring(
-					pterm.Sprintf("Network Status: %s", discoveryv1alpha1.PeeringConditionStatusExternal),
+					pterm.Sprintf("Network Status: %s", discoveryv1alpha1.PeeringConditionStatusDisabled),
 				))
 			}
 
@@ -285,10 +285,10 @@ func expectResourcesToBeContainedIn(text string, genericResources corev1.Resourc
 }
 
 func forgeTestTableEntry(verbose bool, peeringType discoveryv1alpha1.PeeringType,
-	incomingPeeringEnabled bool, outgoingPeeringEnabled bool, internalNetworkEnabled bool,
+	incomingPeeringEnabled bool, outgoingPeeringEnabled bool, networkingEnabled bool,
 ) TableEntry {
-	msg := pterm.Sprintf(`verbose: %t, peeringType: %s, incomingPeeringEnabled: %t, outgoingPeeringEnabled: %t, internalNetworkEnabled: %t`,
-		verbose, peeringType, incomingPeeringEnabled, outgoingPeeringEnabled, internalNetworkEnabled)
+	msg := pterm.Sprintf(`verbose: %t, peeringType: %s, incomingPeeringEnabled: %t, outgoingPeeringEnabled: %t, networkingEnabled: %t`,
+		verbose, peeringType, incomingPeeringEnabled, outgoingPeeringEnabled, networkingEnabled)
 	return Entry(msg, TestArgs{
 		verbose: verbose,
 		peer: TestArgsPeer{
@@ -297,7 +297,7 @@ func forgeTestTableEntry(verbose bool, peeringType discoveryv1alpha1.PeeringType
 			outgoingPeeringEnabled: outgoingPeeringEnabled,
 		},
 		net: TestArgsNet{
-			internalNetworkEnabled: internalNetworkEnabled,
+			networkingEnabled: networkingEnabled,
 		},
 	})
 }
@@ -313,13 +313,13 @@ func forgeTestMatrix() []TableEntry {
 			for _, incomingPeeringEnabled := range []bool{true, false} {
 				for _, outgoingPeeringEnabled := range []bool{true, false} {
 
-					for _, internalNetworkEnabled := range []bool{true, false} {
+					for _, networkingEnabled := range []bool{true, false} {
 						// excludes cases where the network is not enabled and the peering is in-band
-						if !internalNetworkEnabled && peeringType == discoveryv1alpha1.PeeringTypeInBand {
+						if !networkingEnabled && peeringType == discoveryv1alpha1.PeeringTypeInBand {
 							continue
 						}
 						testMatrix = append(testMatrix, forgeTestTableEntry(verbose, peeringType,
-							incomingPeeringEnabled, outgoingPeeringEnabled, internalNetworkEnabled))
+							incomingPeeringEnabled, outgoingPeeringEnabled, networkingEnabled))
 					}
 				}
 			}

--- a/pkg/liqoctl/wait/wait.go
+++ b/pkg/liqoctl/wait/wait.go
@@ -114,7 +114,7 @@ func (w *Waiter) ForAuth(ctx context.Context, remoteClusterID *discoveryv1alpha1
 func (w *Waiter) ForNetwork(ctx context.Context, remoteClusterID *discoveryv1alpha1.ClusterIdentity) error {
 	remName := remoteClusterID.ClusterName
 	s := w.Printer.StartSpinner(fmt.Sprintf("Waiting for network to the remote cluster %q", remName))
-	err := fcutils.PollForEvent(ctx, w.CRClient, remoteClusterID, fcutils.IsNetworkingEstablishedOrExternal, 1*time.Second)
+	err := fcutils.PollForEvent(ctx, w.CRClient, remoteClusterID, fcutils.IsNetworkingEstablishedOrDisabled, 1*time.Second)
 	if err != nil {
 		s.Fail(fmt.Sprintf("Failed establishing networking to the remote cluster %q: %s", remName, output.PrettyErr(err)))
 		return err

--- a/pkg/utils/foreignCluster/peeringStatus.go
+++ b/pkg/utils/foreignCluster/peeringStatus.go
@@ -82,15 +82,15 @@ func IsNetworkingEstablished(foreignCluster *discoveryv1alpha1.ForeignCluster) b
 	return curPhase == discoveryv1alpha1.PeeringConditionStatusEstablished
 }
 
-// IsNetworkingExternal checks if the external network plugin is enabled.
-func IsNetworkingExternal(foreignCluster *discoveryv1alpha1.ForeignCluster) bool {
+// IsNetworkingDisabled checks if the liqo networking module is disabled.
+func IsNetworkingDisabled(foreignCluster *discoveryv1alpha1.ForeignCluster) bool {
 	curPhase := peeringconditionsutils.GetStatus(foreignCluster, discoveryv1alpha1.NetworkStatusCondition)
-	return curPhase == discoveryv1alpha1.PeeringConditionStatusExternal
+	return curPhase == discoveryv1alpha1.PeeringConditionStatusDisabled
 }
 
-// IsNetworkingEstablishedOrExternal checks if the networking has be established or if the external network plugin is enabled.
-func IsNetworkingEstablishedOrExternal(foreignCluster *discoveryv1alpha1.ForeignCluster) bool {
-	return IsNetworkingEstablished(foreignCluster) || IsNetworkingExternal(foreignCluster)
+// IsNetworkingEstablishedOrDisabled checks if the networking has be established or if the liqo networking module is disabled.
+func IsNetworkingEstablishedOrDisabled(foreignCluster *discoveryv1alpha1.ForeignCluster) bool {
+	return IsNetworkingEstablished(foreignCluster) || IsNetworkingDisabled(foreignCluster)
 }
 
 // IsAPIServerReady checks if the api server is ready.

--- a/pkg/utils/testutil/liqo.go
+++ b/pkg/utils/testutil/liqo.go
@@ -77,7 +77,7 @@ func FakeControllerManagerDeployment(argsClusterLabels []string, networkEnabled 
 		containerArgs = append(containerArgs, "--cluster-labels="+strings.Join(argsClusterLabels, ","))
 	}
 	if !networkEnabled {
-		containerArgs = append(containerArgs, "--disable-internal-network")
+		containerArgs = append(containerArgs, "--networking-enabled=false")
 	}
 	return &appv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
# Description

This PR renames the flag to enable/disable the Liqo Networking module and avoid ambiguities.