### PR TITLE
Update linter CI

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,9 +1,5 @@
 run:
   timeout: 10m
-  skip-files:
-    - "zz_generated.*.go"
-  skip-dirs:
-    - "pkg/client"
 
 linters-settings:
   exhaustive:
@@ -58,11 +54,13 @@ linters-settings:
   goimports:
     local-prefixes: github.com/liqotech/liqo
   govet:
-    check-shadowing: true
+    enable:
+      - shadow
+      - nilness
+      - nilfunc
   misspell:
     locale: US
   nolintlint:
-    allow-leading-space: true # don't require machine-readable nolint directives (i.e. with no leading space)
     allow-unused: false # report any unused nolint directives
     require-explanation: true # require an explanation for nolint directives
     require-specific: true # require nolint directives to be specific about which linter is being skipped
@@ -153,3 +151,9 @@ issues:
       linters:
         - whitespace
         - revive  # it does not allow dot imports (e.g. . "github.com/onsi/ginkgo")
+
+  exclude-files:
+    - "zz_generated.*.go"
+  
+  exclude-dirs:
+    - "pkg/client"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 -   repo: https://github.com/golangci/golangci-lint
-    rev: v1.55.1
+    rev: v1.59.1
     hooks:
     - id: golangci-lint
       name: golangci-lint

--- a/apis/ipam/v1alpha1/doc.go
+++ b/apis/ipam/v1alpha1/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package v1alpha1 contains API Schema definitions for the ipam v1alpha1 API group
+package v1alpha1

--- a/cmd/liqoctl/cmd/activate.go
+++ b/cmd/liqoctl/cmd/activate.go
@@ -60,7 +60,7 @@ func newActivateTenantCommand(ctx context.Context, f *factory.Factory) *cobra.Co
 		Args:              cobra.ExactArgs(1),
 		ValidArgsFunction: completion.Tenants(ctx, f, 1),
 
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, args []string) {
 			options.Name = args[0]
 			output.ExitOnErr(options.RunActivateTenant(ctx))
 		},

--- a/cmd/liqoctl/cmd/authenticate.go
+++ b/cmd/liqoctl/cmd/authenticate.go
@@ -49,11 +49,11 @@ func newAuthenticateCommand(ctx context.Context, f *factory.Factory) *cobra.Comm
 		Long:    WithTemplate(liqoctlAuthenticateLongHelp),
 		Args:    cobra.NoArgs,
 
-		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		PersistentPreRun: func(cmd *cobra.Command, _ []string) {
 			twoClustersPersistentPreRun(cmd, options.LocalFactory, options.RemoteFactory, factory.WithScopedPrinter)
 		},
 
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, _ []string) {
 			output.ExitOnErr(options.RunAuthenticate(ctx))
 		},
 	}

--- a/cmd/liqoctl/cmd/cordon.go
+++ b/cmd/liqoctl/cmd/cordon.go
@@ -72,11 +72,11 @@ func newCordonTenantCommand(ctx context.Context, f *factory.Factory) *cobra.Comm
 		Args:              cobra.ExactArgs(1),
 		ValidArgsFunction: completion.Tenants(ctx, f, 1),
 
-		PreRun: func(cmd *cobra.Command, args []string) {
+		PreRun: func(_ *cobra.Command, _ []string) {
 			output.ExitOnErr(options.Printer.AskConfirm("cordon", options.SkipConfirm))
 		},
 
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, args []string) {
 			options.Name = args[0]
 			output.ExitOnErr(options.RunCordonTenant(ctx))
 		},
@@ -101,11 +101,11 @@ func newCordonResourceSliceCommand(ctx context.Context, f *factory.Factory) *cob
 		Args:              cobra.ExactArgs(1),
 		ValidArgsFunction: completion.ResourceSlices(ctx, f, 1),
 
-		PreRun: func(cmd *cobra.Command, args []string) {
+		PreRun: func(_ *cobra.Command, _ []string) {
 			output.ExitOnErr(options.Printer.AskConfirm("cordon", options.SkipConfirm))
 		},
 
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, args []string) {
 			options.Name = args[0]
 			output.ExitOnErr(options.RunCordonResourceSlice(ctx))
 		},

--- a/cmd/liqoctl/cmd/network.go
+++ b/cmd/liqoctl/cmd/network.go
@@ -58,7 +58,7 @@ func newNetworkCommand(ctx context.Context, f *factory.Factory) *cobra.Command {
 		Long:  WithTemplate(liqoctlNetworkLongHelp),
 		Args:  cobra.NoArgs,
 
-		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		PersistentPreRun: func(cmd *cobra.Command, _ []string) {
 			twoClustersPersistentPreRun(cmd, options.LocalFactory, options.RemoteFactory, factory.WithScopedPrinter)
 		},
 	}
