### PR TITLE
Bump golangci-lint version from 1.55.1 to 1.59.1

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,7 +24,7 @@ jobs:
         uses: golangci/golangci-lint-action@v6.0.1
         with:
           only-new-issues: true
-          version: v1.55.1
+          version: v1.59.1
           args: --timeout=900s
 
   gomodtidy:

--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ fmt: gci addlicense
 # Install golangci-lint if not available
 golangci-lint:
 ifeq (, $(shell which golangci-lint))
-	@go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.55.1
+	@go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.59.1
 GOLANGCILINT=$(GOBIN)/golangci-lint
 else
 GOLANGCILINT=$(shell which golangci-lint)


### PR DESCRIPTION
# Description

This PR upgrades golangci-lint from version 1.55.1 to 1.59.1.

This fixes out-of-memory issues.
