### PR TITLE
[Auth] CRD Replicator handle lost permissions on drained tenant

### DIFF
--- a/pkg/liqo-controller-manager/authentication/remoteresourceslice-controller/remoteresourceslice_controller.go
+++ b/pkg/liqo-controller-manager/authentication/remoteresourceslice-controller/remoteresourceslice_controller.go
@@ -21,7 +21,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
@@ -37,10 +36,10 @@ import (
 
 	authv1alpha1 "github.com/liqotech/liqo/apis/authentication/v1alpha1"
 	"github.com/liqotech/liqo/internal/crdReplicator/reflection"
-	"github.com/liqotech/liqo/pkg/consts"
 	identitymanager "github.com/liqotech/liqo/pkg/identityManager"
 	"github.com/liqotech/liqo/pkg/liqo-controller-manager/authentication"
 	"github.com/liqotech/liqo/pkg/utils/getters"
+	liqolabels "github.com/liqotech/liqo/pkg/utils/labels"
 )
 
 // NewRemoteResourceSliceReconciler returns a new RemoteResourceSliceReconciler.
@@ -269,11 +268,8 @@ func (r *RemoteResourceSliceReconciler) resourceSlicesEnquer() func(ctx context.
 			klog.Infof("ClusterID not set for Tenant %q", tenant.Name)
 			return nil
 		}
-
-		resSlices, err := getters.ListResourceSlicesByLabel(ctx, r.Client, corev1.NamespaceAll, labels.SelectorFromSet(labels.Set{
-			consts.ReplicationOriginLabel: tenant.Spec.ClusterIdentity.ClusterID,
-			consts.ReplicationStatusLabel: "true",
-		}))
+		resSlices, err := getters.ListResourceSlicesByLabel(ctx, r.Client, corev1.NamespaceAll,
+			liqolabels.RemoteLabelSelectorForCluster(tenant.Spec.ClusterIdentity.ClusterID))
 		if err != nil {
 			klog.Errorf("Failed to retrieve ResourceSlices for Tenant %q: %v", tenant.Name, err)
 			return nil

--- a/pkg/liqoctl/rest/resourceslice/create.go
+++ b/pkg/liqoctl/rest/resourceslice/create.go
@@ -139,6 +139,7 @@ func (o *Options) handleCreate(ctx context.Context) error {
 	if resourcesCondition == nil || resourcesCondition.Status != authv1alpha1.ResourceSliceConditionAccepted {
 		opts.Printer.Warning.Printfln("ResourceSlice resources not accepted. The provider cluster may have cordoned the tenant or the resourceslice")
 	}
+	opts.Printer.Success.Printfln("ResourceSlice resources: %s", resourcesCondition.Status)
 
 	return nil
 }

--- a/pkg/liqoctl/wait/wait.go
+++ b/pkg/liqoctl/wait/wait.go
@@ -169,7 +169,7 @@ func (w *Waiter) ForResourceSliceAuthentication(ctx context.Context, resourceSli
 		return err
 	}
 
-	s.Success("ResourceSlice authentication accepted")
+	s.Success("ResourceSlice authentication: ", authv1alpha1.ResourceSliceConditionAccepted)
 	return nil
 }
 

--- a/pkg/utils/getters/k8sGetters.go
+++ b/pkg/utils/getters/k8sGetters.go
@@ -103,6 +103,16 @@ func GetNamespaceMapByLabel(ctx context.Context, cl client.Client,
 	}
 }
 
+// ListNamespaceMapsByLabel returns the NamespaceMaps that match the given label selector.
+func ListNamespaceMapsByLabel(ctx context.Context, cl client.Client,
+	ns string, lSelector labels.Selector) ([]virtualkubeletv1alpha1.NamespaceMap, error) {
+	var namespaceMapList virtualkubeletv1alpha1.NamespaceMapList
+	if err := cl.List(ctx, &namespaceMapList, client.MatchingLabelsSelector{Selector: lSelector}, client.InNamespace(ns)); err != nil {
+		return nil, err
+	}
+	return namespaceMapList.Items, nil
+}
+
 // GetServiceByLabel it returns a service instance that matches the given label selector.
 func GetServiceByLabel(ctx context.Context, cl client.Client, ns string, lSelector labels.Selector) (*corev1.Service, error) {
 	list := new(corev1.ServiceList)


### PR DESCRIPTION
# Description

This PR modifies the CRD Replicator to handle lost permissions on a drained tenant,