### PR TITLE
[Network] firewallconfiguration and routeconfiguration reque

### DIFF
--- a/deployments/liqo/templates/liqo-wireguard-gateway-client-template.yaml
+++ b/deployments/liqo/templates/liqo-wireguard-gateway-client-template.yaml
@@ -24,6 +24,8 @@ spec:
           {{- include "liqo.metadataTemplate" $templateConfig | nindent 10 }}
         spec:
           replicas: {{ .Values.networking.gatewayTemplates.replicas }}
+          strategy:
+            type: Recreate
           selector:
             matchLabels:
               {{- include "liqo.labelsTemplate" $templateConfig | nindent 14 }}

--- a/deployments/liqo/templates/liqo-wireguard-gateway-server-template.yaml
+++ b/deployments/liqo/templates/liqo-wireguard-gateway-server-template.yaml
@@ -42,6 +42,8 @@ spec:
           {{- include "liqo.metadataTemplate" $templateConfig | nindent 10 }}
         spec:
           replicas: {{ .Values.networking.gatewayTemplates.replicas }}
+          strategy:
+            type: Recreate
           selector:
             matchLabels:
               {{- include "liqo.labelsTemplate" $templateConfig | nindent 14 }}

--- a/pkg/firewall/firewallconfiguration_controller.go
+++ b/pkg/firewall/firewallconfiguration_controller.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/google/nftables"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -152,7 +153,7 @@ func (r *FirewallConfigurationReconciler) Reconcile(ctx context.Context, req ctr
 
 	klog.Infof("Applied firewallconfiguration %s", req.String())
 
-	return ctrl.Result{}, nil
+	return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 }
 
 // SetupWithManager register the FirewallConfigurationReconciler to the manager.

--- a/pkg/gateway/tunnel/wireguard/publickeys_controller.go
+++ b/pkg/gateway/tunnel/wireguard/publickeys_controller.go
@@ -32,6 +32,7 @@ import (
 
 	networkingv1alpha1 "github.com/liqotech/liqo/apis/networking/v1alpha1"
 	"github.com/liqotech/liqo/pkg/consts"
+	"github.com/liqotech/liqo/pkg/gateway"
 )
 
 // cluster-role
@@ -70,6 +71,12 @@ func (r *PublicKeysReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, fmt.Errorf("unable to get the publicKey %q: %w", req.NamespacedName, err)
+	}
+
+	if r.Options.GwOptions.Mode == gateway.ModeClient && r.Options.EndpointIP == nil {
+		// We don't need to retry because the DNS resolution routine will wakeup this controller.
+		klog.Warning("EndpointIP is not set yet. Maybe the DNS resolution is still in progress")
+		return ctrl.Result{}, nil
 	}
 
 	if err := configureDevice(r.Wgcl, r.Options, wgtypes.Key(publicKey.Spec.PublicKey)); err != nil {

--- a/pkg/liqo-controller-manager/external-network/remapping/ip.go
+++ b/pkg/liqo-controller-manager/external-network/remapping/ip.go
@@ -126,14 +126,14 @@ func mutateFirewallConfigurationMasquerade(fwcfg *networkingv1alpha1.FirewallCon
 
 func enforceFirewallConfigurationSpec(fwcfg *networkingv1alpha1.FirewallConfiguration, ip *ipamv1alpha1.IP) {
 	table := &fwcfg.Spec.Table
-	table.Name = &TableIPMappingGwName
+	table.Name = ptr.To(fmt.Sprintf("%s-%s", TableIPMappingGwName, fwcfg.Namespace))
 	table.Family = ptr.To(firewall.TableFamilyIPv4)
 	enforceFirewallConfigurationChains(fwcfg, ip)
 }
 
 func enforceFirewallConfigurationMasqSpec(fwcfg *networkingv1alpha1.FirewallConfiguration, ip *ipamv1alpha1.IP) {
 	table := &fwcfg.Spec.Table
-	table.Name = &TableIPMappingFabricName
+	table.Name = ptr.To(fmt.Sprintf("%s-%s", TableIPMappingFabricName, fwcfg.Namespace))
 	table.Family = ptr.To(firewall.TableFamilyIPv4)
 	enforceFirewallConfigurationMasqChains(fwcfg, ip)
 }

--- a/pkg/route/routeconfiguration_controller.go
+++ b/pkg/route/routeconfiguration_controller.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -165,7 +166,7 @@ func (r *RouteConfigurationReconciler) Reconcile(ctx context.Context, req ctrl.R
 
 	klog.Infof("Applied routeconfiguration %s", req.String())
 
-	return ctrl.Result{}, nil
+	return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 }
 
 // SetupWithManager register the RouteConfigurationReconciler to the manager.

--- a/pkg/utils/network/geneve/netlink.go
+++ b/pkg/utils/network/geneve/netlink.go
@@ -76,8 +76,11 @@ func CreateGeneveInterface(name string, local, remote net.IP, id uint32, enableA
 		if !geneveLink.Remote.Equal(remote) {
 			klog.Warningf("geneve link already exists with different remote IP (%s -> %s), modifyng it",
 				geneveLink.Remote.String(), remote.String())
+			if err := netlink.LinkDel(geneveLink); err != nil {
+				return fmt.Errorf("cannot delete geneve link: %w", err)
+			}
 			geneveLink = ForgeGeneveInterface(name, remote, id)
-			if err := netlink.LinkModify(geneveLink); err != nil {
+			if err := netlink.LinkAdd(geneveLink); err != nil {
 				return fmt.Errorf("cannot modify geneve link: %w", err)
 			}
 		}


### PR DESCRIPTION
# Description

This PR is a temporary fix to ensure the existence of the firewall and routing rules applied by the firewallconfiguration  controller and the routeconfiguration controller.

This is an unoptimized fix and will be replaced by a more fine-grained solution.