### PR TITLE
[Network] Move forge utilities out of liqoctl package

### DIFF
--- a/cmd/liqo-controller-manager/main.go
+++ b/cmd/liqo-controller-manager/main.go
@@ -63,6 +63,7 @@ import (
 	foreignclusteroperator "github.com/liqotech/liqo/pkg/liqo-controller-manager/foreign-cluster-operator"
 	mapsctrl "github.com/liqotech/liqo/pkg/liqo-controller-manager/namespacemap-controller"
 	nsoffctrl "github.com/liqotech/liqo/pkg/liqo-controller-manager/namespaceoffloading-controller"
+	nwforge "github.com/liqotech/liqo/pkg/liqo-controller-manager/networking/forge"
 	nodefailurectrl "github.com/liqotech/liqo/pkg/liqo-controller-manager/nodefailure-controller"
 	offloadingipmapping "github.com/liqotech/liqo/pkg/liqo-controller-manager/offloading/ipmapping"
 	podstatusctrl "github.com/liqotech/liqo/pkg/liqo-controller-manager/podstatus-controller"
@@ -82,7 +83,6 @@ import (
 	"github.com/liqotech/liqo/pkg/liqo-controller-manager/webhooks/routeconfiguration"
 	shadowpodswh "github.com/liqotech/liqo/pkg/liqo-controller-manager/webhooks/shadowpod"
 	virtualnodewh "github.com/liqotech/liqo/pkg/liqo-controller-manager/webhooks/virtualnode"
-	"github.com/liqotech/liqo/pkg/liqoctl/rest/gatewayserver"
 	peeringroles "github.com/liqotech/liqo/pkg/peering-roles"
 	tenantnamespace "github.com/liqotech/liqo/pkg/tenantNamespace"
 	argsutils "github.com/liqotech/liqo/pkg/utils/args"
@@ -227,10 +227,9 @@ func main() {
 	wgGatewayClientClusterRoleName := flag.String("wg-gateway-client-cluster-role-name", "liqo-gateway",
 		"The name of the cluster role used by the wireguard gateway clients")
 	fabricFullMasqueradeEnabled := flag.Bool("fabric-full-masquerade-enabled", false, "Enable the full masquerade on the fabric network")
-	gatewayServiceType := flag.String("gateway-service-type", string(gatewayserver.DefaultServiceType), "The type of the gateway service")
-	gatewayServicePort := flag.Int("gateway-service-port", gatewayserver.DefaultPort, "The port of the gateway service")
-	gatewayMTU := flag.Int("gateway-mtu", gatewayserver.DefaultMTU, "The MTU of the gateway interface")
-	gatewayProxy := flag.Bool("gateway-proxy", gatewayserver.DefaultProxy, "Enable the proxy on the gateway")
+	gatewayServiceType := flag.String("gateway-service-type", string(nwforge.DefaultGwServerServiceType), "The type of the gateway service")
+	gatewayServicePort := flag.Int("gateway-service-port", nwforge.DefaultGwServerPort, "The port of the gateway service")
+	gatewayMTU := flag.Int("gateway-mtu", nwforge.DefaultMTU, "The MTU of the gateway interface")
 	networkWorkers := flag.Int("network-ctrl-workers", 1, "The number of workers used to reconcile Network resources.")
 	ipWorkers := flag.Int("ip-ctrl-workers", 1, "The number of workers used to reconcile IP resources.")
 	gwmasqbypassEnabled := flag.Bool("gateway-masquerade-bypass-enabled", false, "Enable the gateway masquerade bypass")
@@ -554,7 +553,6 @@ func main() {
 			GatewayServiceType:             corev1.ServiceType(*gatewayServiceType),
 			GatewayServicePort:             int32(*gatewayServicePort),
 			GatewayMTU:                     *gatewayMTU,
-			GatewayProxy:                   *gatewayProxy,
 			NetworkWorkers:                 *networkWorkers,
 			IPWorkers:                      *ipWorkers,
 			FabricFullMasquerade:           *fabricFullMasqueradeEnabled,

--- a/cmd/liqo-controller-manager/modules/networking.go
+++ b/cmd/liqo-controller-manager/modules/networking.go
@@ -61,7 +61,6 @@ type NetworkingOption struct {
 	GatewayServiceType             corev1.ServiceType
 	GatewayServicePort             int32
 	GatewayMTU                     int
-	GatewayProxy                   bool
 	NetworkWorkers                 int
 	IPWorkers                      int
 	FabricFullMasquerade           bool
@@ -133,7 +132,7 @@ func SetupNetworkingModule(ctx context.Context, mgr manager.Manager, opts *Netwo
 
 	externalNetworkReconciler := externalnetwork.NewExternalNetworkReconciler(
 		mgr.GetClient(), mgr.GetScheme(), opts.KubeClient, opts.LiqoNamespace, opts.LocalClusterIdentity,
-		opts.GatewayServiceType, opts.GatewayServicePort, opts.GatewayMTU, opts.GatewayProxy)
+		opts.GatewayServiceType, opts.GatewayServicePort, opts.GatewayMTU)
 	if err := externalNetworkReconciler.SetupWithManager(mgr); err != nil {
 		klog.Errorf("Unable to start the externalNetworkReconciler: %v", err)
 		return err

--- a/cmd/liqoctl/cmd/network.go
+++ b/cmd/liqoctl/cmd/network.go
@@ -22,12 +22,11 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/util/runtime"
 
+	"github.com/liqotech/liqo/pkg/liqo-controller-manager/networking/forge"
 	"github.com/liqotech/liqo/pkg/liqoctl/completion"
 	"github.com/liqotech/liqo/pkg/liqoctl/factory"
 	"github.com/liqotech/liqo/pkg/liqoctl/network"
 	"github.com/liqotech/liqo/pkg/liqoctl/output"
-	"github.com/liqotech/liqo/pkg/liqoctl/rest/gatewayclient"
-	"github.com/liqotech/liqo/pkg/liqoctl/rest/gatewayserver"
 )
 
 const liqoctlNetworkLongHelp = `Manage liqo networking.`
@@ -150,34 +149,33 @@ func newNetworkConnectCommand(ctx context.Context, options *network.Options) *co
 	}
 
 	// Server flags
-	cmd.Flags().StringVar(&options.ServerGatewayType, "server-type", gatewayserver.DefaultGatewayType,
+	cmd.Flags().StringVar(&options.ServerGatewayType, "server-type", forge.DefaultGwServerType,
 		"Type of Gateway Server. Leave empty to use default Liqo implementation of WireGuard")
-	cmd.Flags().StringVar(&options.ServerTemplateName, "server-template-name", gatewayserver.DefaultTemplateName,
+	cmd.Flags().StringVar(&options.ServerTemplateName, "server-template-name", forge.DefaultGwServerTemplateName,
 		"Name of the Gateway Server template")
 	cmd.Flags().StringVar(&options.ServerTemplateNamespace, "server-template-namespace", "",
 		"Namespace of the Gateway Server template")
 	cmd.Flags().Var(options.ServerServiceType, "server-service-type",
-		fmt.Sprintf("Service type of the Gateway Server. Default: %s", gatewayserver.DefaultServiceType))
-	cmd.Flags().Int32Var(&options.ServerPort, "server-port", gatewayserver.DefaultPort,
-		fmt.Sprintf("Port of the Gateway Server. Default: %d", gatewayserver.DefaultPort))
+		fmt.Sprintf("Service type of the Gateway Server. Default: %s", forge.DefaultGwServerServiceType))
+	cmd.Flags().Int32Var(&options.ServerPort, "server-port", forge.DefaultGwServerPort,
+		fmt.Sprintf("Port of the Gateway Server. Default: %d", forge.DefaultGwServerPort))
 	cmd.Flags().Int32Var(&options.ServerNodePort, "node-port", 0,
 		"Force the NodePort of the Gateway Server. Leave empty to let Kubernetes allocate a random NodePort")
 	cmd.Flags().StringVar(&options.ServerLoadBalancerIP, "load-balancer-ip", "",
 		"Force LoadBalancer IP of the Gateway Server. Leave empty to use the one provided by the LoadBalancer provider")
 
 	// Client flags
-	cmd.Flags().StringVar(&options.ClientGatewayType, "client-type", gatewayclient.DefaultGatewayType,
+	cmd.Flags().StringVar(&options.ClientGatewayType, "client-type", forge.DefaultGwClientType,
 		"Type of Gateway Client. Leave empty to use default Liqo implementation of WireGuard")
-	cmd.Flags().StringVar(&options.ClientTemplateName, "client-template-name", gatewayclient.DefaultTemplateName,
+	cmd.Flags().StringVar(&options.ClientTemplateName, "client-template-name", forge.DefaultGwClientTemplateName,
 		"Name of the Gateway Client template")
 	cmd.Flags().StringVar(&options.ClientTemplateNamespace, "client-template-namespace", "",
 		"Namespace of the Gateway Client template")
 
 	// Common flags
-	cmd.Flags().IntVar(&options.MTU, "mtu", gatewayserver.DefaultMTU,
-		fmt.Sprintf("MTU of the Gateway server and client. Default: %d", gatewayserver.DefaultMTU))
+	cmd.Flags().IntVar(&options.MTU, "mtu", forge.DefaultMTU,
+		fmt.Sprintf("MTU of the Gateway server and client. Default: %d", forge.DefaultMTU))
 	cmd.Flags().BoolVar(&options.DisableSharingKeys, "disable-sharing-keys", false, "Disable the sharing of public keys between the two clusters")
-	cmd.Flags().BoolVar(&options.Proxy, "proxy", gatewayserver.DefaultProxy, "Enable proxy for the Gateway Server")
 
 	runtime.Must(cmd.RegisterFlagCompletionFunc("server-service-type", completion.Enumeration(options.ServerServiceType.Allowed)))
 

--- a/pkg/liqo-controller-manager/foreign-cluster-operator/externalnetwork.go
+++ b/pkg/liqo-controller-manager/foreign-cluster-operator/externalnetwork.go
@@ -26,7 +26,7 @@ import (
 	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
 	networkingv1alpha1 "github.com/liqotech/liqo/apis/networking/v1alpha1"
 	"github.com/liqotech/liqo/pkg/consts"
-	"github.com/liqotech/liqo/pkg/liqoctl/rest/configuration"
+	"github.com/liqotech/liqo/pkg/liqo-controller-manager/networking/forge"
 	"github.com/liqotech/liqo/pkg/utils/getters"
 )
 
@@ -43,7 +43,7 @@ func (r *ForeignClusterReconciler) ensureExternalNetwork(ctx context.Context, fc
 
 	localNamespace := fc.Status.TenantNamespace.Local
 
-	conf, err := configuration.ForgeConfigurationForRemoteCluster(ctx, r.Client, localNamespace, r.LiqoNamespace)
+	conf, err := forge.ConfigurationForRemoteCluster(ctx, r.Client, localNamespace, r.LiqoNamespace)
 	if err != nil {
 		klog.Error(err)
 		return err

--- a/pkg/liqo-controller-manager/networking/forge/common.go
+++ b/pkg/liqo-controller-manager/networking/forge/common.go
@@ -1,0 +1,21 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package forge
+
+// Common default values for the networking module.
+const (
+	DefaultMTU      = 1340
+	DefaultProtocol = "UDP"
+)

--- a/pkg/liqo-controller-manager/networking/forge/configuration.go
+++ b/pkg/liqo-controller-manager/networking/forge/configuration.go
@@ -1,0 +1,112 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package forge
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
+	networkingv1alpha1 "github.com/liqotech/liqo/apis/networking/v1alpha1"
+	"github.com/liqotech/liqo/pkg/consts"
+	liqoutils "github.com/liqotech/liqo/pkg/utils"
+	ipamutils "github.com/liqotech/liqo/pkg/utils/ipam"
+)
+
+// DefaultConfigurationName returns the default name for a Configuration.
+func DefaultConfigurationName(remoteClusterIdentity *discoveryv1alpha1.ClusterIdentity) string {
+	return remoteClusterIdentity.ClusterName
+}
+
+// Configuration forges a Configuration resource of a remote cluster.
+func Configuration(name, namespace, remoteClusterID, podCIDR, externalCIDR string) *networkingv1alpha1.Configuration {
+	conf := &networkingv1alpha1.Configuration{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       networkingv1alpha1.ConfigurationKind,
+			APIVersion: networkingv1alpha1.GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				consts.RemoteClusterID: remoteClusterID,
+			},
+		},
+	}
+	MutateConfiguration(conf, remoteClusterID, podCIDR, externalCIDR)
+	return conf
+}
+
+// MutateConfiguration mutates a Configuration resource of a remote cluster.
+func MutateConfiguration(conf *networkingv1alpha1.Configuration, remoteClusterID, podCIDR, externalCIDR string) {
+	conf.Kind = networkingv1alpha1.ConfigurationKind
+	conf.APIVersion = networkingv1alpha1.GroupVersion.String()
+	if conf.Labels == nil {
+		conf.Labels = make(map[string]string)
+	}
+	conf.Labels[consts.RemoteClusterID] = remoteClusterID
+	conf.Spec.Remote.CIDR.Pod = networkingv1alpha1.CIDR(podCIDR)
+	conf.Spec.Remote.CIDR.External = networkingv1alpha1.CIDR(externalCIDR)
+}
+
+// ConfigurationForRemoteCluster forges a Configuration of the local cluster to be applied to a remote cluster.
+// It retrieves the local configuration settings starting from the cluster identity and the IPAM storage.
+func ConfigurationForRemoteCluster(ctx context.Context, cl client.Client,
+	namespace, liqoNamespace string) (*networkingv1alpha1.Configuration, error) {
+	clusterIdentity, err := liqoutils.GetClusterIdentityWithControllerClient(ctx, cl, liqoNamespace)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get cluster identity: %w", err)
+	}
+
+	podCIDR, err := ipamutils.GetPodCIDR(ctx, cl)
+	if err != nil {
+		return nil, fmt.Errorf("unable to retrieve pod CIDR: %w", err)
+	}
+
+	externalCIDR, err := ipamutils.GetExternalCIDR(ctx, cl)
+	if err != nil {
+		return nil, fmt.Errorf("unable to retrieve external CIDR: %w", err)
+	}
+
+	cnf := &networkingv1alpha1.Configuration{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       networkingv1alpha1.ConfigurationKind,
+			APIVersion: networkingv1alpha1.GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: DefaultConfigurationName(&clusterIdentity),
+			Labels: map[string]string{
+				consts.RemoteClusterID: clusterIdentity.ClusterID,
+			},
+		},
+		Spec: networkingv1alpha1.ConfigurationSpec{
+			Remote: networkingv1alpha1.ClusterConfig{
+				CIDR: networkingv1alpha1.ClusterConfigCIDR{
+					Pod:      networkingv1alpha1.CIDR(podCIDR),
+					External: networkingv1alpha1.CIDR(externalCIDR),
+				},
+			},
+		},
+	}
+
+	if namespace != "" && namespace != corev1.NamespaceDefault {
+		cnf.Namespace = namespace
+	}
+	return cnf, nil
+}

--- a/pkg/liqo-controller-manager/networking/forge/doc.go
+++ b/pkg/liqo-controller-manager/networking/forge/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package forge contains utility functions to forge resources of the networking module.
+package forge

--- a/pkg/liqo-controller-manager/networking/forge/publickey.go
+++ b/pkg/liqo-controller-manager/networking/forge/publickey.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package publickey
+package forge
 
 import (
 	"context"
@@ -25,11 +25,17 @@ import (
 	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
 	networkingv1alpha1 "github.com/liqotech/liqo/apis/networking/v1alpha1"
 	"github.com/liqotech/liqo/pkg/consts"
+	"github.com/liqotech/liqo/pkg/liqo-controller-manager/networking/getters"
 	liqoutils "github.com/liqotech/liqo/pkg/utils"
 )
 
-// ForgePublicKey forges a PublicKey.
-func ForgePublicKey(name, namespace, remoteClusterID string, key []byte) (*networkingv1alpha1.PublicKey, error) {
+// DefaultPublicKeyName returns the default name of a PublicKey.
+func DefaultPublicKeyName(remoteClusterIdentity *discoveryv1alpha1.ClusterIdentity) string {
+	return remoteClusterIdentity.ClusterName
+}
+
+// PublicKey forges a PublicKey.
+func PublicKey(name, namespace, remoteClusterID string, key []byte) (*networkingv1alpha1.PublicKey, error) {
 	pubKey := &networkingv1alpha1.PublicKey{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       networkingv1alpha1.PublicKeyKind,
@@ -68,21 +74,8 @@ func MutatePublicKey(pubKey *networkingv1alpha1.PublicKey, remoteClusterID strin
 	return nil
 }
 
-// ExtractKeyFromSecretRef extracts the public key data of a secret from a secret reference.
-func ExtractKeyFromSecretRef(ctx context.Context, cl client.Client, secretRef *corev1.ObjectReference) ([]byte, error) {
-	var secret corev1.Secret
-	if err := cl.Get(ctx, client.ObjectKey{Name: secretRef.Name, Namespace: secretRef.Namespace}, &secret); err != nil {
-		return nil, err
-	}
-	key, ok := secret.Data[consts.PublicKeyField]
-	if !ok {
-		return nil, fmt.Errorf("secret %q does not contain %s field", client.ObjectKeyFromObject(&secret), consts.PublicKeyField)
-	}
-	return key, nil
-}
-
-// ForgePublicKeyForRemoteCluster forges a PublicKey to be applied on a remote cluster.
-func ForgePublicKeyForRemoteCluster(ctx context.Context, cl client.Client,
+// PublicKeyForRemoteCluster forges a PublicKey to be applied on a remote cluster.
+func PublicKeyForRemoteCluster(ctx context.Context, cl client.Client,
 	liqoNamespace, namespace, gatewayName, gatewayType string) (*networkingv1alpha1.PublicKey, error) {
 	clusterIdentity, err := liqoutils.GetClusterIdentityWithControllerClient(ctx, cl, liqoNamespace)
 	if err != nil {
@@ -108,11 +101,11 @@ func ForgePublicKeyForRemoteCluster(ctx context.Context, cl client.Client,
 	}
 
 	// Get public keys of the gateway form the secret reference.
-	secretRef, err := GetGatewaySecretReference(ctx, cl, namespace, gatewayName, gatewayType)
+	secretRef, err := getters.GetGatewaySecretReference(ctx, cl, namespace, gatewayName, gatewayType)
 	if err != nil {
 		return nil, err
 	}
-	key, err := ExtractKeyFromSecretRef(ctx, cl, secretRef)
+	key, err := getters.ExtractKeyFromSecretRef(ctx, cl, secretRef)
 	if err != nil {
 		return nil, err
 	}
@@ -121,29 +114,4 @@ func ForgePublicKeyForRemoteCluster(ctx context.Context, cl client.Client,
 	}
 
 	return pubKey, nil
-}
-
-// GetGatewaySecretReference returns the secret reference of a gateway.
-func GetGatewaySecretReference(ctx context.Context, cl client.Client, namespace, gatewayName, gatewayType string) (*corev1.ObjectReference, error) {
-	switch gatewayType {
-	case consts.GatewayTypeServer:
-		var gwServer networkingv1alpha1.GatewayServer
-		if err := cl.Get(ctx, client.ObjectKey{Namespace: namespace, Name: gatewayName}, &gwServer); err != nil {
-			return nil, err
-		}
-		return gwServer.Status.SecretRef, nil
-	case consts.GatewayTypeClient:
-		var gwClient networkingv1alpha1.GatewayClient
-		if err := cl.Get(ctx, client.ObjectKey{Namespace: namespace, Name: gatewayName}, &gwClient); err != nil {
-			return nil, err
-		}
-		return gwClient.Status.SecretRef, nil
-	default:
-		return nil, fmt.Errorf("unable to forge PublicKey: invalid gateway type %q", gatewayType)
-	}
-}
-
-// DefaultPublicKeyName returns the default name of a PublicKey.
-func DefaultPublicKeyName(remoteClusterIdentity *discoveryv1alpha1.ClusterIdentity) string {
-	return remoteClusterIdentity.ClusterName
 }

--- a/pkg/liqo-controller-manager/networking/getters/doc.go
+++ b/pkg/liqo-controller-manager/networking/getters/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package getters contains utility functions to get resources of the networking module.
+package getters

--- a/pkg/liqo-controller-manager/networking/getters/publickey.go
+++ b/pkg/liqo-controller-manager/networking/getters/publickey.go
@@ -1,0 +1,59 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package getters
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	networkingv1alpha1 "github.com/liqotech/liqo/apis/networking/v1alpha1"
+	"github.com/liqotech/liqo/pkg/consts"
+)
+
+// ExtractKeyFromSecretRef extracts the public key data of a secret from a secret reference.
+func ExtractKeyFromSecretRef(ctx context.Context, cl client.Client, secretRef *corev1.ObjectReference) ([]byte, error) {
+	var secret corev1.Secret
+	if err := cl.Get(ctx, client.ObjectKey{Name: secretRef.Name, Namespace: secretRef.Namespace}, &secret); err != nil {
+		return nil, err
+	}
+	key, ok := secret.Data[consts.PublicKeyField]
+	if !ok {
+		return nil, fmt.Errorf("secret %q does not contain %s field", client.ObjectKeyFromObject(&secret), consts.PublicKeyField)
+	}
+	return key, nil
+}
+
+// GetGatewaySecretReference returns the secret reference of a gateway.
+func GetGatewaySecretReference(ctx context.Context, cl client.Client, namespace, gatewayName, gatewayType string) (*corev1.ObjectReference, error) {
+	switch gatewayType {
+	case consts.GatewayTypeServer:
+		var gwServer networkingv1alpha1.GatewayServer
+		if err := cl.Get(ctx, client.ObjectKey{Namespace: namespace, Name: gatewayName}, &gwServer); err != nil {
+			return nil, err
+		}
+		return gwServer.Status.SecretRef, nil
+	case consts.GatewayTypeClient:
+		var gwClient networkingv1alpha1.GatewayClient
+		if err := cl.Get(ctx, client.ObjectKey{Namespace: namespace, Name: gatewayName}, &gwClient); err != nil {
+			return nil, err
+		}
+		return gwClient.Status.SecretRef, nil
+	default:
+		return nil, fmt.Errorf("unable to forge PublicKey: invalid gateway type %q", gatewayType)
+	}
+}

--- a/pkg/liqoctl/rest/configuration/create.go
+++ b/pkg/liqoctl/rest/configuration/create.go
@@ -28,6 +28,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	networkingv1alpha1 "github.com/liqotech/liqo/apis/networking/v1alpha1"
+	"github.com/liqotech/liqo/pkg/liqo-controller-manager/networking/forge"
 	"github.com/liqotech/liqo/pkg/liqoctl/completion"
 	"github.com/liqotech/liqo/pkg/liqoctl/output"
 	"github.com/liqotech/liqo/pkg/liqoctl/rest"
@@ -88,7 +89,7 @@ func (o *Options) Create(ctx context.Context, options *rest.CreateOptions) *cobr
 func (o *Options) handleCreate(ctx context.Context) error {
 	opts := o.createOptions
 
-	conf := ForgeConfiguration(o.createOptions.Name, o.createOptions.Namespace,
+	conf := forge.Configuration(o.createOptions.Name, o.createOptions.Namespace,
 		o.RemoteClusterID, o.PodCIDR.String(), o.ExternalCIDR.String())
 
 	if opts.OutputFormat != "" {
@@ -98,7 +99,7 @@ func (o *Options) handleCreate(ctx context.Context) error {
 
 	s := opts.Printer.StartSpinner("Creating configuration")
 	_, err := controllerutil.CreateOrUpdate(ctx, opts.CRClient, conf, func() error {
-		MutateConfiguration(conf, o.RemoteClusterID, o.PodCIDR.String(), o.ExternalCIDR.String())
+		forge.MutateConfiguration(conf, o.RemoteClusterID, o.PodCIDR.String(), o.ExternalCIDR.String())
 		return nil
 	})
 	if err != nil {

--- a/pkg/liqoctl/rest/configuration/generate.go
+++ b/pkg/liqoctl/rest/configuration/generate.go
@@ -21,6 +21,7 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/util/runtime"
 
+	"github.com/liqotech/liqo/pkg/liqo-controller-manager/networking/forge"
 	"github.com/liqotech/liqo/pkg/liqoctl/completion"
 	"github.com/liqotech/liqo/pkg/liqoctl/output"
 	"github.com/liqotech/liqo/pkg/liqoctl/rest"
@@ -63,7 +64,7 @@ func (o *Options) Generate(ctx context.Context, options *rest.GenerateOptions) *
 func (o *Options) handleGenerate(ctx context.Context) error {
 	opts := o.generateOptions
 
-	conf, err := ForgeConfigurationForRemoteCluster(ctx, opts.CRClient, opts.Namespace, opts.LiqoNamespace)
+	conf, err := forge.ConfigurationForRemoteCluster(ctx, opts.CRClient, opts.Namespace, opts.LiqoNamespace)
 	if err != nil {
 		opts.Printer.CheckErr(fmt.Errorf("unable to forge local configuration: %w", err))
 		return err

--- a/pkg/liqoctl/rest/configuration/utils.go
+++ b/pkg/liqoctl/rest/configuration/utils.go
@@ -16,101 +16,12 @@ package configuration
 
 import (
 	"context"
-	"fmt"
 
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	discoveryv1alpha1 "github.com/liqotech/liqo/apis/discovery/v1alpha1"
 	networkingv1alpha1 "github.com/liqotech/liqo/apis/networking/v1alpha1"
-	liqoconsts "github.com/liqotech/liqo/pkg/consts"
-	liqoutils "github.com/liqotech/liqo/pkg/utils"
-	ipamutils "github.com/liqotech/liqo/pkg/utils/ipam"
 )
-
-// ForgeConfiguration forges a Configuration resource of a remote cluster.
-func ForgeConfiguration(name, namespace, remoteClusterID, podCIDR, externalCIDR string) *networkingv1alpha1.Configuration {
-	conf := &networkingv1alpha1.Configuration{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       networkingv1alpha1.ConfigurationKind,
-			APIVersion: networkingv1alpha1.GroupVersion.String(),
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-			Labels: map[string]string{
-				liqoconsts.RemoteClusterID: remoteClusterID,
-			},
-		},
-	}
-	MutateConfiguration(conf, remoteClusterID, podCIDR, externalCIDR)
-	return conf
-}
-
-// MutateConfiguration mutates a Configuration resource of a remote cluster.
-func MutateConfiguration(conf *networkingv1alpha1.Configuration, remoteClusterID, podCIDR, externalCIDR string) {
-	conf.Kind = networkingv1alpha1.ConfigurationKind
-	conf.APIVersion = networkingv1alpha1.GroupVersion.String()
-	if conf.Labels == nil {
-		conf.Labels = make(map[string]string)
-	}
-	conf.Labels[liqoconsts.RemoteClusterID] = remoteClusterID
-	conf.Spec.Remote.CIDR.Pod = networkingv1alpha1.CIDR(podCIDR)
-	conf.Spec.Remote.CIDR.External = networkingv1alpha1.CIDR(externalCIDR)
-}
-
-// ForgeConfigurationForRemoteCluster forges a Configuration of the local cluster to be applied to a remote cluster.
-// It retrieves the local configuration settings starting from the cluster identity and the IPAM storage.
-func ForgeConfigurationForRemoteCluster(ctx context.Context, cl client.Client,
-	namespace, liqoNamespace string) (*networkingv1alpha1.Configuration, error) {
-	clusterIdentity, err := liqoutils.GetClusterIdentityWithControllerClient(ctx, cl, liqoNamespace)
-	if err != nil {
-		return nil, fmt.Errorf("unable to get cluster identity: %w", err)
-	}
-
-	podCIDR, err := ipamutils.GetPodCIDR(ctx, cl)
-	if err != nil {
-		return nil, fmt.Errorf("unable to retrieve pod CIDR: %w", err)
-	}
-
-	externalCIDR, err := ipamutils.GetExternalCIDR(ctx, cl)
-	if err != nil {
-		return nil, fmt.Errorf("unable to retrieve external CIDR: %w", err)
-	}
-
-	cnf := &networkingv1alpha1.Configuration{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       networkingv1alpha1.ConfigurationKind,
-			APIVersion: networkingv1alpha1.GroupVersion.String(),
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name: DefaultConfigurationName(&clusterIdentity),
-			Labels: map[string]string{
-				liqoconsts.RemoteClusterID: clusterIdentity.ClusterID,
-			},
-		},
-		Spec: networkingv1alpha1.ConfigurationSpec{
-			Remote: networkingv1alpha1.ClusterConfig{
-				CIDR: networkingv1alpha1.ClusterConfigCIDR{
-					Pod:      networkingv1alpha1.CIDR(podCIDR),
-					External: networkingv1alpha1.CIDR(externalCIDR),
-				},
-			},
-		},
-	}
-
-	if namespace != "" && namespace != corev1.NamespaceDefault {
-		cnf.Namespace = namespace
-	}
-	return cnf, nil
-}
-
-// DefaultConfigurationName returns the default name for a Configuration.
-func DefaultConfigurationName(remoteClusterIdentity *discoveryv1alpha1.ClusterIdentity) string {
-	return remoteClusterIdentity.ClusterName
-}
 
 // IsConfigurationStatusSet check if a Configuration is ready by checking if its status is correctly set.
 func IsConfigurationStatusSet(ctx context.Context, cl client.Client, name, namespace string) (bool, error) {

--- a/pkg/liqoctl/rest/gatewayclient/types.go
+++ b/pkg/liqoctl/rest/gatewayclient/types.go
@@ -15,18 +15,8 @@
 package gatewayclient
 
 import (
-	"k8s.io/client-go/kubernetes"
-
-	rest "github.com/liqotech/liqo/pkg/liqoctl/rest"
-)
-
-// Default values for the gatewayclient command.
-const (
-	DefaultGatewayType  = "networking.liqo.io/v1alpha1/wggatewayclienttemplates"
-	DefaultTemplateName = "wireguard-client"
-	DefaultMTU          = 1340
-	DefaultProtocol     = "UDP"
-	DefaultWait         = false
+	"github.com/liqotech/liqo/pkg/liqo-controller-manager/networking/forge"
+	"github.com/liqotech/liqo/pkg/liqoctl/rest"
 )
 
 // Options encapsulates the arguments of the gatewayclient command.
@@ -60,25 +50,12 @@ func (o *Options) APIOptions() *rest.APIOptions {
 	}
 }
 
-// ForgeOptions encapsulate the options to forge a gatewayclient.
-type ForgeOptions struct {
-	KubeClient        kubernetes.Interface
-	RemoteClusterID   string
-	GatewayType       string
-	TemplateName      string
-	TemplateNamespace string
-	MTU               int
-	Addresses         []string
-	Port              int32
-	Protocol          string
-}
-
-func (o *Options) getForgeOptions() *ForgeOptions {
+func (o *Options) getForgeOptions() *forge.GwClientOptions {
 	if o.TemplateNamespace == "" {
 		o.TemplateNamespace = o.createOptions.LiqoNamespace
 	}
 
-	return &ForgeOptions{
+	return &forge.GwClientOptions{
 		KubeClient:        o.createOptions.KubeClient,
 		RemoteClusterID:   o.RemoteClusterID,
 		GatewayType:       o.GatewayType,

--- a/pkg/liqoctl/rest/gatewayserver/types.go
+++ b/pkg/liqoctl/rest/gatewayserver/types.go
@@ -16,22 +16,11 @@ package gatewayserver
 
 import (
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/utils/ptr"
 
+	"github.com/liqotech/liqo/pkg/liqo-controller-manager/networking/forge"
 	"github.com/liqotech/liqo/pkg/liqoctl/rest"
 	argsutils "github.com/liqotech/liqo/pkg/utils/args"
-)
-
-// Default values for the gatewayserver command.
-const (
-	DefaultGatewayType  = "networking.liqo.io/v1alpha1/wggatewayservertemplates"
-	DefaultTemplateName = "wireguard-server"
-	DefaultServiceType  = corev1.ServiceTypeLoadBalancer
-	DefaultMTU          = 1340
-	DefaultPort         = 51820
-	DefaultProxy        = false
-	DefaultWait         = false
 )
 
 // Options encapsulates the arguments of the gatewayserver command.
@@ -58,7 +47,7 @@ var _ rest.API = &Options{}
 func GatewayServer() rest.API {
 	return &Options{
 		ServiceType: argsutils.NewEnum(
-			[]string{string(corev1.ServiceTypeLoadBalancer), string(corev1.ServiceTypeNodePort)}, string(DefaultServiceType)),
+			[]string{string(corev1.ServiceTypeLoadBalancer), string(corev1.ServiceTypeNodePort)}, string(forge.DefaultGwServerServiceType)),
 	}
 }
 
@@ -70,27 +59,12 @@ func (o *Options) APIOptions() *rest.APIOptions {
 	}
 }
 
-// ForgeOptions encapsulate the options to forge a gatewayserver.
-type ForgeOptions struct {
-	KubeClient        kubernetes.Interface
-	RemoteClusterID   string
-	GatewayType       string
-	TemplateName      string
-	TemplateNamespace string
-	ServiceType       corev1.ServiceType
-	MTU               int
-	Port              int32
-	NodePort          *int32
-	LoadBalancerIP    *string
-	Proxy             bool
-}
-
-func (o *Options) getForgeOptions() *ForgeOptions {
+func (o *Options) getForgeOptions() *forge.GwServerOptions {
 	if o.TemplateNamespace == "" {
 		o.TemplateNamespace = o.createOptions.LiqoNamespace
 	}
 
-	return &ForgeOptions{
+	return &forge.GwServerOptions{
 		KubeClient:        o.createOptions.KubeClient,
 		RemoteClusterID:   o.RemoteClusterID,
 		GatewayType:       o.GatewayType,
@@ -101,6 +75,5 @@ func (o *Options) getForgeOptions() *ForgeOptions {
 		Port:              o.Port,
 		NodePort:          ptr.To(o.NodePort),
 		LoadBalancerIP:    ptr.To(o.LoadBalancerIP),
-		Proxy:             o.Proxy,
 	}
 }

--- a/pkg/liqoctl/rest/publickey/create.go
+++ b/pkg/liqoctl/rest/publickey/create.go
@@ -25,6 +25,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	networkingv1alpha1 "github.com/liqotech/liqo/apis/networking/v1alpha1"
+	"github.com/liqotech/liqo/pkg/liqo-controller-manager/networking/forge"
 	"github.com/liqotech/liqo/pkg/liqoctl/completion"
 	"github.com/liqotech/liqo/pkg/liqoctl/output"
 	"github.com/liqotech/liqo/pkg/liqoctl/rest"
@@ -81,7 +82,7 @@ func (o *Options) Create(ctx context.Context, options *rest.CreateOptions) *cobr
 func (o *Options) handleCreate(ctx context.Context) error {
 	opts := o.createOptions
 
-	pubKey, err := ForgePublicKey(opts.Name, opts.Namespace, o.RemoteClusterID, o.PublicKey)
+	pubKey, err := forge.PublicKey(opts.Name, opts.Namespace, o.RemoteClusterID, o.PublicKey)
 	if err != nil {
 		opts.Printer.CheckErr(err)
 		return err
@@ -95,7 +96,7 @@ func (o *Options) handleCreate(ctx context.Context) error {
 	s := opts.Printer.StartSpinner("Creating publickey")
 
 	_, err = controllerutil.CreateOrUpdate(ctx, opts.CRClient, pubKey, func() error {
-		return MutatePublicKey(pubKey, o.RemoteClusterID, o.PublicKey)
+		return forge.MutatePublicKey(pubKey, o.RemoteClusterID, o.PublicKey)
 	})
 	if err != nil {
 		s.Fail("Unable to create publickey: %v", output.PrettyErr(err))

--- a/pkg/liqoctl/rest/publickey/generate.go
+++ b/pkg/liqoctl/rest/publickey/generate.go
@@ -21,6 +21,7 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/util/runtime"
 
+	"github.com/liqotech/liqo/pkg/liqo-controller-manager/networking/forge"
 	"github.com/liqotech/liqo/pkg/liqoctl/completion"
 	"github.com/liqotech/liqo/pkg/liqoctl/output"
 	"github.com/liqotech/liqo/pkg/liqoctl/rest"
@@ -71,7 +72,7 @@ func (o *Options) Generate(ctx context.Context, options *rest.GenerateOptions) *
 func (o *Options) handleGenerate(ctx context.Context) error {
 	opts := o.generateOptions
 
-	pubKey, err := ForgePublicKeyForRemoteCluster(ctx, opts.CRClient, opts.LiqoNamespace, opts.Namespace, o.GatewayName, o.GatewayType.Value)
+	pubKey, err := forge.PublicKeyForRemoteCluster(ctx, opts.CRClient, opts.LiqoNamespace, opts.Namespace, o.GatewayName, o.GatewayType.Value)
 	if err != nil {
 		opts.Printer.CheckErr(fmt.Errorf("unable to forge PublicKey for remote cluster %q: %w", o.RemoteClusterID, err))
 		return err


### PR DESCRIPTION
# Description

This PR moves forge utilities of network resources out of liqoctl pkg to a core pkg. This is done to move logic out of liqoctl and for better reusability.