@@ -99,7 +99,7 @@ func newNetworkInitCommand(ctx context.Context, options *network.Options) *cobra
 		Long:  WithTemplate(liqoctlNetworkInitLongHelp),
 		Args:  cobra.NoArgs,
 
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, _ []string) {
 			err := options.RunInit(ctx)
 			if err != nil {
 				options.LocalFactory.Printer.CheckErr(
@@ -119,11 +119,11 @@ func newNetworkResetCommand(ctx context.Context, options *network.Options) *cobr
 		Long:  WithTemplate(liqoctlNetworkResetLongHelp),
 		Args:  cobra.NoArgs,
 
-		PreRun: func(cmd *cobra.Command, args []string) {
+		PreRun: func(_ *cobra.Command, _ []string) {
 			output.ExitOnErr(options.LocalFactory.Printer.AskConfirm("reset", options.LocalFactory.SkipConfirm))
 		},
 
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, _ []string) {
 			output.ExitOnErr(options.RunReset(ctx))
 		},
 	}
@@ -138,7 +138,7 @@ func newNetworkConnectCommand(ctx context.Context, options *network.Options) *co
 		Long:  WithTemplate(liqoctlNetworConnectLongHelp),
 		Args:  cobra.NoArgs,
 
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, _ []string) {
 			err := options.RunConnect(ctx)
 			if err != nil {
 				options.LocalFactory.Printer.CheckErr(
@@ -189,11 +189,11 @@ func newNetworkDisconnectCommand(ctx context.Context, options *network.Options) 
 		Long:  WithTemplate(liqoctlNetworkDisconnectLongHelp),
 		Args:  cobra.NoArgs,
 
-		PreRun: func(cmd *cobra.Command, args []string) {
+		PreRun: func(_ *cobra.Command, _ []string) {
 			output.ExitOnErr(options.LocalFactory.Printer.AskConfirm("disconnect", options.LocalFactory.SkipConfirm))
 		},
 
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, _ []string) {
 			output.ExitOnErr(options.RunDisconnect(ctx))
 		},
 	}

--- a/cmd/liqoctl/cmd/peer.go
+++ b/cmd/liqoctl/cmd/peer.go
@@ -65,11 +65,11 @@ func newPeerCommand(ctx context.Context, f *factory.Factory) *cobra.Command {
 		Long:  WithTemplate(liqoctlPeerLongHelp),
 		Args:  cobra.NoArgs,
 
-		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		PersistentPreRun: func(cmd *cobra.Command, _ []string) {
 			twoClustersPersistentPreRun(cmd, options.LocalFactory, options.RemoteFactory, factory.WithScopedPrinter)
 		},
 
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, _ []string) {
 			output.ExitOnErr(options.RunPeer(ctx))
 		},
 	}

--- a/cmd/liqoctl/cmd/unauthenticate.go
+++ b/cmd/liqoctl/cmd/unauthenticate.go
@@ -49,11 +49,11 @@ func newUnauthenticateCommand(ctx context.Context, f *factory.Factory) *cobra.Co
 		Long:    WithTemplate(liqoctlUnauthenticateLongHelp),
 		Args:    cobra.NoArgs,
 
-		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		PersistentPreRun: func(cmd *cobra.Command, _ []string) {
 			twoClustersPersistentPreRun(cmd, options.LocalFactory, options.RemoteFactory, factory.WithScopedPrinter)
 		},
 
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, _ []string) {
 			output.ExitOnErr(options.RunUnauthenticate(ctx))
 		},
 	}

--- a/cmd/liqoctl/cmd/uncordon.go
+++ b/cmd/liqoctl/cmd/uncordon.go
@@ -71,7 +71,7 @@ func newUncordonTenantCommand(ctx context.Context, f *factory.Factory) *cobra.Co
 		Args:              cobra.ExactArgs(1),
 		ValidArgsFunction: completion.Tenants(ctx, f, 1),
 
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, args []string) {
 			options.Name = args[0]
 			output.ExitOnErr(options.RunUncordonTenant(ctx))
 		},
@@ -95,11 +95,11 @@ func newUncordonResourceSliceCommand(ctx context.Context, f *factory.Factory) *c
 		Args:              cobra.ExactArgs(1),
 		ValidArgsFunction: completion.ResourceSlices(ctx, f, 1),
 
-		PreRun: func(cmd *cobra.Command, args []string) {
+		PreRun: func(_ *cobra.Command, _ []string) {
 			output.ExitOnErr(options.Printer.AskConfirm("uncordon", options.SkipConfirm))
 		},
 
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, args []string) {
 			options.Name = args[0]
 			output.ExitOnErr(options.RunUncordonResourceSlice(ctx))
 		},

--- a/cmd/liqoctl/cmd/unpeer.go
+++ b/cmd/liqoctl/cmd/unpeer.go
@@ -55,11 +55,11 @@ func newUnpeerCommand(ctx context.Context, f *factory.Factory) *cobra.Command {
 		Long:  WithTemplate(liqoctlUnpeerLongHelp),
 		Args:  cobra.NoArgs,
 
-		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		PersistentPreRun: func(cmd *cobra.Command, _ []string) {
 			twoClustersPersistentPreRun(cmd, options.LocalFactory, options.RemoteFactory, factory.WithScopedPrinter)
 		},
 
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, _ []string) {
 			output.ExitOnErr(options.RunUnpeer(ctx))
 		},
 	}

--- a/cmd/liqoctl/cmd/version.go
+++ b/cmd/liqoctl/cmd/version.go
@@ -42,7 +42,7 @@ func newVersionCommand(ctx context.Context, f *factory.Factory) *cobra.Command {
 		Long:  WithTemplate(liqoctlVersionLongHelp),
 		Args:  cobra.NoArgs,
 
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, _ []string) {
 			output.ExitOnErr(options.Run(ctx))
 		},
 	}

