### PR TITLE
Network: restored addlicense after cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,6 +101,7 @@ fmt: gci addlicense
 	go mod tidy
 	go fmt ./...
 	find . -type f -name '*.go' -a ! -name '*zz_generated*' -exec $(GCI) write -s standard -s default -s "prefix(github.com/liqotech/liqo)" {} \;
+	find . -type f -name '*.go' -exec $(ADDLICENSE) -l apache -c "The Liqo Authors" -y "2019-$(shell date +%Y)" {} \;
 
 # Install golangci-lint if not available
 golangci-lint:


### PR DESCRIPTION
# Description

This PR restores the "addlicense" command inside the makefile after the cleanup.
