### PR TITLE
[Offloading] Fix panic identity creator when resourceslice has no provider

### DIFF
--- a/pkg/liqo-controller-manager/authentication/forge/resourceslice.go
+++ b/pkg/liqo-controller-manager/authentication/forge/resourceslice.go
@@ -18,6 +18,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 
 	authv1alpha1 "github.com/liqotech/liqo/apis/authentication/v1alpha1"
 	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
@@ -67,8 +68,9 @@ func MutateResourceSlice(resourceSlice *authv1alpha1.ResourceSlice, remoteCluste
 	}
 
 	resourceSlice.Spec = authv1alpha1.ResourceSliceSpec{
-		Class:     opts.Class,
-		Resources: rl,
+		Class:             opts.Class,
+		ProviderClusterID: ptr.To(remoteClusterID),
+		Resources:         rl,
 	}
 	return nil
 }

--- a/pkg/liqo-controller-manager/authentication/identitycreator-controller/identitycreator_controller.go
+++ b/pkg/liqo-controller-manager/authentication/identitycreator-controller/identitycreator_controller.go
@@ -16,6 +16,7 @@ package identitycreatorcontroller
 
 import (
 	"context"
+	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -90,6 +91,18 @@ func (r *IdentityCreatorReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 			r.eventRecorder.Event(&resourceSlice, corev1.EventTypeNormal, "IdentityDeleted", "Identity deleted")
 		}
 		return ctrl.Result{}, nil
+	}
+
+	if resourceSlice.Spec.ProviderClusterID == nil {
+		err := fmt.Errorf("ResourceSlice %q has no ProviderClusterID", req.NamespacedName)
+		klog.Error(err)
+		return ctrl.Result{}, err
+	}
+
+	if resourceSlice.Status.AuthParams == nil {
+		err := fmt.Errorf("ResourceSlice %q has no AuthParams", req.NamespacedName)
+		klog.Error(err)
+		return ctrl.Result{}, err
 	}
 
 	// Create or update the Identity resource.


### PR DESCRIPTION
# Description

This PR fixes a bug where the identitycreator controller would panic if no providerClusterID is set in the reconciled ResourceSlice.