--- a/cmd/virtual-kubelet/root/http.go
+++ b/cmd/virtual-kubelet/root/http.go
@@ -169,7 +169,7 @@ func newCertificateRetriever(kubeClient kubernetes.Interface, signer, nodeName s
 	}
 
 	mgr, err := certificate.NewManager(&certificate.Config{
-		ClientsetFn: func(current *tls.Certificate) (kubernetes.Interface, error) {
+		ClientsetFn: func(_ *tls.Certificate) (kubernetes.Interface, error) {
 			return kubeClient, nil
 		},
 		GetTemplate: getTemplate,

--- a/cmd/virtual-kubelet/root/opts.go
+++ b/cmd/virtual-kubelet/root/opts.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/virtual-kubelet/virtual-kubelet/node"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	vkv1alpha1 "github.com/liqotech/liqo/apis/virtualkubelet/v1alpha1"
 	"github.com/liqotech/liqo/pkg/consts"
@@ -167,7 +167,7 @@ func initReflectionWorkers() map[string]*uint {
 	reflectionWorkers := make(map[string]*uint, len(resources.Reflectors))
 	for i := range resources.Reflectors {
 		resource := &resources.Reflectors[i]
-		reflectionWorkers[string(*resource)] = pointer.Uint(DefaultReflectorsWorkers[*resource])
+		reflectionWorkers[string(*resource)] = ptr.To(DefaultReflectorsWorkers[*resource])
 	}
 	return reflectionWorkers
 }
@@ -176,7 +176,7 @@ func initReflectionType() map[string]*string {
 	reflectionType := make(map[string]*string, len(resources.ReflectorsCustomizableType))
 	for i := range resources.ReflectorsCustomizableType {
 		resource := &resources.ReflectorsCustomizableType[i]
-		reflectionType[string(*resource)] = pointer.String(string(DefaultReflectorsTypes[*resource]))
+		reflectionType[string(*resource)] = ptr.To(string(DefaultReflectorsTypes[*resource]))
 	}
 	return reflectionType
 }

--- a/cmd/virtual-kubelet/root/root.go
+++ b/cmd/virtual-kubelet/root/root.go
@@ -73,7 +73,7 @@ func NewCommand(ctx context.Context, name string, c *Opts) *cobra.Command {
 		Use:   name,
 		Short: name + " implements the Liqo Virtual Kubelet logic.",
 		Long:  name + " implements the Liqo Virtual Kubelet logic.",
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return runRootCommand(ctx, c)
 		},
 	}
@@ -268,7 +268,7 @@ func runRootCommand(ctx context.Context, c *Opts) error {
 			node.WithNodeEnableLeaseV1(localClient.CoordinationV1().Leases(corev1.NamespaceNodeLease), int32(c.NodeLeaseDuration.Seconds())),
 			node.WithNodePingInterval(c.NodePingInterval), node.WithNodePingTimeout(c.NodePingTimeout),
 			node.WithNodeStatusUpdateErrorHandler(
-				func(ctx context.Context, err error) error {
+				func(ctx context.Context, _ error) error {
 					klog.Info("node setting up")
 					newNode := nodeProvider.GetNode().DeepCopy()
 					newNode.ResourceVersion = ""
@@ -322,13 +322,13 @@ func runRootCommand(ctx context.Context, c *Opts) error {
 }
 
 func getVersion(config *rest.Config) string {
-	client, err := discovery.NewDiscoveryClientForConfig(config)
+	discoveryClient, err := discovery.NewDiscoveryClientForConfig(config)
 	if err != nil {
 		klog.Warningf("Cannot read k8s version: using default version %v; error: %v", defaultVersion, err)
 		return defaultVersion
 	}
 
-	version, err := client.ServerVersion()
+	version, err := discoveryClient.ServerVersion()
 	if err != nil {
 		klog.Warningf("Cannot read k8s version: using default version %v; error: %v", defaultVersion, err)
 		return defaultVersion

--- a/internal/crdReplicator/crdReplicator-operator.go
+++ b/internal/crdReplicator/crdReplicator-operator.go
@@ -156,7 +156,7 @@ func (c *Controller) Reconcile(ctx context.Context, req ctrl.Request) (result ct
 // SetupWithManager registers a new controller for identity Secrets.
 func (c *Controller) SetupWithManager(mgr ctrl.Manager) error {
 	resourceToBeProccesedPredicate := predicate.Funcs{
-		DeleteFunc: func(e event.DeleteEvent) bool {
+		DeleteFunc: func(_ event.DeleteEvent) bool {
 			return false
 		},
 	}

--- a/pkg/liqo-controller-manager/networking/external-network/remapping/configuration_controller.go
+++ b/pkg/liqo-controller-manager/networking/external-network/remapping/configuration_controller.go
@@ -64,8 +64,8 @@ func NewRemappingReconciler(cl client.Client, s *runtime.Scheme, er record.Event
 
 // Reconcile manage Configuration resources.
 func (r *RemappingReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	configuration := &networkingv1alpha1.Configuration{}
-	if err := r.Client.Get(ctx, req.NamespacedName, configuration); err != nil {
+	conf := &networkingv1alpha1.Configuration{}
+	if err := r.Client.Get(ctx, req.NamespacedName, conf); err != nil {
 		if apierrors.IsNotFound(err) {
 			klog.Infof("There is no configuration %s", req.String())
 			return ctrl.Result{}, nil
@@ -74,15 +74,15 @@ func (r *RemappingReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	}
 	klog.V(4).Infof("Reconciling configuration %q", req.NamespacedName)
 
-	if configuration.Spec.Remote.CIDR.Pod != configuration.Status.Remote.CIDR.Pod {
-		if err := CreateOrUpdateNatMappingCIDR(ctx, r.Client, r.Options, configuration,
+	if conf.Spec.Remote.CIDR.Pod != conf.Status.Remote.CIDR.Pod {
+		if err := CreateOrUpdateNatMappingCIDR(ctx, r.Client, r.Options, conf,
 			r.Scheme, PodCIDR); err != nil {
 			return ctrl.Result{}, err
 		}
 	}
 
-	if configuration.Spec.Remote.CIDR.External != configuration.Status.Remote.CIDR.External {
-		if err := CreateOrUpdateNatMappingCIDR(ctx, r.Client, r.Options, configuration,
+	if conf.Spec.Remote.CIDR.External != conf.Status.Remote.CIDR.External {
+		if err := CreateOrUpdateNatMappingCIDR(ctx, r.Client, r.Options, conf,
 			r.Scheme, ExternalCIDR); err != nil {
 			return ctrl.Result{}, err
 		}

--- a/pkg/liqo-controller-manager/networking/external-network/route/configuration_controller.go
+++ b/pkg/liqo-controller-manager/networking/external-network/route/configuration_controller.go
@@ -63,8 +63,8 @@ func NewConfigurationReconciler(cl client.Client, s *runtime.Scheme,
 // Reconcile manage Configurations.
 func (r *ConfigurationReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	var err error
-	configuration := &networkingv1alpha1.Configuration{}
-	if err = r.Get(ctx, req.NamespacedName, configuration); err != nil {
+	conf := &networkingv1alpha1.Configuration{}
+	if err = r.Get(ctx, req.NamespacedName, conf); err != nil {
 		if apierrors.IsNotFound(err) {
 			klog.Infof("There is no configuration %s", req.String())
 			return ctrl.Result{}, nil
@@ -74,7 +74,7 @@ func (r *ConfigurationReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 	klog.V(4).Infof("Reconciling configuration %s", req.String())
 
-	return ctrl.Result{}, enforeRouteConfigurationPresence(ctx, r.Client, r.Scheme, configuration)
+	return ctrl.Result{}, enforeRouteConfigurationPresence(ctx, r.Client, r.Scheme, conf)
 }
 
 // SetupWithManager register the ConfigurationReconciler to the manager.

--- a/pkg/liqo-controller-manager/networking/internal-network/internalfabric-controller/internalfabric_controller.go
+++ b/pkg/liqo-controller-manager/networking/internal-network/internalfabric-controller/internalfabric_controller.go
@@ -100,7 +100,7 @@ func (r *InternalFabricReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 // SetupWithManager register the InternalFabricReconciler to the manager.
 func (r *InternalFabricReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	internalNodeEnqueuer := handler.EnqueueRequestsFromMapFunc(
-		func(ctx context.Context, obj client.Object) []reconcile.Request {
+		func(ctx context.Context, _ client.Object) []reconcile.Request {
 			var requests []reconcile.Request
 
 			var internalFabricList networkingv1alpha1.InternalFabricList

--- a/pkg/liqo-controller-manager/networking/ip-controller/ip_controller.go
+++ b/pkg/liqo-controller-manager/networking/ip-controller/ip_controller.go
@@ -170,7 +170,7 @@ func (r *IPReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Re
 // SetupWithManager monitors IP resources.
 func (r *IPReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, workers int) error {
 	// List all IP resources and enqueue them.
-	enqueuer := func(_ context.Context, obj client.Object) []reconcile.Request {
+	enqueuer := func(_ context.Context, _ client.Object) []reconcile.Request {
 		var ipList ipamv1alpha1.IPList
 		if err := r.List(ctx, &ipList); err != nil {
 			klog.Errorf("error while listing IPs: %v", err)

--- a/pkg/liqo-controller-manager/offloading/namespaceoffloading-controller/namespaceoffloading_controller.go
+++ b/pkg/liqo-controller-manager/offloading/namespaceoffloading-controller/namespaceoffloading_controller.go
@@ -149,7 +149,7 @@ func (r *NamespaceOffloadingReconciler) namespaceMapHandlers() handler.EventHand
 	}
 
 	return handler.Funcs{
-		CreateFunc: func(_ context.Context, ce event.CreateEvent, rli workqueue.RateLimitingInterface) {
+		CreateFunc: func(_ context.Context, _ event.CreateEvent, rli workqueue.RateLimitingInterface) {
 			// Enqueue an event for all known NamespaceOffloadings.
 			r.namespaces.ForEach(func(namespace string) { enqueue(rli, namespace) })
 		},
@@ -171,7 +171,7 @@ func (r *NamespaceOffloadingReconciler) namespaceMapHandlers() handler.EventHand
 				}
 			}
 		},
-		DeleteFunc: func(_ context.Context, de event.DeleteEvent, rli workqueue.RateLimitingInterface) {
+		DeleteFunc: func(_ context.Context, _ event.DeleteEvent, rli workqueue.RateLimitingInterface) {
 			// Enqueue an event for all known NamespaceOffloadings.
 			r.namespaces.ForEach(func(namespace string) { enqueue(rli, namespace) })
 		},
@@ -179,7 +179,7 @@ func (r *NamespaceOffloadingReconciler) namespaceMapHandlers() handler.EventHand
 }
 
 func (r *NamespaceOffloadingReconciler) enqueueAll() handler.EventHandler {
-	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, o client.Object) []reconcile.Request {
+	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, _ client.Object) []reconcile.Request {
 		var nsolist offv1alpha1.NamespaceOffloadingList
 		if err := r.Client.List(ctx, &nsolist); err != nil {
 			klog.Errorf("Failed to retrieve NamespaceOffloadingList: %v", err)

--- a/pkg/liqo-controller-manager/offloading/shadowendpointslice-controller/shadowendpointslice_controller.go
+++ b/pkg/liqo-controller-manager/offloading/shadowendpointslice-controller/shadowendpointslice_controller.go
@@ -238,10 +238,10 @@ func (r *Reconciler) endpointsShouldBeUpdated(newObj, oldObj client.Object) bool
 func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, workers int) error {
 	// Trigger a reconciliation only for Update Events on NetworkStatus of the ForeignCluster.
 	fcPredicates := predicate.Funcs{
-		DeleteFunc:  func(e event.DeleteEvent) bool { return false },
-		CreateFunc:  func(e event.CreateEvent) bool { return false },
+		DeleteFunc:  func(_ event.DeleteEvent) bool { return false },
+		CreateFunc:  func(_ event.CreateEvent) bool { return false },
 		UpdateFunc:  func(e event.UpdateEvent) bool { return r.endpointsShouldBeUpdated(e.ObjectNew, e.ObjectOld) },
-		GenericFunc: func(e event.GenericEvent) bool { return false },
+		GenericFunc: func(_ event.GenericEvent) bool { return false },
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/pkg/liqo-controller-manager/offloading/shadowpod-controller/shadowpod_controller.go
+++ b/pkg/liqo-controller-manager/offloading/shadowpod-controller/shadowpod_controller.go
@@ -149,10 +149,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 func (r *Reconciler) SetupWithManager(mgr ctrl.Manager, workers int) error {
 	// Trigger a reconciliation only for Delete and Update Events.
 	reconciledPredicates := predicate.Funcs{
-		DeleteFunc:  func(e event.DeleteEvent) bool { return true },
-		CreateFunc:  func(e event.CreateEvent) bool { return false },
-		UpdateFunc:  func(e event.UpdateEvent) bool { return true },
-		GenericFunc: func(e event.GenericEvent) bool { return false },
+		DeleteFunc:  func(_ event.DeleteEvent) bool { return true },
+		CreateFunc:  func(_ event.CreateEvent) bool { return false },
+		UpdateFunc:  func(_ event.UpdateEvent) bool { return true },
+		GenericFunc: func(_ event.GenericEvent) bool { return false },
 	}
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&vkv1alpha1.ShadowPod{}).

--- a/pkg/liqoctl/completion/completion.go
+++ b/pkg/liqoctl/completion/completion.go
@@ -70,7 +70,7 @@ func common(ctx context.Context, f *factory.Factory, argsLimit int, retrieve ret
 
 // Enumeration returns a function to autocomplete enumeration values.
 func Enumeration(values []string) FnType {
-	return func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	return func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 		return values, cobra.ShellCompDirectiveNoFileComp
 	}
 }

--- a/pkg/liqoctl/docs/handler.go
+++ b/pkg/liqoctl/docs/handler.go
@@ -37,7 +37,7 @@ type Options struct {
 }
 
 // Run implements the docs command.
-func (o *Options) Run(ctx context.Context) error {
+func (o *Options) Run(_ context.Context) error {
 	switch o.DocTypeString {
 	case "markdown":
 		if o.GenerateHeaders {

--- a/pkg/liqoctl/install/eks/provider.go
+++ b/pkg/liqoctl/install/eks/provider.go
@@ -81,7 +81,7 @@ func (o *Options) RegisterFlags(cmd *cobra.Command) {
 }
 
 // Initialize performs the initialization tasks to retrieve the provider-specific parameters.
-func (o *Options) Initialize(ctx context.Context) error {
+func (o *Options) Initialize(_ context.Context) error {
 	o.Printer.Verbosef("EKS Region: %q", o.region)
 	o.Printer.Verbosef("EKS ClusterName: %q", o.eksClusterName)
 

--- a/pkg/liqoctl/rest/configuration/create.go
+++ b/pkg/liqoctl/rest/configuration/create.go
@@ -56,13 +56,13 @@ func (o *Options) Create(ctx context.Context, options *rest.CreateOptions) *cobr
 		Long:    liqoctlCreateConfigurationLongHelp,
 		Args:    cobra.ExactArgs(1),
 
-		PreRun: func(cmd *cobra.Command, args []string) {
+		PreRun: func(_ *cobra.Command, args []string) {
 			options.OutputFormat = outputFormat.Value
 			options.Name = args[0]
 			o.createOptions = options
 		},
 
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, _ []string) {
 			output.ExitOnErr(o.handleCreate(ctx))
 		},
 	}

--- a/pkg/liqoctl/rest/configuration/delete.go
+++ b/pkg/liqoctl/rest/configuration/delete.go
@@ -45,12 +45,12 @@ func (o *Options) Delete(ctx context.Context, options *rest.DeleteOptions) *cobr
 		Args:              cobra.ExactArgs(1),
 		ValidArgsFunction: completion.Configurations(ctx, o.deleteOptions.Factory, 1),
 
-		PreRun: func(cmd *cobra.Command, args []string) {
+		PreRun: func(_ *cobra.Command, args []string) {
 			options.Name = args[0]
 			o.deleteOptions = options
 		},
 
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, _ []string) {
 			output.ExitOnErr(o.handleDelete(ctx))
 		},
 	}

--- a/pkg/liqoctl/rest/configuration/generate.go
+++ b/pkg/liqoctl/rest/configuration/generate.go
@@ -43,12 +43,12 @@ func (o *Options) Generate(ctx context.Context, options *rest.GenerateOptions) *
 		Long:    liqoctlGenerateConfigHelp,
 		Args:    cobra.NoArgs,
 
-		PreRun: func(cmd *cobra.Command, args []string) {
+		PreRun: func(_ *cobra.Command, _ []string) {
 			options.OutputFormat = outputFormat.Value
 			o.generateOptions = options
 		},
 
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, _ []string) {
 			output.ExitOnErr(o.handleGenerate(ctx))
 		},
 	}

--- a/pkg/liqoctl/rest/gatewayclient/create.go
+++ b/pkg/liqoctl/rest/gatewayclient/create.go
@@ -57,13 +57,13 @@ func (o *Options) Create(ctx context.Context, options *rest.CreateOptions) *cobr
 		Long:    liqoctlCreateGatewayClientLongHelp,
 		Args:    cobra.ExactArgs(1),
 
-		PreRun: func(cmd *cobra.Command, args []string) {
+		PreRun: func(_ *cobra.Command, args []string) {
 			options.OutputFormat = outputFormat.Value
 			options.Name = args[0]
 			o.createOptions = options
 		},
 
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, _ []string) {
 			output.ExitOnErr(o.handleCreate(ctx))
 		},
 	}

--- a/pkg/liqoctl/rest/gatewayclient/delete.go
+++ b/pkg/liqoctl/rest/gatewayclient/delete.go
@@ -45,12 +45,12 @@ func (o *Options) Delete(ctx context.Context, options *rest.DeleteOptions) *cobr
 		Args:              cobra.ExactArgs(1),
 		ValidArgsFunction: completion.GatewayClients(ctx, o.deleteOptions.Factory, 1),
 
-		PreRun: func(cmd *cobra.Command, args []string) {
+		PreRun: func(_ *cobra.Command, args []string) {
 			options.Name = args[0]
 			o.deleteOptions = options
 		},
 
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, _ []string) {
 			output.ExitOnErr(o.handleDelete(ctx))
 		},
 	}

--- a/pkg/liqoctl/rest/gatewayserver/create.go
+++ b/pkg/liqoctl/rest/gatewayserver/create.go
@@ -57,13 +57,13 @@ func (o *Options) Create(ctx context.Context, options *rest.CreateOptions) *cobr
 		Long:    liqoctlCreateGatewayServerLongHelp,
 		Args:    cobra.ExactArgs(1),
 
-		PreRun: func(cmd *cobra.Command, args []string) {
+		PreRun: func(_ *cobra.Command, args []string) {
 			options.OutputFormat = outputFormat.Value
 			options.Name = args[0]
 			o.createOptions = options
 		},
 
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, _ []string) {
 			output.ExitOnErr(o.handleCreate(ctx))
 		},
 	}

--- a/pkg/liqoctl/rest/gatewayserver/delete.go
+++ b/pkg/liqoctl/rest/gatewayserver/delete.go
@@ -45,12 +45,12 @@ func (o *Options) Delete(ctx context.Context, options *rest.DeleteOptions) *cobr
 		Args:              cobra.ExactArgs(1),
 		ValidArgsFunction: completion.GatewayServers(ctx, o.deleteOptions.Factory, 1),
 
-		PreRun: func(cmd *cobra.Command, args []string) {
+		PreRun: func(_ *cobra.Command, args []string) {
 			options.Name = args[0]
 			o.deleteOptions = options
 		},
 
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, _ []string) {
 			output.ExitOnErr(o.handleDelete(ctx))
 		},
 	}

--- a/pkg/liqoctl/rest/identity/generate.go
+++ b/pkg/liqoctl/rest/identity/generate.go
@@ -51,12 +51,12 @@ func (o *Options) Generate(ctx context.Context, options *rest.GenerateOptions) *
 		Long:    liqoctlGenerateConfigHelp,
 		Args:    cobra.NoArgs,
 
-		PreRun: func(cmd *cobra.Command, args []string) {
+		PreRun: func(_ *cobra.Command, _ []string) {
 			options.OutputFormat = outputFormat.Value
 			o.generateOptions = options
 		},
 
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, _ []string) {
 			output.ExitOnErr(o.handleGenerate(ctx))
 		},
 	}

--- a/pkg/liqoctl/rest/kubeconfig/get.go
+++ b/pkg/liqoctl/rest/kubeconfig/get.go
@@ -47,13 +47,13 @@ func (o *Options) Get(ctx context.Context, options *rest.GetOptions) *cobra.Comm
 		Long:    liqoctlGetKubeconfigLongHelp,
 		Args:    cobra.ExactArgs(1),
 
-		PreRun: func(cmd *cobra.Command, args []string) {
+		PreRun: func(_ *cobra.Command, args []string) {
 			o.getOptions = options
 			o.identityName = args[0]
 			o.namespaceManager = tenantnamespace.NewManager(options.KubeClient)
 		},
 
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, _ []string) {
 			output.ExitOnErr(o.handleGet(ctx))
 		},
 	}

--- a/pkg/liqoctl/rest/nonce/create.go
+++ b/pkg/liqoctl/rest/nonce/create.go
@@ -53,14 +53,14 @@ func (o *Options) Create(ctx context.Context, options *rest.CreateOptions) *cobr
 		Long:    liqoctlCreateNonceLongHelp,
 		Args:    cobra.NoArgs,
 
-		PreRun: func(cmd *cobra.Command, args []string) {
+		PreRun: func(_ *cobra.Command, _ []string) {
 			options.OutputFormat = outputFormat.Value
 			o.createOptions = options
 
 			o.namespaceManager = tenantnamespace.NewManager(options.KubeClient)
 		},
 
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, _ []string) {
 			output.ExitOnErr(o.handleCreate(ctx))
 		},
 	}

--- a/pkg/liqoctl/rest/nonce/get.go
+++ b/pkg/liqoctl/rest/nonce/get.go
@@ -45,11 +45,11 @@ func (o *Options) Get(ctx context.Context, options *rest.GetOptions) *cobra.Comm
 		Long:    liqoctlGetNonceLongHelp,
 		Args:    cobra.NoArgs,
 
-		PreRun: func(cmd *cobra.Command, args []string) {
+		PreRun: func(_ *cobra.Command, _ []string) {
 			o.getOptions = options
 		},
 
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, _ []string) {
 			output.ExitOnErr(o.handleGet(ctx))
 		},
 	}

--- a/pkg/liqoctl/rest/publickey/create.go
+++ b/pkg/liqoctl/rest/publickey/create.go
@@ -52,13 +52,13 @@ func (o *Options) Create(ctx context.Context, options *rest.CreateOptions) *cobr
 		Long:    liqoctlCreatePublicKeyLongHelp,
 		Args:    cobra.ExactArgs(1),
 
-		PreRun: func(cmd *cobra.Command, args []string) {
+		PreRun: func(_ *cobra.Command, args []string) {
 			options.OutputFormat = outputFormat.Value
 			options.Name = args[0]
 			o.createOptions = options
 		},
 
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, _ []string) {
 			output.ExitOnErr(o.handleCreate(ctx))
 		},
 	}

--- a/pkg/liqoctl/rest/publickey/delete.go
+++ b/pkg/liqoctl/rest/publickey/delete.go
@@ -45,12 +45,12 @@ func (o *Options) Delete(ctx context.Context, options *rest.DeleteOptions) *cobr
 		Args:              cobra.ExactArgs(1),
 		ValidArgsFunction: completion.PublicKeys(ctx, o.deleteOptions.Factory, 1),
 
-		PreRun: func(cmd *cobra.Command, args []string) {
+		PreRun: func(_ *cobra.Command, args []string) {
 			options.Name = args[0]
 			o.deleteOptions = options
 		},
 
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, _ []string) {
 			output.ExitOnErr(o.handleDelete(ctx))
 		},
 	}

--- a/pkg/liqoctl/rest/publickey/generate.go
+++ b/pkg/liqoctl/rest/publickey/generate.go
@@ -43,12 +43,12 @@ func (o *Options) Generate(ctx context.Context, options *rest.GenerateOptions) *
 		Long:    liqoctlGeneratePuclicKeyHelp,
 		Args:    cobra.NoArgs,
 
-		PreRun: func(cmd *cobra.Command, args []string) {
+		PreRun: func(_ *cobra.Command, _ []string) {
 			options.OutputFormat = outputFormat.Value
 			o.generateOptions = options
 		},
 
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, _ []string) {
 			output.ExitOnErr(o.handleGenerate(ctx))
 		},
 	}

--- a/pkg/liqoctl/rest/resourceslice/create.go
+++ b/pkg/liqoctl/rest/resourceslice/create.go
@@ -59,7 +59,7 @@ func (o *Options) Create(ctx context.Context, options *rest.CreateOptions) *cobr
 		Long:    liqoctlCreateResourceSliceLongHelp,
 		Args:    cobra.ExactArgs(1),
 
-		PreRun: func(cmd *cobra.Command, args []string) {
+		PreRun: func(_ *cobra.Command, args []string) {
 			options.OutputFormat = outputFormat.Value
 			options.Name = args[0]
 			o.CreateOptions = options
@@ -67,7 +67,7 @@ func (o *Options) Create(ctx context.Context, options *rest.CreateOptions) *cobr
 			o.NamespaceManager = tenantnamespace.NewManager(options.Factory.KubeClient)
 		},
 
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, _ []string) {
 			output.ExitOnErr(o.HandleCreate(ctx))
 		},
 	}

--- a/pkg/liqoctl/rest/tenant/generate.go
+++ b/pkg/liqoctl/rest/tenant/generate.go
@@ -53,14 +53,14 @@ func (o *Options) Generate(ctx context.Context, options *rest.GenerateOptions) *
 		Long:    liqoctlGenerateConfigHelp,
 		Args:    cobra.NoArgs,
 
-		PreRun: func(cmd *cobra.Command, args []string) {
+		PreRun: func(_ *cobra.Command, _ []string) {
 			options.OutputFormat = outputFormat.Value
 			o.generateOptions = options
 
 			o.namespaceManager = tenantnamespace.NewManager(options.KubeClient)
 		},
 
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, _ []string) {
 			output.ExitOnErr(o.handleGenerate(ctx))
 		},
 	}

--- a/pkg/liqoctl/rest/virtualnode/create.go
+++ b/pkg/liqoctl/rest/virtualnode/create.go
@@ -64,7 +64,7 @@ func (o *Options) Create(ctx context.Context, options *rest.CreateOptions) *cobr
 		Long:    liqoctlCreateVirtualNodeLongHelp,
 		Args:    cobra.ExactArgs(1),
 
-		PreRun: func(cmd *cobra.Command, args []string) {
+		PreRun: func(_ *cobra.Command, args []string) {
 			options.OutputFormat = outputFormat.Value
 			options.Name = args[0]
 			o.createOptions = options
@@ -72,7 +72,7 @@ func (o *Options) Create(ctx context.Context, options *rest.CreateOptions) *cobr
 			o.namespaceManager = tenantnamespace.NewManager(options.KubeClient)
 		},
 
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, _ []string) {
 			output.ExitOnErr(o.handleCreate(ctx))
 		},
 	}

--- a/pkg/liqoctl/rest/virtualnode/delete.go
+++ b/pkg/liqoctl/rest/virtualnode/delete.go
@@ -45,12 +45,12 @@ func (o *Options) Delete(ctx context.Context, options *rest.DeleteOptions) *cobr
 		Args:              cobra.ExactArgs(1),
 		ValidArgsFunction: completion.VirtualNodes(ctx, o.deleteOptions.Factory, 1),
 
-		PreRun: func(cmd *cobra.Command, args []string) {
+		PreRun: func(_ *cobra.Command, args []string) {
 			options.Name = args[0]
 			o.deleteOptions = options
 		},
 
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, _ []string) {
 			output.ExitOnErr(o.handleDelete(ctx))
 		},
 	}

--- a/pkg/utils/testutil/kubernetes.go
+++ b/pkg/utils/testutil/kubernetes.go
@@ -24,7 +24,7 @@ import (
 )
 
 // FakeClusterIDConfigMap returns a fake ClusterID ConfigMap.
-func FakeClusterIDConfigMap(namespace, clusterID, clusterName string) *corev1.ConfigMap {
+func FakeClusterIDConfigMap(namespace, clusterID string) *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace, Name: "whatever",

--- a/pkg/virtualKubelet/provider/provider.go
+++ b/pkg/virtualKubelet/provider/provider.go
@@ -175,13 +175,13 @@ func (p *LiqoProvider) PodHandler() workload.PodHandler {
 }
 
 func isSATokenAPISupport(localClient kubernetes.Interface) (bool, error) {
-	resources, err := localClient.Discovery().ServerResourcesForGroupVersion(corev1.SchemeGroupVersion.String())
+	res, err := localClient.Discovery().ServerResourcesForGroupVersion(corev1.SchemeGroupVersion.String())
 	if err != nil {
 		return false, err
 	}
 
-	for i := range resources.APIResources {
-		if resources.APIResources[i].Name == "serviceaccounts/token" {
+	for i := range res.APIResources {
+		if res.APIResources[i].Name == "serviceaccounts/token" {
 			return true, nil
 		}
 	}

--- a/pkg/virtualKubelet/reflection/storage/persistentvolumeclaim.go
+++ b/pkg/virtualKubelet/reflection/storage/persistentvolumeclaim.go
@@ -175,7 +175,7 @@ func (npvcr *NamespacedPersistentVolumeClaimReflector) Handle(ctx context.Contex
 	// https://github.com/kubernetes-sigs/sig-storage-lib-external-provisioner/blob/v7.0.1/controller/controller.go#L1275
 	// In addition, we use the provisionFunc to ensure the provisioning of the remote PVC.
 	state, err := npvcr.provisionClaimOperation(ctx, local,
-		func(c context.Context, options controller.ProvisionOptions) (*corev1.PersistentVolume, controller.ProvisioningState, error) {
+		func(_ context.Context, options controller.ProvisionOptions) (*corev1.PersistentVolume, controller.ProvisioningState, error) {
 			if clusterID, found := utils.GetNodeClusterID(options.SelectedNode); !found || clusterID != string(forge.RemoteCluster) {
 				return nil, controller.ProvisioningFinished, &controller.IgnoredError{Reason: "this provisioner is not provisioning storage on that node"}
 			}


### PR DESCRIPTION
# Description

This PR updates the linter on the CI after the latest bumps of `golangci-lint`. It also fixes some linter errors on files from the new releases.