### PR TITLE
Do not reflect OpenStack LoadBalancer id annotation

### DIFF
--- a/deployments/liqo/README.md
+++ b/deployments/liqo/README.md
@@ -176,7 +176,7 @@
 | reflection.service.type | string | `"DenyList"` | The type of reflection used for the services reflector. Ammitted values: "DenyList", "AllowList". |
 | reflection.service.workers | int | `3` | The number of workers used for the services reflector. Set 0 to disable the reflection of services. |
 | reflection.serviceaccount.workers | int | `3` | The number of workers used for the serviceaccounts reflector. Set 0 to disable the reflection of serviceaccounts. |
-| reflection.skip.annotations | list | `["cloud.google.com/neg","cloud.google.com/neg-status","kubernetes.digitalocean.com/load-balancer-id","ingress.kubernetes.io/backends","ingress.kubernetes.io/forwarding-rule","ingress.kubernetes.io/target-proxy","ingress.kubernetes.io/url-map","metallb.universe.tf/address-pool","metallb.universe.tf/ip-allocated-from-pool","metallb.universe.tf/loadBalancerIPs"]` | List of annotations that must not be reflected on remote clusters. |
+| reflection.skip.annotations | list | `["cloud.google.com/neg","cloud.google.com/neg-status","kubernetes.digitalocean.com/load-balancer-id","ingress.kubernetes.io/backends","ingress.kubernetes.io/forwarding-rule","ingress.kubernetes.io/target-proxy","ingress.kubernetes.io/url-map","metallb.universe.tf/address-pool","metallb.universe.tf/ip-allocated-from-pool","metallb.universe.tf/loadBalancerIPs","loadbalancer.openstack.org/load-balancer-id"]` | List of annotations that must not be reflected on remote clusters. |
 | reflection.skip.labels | list | `[]` | List of labels that must not be reflected on remote clusters. |
 | route.imageName | string | `"ghcr.io/liqotech/liqonet"` | Image repository for the route pod. |
 | route.pod.annotations | object | `{}` | Annotations for the route pod. |

--- a/deployments/liqo/values.yaml
+++ b/deployments/liqo/values.yaml
@@ -56,6 +56,7 @@ reflection:
       metallb.universe.tf/address-pool,
       metallb.universe.tf/ip-allocated-from-pool,
       metallb.universe.tf/loadBalancerIPs,
+      loadbalancer.openstack.org/load-balancer-id,
     ]
   pod:
     # -- The number of workers used for the pods reflector. Set 0 to disable the reflection of pods.


### PR DESCRIPTION
# Description

This PR adds to the list of well-known annotations to **not** reflect the `loadbalancer.openstack.org/load-balancer-id` annotation.
