### PR TITLE
[Auth] Cordon Tenant

### DIFF
--- a/apis/authentication/v1alpha1/identity_types.go
+++ b/apis/authentication/v1alpha1/identity_types.go
@@ -71,6 +71,8 @@ type IdentityStatus struct {
 // +kubebuilder:resource:categories=liqo
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
+// +kubebuilder:printcolumn:name="Type",type=string,JSONPath=`.spec.type`
+// +kubebuilder:printcolumn:name="KubeconfigSecret",type=string,JSONPath=`.status.kubeconfigSecretRef.name`
 
 // Identity contains the information to operate in a remote cluster.
 type Identity struct {

--- a/apis/authentication/v1alpha1/resourceslice_types.go
+++ b/apis/authentication/v1alpha1/resourceslice_types.go
@@ -117,6 +117,8 @@ type ResourceSliceStatus struct {
 // +kubebuilder:resource:categories=liqo
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
+// +kubebuilder:printcolumn:name="Authentication",type=string,JSONPath=`.status.conditions[?(@.type=="Authentication")].status`
+// +kubebuilder:printcolumn:name="Resources",type=string,JSONPath=`.status.conditions[?(@.type=="Resources")].status`
 
 // ResourceSlice represents a slice of resources given by the provider cluster to the consumer cluster.
 type ResourceSlice struct {

--- a/apis/authentication/v1alpha1/tenant_types.go
+++ b/apis/authentication/v1alpha1/tenant_types.go
@@ -45,7 +45,23 @@ type TenantSpec struct {
 	Signature []byte `json:"signature,omitempty"`
 	// ProxyURL is the URL of the proxy used by the tenant cluster to connect to the local cluster (optional).
 	ProxyURL *string `json:"proxyURL,omitempty"`
+	// TenantCondition contains the conditions of the tenant.
+	// +kubebuilder:validation:Enum=Active;Cordoned;Drained
+	// +kubebuilder:default=Active
+	TenantCondition TenantCondition `json:"tenantCondition,omitempty"`
 }
+
+// TenantCondition contains the conditions of the tenant.
+type TenantCondition string
+
+const (
+	// TenantConditionActive indicates that the tenant is active: it can consume resources and negotiate new ones.
+	TenantConditionActive TenantCondition = "Active"
+	// TenantConditionCordoned indicates that the tenant is cordoned: it can consume existing resources but can't negotiate new ones.
+	TenantConditionCordoned TenantCondition = "Cordoned"
+	// TenantConditionDrained indicates that the tenant is drained: it can't consume resources nor negotiate new ones.
+	TenantConditionDrained TenantCondition = "Drained"
+)
 
 // TenantStatus defines the observed state of Tenant.
 type TenantStatus struct {

--- a/apis/authentication/v1alpha1/tenant_types.go
+++ b/apis/authentication/v1alpha1/tenant_types.go
@@ -75,6 +75,7 @@ type TenantStatus struct {
 // +kubebuilder:resource:scope=Cluster,categories=liqo
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
+// +kubebuilder:printcolumn:name="Condition",type=string,JSONPath=`.spec.tenantCondition`
 
 // Tenant represents a consumer cluster.
 type Tenant struct {

--- a/cmd/liqoctl/cmd/cordon.go
+++ b/cmd/liqoctl/cmd/cordon.go
@@ -1,0 +1,79 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"context"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/liqotech/liqo/pkg/liqoctl/completion"
+	"github.com/liqotech/liqo/pkg/liqoctl/cordon"
+	"github.com/liqotech/liqo/pkg/liqoctl/factory"
+	"github.com/liqotech/liqo/pkg/liqoctl/output"
+)
+
+const liqoctlCordonTenantLongHelp = `Cordon a tenant cluster.
+
+This command allows to cordon a tenant cluster, preventing it from receiving new resources.
+Resources provided by existing ResourceSlices are left untouched, while new ResourceSlices
+are denied.
+
+Examples:
+  $ {{ .Executable }} cordon tenant my-tenant-name
+`
+
+// newCordonCommand represents the cordon command.
+func newCordonCommand(ctx context.Context, f *factory.Factory) *cobra.Command {
+	var cmd = &cobra.Command{
+		Use:   "cordon",
+		Short: "Cordon a liqo resource",
+		Long:  "Cordon a liqo resource",
+		Args:  cobra.NoArgs,
+	}
+
+	cmd.AddCommand(newCordonTenantCommand(ctx, f))
+
+	return cmd
+}
+
+// newCordonTenantCommand represents the cordon command.
+func newCordonTenantCommand(ctx context.Context, f *factory.Factory) *cobra.Command {
+	options := cordon.NewOptions(f)
+
+	var cmd = &cobra.Command{
+		Use:               "tenant",
+		Short:             "Cordon a tenant cluster",
+		Long:              WithTemplate(liqoctlCordonTenantLongHelp),
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: completion.Tenants(ctx, f, 1),
+
+		PreRun: func(cmd *cobra.Command, args []string) {
+			output.ExitOnErr(options.Printer.AskConfirm("cordon", options.SkipConfirm))
+		},
+
+		Run: func(cmd *cobra.Command, args []string) {
+			options.TenantName = args[0]
+			output.ExitOnErr(options.RunCordonTenant(ctx))
+		},
+	}
+
+	options.Factory.AddFlags(cmd.PersistentFlags(), cmd.RegisterFlagCompletionFunc)
+
+	cmd.PersistentFlags().DurationVar(&options.Timeout, "timeout", 120*time.Second, "Timeout for cordon completion")
+
+	return cmd
+}

--- a/cmd/liqoctl/cmd/root.go
+++ b/cmd/liqoctl/cmd/root.go
@@ -137,6 +137,8 @@ func NewRootCommand(ctx context.Context) *cobra.Command {
 	cmd.AddCommand(newVersionCommand(ctx, f))
 	cmd.AddCommand(newDocsCommand(ctx))
 	cmd.AddCommand(newAuthenticateCommand(ctx, f))
+	cmd.AddCommand(newCordonCommand(ctx, f))
+	cmd.AddCommand(newUncordonCommand(ctx, f))
 	cmd.AddCommand(create.NewCreateCommand(ctx, liqoResources, f))
 	cmd.AddCommand(get.NewGetCommand(ctx, liqoResources, f))
 	cmd.AddCommand(delete.NewDeleteCommand(ctx, liqoResources, f))

--- a/cmd/liqoctl/cmd/uncordon.go
+++ b/cmd/liqoctl/cmd/uncordon.go
@@ -1,0 +1,78 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"context"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/liqotech/liqo/pkg/liqoctl/completion"
+	"github.com/liqotech/liqo/pkg/liqoctl/factory"
+	"github.com/liqotech/liqo/pkg/liqoctl/output"
+	"github.com/liqotech/liqo/pkg/liqoctl/uncordon"
+)
+
+const liqoctlUncordonTenantLongHelp = `Uncordon a tenant cluster.
+
+This command allows to uncordon a tenant cluster, allowing it to receive and accept new resources. 
+Resources provided by existing ResourceSlices can be accepted again.
+
+Examples:
+  $ {{ .Executable }} uncordon tenant my-tenant-name
+`
+
+// newUncordonCommand represents the uncordon command.
+func newUncordonCommand(ctx context.Context, f *factory.Factory) *cobra.Command {
+	var cmd = &cobra.Command{
+		Use:   "uncordon",
+		Short: "Uncordon a liqo resource",
+		Long:  "Uncordon a liqo resource",
+		Args:  cobra.NoArgs,
+	}
+
+	cmd.AddCommand(newUncordonTenantCommand(ctx, f))
+
+	return cmd
+}
+
+// newUncordonTenantCommand represents the uncordon command.
+func newUncordonTenantCommand(ctx context.Context, f *factory.Factory) *cobra.Command {
+	options := uncordon.NewOptions(f)
+
+	var cmd = &cobra.Command{
+		Use:               "tenant",
+		Short:             "Uncordon a tenant cluster",
+		Long:              WithTemplate(liqoctlUncordonTenantLongHelp),
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: completion.Tenants(ctx, f, 1),
+
+		PreRun: func(cmd *cobra.Command, args []string) {
+			output.ExitOnErr(options.Printer.AskConfirm("uncordon", options.SkipConfirm))
+		},
+
+		Run: func(cmd *cobra.Command, args []string) {
+			options.TenantName = args[0]
+			output.ExitOnErr(options.RunUncordonTenant(ctx))
+		},
+	}
+
+	options.Factory.AddFlags(cmd.PersistentFlags(), cmd.RegisterFlagCompletionFunc)
+
+	cmd.PersistentFlags().DurationVar(&options.Timeout, "timeout", 120*time.Second, "Timeout for uncordon completion")
+
+	return cmd
+}

--- a/deployments/liqo/crds/authentication.liqo.io_identities.yaml
+++ b/deployments/liqo/crds/authentication.liqo.io_identities.yaml
@@ -20,6 +20,12 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    - jsonPath: .spec.type
+      name: Type
+      type: string
+    - jsonPath: .status.kubeconfigSecretRef.name
+      name: KubeconfigSecret
+      type: string
     name: v1alpha1
     schema:
       openAPIV3Schema:

--- a/deployments/liqo/crds/authentication.liqo.io_resourceslices.yaml
+++ b/deployments/liqo/crds/authentication.liqo.io_resourceslices.yaml
@@ -20,6 +20,12 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    - jsonPath: .status.conditions[?(@.type=="Authentication")].status
+      name: Authentication
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Resources")].status
+      name: Resources
+      type: string
     name: v1alpha1
     schema:
       openAPIV3Schema:

--- a/deployments/liqo/crds/authentication.liqo.io_tenants.yaml
+++ b/deployments/liqo/crds/authentication.liqo.io_tenants.yaml
@@ -20,6 +20,9 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    - jsonPath: .spec.tenantCondition
+      name: Condition
+      type: string
     name: v1alpha1
     schema:
       openAPIV3Schema:

--- a/deployments/liqo/crds/authentication.liqo.io_tenants.yaml
+++ b/deployments/liqo/crds/authentication.liqo.io_tenants.yaml
@@ -76,6 +76,14 @@ spec:
                 description: Signature contains the nonce signed by the tenant cluster.
                 format: byte
                 type: string
+              tenantCondition:
+                default: Active
+                description: TenantCondition contains the conditions of the tenant.
+                enum:
+                - Active
+                - Cordoned
+                - Drained
+                type: string
             type: object
           status:
             description: TenantStatus defines the observed state of Tenant.

--- a/deployments/liqo/files/liqo-controller-manager-ClusterRole.yaml
+++ b/deployments/liqo/files/liqo-controller-manager-ClusterRole.yaml
@@ -97,6 +97,14 @@ rules:
   - authentication.liqo.io
   resources:
   - tenants
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - authentication.liqo.io
+  resources:
+  - tenants
   - tenants/status
   verbs:
   - create

--- a/pkg/liqoctl/authenticate/handler.go
+++ b/pkg/liqoctl/authenticate/handler.go
@@ -21,7 +21,7 @@ import (
 	"github.com/liqotech/liqo/pkg/liqoctl/factory"
 )
 
-// Options encapsulates the arguments of the network command.
+// Options encapsulates the arguments of the authenticate command.
 type Options struct {
 	LocalFactory  *factory.Factory
 	RemoteFactory *factory.Factory

--- a/pkg/liqoctl/completion/completion.go
+++ b/pkg/liqoctl/completion/completion.go
@@ -246,6 +246,24 @@ func ClusterNames(ctx context.Context, f *factory.Factory, argsLimit int) FnType
 	return common(ctx, f, argsLimit, retriever)
 }
 
+// Tenants returns a function to autocomplete Tenant names.
+func Tenants(ctx context.Context, f *factory.Factory, argsLimit int) FnType {
+	retriever := func(ctx context.Context, f *factory.Factory) ([]string, error) {
+		var tenants authv1alpha1.TenantList
+		if err := f.CRClient.List(ctx, &tenants); err != nil {
+			return nil, err
+		}
+
+		var names []string
+		for i := range tenants.Items {
+			names = append(names, tenants.Items[i].Name)
+		}
+		return names, nil
+	}
+
+	return common(ctx, f, argsLimit, retriever)
+}
+
 // KubeconfigSecretNames returns a function to autocomplete kubeconfig secret names.
 func KubeconfigSecretNames(ctx context.Context, f *factory.Factory, argsLimit int, namespace string, identityType authv1alpha1.IdentityType) FnType {
 	retriever := func(ctx context.Context, f *factory.Factory) ([]string, error) {

--- a/pkg/liqoctl/cordon/doc.go
+++ b/pkg/liqoctl/cordon/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package cordon contains the commands to cordon Liqo resources.
+package cordon

--- a/pkg/liqoctl/cordon/handler.go
+++ b/pkg/liqoctl/cordon/handler.go
@@ -1,0 +1,65 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cordon
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	authv1alpha1 "github.com/liqotech/liqo/apis/authentication/v1alpha1"
+	"github.com/liqotech/liqo/pkg/liqoctl/factory"
+	"github.com/liqotech/liqo/pkg/liqoctl/output"
+)
+
+// Options encapsulates the arguments of the cordon command.
+type Options struct {
+	*factory.Factory
+
+	TenantName string
+
+	Timeout time.Duration
+}
+
+// NewOptions returns a new Options struct.
+func NewOptions(f *factory.Factory) *Options {
+	return &Options{
+		Factory: f,
+	}
+}
+
+// RunCordonTenant cordons a tenant cluster.
+func (o *Options) RunCordonTenant(ctx context.Context) error {
+	ctx, cancel := context.WithTimeout(ctx, o.Timeout)
+	defer cancel()
+
+	var tenant authv1alpha1.Tenant
+	if err := o.CRClient.Get(ctx, client.ObjectKey{Name: o.TenantName}, &tenant); err != nil {
+		o.Printer.CheckErr(fmt.Errorf("unable to get tenant: %v", output.PrettyErr(err)))
+		return err
+	}
+
+	tenant.Spec.TenantCondition = authv1alpha1.TenantConditionCordoned
+	if err := o.CRClient.Update(ctx, &tenant); err != nil {
+		o.Printer.CheckErr(fmt.Errorf("unable to update tenant: %v", output.PrettyErr(err)))
+		return err
+	}
+
+	o.Printer.Success.Printfln("Tenant %q cordoned", o.TenantName)
+
+	return nil
+}

--- a/pkg/liqoctl/uncordon/doc.go
+++ b/pkg/liqoctl/uncordon/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package uncordon contains the commands to uncordon Liqo resources.
+package uncordon

--- a/pkg/liqoctl/uncordon/handler.go
+++ b/pkg/liqoctl/uncordon/handler.go
@@ -1,0 +1,65 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package uncordon
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	authv1alpha1 "github.com/liqotech/liqo/apis/authentication/v1alpha1"
+	"github.com/liqotech/liqo/pkg/liqoctl/factory"
+	"github.com/liqotech/liqo/pkg/liqoctl/output"
+)
+
+// Options encapsulates the arguments of the uncordon command.
+type Options struct {
+	*factory.Factory
+
+	TenantName string
+
+	Timeout time.Duration
+}
+
+// NewOptions returns a new Options struct.
+func NewOptions(f *factory.Factory) *Options {
+	return &Options{
+		Factory: f,
+	}
+}
+
+// RunUncordonTenant uncordons a tenant cluster.
+func (o *Options) RunUncordonTenant(ctx context.Context) error {
+	ctx, cancel := context.WithTimeout(ctx, o.Timeout)
+	defer cancel()
+
+	var tenant authv1alpha1.Tenant
+	if err := o.CRClient.Get(ctx, client.ObjectKey{Name: o.TenantName}, &tenant); err != nil {
+		o.Printer.CheckErr(fmt.Errorf("unable to get tenant: %v", output.PrettyErr(err)))
+		return err
+	}
+
+	tenant.Spec.TenantCondition = authv1alpha1.TenantConditionActive
+	if err := o.CRClient.Update(ctx, &tenant); err != nil {
+		o.Printer.CheckErr(fmt.Errorf("unable to update tenant: %v", output.PrettyErr(err)))
+		return err
+	}
+
+	o.Printer.Success.Printfln("Tenant %q uncordoned", o.TenantName)
+
+	return nil
+}

--- a/pkg/liqoctl/wait/wait.go
+++ b/pkg/liqoctl/wait/wait.go
@@ -148,9 +148,9 @@ func (w *Waiter) ForIncomingPeering(ctx context.Context, remoteClusterID *discov
 	return nil
 }
 
-// ForResourceSlice waits until the ResourceSlice has been accepted or the timeout expires.
-func (w *Waiter) ForResourceSlice(ctx context.Context, resourceSlice *authv1alpha1.ResourceSlice) error {
-	s := w.Printer.StartSpinner("Waiting for ResourceSlice to be accepted")
+// ForResourceSliceAuthentication waits until the ResourceSlice authentication has been accepted or the timeout expires.
+func (w *Waiter) ForResourceSliceAuthentication(ctx context.Context, resourceSlice *authv1alpha1.ResourceSlice) error {
+	s := w.Printer.StartSpinner("Waiting for ResourceSlice authentication to be accepted")
 
 	nsName := client.ObjectKeyFromObject(resourceSlice)
 	err := wait.PollUntilContextCancel(ctx, 1*time.Second, true, func(ctx context.Context) (done bool, err error) {
@@ -159,19 +159,17 @@ func (w *Waiter) ForResourceSlice(ctx context.Context, resourceSlice *authv1alph
 		}
 
 		authCondition := authentication.GetCondition(resourceSlice, authv1alpha1.ResourceSliceConditionTypeAuthentication)
-		resourcesCondition := authentication.GetCondition(resourceSlice, authv1alpha1.ResourceSliceConditionTypeResources)
-		if authCondition != nil && authCondition.Status == authv1alpha1.ResourceSliceConditionAccepted &&
-			resourcesCondition != nil && resourcesCondition.Status == authv1alpha1.ResourceSliceConditionAccepted {
+		if authCondition != nil && authCondition.Status == authv1alpha1.ResourceSliceConditionAccepted {
 			return true, nil
 		}
 		return false, nil
 	})
 	if err != nil {
-		s.Fail(fmt.Sprintf("Failed waiting for ResourceSlice to be accepted: %s", output.PrettyErr(err)))
+		s.Fail(fmt.Sprintf("Failed waiting for ResourceSlice authentication to be accepted: %s", output.PrettyErr(err)))
 		return err
 	}
 
-	s.Success("ResourceSlice accepted")
+	s.Success("ResourceSlice authentication accepted")
 	return nil
 }
 


### PR DESCRIPTION
# Description

This PR allows a provider cluster to cordon a Tenant: all new resources (negotiated with a ResourceSlice) will be rejected while existing ones are left untouched.