### PR TITLE
[Offloading] Remove IPAM client from virtual kubelet

### DIFF
--- a/cmd/liqo-controller-manager/main.go
+++ b/cmd/liqo-controller-manager/main.go
@@ -302,7 +302,6 @@ func main() {
 		RequestsRAM:          kubeletRAMRequests.Quantity,
 		LimitsCPU:            kubeletCPULimits.Quantity,
 		LimitsRAM:            kubeletRAMLimits.Quantity,
-		IpamEndpoint:         *ipamServer,
 		MetricsAddress:       kubeletMetricsAddress,
 		MetricsEnabled:       kubeletMetricsEnabled,
 		ReflectorsWorkers:    reflectorsWorkers,

--- a/cmd/virtual-kubelet/root/flag.go
+++ b/cmd/virtual-kubelet/root/flag.go
@@ -38,8 +38,6 @@ func InstallFlags(flags *pflag.FlagSet, o *Opts) {
 
 	flags.Var(&o.HomeCluster, "home-cluster-id", "The ID of the home cluster")
 	flags.Var(&o.ForeignCluster, "foreign-cluster-id", "The ID of the foreign cluster")
-	flags.StringVar(&o.LiqoIpamServer, "ipam-server", o.LiqoIpamServer,
-		"The address to contact the IPAM module (leave it empty to disable the IPAM module)")
 	flags.BoolVar(&o.DisableIPReflection, "disable-ip-reflection", o.DisableIPReflection,
 		"Disable the IP reflection for the offloaded pods")
 	flags.StringVar(&o.LocalPodCIDR, "local-podcidr", o.LocalPodCIDR, "The CIDR used for the local pods")

--- a/cmd/virtual-kubelet/root/opts.go
+++ b/cmd/virtual-kubelet/root/opts.go
@@ -86,7 +86,6 @@ type Opts struct {
 
 	HomeCluster         argsutils.ClusterIDFlags
 	ForeignCluster      argsutils.ClusterIDFlags
-	LiqoIpamServer      string
 	DisableIPReflection bool
 	LocalPodCIDR        string
 

--- a/deployments/liqo/files/liqo-virtual-kubelet-local-ClusterRole.yaml
+++ b/deployments/liqo/files/liqo-virtual-kubelet-local-ClusterRole.yaml
@@ -158,6 +158,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - networking.liqo.io
+  resources:
+  - configurations
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - storage.k8s.io
   resources:
   - storageclasses

--- a/pkg/consts/replication.go
+++ b/pkg/consts/replication.go
@@ -77,9 +77,6 @@ const (
 	// PodAntiAffinityPresetKey is the annotation key used to express an anti-affinity preset to apply to offloaded pods.
 	PodAntiAffinityPresetKey = "liqo.io/anti-affinity-preset"
 
-	// VKSkipUnmapIPAnnotationKey is the annotation key used to tell the VK to skip the unmapping of the IP as already managed by another entity.
-	VKSkipUnmapIPAnnotationKey = "liqo.io/vk-skip-unmap-ip"
-
 	// PodAntiAffinityPresetValueSoft is the annotation value corresponding to the "soft" anti-affinity preset (i.e., preferred).
 	PodAntiAffinityPresetValueSoft = "soft"
 

--- a/pkg/liqo-controller-manager/ip-controller/exposition.go
+++ b/pkg/liqo-controller-manager/ip-controller/exposition.go
@@ -29,7 +29,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	ipamv1alpha1 "github.com/liqotech/liqo/apis/ipam/v1alpha1"
-	"github.com/liqotech/liqo/pkg/consts"
 )
 
 // handleAssociatedService creates, updates or deletes the service associated to the IP.
@@ -53,7 +52,6 @@ func (r *IPReconciler) handleAssociatedService(ctx context.Context, ip *ipamv1al
 	}}
 	epsMutateFn := func() error {
 		eps.SetLabels(labels.Merge(eps.GetLabels(), labels.Set{discoveryv1.LabelServiceName: svc.Name}))
-		eps.SetAnnotations(labels.Merge(eps.GetAnnotations(), labels.Set{consts.VKSkipUnmapIPAnnotationKey: "true"}))
 		eps.AddressType = discoveryv1.AddressTypeIPv4
 		eps.Endpoints = []discoveryv1.Endpoint{
 			{

--- a/pkg/liqo-controller-manager/shadowendpointslice-controller/mapping.go
+++ b/pkg/liqo-controller-manager/shadowendpointslice-controller/mapping.go
@@ -31,7 +31,7 @@ func MapEndpointsWithConfiguration(ctx context.Context, cl client.Client,
 		for j := range endpoints[i].Addresses {
 			addr := endpoints[i].Addresses[j]
 
-			rAddr, err := ipamips.MapAddressWithConfiguration(ctx, cl, clusterID, addr)
+			rAddr, err := ipamips.MapAddress(ctx, cl, clusterID, addr)
 			if err != nil {
 				return err
 			}

--- a/pkg/liqo-controller-manager/shadowpod-controller/shadowpod_controller.go
+++ b/pkg/liqo-controller-manager/shadowpod-controller/shadowpod_controller.go
@@ -177,7 +177,7 @@ func (r *Reconciler) mutatePodSpec(ctx context.Context,
 		ip := podSpec.HostAliases[i].IP
 
 		// Get the remapped IP for the Kubernetes service.
-		rIP, err := ipamips.MapAddressWithConfiguration(ctx, r.Client, remoteClusterID, ip)
+		rIP, err := ipamips.MapAddress(ctx, r.Client, remoteClusterID, ip)
 		if err != nil {
 			return err
 		}

--- a/pkg/liqo-controller-manager/webhooks/virtualnode/mutate.go
+++ b/pkg/liqo-controller-manager/webhooks/virtualnode/mutate.go
@@ -85,10 +85,7 @@ func mutateVKOptionsMetadata(opts *vkforge.VirtualKubeletOpts, meta *metav1.Obje
 
 func mutateVKOptionsFlags(opts *vkforge.VirtualKubeletOpts, container *corev1.Container) {
 	for _, arg := range container.Args {
-		if found := strings.HasPrefix(arg, string(vkforge.IpamEndpoint)); found {
-			value := strings.TrimPrefix(arg, string(vkforge.IpamEndpoint))
-			opts.IpamEndpoint = strings.TrimLeft(value, " ")
-		} else if found := strings.HasPrefix(arg, string(vkforge.NodeExtraAnnotations)); found {
+		if found := strings.HasPrefix(arg, string(vkforge.NodeExtraAnnotations)); found {
 			value := strings.TrimPrefix(arg, string(vkforge.NodeExtraAnnotations))
 			annotations := strings.TrimLeft(value, " ")
 			for _, annotation := range strings.Split(annotations, ",") {

--- a/pkg/utils/ipam/ips/ips.go
+++ b/pkg/utils/ipam/ips/ips.go
@@ -64,17 +64,23 @@ func EnforceAPIServerIPRemapping(ctx context.Context, cl client.Client, liqoName
 	return nil
 }
 
-// MapAddressWithConfiguration maps the address with the network configuration of the cluster.
-func MapAddressWithConfiguration(ctx context.Context, cl client.Client,
+// MapAddress maps the address with the network configuration of the cluster.
+func MapAddress(ctx context.Context, cl client.Client,
 	clusterID discoveryv1alpha1.ClusterID, address string) (string, error) {
 	cfg, err := getters.GetConfigurationByClusterID(ctx, cl, clusterID)
 	if err != nil {
 		return "", err
 	}
 
+	return MapAddressWithConfiguration(cfg, address)
+}
+
+// MapAddressWithConfiguration maps the address with the network configuration of the cluster.
+func MapAddressWithConfiguration(cfg *networkingv1alpha1.Configuration, address string) (string, error) {
 	var (
 		podnet, podnetMapped, extnet, extnetMapped *net.IPNet
 		podNetMaskLen, extNetMaskLen               int
+		err                                        error
 	)
 
 	podNeedsRemap := cfg.Spec.Remote.CIDR.Pod.String() != cfg.Status.Remote.CIDR.Pod.String()

--- a/pkg/virtualKubelet/roles/local/role.go
+++ b/pkg/virtualKubelet/roles/local/role.go
@@ -41,3 +41,4 @@ package local
 
 // Additional permissions necessary for the networking module
 // +kubebuilder:rbac:groups=ipam.liqo.io,resources=ips,verbs=get;list;watch
+// +kubebuilder:rbac:groups=networking.liqo.io,resources=configurations,verbs=get;list;watch

--- a/pkg/vkMachinery/forge/forge.go
+++ b/pkg/vkMachinery/forge/forge.go
@@ -74,10 +74,6 @@ func forgeVKContainers(
 		stringifyArgument(string(LocalPodCIDR), opts.LocalPodCIDR),
 	}
 
-	if opts.IpamEndpoint != "" {
-		args = append(args, stringifyArgument(string(IpamEndpoint), opts.IpamEndpoint))
-	}
-
 	if len(storageClasses) > 0 {
 		args = append(args, string(EnableStorage),
 			stringifyArgument(string(RemoteRealStorageClassName),

--- a/pkg/vkMachinery/forge/type.go
+++ b/pkg/vkMachinery/forge/type.go
@@ -33,7 +33,6 @@ type VirtualKubeletOpts struct {
 	LimitsCPU            resource.Quantity
 	RequestsRAM          resource.Quantity
 	LimitsRAM            resource.Quantity
-	IpamEndpoint         string
 	MetricsEnabled       bool
 	MetricsAddress       string
 	ReflectorsWorkers    map[string]*uint
@@ -63,8 +62,6 @@ const (
 	HomeClusterID VirtualKubeletOptsFlag = "--home-cluster-id"
 	// LocalPodCIDR is the flag used to specify the local pod CIDR.
 	LocalPodCIDR VirtualKubeletOptsFlag = "--local-podcidr"
-	// IpamEndpoint is the flag used to specify the IPAM endpoint.
-	IpamEndpoint VirtualKubeletOptsFlag = "--ipam-server"
 	// EnableStorage is the flag used to enable the storage.
 	EnableStorage VirtualKubeletOptsFlag = "--enable-storage"
 	// RemoteRealStorageClassName is the flag used to specify the remote real storage class name.


### PR DESCRIPTION
# Description

This pr removes the ipam client from the virtual kubelet pod, it now exclusively uses the liqo k8s apis

# How Has This Been Tested?

- [x] locally
