### PR TITLE
Network: enable full masquerade

### DIFF
--- a/cmd/liqo-controller-manager/main.go
+++ b/cmd/liqo-controller-manager/main.go
@@ -226,6 +226,7 @@ func main() {
 		"The name of the cluster role used by the wireguard gateway servers")
 	wgGatewayClientClusterRoleName := flag.String("wg-gateway-client-cluster-role-name", "liqo-gateway",
 		"The name of the cluster role used by the wireguard gateway clients")
+	fabricFullMasqueradeEnabled := flag.Bool("fabric-full-masquerade-enabled", false, "Enable the full masquerade on the fabric network")
 	gatewayServiceType := flag.String("gateway-service-type", string(gatewayserver.DefaultServiceType), "The type of the gateway service")
 	gatewayServicePort := flag.Int("gateway-service-port", gatewayserver.DefaultPort, "The port of the gateway service")
 	gatewayMTU := flag.Int("gateway-mtu", gatewayserver.DefaultMTU, "The MTU of the gateway interface")
@@ -536,7 +537,7 @@ func main() {
 	}
 
 	if *networkingEnabled {
-		opts := &modules.NetworkingOption{
+		if err := modules.SetupNetworkingModule(ctx, mgr, &modules.NetworkingOption{
 			DynClient:  dynClient,
 			Factory:    factory,
 			KubeClient: clientset,
@@ -555,9 +556,8 @@ func main() {
 			GatewayProxy:                   *gatewayProxy,
 			NetworkWorkers:                 *networkWorkers,
 			IPWorkers:                      *ipWorkers,
-		}
-
-		if err := modules.SetupNetworkingModule(ctx, mgr, opts); err != nil {
+			FabricFullMasquerade:           *fabricFullMasqueradeEnabled,
+		}); err != nil {
 			klog.Fatalf("Unable to setup the networking module: %v", err)
 		}
 	}

--- a/cmd/liqo-controller-manager/modules/networking.go
+++ b/cmd/liqo-controller-manager/modules/networking.go
@@ -63,6 +63,7 @@ type NetworkingOption struct {
 	GatewayProxy                   bool
 	NetworkWorkers                 int
 	IPWorkers                      int
+	FabricFullMasquerade           bool
 }
 
 // SetupNetworkingModule setup the networking module and initializes its controllers .
@@ -154,7 +155,10 @@ func SetupNetworkingModule(ctx context.Context, mgr manager.Manager, opts *Netwo
 		return err
 	}
 
-	configurationReconciler := internalconfigurationcontroller.NewConfigurationReconciler(mgr.GetClient(), mgr.GetScheme())
+	configurationReconciler := internalconfigurationcontroller.NewConfigurationReconciler(mgr.GetClient(), mgr.GetScheme(),
+		&internalconfigurationcontroller.Options{
+			FullMasqueradeEnabled: opts.FabricFullMasquerade,
+		})
 	if err := configurationReconciler.SetupWithManager(mgr); err != nil {
 		klog.Errorf("Unable to start the configurationReconciler: %v", err)
 		return err

--- a/deployments/liqo/README.md
+++ b/deployments/liqo/README.md
@@ -87,6 +87,7 @@
 | discovery.pod.labels | object | `{}` | Labels for the discovery pod. |
 | discovery.pod.priorityClassName | string | `""` | PriorityClassName (https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#pod-priority) for the discovery pod. |
 | discovery.pod.resources | object | `{"limits":{},"requests":{}}` | Resource requests and limits (https://kubernetes.io/docs/user-guide/compute-resources/) for the discovery pod. |
+| fabric.config.fullMasquerade | bool | `false` | Enabe/Disable the full masquerade mode for the fabric pod. It means that all traffic will be masquerade using the first external cidr IP, instead of using the pod IP. Full masquerade is useful when the cluster nodeports uses a PodCIDR IP to masqerade the incoming traffic. IMPORTANT: Please consider that enabling this feature will masquerade the source IP of traffic towards a remote cluster,  making impossible for a pod that receives the traffic to know the original source IP.  |
 | fabric.image.name | string | `"ghcr.io/liqotech/fabric"` | Image repository for the fabric pod. |
 | fabric.image.version | string | `""` | Custom version for the fabric image. If not specified, the global tag is used. |
 | fabric.pod.annotations | object | `{}` | Annotations for the fabric pod. |

--- a/deployments/liqo/templates/liqo-controller-manager-deployment.yaml
+++ b/deployments/liqo/templates/liqo-controller-manager-deployment.yaml
@@ -95,6 +95,7 @@ spec:
           {{- if not .Values.offloading.runtimeClass.enable }}
           - --add-virtual-node-toleration-on-offloaded-pods
           {{- end }}
+          - --fabric-full-masquerade-enabled={{ .Values.fabric.config.fullMasquerade }}
           - --gateway-service-type={{ .Values.peering.networking.gateway.server.service.type }}
           - --gateway-service-port={{ .Values.peering.networking.gateway.server.service.port }}
           - --gateway-mtu={{ .Values.peering.networking.gateway.mtu }}

--- a/deployments/liqo/values.yaml
+++ b/deployments/liqo/values.yaml
@@ -309,6 +309,13 @@ fabric:
     version: ""
   # -- Extra tolerations for the fabric daemonset.
   tolerations: []
+  config:
+    # -- Enabe/Disable the full masquerade mode for the fabric pod.
+    # It means that all traffic will be masquerade using the first external cidr IP, instead of using the pod IP.
+    # Full masquerade is useful when the cluster nodeports uses a PodCIDR IP to masqerade the incoming traffic.
+    # IMPORTANT: Please consider that enabling this feature will masquerade the source IP of traffic towards a remote cluster, 
+    # making impossible for a pod that receives the traffic to know the original source IP. 
+    fullMasquerade: false
 
 crdReplicator:
   pod:

--- a/pkg/liqo-controller-manager/internal-network/configuration-controller/configuration_controller.go
+++ b/pkg/liqo-controller-manager/internal-network/configuration-controller/configuration_controller.go
@@ -33,14 +33,16 @@ import (
 // ConfigurationReconciler manage Configuration lifecycle.
 type ConfigurationReconciler struct {
 	client.Client
-	Scheme *runtime.Scheme
+	Scheme  *runtime.Scheme
+	Options *Options
 }
 
 // NewConfigurationReconciler returns a new ConfigurationReconciler.
-func NewConfigurationReconciler(cl client.Client, s *runtime.Scheme) *ConfigurationReconciler {
+func NewConfigurationReconciler(cl client.Client, s *runtime.Scheme, opts *Options) *ConfigurationReconciler {
 	return &ConfigurationReconciler{
-		Client: cl,
-		Scheme: s,
+		Client:  cl,
+		Scheme:  s,
+		Options: opts,
 	}
 }
 
@@ -63,7 +65,7 @@ func (r *ConfigurationReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 	klog.V(4).Infof("Reconciling Configuration %q", req.NamespacedName)
 
-	err = r.ensureFirewallConfiguration(ctx, cfg)
+	err = r.ensureFirewallConfiguration(ctx, cfg, r.Options)
 
 	if err != nil {
 		return ctrl.Result{}, err

--- a/pkg/liqo-controller-manager/internal-network/configuration-controller/options.go
+++ b/pkg/liqo-controller-manager/internal-network/configuration-controller/options.go
@@ -1,0 +1,20 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package configurationcontroller
+
+// Options contains the configuration options for the ConfigurationController.
+type Options struct {
+	FullMasqueradeEnabled bool
+}


### PR DESCRIPTION
# Description

This PR introduces the **fabric-full-masquerade-enabled** flag. If enabled it masquerade all the traffic using the first IP of the local externalCIDR