### PR TITLE
Liqoctl: test network

### DIFF
--- a/cmd/liqoctl/cmd/root.go
+++ b/cmd/liqoctl/cmd/root.go
@@ -154,6 +154,7 @@ func NewRootCommand(ctx context.Context) *cobra.Command {
 	cmd.AddCommand(generate.NewGenerateCommand(ctx, liqoResources, f))
 	cmd.AddCommand(get.NewGetCommand(ctx, liqoResources, f))
 	cmd.AddCommand(delete.NewDeleteCommand(ctx, liqoResources, f))
+	cmd.AddCommand(newTestCommand(ctx, f))
 
 	return cmd
 }

--- a/cmd/liqoctl/cmd/test.go
+++ b/cmd/liqoctl/cmd/test.go
@@ -1,0 +1,93 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/util/runtime"
+
+	"github.com/liqotech/liqo/pkg/liqoctl/completion"
+	"github.com/liqotech/liqo/pkg/liqoctl/factory"
+	"github.com/liqotech/liqo/pkg/liqoctl/output"
+	"github.com/liqotech/liqo/pkg/liqoctl/test"
+	"github.com/liqotech/liqo/pkg/liqoctl/test/network"
+	"github.com/liqotech/liqo/pkg/liqoctl/test/network/flags"
+)
+
+const liqoctlTestNetworkLongHelp = `Launch network E2E tests.
+
+WARNING: to run the tests you need to have kyverno installed on every cluster https://kyverno.io/docs/installation/methods/ .
+
+This command allows to launch E2E tests, which are used to check the network functionalities between the clusters.
+The command needs to be run on the cluster that will act as the consumer,
+and it requires the kubeconfig of the remote cluster that will act as the providers.
+The consumer cluster must be peered with the providers, previously using "{{ .Executable }} peer".
+
+
+Examples:
+  $ {{ .Executable }} test network --remote-kubeconfigs $HOME/.kube/config2,$HOME/.kube/config3
+or
+  $ {{ .Executable }} test network --remote-kubeconfigs $HOME/.kube/config2,$HOME/.kube/config3 --basic
+or
+  $ {{ .Executable }} test network --remote-kubeconfigs $HOME/.kube/config2,$HOME/.kube/config3 --np-nodes all --np-ext --pod-np
+or
+  $ {{ .Executable }} test network --remote-kubeconfigs $HOME/.kube/config2,$HOME/.kube/config3 --ip
+or
+  $ {{ .Executable }} test network --remote-kubeconfigs $HOME/.kube/config2,$HOME/.kube/config3 --lb
+`
+
+func newTestCommand(ctx context.Context, f *factory.Factory) *cobra.Command {
+	options := test.NewOptions(f)
+	var cmd = &cobra.Command{
+		Use:   "test",
+		Short: "Launch E2E tests",
+		Long:  "Launch E2E tests",
+		Args:  cobra.NoArgs,
+	}
+
+	cmd.AddCommand(newTestNetworkCommand(ctx, options))
+
+	options.AddFlags(cmd.PersistentFlags())
+
+	return cmd
+}
+
+// newTestNetworkCommand represents the test network command.
+func newTestNetworkCommand(ctx context.Context, topts *test.Options) *cobra.Command {
+	options := network.NewOptions(flags.NewOptions(topts))
+
+	var cmd = &cobra.Command{
+		Use:     "network",
+		Aliases: []string{"net"},
+		Short:   "Launch E2E tests for the network",
+		Long:    WithTemplate(liqoctlTestNetworkLongHelp),
+		Args:    cobra.NoArgs,
+		Run: func(_ *cobra.Command, _ []string) {
+			if err := options.RunNetworkTest(ctx); err != nil {
+				topts.LocalFactory.Printer.ExitWithMessage(output.PrettyErr(err))
+			}
+		},
+	}
+
+	options.Nopts.AddFlags(cmd.Flags())
+	runtime.Must(cmd.RegisterFlagCompletionFunc(
+		string(flags.FlagNamesNodeportNodes), completion.Enumeration(flags.NodePortNodesValues),
+	))
+	runtime.Must(cmd.MarkFlagRequired(string(flags.FlagNamesProducersKubeconfigs)))
+
+	return cmd
+}

--- a/pkg/liqoctl/install/kubeadm/provider.go
+++ b/pkg/liqoctl/install/kubeadm/provider.go
@@ -23,7 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 
 	"github.com/liqotech/liqo/pkg/liqoctl/install"
-	"github.com/liqotech/liqo/pkg/liqoctl/util"
+	"github.com/liqotech/liqo/pkg/liqoctl/utils"
 )
 
 var _ install.Provider = (*Options)(nil)
@@ -80,8 +80,8 @@ func (o *Options) Initialize(ctx context.Context) error {
 	}
 
 	command := cm.Items[0].Spec.Containers[0].Command
-	o.PodCIDR = util.ExtractValuesFromArgumentListOrDefault(podCIDRParameterFilter, command, defaultPodCIDR)
-	o.ServiceCIDR = util.ExtractValuesFromArgumentListOrDefault(serviceCIDRParameterFilter, command, defaultServiceCIDR)
+	o.PodCIDR = utils.ExtractValuesFromArgumentListOrDefault(podCIDRParameterFilter, command, defaultPodCIDR)
+	o.ServiceCIDR = utils.ExtractValuesFromArgumentListOrDefault(serviceCIDRParameterFilter, command, defaultServiceCIDR)
 
 	return nil
 }

--- a/pkg/liqoctl/install/warning.go
+++ b/pkg/liqoctl/install/warning.go
@@ -20,7 +20,7 @@ import (
 	"github.com/pterm/pterm"
 	corev1 "k8s.io/api/core/v1"
 
-	"github.com/liqotech/liqo/pkg/liqoctl/util"
+	"github.com/liqotech/liqo/pkg/liqoctl/utils"
 )
 
 type warner interface {
@@ -48,7 +48,7 @@ func (sw *serviceWarner) check(values map[string]interface{}) (bool, error) {
 	components := []string{"gateway", "auth"}
 
 	for _, component := range components {
-		if value, err = util.ExtractValuesFromNestedMaps(values, component, "service", "type"); err != nil {
+		if value, err = utils.ExtractValuesFromNestedMaps(values, component, "service", "type"); err != nil {
 			return false, err
 		}
 

--- a/pkg/liqoctl/output/output.go
+++ b/pkg/liqoctl/output/output.go
@@ -95,6 +95,8 @@ type Printer struct {
 	BulletList *pterm.BulletListPrinter
 	Section    *pterm.SectionPrinter
 	Paragraph  *pterm.ParagraphPrinter
+	Logger     *pterm.Logger
+	Table      *pterm.TablePrinter
 	verbose    bool
 }
 
@@ -271,22 +273,22 @@ func newPrinter(scope string, color pterm.Color, scoped, verbose bool) *Printer 
 		verbose: verbose,
 		Info: generic.WithPrefix(pterm.Prefix{
 			Text:  "INFO",
-			Style: pterm.NewStyle(pterm.FgDarkGray),
+			Style: pterm.NewStyle(pterm.FgDarkGray, pterm.Bold),
 		}),
 
 		Success: generic.WithPrefix(pterm.Prefix{
 			Text:  "INFO",
-			Style: pterm.NewStyle(pterm.FgGreen),
+			Style: pterm.NewStyle(pterm.FgGreen, pterm.Bold),
 		}),
 
 		Warning: generic.WithPrefix(pterm.Prefix{
 			Text:  "WARN",
-			Style: pterm.NewStyle(pterm.FgYellow),
+			Style: pterm.NewStyle(pterm.FgYellow, pterm.Bold),
 		}),
 
 		Error: generic.WithPrefix(pterm.Prefix{
 			Text:  "ERRO",
-			Style: pterm.NewStyle(pterm.FgRed),
+			Style: pterm.NewStyle(pterm.FgRed, pterm.Bold),
 		}),
 	}
 
@@ -315,6 +317,10 @@ func newPrinter(scope string, color pterm.Color, scoped, verbose bool) *Printer 
 	printer.Paragraph = &pterm.ParagraphPrinter{
 		MaxWidth: boxWidth - len(pterm.RemoveColorFromString(printer.Error.Prefix.Text)) - 3,
 	}
+
+	printer.Logger = pterm.DefaultLogger.WithTime(false)
+
+	printer.Table = pterm.DefaultTable.WithHasHeader().WithBoxed()
 
 	return printer
 }

--- a/pkg/liqoctl/test/doc.go
+++ b/pkg/liqoctl/test/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package test contains the tests for the liqoctl package.
+package test

--- a/pkg/liqoctl/test/flags.go
+++ b/pkg/liqoctl/test/flags.go
@@ -12,24 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package ipam
+package test
 
 import (
-	ipamv1alpha1 "github.com/liqotech/liqo/apis/ipam/v1alpha1"
-	networkingv1alpha1 "github.com/liqotech/liqo/apis/networking/v1alpha1"
-	"github.com/liqotech/liqo/pkg/consts"
+	"github.com/spf13/pflag"
 )
 
-// IsAPIServerIP checks if the resource is an IP of type API server.
-func IsAPIServerIP(ip *ipamv1alpha1.IP) bool {
-	ipType, ok := ip.Labels[consts.IPTypeLabelKey]
-	return ok && ipType == consts.IPTypeAPIServer
-}
+// FlagNames contains the names of the flags.
+type FlagNames string
 
-// GetRemappedIP returns the remapped IP of the given IP resource.
-func GetRemappedIP(ip *ipamv1alpha1.IP) networkingv1alpha1.IP {
-	for _, ipremapped := range ip.Status.IPMappings {
-		return ipremapped
-	}
-	return ""
+const (
+	// FlagNamesVerbose is the flag name for the verbose output.
+	FlagNamesVerbose FlagNames = "verbose"
+	// FlagNamesFailFast is the flag name for the fail-fast option.
+	FlagNamesFailFast FlagNames = "fail-fast"
+)
+
+// AddFlags adds the flags to the flag set.
+func (o *Options) AddFlags(fs *pflag.FlagSet) {
+	fs.BoolVarP(&o.Verbose, string(FlagNamesVerbose), "v", false, "Verbose output")
+	fs.BoolVar(&o.FailFast, string(FlagNamesFailFast), false, "Stop the test as soon as an error is encountered")
 }

--- a/pkg/liqoctl/test/network/check/check.go
+++ b/pkg/liqoctl/test/network/check/check.go
@@ -1,0 +1,142 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package check
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pterm/pterm"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+
+	"github.com/liqotech/liqo/pkg/liqoctl/test/network/client"
+	"github.com/liqotech/liqo/pkg/liqoctl/test/network/flags"
+)
+
+// RunChecks runs all the checks.
+func RunChecks(ctx context.Context, cl *client.Client, cfg client.Configs, opts *flags.Options, totreplicas int32) error {
+	logger := opts.Topts.LocalFactory.Printer.Logger
+	var successCountTot, errorCountTot int32
+
+	logger.Info("Running checks pod to pod")
+	successCount, errorCount, err := RunChecksPodToPod(ctx, cl, cfg, opts, totreplicas)
+	PrintCheckResults(successCount, errorCount, logger)
+	if err != nil {
+		return fmt.Errorf("failed to run checks pod to pod: %w", err)
+	}
+	successCountTot += successCount
+	errorCountTot += errorCount
+
+	if opts.Basic {
+		return nil
+	}
+
+	logger.Info("Running checks pod to service")
+	successCount, errorCount, err = RunCheckPodToClusterIPService(ctx, cl, cfg, opts, totreplicas)
+	PrintCheckResults(successCount, errorCount, logger)
+	if err != nil {
+		return fmt.Errorf("failed to run checks pod to service: %w", err)
+	}
+	successCountTot += successCount
+	errorCountTot += errorCount
+
+	logger.Info("Running checks node to pod")
+	successCount, errorCount, err = RunChecksNodeToPod(ctx, cl, cfg, opts, totreplicas)
+	PrintCheckResults(successCount, errorCount, logger)
+	if err != nil {
+		return fmt.Errorf("failed to run checks node to pod: %w", err)
+	}
+	successCountTot += successCount
+	errorCountTot += errorCount
+
+	if opts.PodToNodePort {
+		logger.Info("Running checks pod to nodeport")
+		successCount, errorCount, err = RunsCheckPodToNodePortService(ctx, cl, cfg, opts, totreplicas)
+		PrintCheckResults(successCount, errorCount, logger)
+		if err != nil {
+			return fmt.Errorf("failed to run checks pod to nodeport: %w", err)
+		}
+		successCountTot += successCount
+		errorCountTot += errorCount
+	}
+
+	if opts.NodePortExt {
+		logger.Info("Running checks external to nodeport service")
+		successCount, errorCount, err = RunsCheckExternalToNodePortService(ctx, cl, opts, totreplicas)
+		PrintCheckResults(successCount, errorCount, logger)
+		if err != nil {
+			return fmt.Errorf("failed to run checks external to nodeport service: %w", err)
+		}
+		successCountTot += successCount
+		errorCountTot += errorCount
+	}
+
+	if opts.LoadBalancer {
+		logger.Info("Running checks external to loadbalancer service")
+		successCount, errorCount, err = RunsCheckExternalToLoadBalancerService(ctx, cl, opts, totreplicas)
+		PrintCheckResults(successCount, errorCount, logger)
+		if err != nil {
+			return fmt.Errorf("failed to run checks external to loadbalancer service: %w", err)
+		}
+		successCountTot += successCount
+		errorCountTot += errorCount
+	}
+
+	logger.Info("Running checks pod to external")
+	successCount, errorCount, err = RunChecksPodToExternal(ctx, cl, cfg, opts)
+	PrintCheckResults(successCount, errorCount, logger)
+	if err != nil {
+		return fmt.Errorf("failed to run checks pod to external: %w", err)
+	}
+	successCountTot += successCount
+	errorCountTot += errorCount
+
+	if opts.IPRemapping {
+		logger.Info("Running checks pod to external remapped IP")
+		successCount, errorCount, err := RunChecksPodToExternalRemappedIP(ctx, cl, cfg, opts)
+		PrintCheckResults(successCount, errorCount, logger)
+		if err != nil {
+			return fmt.Errorf("failed to run checks pod to external remapped IP: %w", err)
+		}
+		successCountTot += successCount
+		errorCountTot += errorCount
+	}
+
+	logger.Info("All checks completed")
+	PrintCheckResults(successCountTot, errorCountTot, logger)
+
+	return nil
+}
+
+// InitClientSet initializes the clientset.
+func InitClientSet(cfg *rest.Config) (*kubernetes.Clientset, error) {
+	// Create Clientset from Config
+	clientset, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create client: %w", err)
+	}
+	return clientset, nil
+}
+
+// PrintCheckResults prints the check results.
+func PrintCheckResults(successCount, errorCount int32, logger *pterm.Logger) {
+	if successCount > 0 {
+		logger.Info("Checks succeeded", logger.Args("counter", successCount))
+	}
+	if errorCount > 0 {
+		logger.Error("Checks failed", logger.Args("counter", errorCount))
+	}
+}

--- a/pkg/liqoctl/test/network/check/doc.go
+++ b/pkg/liqoctl/test/network/check/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package check contains the check functions to test the network commands.
+package check

--- a/pkg/liqoctl/test/network/check/endpointslices.go
+++ b/pkg/liqoctl/test/network/check/endpointslices.go
@@ -1,0 +1,120 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package check
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	discoveryv1 "k8s.io/api/discovery/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/liqotech/liqo/pkg/liqoctl/test/network/client"
+	"github.com/liqotech/liqo/pkg/liqoctl/test/network/setup"
+)
+
+// Targets ia a map where the key is the name of the producer/consumer
+// and the values are the endpoints from their point of view.
+type Targets map[string][]string
+
+// ForgePodTargets creates a map of targets for the pod-to-pod tests.
+func ForgePodTargets(ctx context.Context, cl *client.Client, totalReplicas int32) (Targets, error) {
+	var target Targets = make(map[string][]string)
+
+	if err := ForgePodTargetForConsumer(ctx, cl, totalReplicas, target); err != nil {
+		return nil, err
+	}
+
+	for k := range cl.Providers {
+		if err := ForgePodTargetForProvider(ctx, cl, k, totalReplicas, target); err != nil {
+			return nil, err
+		}
+	}
+	return target, nil
+}
+
+// ForgePodTargetForProvider creates a target for a specific cluster.
+func ForgePodTargetForProvider(ctx context.Context, cl *client.Client, name string, totalReplicas int32, target Targets) error {
+	eps := discoveryv1.EndpointSliceList{}
+
+	timeout, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	if err := wait.PollUntilContextCancel(timeout, 5*time.Second, true, func(ctx context.Context) (done bool, err error) {
+		if err := cl.Providers[name].List(ctx, &eps,
+			ctrlclient.InNamespace(setup.NamespaceName),
+			ctrlclient.MatchingLabels{
+				"kubernetes.io/service-name": setup.DeploymentName,
+			},
+		); err != nil {
+			return false, err
+		}
+		return len(eps.Items) == 2, nil
+	}); err != nil {
+		if len(eps.Items) != 2 {
+			return fmt.Errorf("%q expected 2 endpoint slice, got %d", name, len(eps.Items))
+		}
+		return fmt.Errorf("error waiting for producer %q endpoint slice: %w", name, err)
+	}
+
+	if len(eps.Items[0].Endpoints)+len(eps.Items[1].Endpoints) != int(totalReplicas) {
+		return fmt.Errorf("%q expected %d endpoints, got %d", name, totalReplicas, len(eps.Items[0].Endpoints)+len(eps.Items[1].Endpoints))
+	}
+
+	target[name] = make([]string, len(eps.Items[0].Endpoints)+len(eps.Items[1].Endpoints))
+	for i := range eps.Items[0].Endpoints {
+		target[name][i] = eps.Items[0].Endpoints[i].Addresses[0]
+	}
+
+	for i := range eps.Items[1].Endpoints {
+		target[name][i+len(eps.Items[0].Endpoints)] = eps.Items[1].Endpoints[i].Addresses[0]
+	}
+	return nil
+}
+
+// ForgePodTargetForConsumer creates a target for the consumer cluster.
+func ForgePodTargetForConsumer(ctx context.Context, cl *client.Client, totalReplicas int32, target Targets) error {
+	eps := discoveryv1.EndpointSliceList{}
+
+	timeout, cancel := context.WithTimeout(ctx, 60*time.Second)
+	defer cancel()
+	if err := wait.PollUntilContextCancel(timeout, 5*time.Second, true, func(ctx context.Context) (done bool, err error) {
+		if err := cl.Consumer.List(ctx, &eps,
+			ctrlclient.InNamespace(setup.NamespaceName),
+			ctrlclient.MatchingLabels{
+				"kubernetes.io/service-name": setup.DeploymentName,
+			},
+		); err != nil {
+			return false, err
+		}
+		return len(eps.Items) == 1, nil
+	}); err != nil {
+		if len(eps.Items) != 1 {
+			return fmt.Errorf("consumer expected 1 endpoint slice, got %d", len(eps.Items))
+		}
+		return fmt.Errorf("error waiting for consumer endpoint slice: %w", err)
+	}
+
+	if len(eps.Items[0].Endpoints) != int(totalReplicas) {
+		return fmt.Errorf("consumer expected %d endpoints, got %d", totalReplicas, len(eps.Items[0].Endpoints))
+	}
+
+	target[cl.ConsumerName] = make([]string, len(eps.Items[0].Endpoints))
+	for i := range eps.Items[0].Endpoints {
+		target[cl.ConsumerName][i] = eps.Items[0].Endpoints[i].Addresses[0]
+	}
+	return nil
+}

--- a/pkg/liqoctl/test/network/check/exec.go
+++ b/pkg/liqoctl/test/network/check/exec.go
@@ -1,0 +1,122 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package check
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/pterm/pterm"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/liqotech/liqo/pkg/liqoctl/test/network/flags"
+	testutils "github.com/liqotech/liqo/pkg/liqoctl/test/utils"
+	podutils "github.com/liqotech/liqo/pkg/liqoctl/utils/pod"
+)
+
+// MaxRetries is the maximum number of retries for the command.
+const MaxRetries = 3
+
+// ExecFunc is the function to execute.
+type ExecFunc func(ctx context.Context, pod *corev1.Pod, clset *kubernetes.Clientset,
+	cfg *rest.Config, quiet bool, endpoint string, logger *pterm.Logger) (ok bool, err error)
+
+// RunCheckToTargets runs the checks to the targets.
+func RunCheckToTargets(ctx context.Context, cl ctrlclient.Client, cfg *rest.Config, opts *flags.Options,
+	owner string, targets []string, hostnetwork bool, execFunc ExecFunc) (successCount, errorCount int32, err error) {
+	logger := opts.Topts.LocalFactory.Printer.Logger
+	pods, err := listPods(ctx, cl, owner, hostnetwork)
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to list pods: %w", err)
+	}
+
+	clset, err := InitClientSet(cfg)
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to initialize clientset: %w", err)
+	}
+	for i := range pods.Items {
+		for j := range targets {
+			ok, err := podutils.TryFor(ctx, MaxRetries, func() (bool, error) {
+				return execFunc(ctx, &pods.Items[i], clset, cfg, !opts.Topts.Verbose, targets[j], logger)
+			})
+			if !ok || err != nil {
+				logger.Error(fmt.Sprintf("Curl command failed after %d retries", MaxRetries), logger.Args(
+					"pod", pods.Items[i].Name, "target", targets[j], "error", err,
+				))
+			}
+			successCount, errorCount, err = testutils.ManageResults(opts.Topts.FailFast, err, ok, successCount, errorCount)
+			if err != nil {
+				return successCount, errorCount, err
+			}
+		}
+	}
+	return successCount, errorCount, nil
+}
+
+// ExecCurl executes a curl command.
+func ExecCurl(ctx context.Context, pod *corev1.Pod, clset *kubernetes.Clientset,
+	cfg *rest.Config, quiet bool, endpoint string, logger *pterm.Logger) (ok bool, err error) {
+	cmd := fmt.Sprintf("curl -k --connect-timeout 1 -I %s", endpoint)
+	stdout, stderr, err := podutils.ExecInPod(ctx, clset, cfg, pod, cmd)
+	if err != nil {
+		return false, fmt.Errorf("failed to execute curl command: %w", err)
+	}
+
+	// Check if the curl command was successful
+	if strings.Contains(stdout, "200 OK") || strings.Contains(stdout, "HTTP/2 200") {
+		if !quiet {
+			logger.Info("Curl command successful", logger.Args(
+				"pod", pod.Name, "target", endpoint,
+			))
+		}
+		return true, nil
+	}
+
+	logger.Warn("Curl command failed", logger.Args(
+		"pod", pod.Name, "target", endpoint, "stderr", stderr, "error", err,
+	))
+
+	return false, nil
+}
+
+// ExecNetcatTCPConnect executes a netcat command.
+func ExecNetcatTCPConnect(ctx context.Context, pod *corev1.Pod,
+	clset *kubernetes.Clientset, cfg *rest.Config, quiet bool, endpoint string, logger *pterm.Logger) (ok bool, err error) {
+	cmd := fmt.Sprintf("nc -z %s 443", endpoint)
+	_, stderr, err := podutils.ExecInPod(ctx, clset, cfg, pod, cmd)
+	if err != nil {
+		return false, fmt.Errorf("failed to execute curl command: %w", err)
+	}
+
+	// Check if the curl command was successful
+	if strings.Contains(stderr, "succeeded") {
+		if !quiet {
+			logger.Info("Netcat connection successful", logger.Args(
+				"pod", pod.Name, "target", endpoint,
+			))
+		}
+		return true, nil
+	}
+
+	logger.Warn("Netcat connection failed", logger.Args(
+		"pod", pod.Name, "target", endpoint, "stderr", stderr, "error", err,
+	))
+
+	return false, nil
+}

--- a/pkg/liqoctl/test/network/check/external.go
+++ b/pkg/liqoctl/test/network/check/external.go
@@ -1,0 +1,51 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package check
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/liqotech/liqo/pkg/liqoctl/test/network/client"
+	"github.com/liqotech/liqo/pkg/liqoctl/test/network/flags"
+)
+
+// RunChecksPodToExternal runs the checks from pod to an external target.
+func RunChecksPodToExternal(ctx context.Context, cl *client.Client,
+	cfg client.Configs, opts *flags.Options) (successCount, errorCount int32, err error) {
+	var successCountTot, errorCountTot int32
+
+	target := []string{"https://liqo.io"}
+
+	successCount, errorCount, err = RunCheckToTargets(ctx, cl.Consumer, cfg[cl.ConsumerName],
+		opts, cl.ConsumerName, target, false, ExecCurl)
+	successCountTot += successCount
+	errorCountTot += errorCount
+	if err != nil {
+		return successCountTot, errorCountTot, fmt.Errorf("consumer failed to run checks: %w", err)
+	}
+
+	for k := range cl.Providers {
+		successCount, errorCount, err := RunCheckToTargets(ctx, cl.Providers[k], cfg[k],
+			opts, k, target, false, ExecCurl)
+		successCountTot += successCount
+		errorCountTot += errorCount
+		if err != nil {
+			return successCountTot, errorCountTot, fmt.Errorf("producer %q failed to run checks: %w", k, err)
+		}
+	}
+
+	return successCountTot, errorCountTot, nil
+}

--- a/pkg/liqoctl/test/network/check/ip.go
+++ b/pkg/liqoctl/test/network/check/ip.go
@@ -1,0 +1,171 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package check
+
+import (
+	"context"
+	"fmt"
+	"net"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientctrl "sigs.k8s.io/controller-runtime/pkg/client"
+
+	ipamv1alpha1 "github.com/liqotech/liqo/apis/ipam/v1alpha1"
+	networkingv1alpha1 "github.com/liqotech/liqo/apis/networking/v1alpha1"
+	"github.com/liqotech/liqo/pkg/consts"
+	"github.com/liqotech/liqo/pkg/liqoctl/test/network/client"
+	"github.com/liqotech/liqo/pkg/liqoctl/test/network/flags"
+	"github.com/liqotech/liqo/pkg/liqoctl/test/network/setup"
+	ipamutils "github.com/liqotech/liqo/pkg/utils/ipam"
+	"github.com/liqotech/liqo/pkg/utils/ipam/mapping"
+)
+
+// RunChecksPodToExternalRemappedIP runs all the checks from the pod to the external remapped IP.
+func RunChecksPodToExternalRemappedIP(ctx context.Context, cl *client.Client,
+	cfg client.Configs, opts *flags.Options) (successCount, errorCount int32, err error) {
+	var successCountTot, errorCountTot int32
+
+	targets, err := ForgeIPTargets(ctx, cl)
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to forge targets: %w", err)
+	}
+
+	successCount, errorCount, err = RunCheckToTargets(ctx, cl.Consumer, cfg[cl.ConsumerName],
+		opts, cl.ConsumerName, targets[cl.ConsumerName], false, ExecNetcatTCPConnect)
+	successCountTot += successCount
+	errorCountTot += errorCount
+	if err != nil {
+		return successCountTot, errorCountTot, fmt.Errorf("consumer failed to run checks: %w", err)
+	}
+
+	for k := range cl.Providers {
+		successCount, errorCount, err := RunCheckToTargets(ctx, cl.Providers[k], cfg[k],
+			opts, k, targets[k], false, ExecNetcatTCPConnect)
+		successCountTot += successCount
+		errorCountTot += errorCount
+		if err != nil {
+			return successCountTot, errorCountTot, fmt.Errorf("producer %q failed to run checks: %w", k, err)
+		}
+	}
+
+	return successCountTot, errorCountTot, nil
+}
+
+// ForgeIPTargets forges the IP targets for the consumer and the providers.
+func ForgeIPTargets(ctx context.Context, cl *client.Client) (Targets, error) {
+	localIPRemapped, err := GetLocalIPRemapped(ctx, cl)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get local IP remapped: %w", err)
+	}
+
+	targets := Targets{}
+
+	targets[cl.ConsumerName], err = forgeIPTarget(ctx, cl.Consumer, localIPRemapped, cl.ConsumerName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to forge consumer IP target: %w", err)
+	}
+
+	for k := range cl.Providers {
+		targets[k], err = forgeIPTarget(ctx, cl.Providers[k], localIPRemapped, k)
+		if err != nil {
+			return nil, fmt.Errorf("failed to forge producer %q IP target: %w", k, err)
+		}
+	}
+
+	return targets, nil
+}
+
+func forgeIPTarget(ctx context.Context, cl clientctrl.Client, localIPRemapped map[string]string, localName string) ([]string, error) {
+	target := []string{
+		localIPRemapped[localName],
+	}
+
+	cfgs := networkingv1alpha1.ConfigurationList{}
+	if err := cl.List(ctx, &cfgs); err != nil {
+		return nil, fmt.Errorf("failed to list configurations: %w", err)
+	}
+
+	for i := range cfgs.Items {
+		if cfgs.Items[i].Labels == nil {
+			continue
+		}
+
+		id, ok := cfgs.Items[i].Labels[consts.RemoteClusterID]
+		if !ok {
+			continue
+		}
+
+		ip, ok := localIPRemapped[id]
+		if !ok {
+			return nil, fmt.Errorf("failed to get IP target for remote cluster %q", id)
+		}
+
+		ipnet := net.ParseIP(ip)
+		if ipnet == nil {
+			return nil, fmt.Errorf("failed to parse IP: %s", ip)
+		}
+
+		_, cidrtarget, err := net.ParseCIDR(cfgs.Items[i].Status.Remote.CIDR.External.String())
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse CIDR: %w", err)
+		}
+
+		needsRemap := !cidrtarget.Contains(net.ParseIP(ip))
+		if !needsRemap {
+			target = append(target, ipnet.String())
+		} else {
+			maskLen, _ := cidrtarget.Mask.Size()
+			mapping.RemapMask(ipnet, *cidrtarget, maskLen)
+			target = append(target, ipnet.String())
+		}
+	}
+	return target, nil
+}
+
+// GetLocalIPRemapped gets the local IP remapped for the consumer and the providers.
+func GetLocalIPRemapped(ctx context.Context, cl *client.Client) (map[string]string, error) {
+	var localIPRemapped = make(map[string]string)
+	ip := ipamv1alpha1.IP{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      setup.IPName,
+			Namespace: setup.IPNamespace,
+		},
+	}
+
+	if err := cl.Consumer.Get(ctx, clientctrl.ObjectKeyFromObject(&ip), &ip); err != nil {
+		return nil, fmt.Errorf("failed to get consumer IP: %w", err)
+	}
+
+	v := ipamutils.GetRemappedIP(&ip)
+	localIPRemapped[cl.ConsumerName] = v.String()
+
+	for providerName := range cl.Providers {
+		ip := ipamv1alpha1.IP{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      setup.IPName,
+				Namespace: setup.IPNamespace,
+			},
+		}
+
+		if err := cl.Providers[providerName].Get(ctx, clientctrl.ObjectKeyFromObject(&ip), &ip); err != nil {
+			return nil, fmt.Errorf("failed to get provider %q IP: %w", providerName, err)
+		}
+
+		v := ipamutils.GetRemappedIP(&ip)
+		localIPRemapped[providerName] = v.String()
+	}
+
+	return localIPRemapped, nil
+}

--- a/pkg/liqoctl/test/network/check/node.go
+++ b/pkg/liqoctl/test/network/check/node.go
@@ -1,0 +1,54 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package check
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/liqotech/liqo/pkg/liqoctl/test/network/client"
+	"github.com/liqotech/liqo/pkg/liqoctl/test/network/flags"
+)
+
+// RunChecksNodeToPod runs the checks from the nodes to the pods.
+func RunChecksNodeToPod(ctx context.Context, cl *client.Client, cfg client.Configs, opts *flags.Options,
+	totreplicas int32) (successCount, errorCount int32, err error) {
+	var successCountTot, errorCountTot int32
+
+	targets, err := ForgePodTargets(ctx, cl, totreplicas)
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to forge targets: %w", err)
+	}
+
+	successCount, errorCount, err = RunCheckToTargets(ctx, cl.Consumer, cfg[cl.ConsumerName],
+		opts, cl.ConsumerName, targets[cl.ConsumerName], true, ExecCurl)
+	if err != nil {
+		return 0, 0, fmt.Errorf("consumer failed to run checks: %w", err)
+	}
+	successCountTot += successCount
+	errorCountTot += errorCount
+
+	for k := range cl.Providers {
+		successCount, errorCount, err := RunCheckToTargets(ctx, cl.Providers[k],
+			cfg[k], opts, k, targets[k], true, ExecCurl)
+		if err != nil {
+			return 0, 0, fmt.Errorf("producer %q failed to run checks: %w", k, err)
+		}
+		successCountTot += successCount
+		errorCountTot += errorCount
+	}
+
+	return successCountTot, errorCountTot, nil
+}

--- a/pkg/liqoctl/test/network/check/pod.go
+++ b/pkg/liqoctl/test/network/check/pod.go
@@ -1,0 +1,54 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package check
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/liqotech/liqo/pkg/liqoctl/test/network/client"
+	"github.com/liqotech/liqo/pkg/liqoctl/test/network/flags"
+)
+
+// RunChecksPodToPod runs the checks from the pods to the pods.
+func RunChecksPodToPod(ctx context.Context, cl *client.Client, cfg client.Configs, opts *flags.Options,
+	totreplicas int32) (successCount, errorCount int32, err error) {
+	var successCountTot, errorCountTot int32
+
+	targets, err := ForgePodTargets(ctx, cl, totreplicas)
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to forge targets: %w", err)
+	}
+
+	successCount, errorCount, err = RunCheckToTargets(ctx, cl.Consumer, cfg[cl.ConsumerName],
+		opts, cl.ConsumerName, targets[cl.ConsumerName], false, ExecCurl)
+	successCountTot += successCount
+	errorCountTot += errorCount
+	if err != nil {
+		return successCountTot, errorCountTot, fmt.Errorf("consumer failed to run checks: %w", err)
+	}
+
+	for k := range cl.Providers {
+		successCount, errorCount, err := RunCheckToTargets(ctx, cl.Providers[k], cfg[k],
+			opts, k, targets[k], false, ExecCurl)
+		successCountTot += successCount
+		errorCountTot += errorCount
+		if err != nil {
+			return successCountTot, errorCountTot, fmt.Errorf("producer %q failed to run checks: %w", k, err)
+		}
+	}
+
+	return successCountTot, errorCountTot, nil
+}

--- a/pkg/liqoctl/test/network/check/service.go
+++ b/pkg/liqoctl/test/network/check/service.go
@@ -1,0 +1,279 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package check
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/liqotech/liqo/pkg/consts"
+	"github.com/liqotech/liqo/pkg/liqoctl/test/network/client"
+	"github.com/liqotech/liqo/pkg/liqoctl/test/network/flags"
+	"github.com/liqotech/liqo/pkg/liqoctl/test/network/setup"
+	"github.com/liqotech/liqo/pkg/liqoctl/test/utils"
+)
+
+var preferOrder = []corev1.NodeAddressType{
+	corev1.NodeExternalDNS,
+	corev1.NodeExternalIP,
+	corev1.NodeInternalDNS,
+	corev1.NodeInternalIP,
+	corev1.NodeHostName,
+}
+
+// GetNodeAddress returns the address of the node.
+func GetNodeAddress(node *corev1.Node) string {
+	for _, addrType := range preferOrder {
+		for _, addr := range node.Status.Addresses {
+			if addr.Type == addrType {
+				return addr.Address
+			}
+		}
+	}
+	return ""
+}
+
+// RunCheckPodToClusterIPService runs all the checks from the pod to the cluster IP service.
+func RunCheckPodToClusterIPService(ctx context.Context, cl *client.Client, cfg client.Configs, opts *flags.Options,
+	totreplicas int32) (successCount, errorCount int32, err error) {
+	var successCountTot, errorCountTot int32
+
+	svcName := fmt.Sprintf("%s.%s", setup.DeploymentName, setup.NamespaceName)
+
+	for i := 0; i < int(totreplicas*2); i++ {
+		successCount, errorCount, err = RunCheckToTargets(ctx, cl.Consumer, cfg[cl.ConsumerName],
+			opts, cl.ConsumerName, []string{svcName}, false, ExecCurl)
+		successCountTot += successCount
+		errorCountTot += errorCount
+		if err != nil {
+			return successCountTot, errorCountTot, fmt.Errorf("consumer failed to run checks: %w", err)
+		}
+	}
+
+	for k := range cl.Providers {
+		// The test is repeated twice for each producer and consumer pods.
+		// This is to ensure that all pods have been contacted from each other pods through the service.
+		for i := 0; i < int(totreplicas*2); i++ {
+			successCount, errorCount, err := RunCheckToTargets(ctx, cl.Providers[k], cfg[k],
+				opts, k, []string{svcName}, false, ExecCurl)
+			successCountTot += successCount
+			errorCountTot += errorCount
+			if err != nil {
+				return successCountTot, errorCountTot, fmt.Errorf("producer %q failed to run checks: %w", k, err)
+			}
+		}
+	}
+
+	return successCountTot, errorCountTot, nil
+}
+
+// RunCheckExternalToNodePortServiceWithClient runs all the checks from the external to the node port service.
+func RunCheckExternalToNodePortServiceWithClient(ctx context.Context, cl ctrlclient.Client,
+	opts *flags.Options, totreplicas int32, httpclient *client.HTTPClient) (successCount, errorCount int32, err error) {
+	svcnp := corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: setup.DeploymentName + "np", Namespace: setup.NamespaceName},
+	}
+
+	if err := cl.Get(ctx, ctrlclient.ObjectKeyFromObject(&svcnp), &svcnp); err != nil {
+		return 0, 0, fmt.Errorf("failed to get service: %w", err)
+	}
+
+	nodeport := svcnp.Spec.Ports[0].NodePort
+
+	nodes := corev1.NodeList{}
+	if err := cl.List(ctx, &nodes); err != nil {
+		return 0, 0, fmt.Errorf("failed to list nodes: %w", err)
+	}
+
+	for i := 0; i < int(totreplicas*2); i++ {
+		for i := range nodes.Items {
+			if nodes.Items[i].GetLabels()[consts.TypeLabel] == consts.TypeNode {
+				continue
+			}
+			if opts.NodePortNodes == flags.NodePortNodesWorkers && setup.IsNodeControlPlane(nodes.Items[i].Spec.Taints) {
+				continue
+			}
+			nodeip := GetNodeAddress(&nodes.Items[i])
+			ok, err := httpclient.Curl(ctx, fmt.Sprintf("http://%s:%d", nodeip, nodeport), !opts.Topts.Verbose, opts.Topts.LocalFactory.Printer.Logger)
+			successCount, errorCount, err = utils.ManageResults(opts.Topts.FailFast, err, ok, successCount, errorCount)
+			if err != nil {
+				return successCount, errorCount, err
+			}
+		}
+	}
+	return successCount, errorCount, nil
+}
+
+// RunsCheckExternalToNodePortService runs all the checks from the external to the node port service.
+func RunsCheckExternalToNodePortService(ctx context.Context, cl *client.Client, opts *flags.Options,
+	totreplicas int32) (successCountTot, errorCountTot int32, err error) {
+	httpclient := client.NewHTTPClient(time.Second * 5)
+
+	successCount, errorCount, err := RunCheckExternalToNodePortServiceWithClient(ctx, cl.Consumer, opts, totreplicas, httpclient)
+	successCountTot += successCount
+	errorCountTot += errorCount
+	if err != nil {
+		return successCount, errorCount, fmt.Errorf("consumer failed to run checks: %w", err)
+	}
+	for k := range cl.Providers {
+		successCount, errorCount, err = RunCheckExternalToNodePortServiceWithClient(ctx, cl.Providers[k], opts, totreplicas, httpclient)
+		successCountTot += successCount
+		errorCountTot += errorCount
+		if err != nil {
+			return successCount, errorCount, fmt.Errorf("producer %q failed to run checks: %w", k, err)
+		}
+	}
+
+	return successCountTot, errorCountTot, nil
+}
+
+// RunsCheckExternalToLoadBalancerServiceWithClient runs all the checks from the external to the load balancer service.
+func RunsCheckExternalToLoadBalancerServiceWithClient(ctx context.Context, cl ctrlclient.Client,
+	opts *flags.Options, httpclient *client.HTTPClient, totreplicas int32) (successCount, errorCount int32, err error) {
+	svclb := corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: setup.DeploymentName + "lb", Namespace: setup.NamespaceName},
+	}
+
+	var lbip string
+	timeout, cancel := context.WithTimeout(ctx, 3*time.Minute)
+	defer cancel()
+	if err = wait.PollUntilContextCancel(timeout, time.Second*5, true, func(ctx context.Context) (bool, error) {
+		if err := cl.Get(ctx, ctrlclient.ObjectKeyFromObject(&svclb), &svclb); err != nil {
+			return false, err
+		}
+		if len(svclb.Status.LoadBalancer.Ingress) == 0 {
+			return false, nil
+		}
+		lbip = svclb.Status.LoadBalancer.Ingress[0].IP
+		if lbip == "" {
+			lbip = svclb.Status.LoadBalancer.Ingress[0].Hostname
+			if lbip == "" {
+				return false, nil
+			}
+			hosts, err := net.LookupIP(lbip)
+			if err != nil {
+				return false, nil
+			}
+			return len(hosts) > 0, nil
+		}
+		return true, nil
+	}); err != nil {
+		return 0, 0, fmt.Errorf("failed to get load balancer IP: %w", err)
+	}
+
+	for i := 0; i < int(totreplicas*2); i++ {
+		ok, err := httpclient.Curl(ctx, fmt.Sprintf("http://%s", lbip), !opts.Topts.Verbose, opts.Topts.LocalFactory.Printer.Logger)
+		successCount, errorCount, err = utils.ManageResults(opts.Topts.FailFast, err, ok, successCount, errorCount)
+		if err != nil {
+			return successCount, errorCount, err
+		}
+	}
+
+	return successCount, errorCount, nil
+}
+
+// RunsCheckExternalToLoadBalancerService runs all the checks from the external to the load balancer service.
+func RunsCheckExternalToLoadBalancerService(ctx context.Context, cl *client.Client, opts *flags.Options,
+	totreplicas int32) (successCountTot, errorCountTot int32, err error) {
+	httpclient := client.NewHTTPClient(time.Second * 5)
+
+	successCount, errorCount, err := RunsCheckExternalToLoadBalancerServiceWithClient(ctx, cl.Consumer, opts, httpclient, totreplicas)
+	successCountTot += successCount
+	errorCountTot += errorCount
+	if err != nil {
+		return successCount, errorCount, fmt.Errorf("consumer failed to run checks: %w", err)
+	}
+
+	for k := range cl.Providers {
+		successCount, errorCount, err = RunsCheckExternalToLoadBalancerServiceWithClient(ctx, cl.Providers[k], opts, httpclient, totreplicas)
+		successCountTot += successCount
+		errorCountTot += errorCount
+		if err != nil {
+			return successCount, errorCount, fmt.Errorf("producer %q failed to run checks: %w", k, err)
+		}
+	}
+
+	return successCountTot, errorCountTot, nil
+}
+
+// RunsCheckPodToNodePortService runs all the checks from the pod to the node port service.
+func RunsCheckPodToNodePortService(ctx context.Context, cl *client.Client, cfg client.Configs, opts *flags.Options,
+	totreplicas int32) (successCountTot, errorCountTot int32, err error) {
+	successCount, errorCount, err := RunsCheckPodToNodePortServiceWithClient(ctx, cl.Consumer, cfg, opts, totreplicas, cl.ConsumerName)
+	successCountTot += successCount
+	errorCountTot += errorCount
+	if err != nil {
+		return successCount, errorCount, fmt.Errorf("consumer failed to run checks: %w", err)
+	}
+
+	for k := range cl.Providers {
+		successCount, errorCount, err = RunsCheckPodToNodePortServiceWithClient(ctx, cl.Providers[k], cfg, opts, totreplicas, k)
+		successCountTot += successCount
+		errorCountTot += errorCount
+		if err != nil {
+			return successCount, errorCount, fmt.Errorf("producer %q failed to run checks: %w", k, err)
+		}
+	}
+
+	return successCountTot, errorCountTot, nil
+}
+
+// RunsCheckPodToNodePortServiceWithClient runs all the checks from the pod to the node port service.
+func RunsCheckPodToNodePortServiceWithClient(ctx context.Context, cl ctrlclient.Client, cfg client.Configs, opts *flags.Options,
+	totreplicas int32, name string) (successCount, errorCount int32, err error) {
+	svcnp := corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: setup.DeploymentName + "np", Namespace: setup.NamespaceName},
+	}
+
+	if err := cl.Get(ctx, ctrlclient.ObjectKeyFromObject(&svcnp), &svcnp); err != nil {
+		return 0, 0, fmt.Errorf("failed to get service: %w", err)
+	}
+
+	nodeport := svcnp.Spec.Ports[0].NodePort
+
+	nodes := corev1.NodeList{}
+	if err := cl.List(ctx, &nodes); err != nil {
+		return 0, 0, fmt.Errorf("failed to list nodes: %w", err)
+	}
+
+	var successCountTot, errorCountTot int32
+	for i := 0; i < int(totreplicas*2); i++ {
+		for i := range nodes.Items {
+			if nodes.Items[i].GetLabels()[consts.TypeLabel] == consts.TypeNode {
+				continue
+			}
+			if opts.NodePortNodes == "workers" && setup.IsNodeControlPlane(nodes.Items[i].Spec.Taints) {
+				continue
+			}
+			nodeip := GetNodeAddress(&nodes.Items[i])
+			successCount, errorCount, err = RunCheckToTargets(ctx, cl, cfg[name],
+				opts, name, []string{fmt.Sprintf("http://%s:%d", nodeip, nodeport)}, false, ExecCurl)
+			successCountTot += successCount
+			errorCountTot += errorCount
+			if err != nil {
+				return successCountTot, errorCountTot, fmt.Errorf("consumer failed to run checks: %w", err)
+			}
+		}
+	}
+
+	return successCountTot, errorCountTot, nil
+}

--- a/pkg/liqoctl/test/network/check/utils.go
+++ b/pkg/liqoctl/test/network/check/utils.go
@@ -1,0 +1,41 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package check
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/liqotech/liqo/pkg/liqoctl/test/network/setup"
+)
+
+// listPods lists the pods.
+func listPods(ctx context.Context, cl ctrlclient.Client, owner string, hostnetwork bool) (*corev1.PodList, error) {
+	deploymentName := setup.DeploymentName
+	if hostnetwork {
+		deploymentName = setup.DeploymentName + "-host"
+	}
+	pods := corev1.PodList{}
+	if err := cl.List(ctx, &pods,
+		ctrlclient.InNamespace(setup.NamespaceName),
+		ctrlclient.MatchingLabels{setup.PodLabelAppCluster: deploymentName + "-" + owner},
+	); err != nil {
+		return nil, fmt.Errorf("failed to list pods: %w", err)
+	}
+	return &pods, nil
+}

--- a/pkg/liqoctl/test/network/client/doc.go
+++ b/pkg/liqoctl/test/network/client/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package client contains the functions to initialize clients for the tests.
+package client

--- a/pkg/liqoctl/test/network/client/http.go
+++ b/pkg/liqoctl/test/network/client/http.go
@@ -1,0 +1,72 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/pterm/pterm"
+)
+
+// HTTPClient struct to handle http requests.
+type HTTPClient struct {
+	Client *http.Client
+}
+
+// NewHTTPClient creates a new HttpClient with a specified timeout.
+func NewHTTPClient(timeout time.Duration) *HTTPClient {
+	return &HTTPClient{
+		Client: &http.Client{
+			Timeout: timeout,
+		},
+	}
+}
+
+// Curl executes a curl command to the specified target.
+func (hc *HTTPClient) Curl(ctx context.Context, url string, quiet bool, logger *pterm.Logger) (ok bool, err error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", url, http.NoBody)
+	if err != nil {
+		logger.Warn("Failed to create HTTP request", logger.Args(
+			"target", url, "error", err.Error(),
+		))
+		return false, fmt.Errorf("failed to create HTTP request: %w", err)
+	}
+
+	resp, err := hc.Client.Do(req)
+	if err != nil {
+		logger.Warn("Curl command failed", logger.Args(
+			"target", url, "error", err.Error(),
+		))
+		return false, fmt.Errorf("failed to execute curl command: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusOK {
+		if !quiet {
+			logger.Info("Curl command successful", logger.Args(
+				"target", url,
+			))
+		}
+		return true, nil
+	}
+	logger.Warn("Curl command failed", logger.Args(
+		"target", url,
+	))
+
+	return false, nil
+}

--- a/pkg/liqoctl/test/network/client/k8s.go
+++ b/pkg/liqoctl/test/network/client/k8s.go
@@ -1,0 +1,115 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"context"
+
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/liqotech/liqo/pkg/liqoctl/test/network/flags"
+	"github.com/liqotech/liqo/pkg/utils"
+)
+
+// Client is a struct that contains all the k8s clients used in tests.
+type Client struct {
+	Consumer        client.Client
+	ConsumerName    string
+	ConsumerDynamic *dynamic.DynamicClient
+	// Providers key is the name of the producer kubeconfig file.
+	Providers map[string]client.Client
+	// ProvidersDynamic key is the name of the producer kubeconfig file.
+	ProvidersDynamic map[string]*dynamic.DynamicClient
+}
+
+// Configs is a map that contains the rest configuration for each client.
+type Configs map[string]*rest.Config
+
+// NewClient returns a new Client struct.
+func NewClient(ctx context.Context, opts *flags.Options) (*Client, Configs, error) {
+	var cl Client
+	cfg := Configs{}
+
+	if err := initConfigAndClient(ctx, "", &cl, cfg, opts); err != nil {
+		return nil, nil, err
+	}
+
+	for _, kubeconfig := range opts.RemoteKubeconfigs {
+		if err := initConfigAndClient(ctx, kubeconfig, &cl, cfg, opts); err != nil {
+			return nil, nil, err
+		}
+	}
+
+	return &cl, cfg, nil
+}
+
+func initConfigAndClient(ctx context.Context, kubeconfig string, cl *Client, cfg Configs, opts *flags.Options) error {
+	var err error
+	var cfgtmp *rest.Config
+	var cltmp client.Client
+	var cldyntmp *dynamic.DynamicClient
+	if kubeconfig == "" {
+		cfgtmp = opts.Topts.LocalFactory.RESTConfig
+		cltmp = opts.Topts.LocalFactory.CRClient
+		cldyntmp, err = dynamic.NewForConfig(cfgtmp)
+		if err != nil {
+			return err
+		}
+	} else {
+		cfgtmp, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
+		if err != nil {
+			return err
+		}
+		cltmp, err = client.New(cfgtmp, client.Options{
+			Scheme: opts.Topts.LocalFactory.CRClient.Scheme(),
+		})
+		if err != nil {
+			return err
+		}
+		cldyntmp, err = dynamic.NewForConfig(cfgtmp)
+		if err != nil {
+			return err
+		}
+	}
+
+	name, err := utils.GetClusterIDWithControllerClient(ctx, cltmp, opts.Topts.LocalFactory.LiqoNamespace)
+	if err != nil {
+		return err
+	}
+
+	sname := string(name)
+
+	cfg[sname] = cfgtmp
+	if cl.ConsumerName == "" {
+		cl.ConsumerName = sname
+		cl.Consumer = cltmp
+		cl.ConsumerDynamic = cldyntmp
+	} else {
+		if cl.Providers == nil {
+			cl.Providers = make(map[string]client.Client)
+		}
+		cl.Providers[sname] = cltmp
+
+		if cl.ProvidersDynamic == nil {
+			cl.ProvidersDynamic = make(map[string]*dynamic.DynamicClient)
+		}
+		cl.ProvidersDynamic[sname] = cldyntmp
+	}
+
+	return err
+}

--- a/pkg/liqoctl/test/network/doc.go
+++ b/pkg/liqoctl/test/network/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package network contains the logic to launch network E2E tests.
+package network

--- a/pkg/liqoctl/test/network/flags/doc.go
+++ b/pkg/liqoctl/test/network/flags/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package flags contains the flags used by the network commands.
+package flags

--- a/pkg/liqoctl/test/network/flags/flags.go
+++ b/pkg/liqoctl/test/network/flags/flags.go
@@ -1,0 +1,56 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package flags
+
+import (
+	"github.com/spf13/pflag"
+)
+
+// FlagNames defines the names of the flags used by the network tests.
+type FlagNames string
+
+const (
+	// FlagNamesProducersKubeconfigs is the flag name for the kubeconfigs of the remote clusters.
+	FlagNamesProducersKubeconfigs FlagNames = "remote-kubeconfigs"
+	// FlagNamesInfo is the flag name for the information output.
+	FlagNamesInfo FlagNames = "info"
+	// FlagNamesRemoveNamespace is the flag name for the namespace removal.
+	FlagNamesRemoveNamespace FlagNames = "rm"
+	// FlagNamesNodeportExternal is the flag that enables curl from external to nodeport service.
+	FlagNamesNodeportExternal FlagNames = "np-ext"
+	// FlagNamesNodeportNodes is the flag that selects nodes type for NodePort tests.
+	FlagNamesNodeportNodes FlagNames = "np-nodes"
+	// FlagNamesLoadbalancer is the flag that enables curl from external to loadbalancer service.
+	FlagNamesLoadbalancer FlagNames = "lb"
+	// FlagNamesBasic is the flag that runs only pod-to-pod checks.
+	FlagNamesBasic FlagNames = "basic"
+	// FlagNamesPodNodeport is the flag that enables curl from pod to nodeport service.
+	FlagNamesPodNodeport FlagNames = "pod-np"
+	// FlagNamesIP is the flag that enables IP remapping for the tests.
+	FlagNamesIP FlagNames = "ip"
+)
+
+// AddFlags adds the flags used by the network tests to the given flag set.
+func (o *Options) AddFlags(fs *pflag.FlagSet) {
+	fs.StringSliceVarP(&o.RemoteKubeconfigs, string(FlagNamesProducersKubeconfigs), "p", []string{}, "A list of kubeconfigs for remote provider clusters")
+	fs.BoolVar(&o.RemoveNamespace, string(FlagNamesRemoveNamespace), false, "Remove namespace after the test")
+	fs.BoolVar(&o.Info, string(FlagNamesInfo), false, "Print information about the network configurations of the clusters")
+	fs.BoolVar(&o.NodePortExt, string(FlagNamesNodeportExternal), false, "Enable curl from external to nodeport service")
+	fs.Var(&o.NodePortNodes, string(FlagNamesNodeportNodes), "Select nodes type for NodePort tests. Possible values: all, workers")
+	fs.BoolVar(&o.LoadBalancer, string(FlagNamesLoadbalancer), false, "Enable curl from external to loadbalancer service")
+	fs.BoolVar(&o.Basic, string(FlagNamesBasic), false, "Run only pod-to-pod checks")
+	fs.BoolVar(&o.PodToNodePort, string(FlagNamesPodNodeport), false, "Enable curl from pod to nodeport service")
+	fs.BoolVar(&o.IPRemapping, string(FlagNamesIP), false, "Enable IP remapping for the tests")
+}

--- a/pkg/liqoctl/test/network/flags/options.go
+++ b/pkg/liqoctl/test/network/flags/options.go
@@ -1,0 +1,94 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package flags
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/liqotech/liqo/pkg/liqoctl/test"
+)
+
+// NodePortNodes represents the type of nodes to target in NodePort tests.
+type NodePortNodes string
+
+const (
+	// NodePortNodesAll represents the value to target all nodes.
+	NodePortNodesAll NodePortNodes = "all"
+	// NodePortNodesWorkers represents the value to target worker nodes.
+	NodePortNodesWorkers NodePortNodes = "workers"
+)
+
+// NodePortNodesValues contains the possible values for NodePortNodes.
+var NodePortNodesValues = []string{
+	string(NodePortNodesAll),
+	string(NodePortNodesWorkers),
+}
+
+// String returns the string representation of the NodePortNodes.
+func (npn *NodePortNodes) String() string {
+	return string(*npn)
+}
+
+// Set sets the NodePortNodes value.
+func (npn *NodePortNodes) Set(s string) error {
+	if s != "" && s != string(NodePortNodesAll) && s != string(NodePortNodesWorkers) {
+		return fmt.Errorf("valid values are %s", strings.Join(NodePortNodesValues, ","))
+	}
+	if s == "" {
+		*npn = NodePortNodesAll
+		return nil
+	}
+	*npn = NodePortNodes(s)
+	return nil
+}
+
+// Type returns the enum type.
+func (npn *NodePortNodes) Type() string {
+	return "string"
+}
+
+// NewOptions returns a new Options struct.
+func NewOptions(topts *test.Options) *Options {
+	return &Options{
+		Topts:         topts,
+		NodePortNodes: NodePortNodesAll,
+	}
+}
+
+// Options contains the options for the network tests.
+type Options struct {
+	Topts *test.Options
+
+	RemoteKubeconfigs []string
+	Info              bool
+	RemoveNamespace   bool
+
+	// Basic
+	Basic bool
+	// Enable curl from external to nodeport service
+	NodePortExt bool
+	// Select nodes type for NodePort tests.
+	// It has 2 possible values:
+	// all: curl from all nodes
+	// workers: curl from worker nodes
+	NodePortNodes NodePortNodes
+	// Enable curl from external to loadbalancer service
+	LoadBalancer bool
+	// PodToNodePort
+	PodToNodePort bool
+	// IpRemapping
+	IPRemapping bool
+}

--- a/pkg/liqoctl/test/network/handler.go
+++ b/pkg/liqoctl/test/network/handler.go
@@ -1,0 +1,77 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package network
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/liqotech/liqo/pkg/liqoctl/test/network/check"
+	"github.com/liqotech/liqo/pkg/liqoctl/test/network/client"
+	"github.com/liqotech/liqo/pkg/liqoctl/test/network/flags"
+	"github.com/liqotech/liqo/pkg/liqoctl/test/network/info"
+	"github.com/liqotech/liqo/pkg/liqoctl/test/network/setup"
+)
+
+// Options contains the options for the network tests.
+type Options struct {
+	Nopts *flags.Options
+}
+
+// NewOptions creates a new Options instance.
+func NewOptions(o *flags.Options) *Options {
+	return &Options{
+		Nopts: o,
+	}
+}
+
+// RunNetworkTest runs the E2E tests.
+func (o *Options) RunNetworkTest(ctx context.Context) error {
+	printer := o.Nopts.Topts.LocalFactory.Printer
+
+	printer.Logger.Info("Initializing client")
+	cl, cfg, err := client.NewClient(ctx, o.Nopts)
+	if err != nil {
+		return fmt.Errorf("cannot create client: %w", err)
+	}
+	printer.Logger.Info("Client initialized")
+
+	if o.Nopts.Info {
+		if err := info.Info(ctx, cl, printer.Table); err != nil {
+			return fmt.Errorf("error getting info: %w", err)
+		}
+	}
+
+	printer.Logger.Info("Setting up infrastructure")
+	totreplicas, err := setup.MakeInfrastructure(ctx, cl, o.Nopts)
+	if err != nil {
+		return fmt.Errorf("error setting up infrastructure: %w", err)
+	}
+	printer.Logger.Info("Infrastructure set up")
+
+	if err := check.RunChecks(ctx, cl, cfg, o.Nopts, totreplicas); err != nil {
+		return fmt.Errorf("error running checks: %w", err)
+	}
+
+	if o.Nopts.RemoveNamespace {
+		printer.Logger.Info("Removing namespace")
+		if err := setup.RemoveNamespace(ctx, cl); err != nil {
+			return fmt.Errorf("error removing namespace: %w", err)
+		}
+		printer.Logger.Info("Namespace removed")
+	}
+
+	return nil
+}

--- a/pkg/liqoctl/test/network/info/doc.go
+++ b/pkg/liqoctl/test/network/info/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package info contains the logic to get info in network E2E tests.
+package info

--- a/pkg/liqoctl/test/network/info/info.go
+++ b/pkg/liqoctl/test/network/info/info.go
@@ -1,0 +1,87 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package info
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pterm/pterm"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	networkingv1alpha1 "github.com/liqotech/liqo/apis/networking/v1alpha1"
+	"github.com/liqotech/liqo/pkg/liqoctl/test/network/client"
+)
+
+// Info prints the configurations of the clusters.
+func Info(ctx context.Context, cl *client.Client, table *pterm.TablePrinter) error {
+	pterm.Println("")
+	pterm.NewStyle(pterm.FgMagenta, pterm.Bold).Printfln("Cluster %q configurations", cl.ConsumerName)
+	if err := PrintConfigurations(ctx, cl.Consumer, table); err != nil {
+		return fmt.Errorf("error printing configurations for consumer: %w", err)
+	}
+	for k := range cl.Providers {
+		pterm.Println("")
+		pterm.NewStyle(pterm.FgMagenta, pterm.Bold).Printfln("Cluster %q configurations", k)
+		if err := PrintConfigurations(ctx, cl.Providers[k], table); err != nil {
+			return fmt.Errorf("error printing configuration for provider %q: %w", k, err)
+		}
+	}
+	pterm.Println("")
+	return nil
+}
+
+// ForgeTableData creates a table data.
+func ForgeTableData() pterm.TableData {
+	return pterm.TableData{
+		{"Cluster", "Pod CIDR", "Pod CIDR remap", "External CIDR", "External CIDR remap"},
+	}
+}
+
+// PrintConfigurations prints the configurations of the clusters.
+func PrintConfigurations(ctx context.Context, cl ctrlclient.Client, table *pterm.TablePrinter) error {
+	td := ForgeTableData()
+	cfglist := networkingv1alpha1.ConfigurationList{}
+	if err := cl.List(ctx, &cfglist); err != nil {
+		return err
+	}
+	td = AppendLocalConfigurationTableData(&cfglist.Items[0], td)
+	for i := range cfglist.Items {
+		td = AppendRemoteConfigurationTableData(&cfglist.Items[i], td)
+	}
+	if err := table.WithData(td).Render(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// AppendLocalConfigurationTableData appends the local configuration to the table data.
+func AppendLocalConfigurationTableData(cfg *networkingv1alpha1.Configuration, td pterm.TableData) pterm.TableData {
+	return append(td, []string{
+		"local",
+		cfg.Spec.Local.CIDR.Pod.String(), "N/R",
+		cfg.Spec.Local.CIDR.External.String(), "N/R",
+	})
+}
+
+// AppendRemoteConfigurationTableData appends the remote configuration to the table data.
+func AppendRemoteConfigurationTableData(cfg *networkingv1alpha1.Configuration, td pterm.TableData) pterm.TableData {
+	return append(td, []string{
+		cfg.Name,
+		cfg.Spec.Remote.CIDR.Pod.String(), cfg.Status.Remote.CIDR.Pod.String(),
+		cfg.Spec.Remote.CIDR.External.String(), cfg.Status.Remote.CIDR.External.String(),
+	})
+}

--- a/pkg/liqoctl/test/network/setup/const.go
+++ b/pkg/liqoctl/test/network/setup/const.go
@@ -1,0 +1,29 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package setup
+
+const (
+	// NamespaceName is the namespace where the test resources are created.
+	NamespaceName = "liqo-network-test"
+	// DeploymentName is the name of the deployment used for the tests.
+	DeploymentName = "netshoot"
+	// ControlPlaneTaintKey is the key of the taint applied to the control plane nodes.
+	ControlPlaneTaintKey = "node-role.kubernetes.io/control-plane"
+
+	// PodLabelApp is the label key used to identify the pods created by the test.
+	PodLabelApp = "app"
+	// PodLabelAppCluster is the label key used to identify the pods created by the test.
+	PodLabelAppCluster = "app-cluster"
+)

--- a/pkg/liqoctl/test/network/setup/deployment.go
+++ b/pkg/liqoctl/test/network/setup/deployment.go
@@ -1,0 +1,140 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package setup
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/liqotech/liqo/pkg/consts"
+	"github.com/liqotech/liqo/pkg/liqoctl/test/network/client"
+)
+
+// CreateAllDeployments creates all the deployments.
+func CreateAllDeployments(ctx context.Context, cl *client.Client) (totreplicas int32, err error) {
+	replicas, err := getReplicas(ctx, cl.Consumer)
+	if err != nil {
+		return 0, fmt.Errorf("consumer error getting replicas: %w", err)
+	}
+	totreplicas += replicas
+	if err := CreateDeployment(ctx, cl.Consumer, replicas, cl.ConsumerName, false); err != nil {
+		return 0, fmt.Errorf("consumer error creating deployment: %w", err)
+	}
+	if err := CreateDeployment(ctx, cl.Consumer, replicas, cl.ConsumerName, true); err != nil {
+		return 0, fmt.Errorf("consumer error creating deployment: %w", err)
+	}
+	for k := range cl.Providers {
+		replicas, err := getReplicas(ctx, cl.Providers[k])
+		if err != nil {
+			return 0, fmt.Errorf("producer %q error getting replicas: %w", k, err)
+		}
+		totreplicas += replicas
+		if err := CreateDeployment(ctx, cl.Consumer, replicas, k, false); err != nil {
+			return 0, fmt.Errorf("producer %q error creating deployment: %w", k, err)
+		}
+		if err := CreateDeployment(ctx, cl.Consumer, replicas, k, true); err != nil {
+			return 0, fmt.Errorf("consumer error creating deployment: %w", err)
+		}
+	}
+
+	if err := WaitDeploymentReady(ctx, cl.Consumer, cl.ConsumerName, false); err != nil {
+		return 0, fmt.Errorf("consumer error waiting for deployments to be ready: %w", err)
+	}
+	if err := WaitDeploymentReady(ctx, cl.Consumer, cl.ConsumerName, true); err != nil {
+		return 0, fmt.Errorf("consumer error waiting for deployments to be ready: %w", err)
+	}
+	for k := range cl.Providers {
+		if err := WaitDeploymentReady(ctx, cl.Consumer, k, false); err != nil {
+			return 0, fmt.Errorf("producer %q error waiting for deployments to be ready: %w", k, err)
+		}
+		if err := WaitDeploymentReady(ctx, cl.Consumer, k, true); err != nil {
+			return 0, fmt.Errorf("producer %q error waiting for deployments to be ready: %w", k, err)
+		}
+	}
+	return totreplicas, nil
+}
+
+// CreateDeployment creates a deployment.
+func CreateDeployment(ctx context.Context, cl ctrlclient.Client, replicas int32, suffix string, hostnetwork bool) error {
+	deploymentName := DeploymentName
+	ports := []corev1.ContainerPort{{ContainerPort: 80}}
+	if hostnetwork {
+		deploymentName = DeploymentName + "-host"
+		ports = []corev1.ContainerPort{}
+	}
+	dp := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      deploymentName + "-" + suffix,
+			Namespace: NamespaceName,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{
+				PodLabelAppCluster: deploymentName + "-" + suffix,
+			}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						PodLabelApp:        deploymentName,
+						PodLabelAppCluster: deploymentName + "-" + suffix,
+					},
+				},
+				Spec: corev1.PodSpec{
+					HostNetwork: hostnetwork,
+					Containers: []corev1.Container{
+						{
+							Name:    "netshoot",
+							Image:   "nicolaka/netshoot",
+							Command: []string{"python3", "-m", "http.server", "80"},
+							Ports:   ports},
+					},
+					NodeSelector: map[string]string{consts.RemoteClusterID: suffix},
+				},
+			},
+		},
+	}
+	if err := cl.Create(ctx, dp); err != nil && ctrlclient.IgnoreAlreadyExists(err) != nil {
+		return err
+	}
+	return nil
+}
+
+// WaitDeploymentReady waits for the deployment to be ready.
+func WaitDeploymentReady(ctx context.Context, cl ctrlclient.Client, suffix string, hostnetwork bool) error {
+	deploymentName := DeploymentName
+	if hostnetwork {
+		deploymentName = DeploymentName + "-host"
+	}
+	if err := wait.PollUntilContextCancel(ctx, time.Second*2, true, func(ctx context.Context) (done bool, err error) {
+		dp := &appsv1.Deployment{}
+		if err := cl.Get(ctx, ctrlclient.ObjectKey{Namespace: NamespaceName, Name: deploymentName + "-" + suffix}, dp); err != nil {
+			return false, err
+		}
+		if dp.Status.ReadyReplicas == *dp.Spec.Replicas {
+			return true, nil
+		}
+		return false, nil
+	}); err != nil {
+		return fmt.Errorf("error waiting for deployment to be ready: %w", err)
+	}
+	return nil
+}

--- a/pkg/liqoctl/test/network/setup/doc.go
+++ b/pkg/liqoctl/test/network/setup/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package setup contains the logic to setup network E2E tests.
+package setup

--- a/pkg/liqoctl/test/network/setup/ip.go
+++ b/pkg/liqoctl/test/network/setup/ip.go
@@ -1,0 +1,96 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package setup
+
+import (
+	"context"
+	"net"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/utils/ptr"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	ipamv1alpha1 "github.com/liqotech/liqo/apis/ipam/v1alpha1"
+	networkingv1alpha1 "github.com/liqotech/liqo/apis/networking/v1alpha1"
+	"github.com/liqotech/liqo/pkg/liqo-controller-manager/networking/external-network/remapping"
+	"github.com/liqotech/liqo/pkg/liqoctl/test/network/client"
+)
+
+const (
+	// IPName is the name of the IP resource.
+	IPName = "external-ip"
+	// IPNamespace is the namespace of the IP resource.
+	IPNamespace = "default"
+	// ExternalURL is the external URL to use for the IP.
+	ExternalURL = "liqo.io"
+)
+
+// CreateAllIP creates all the IP resources.
+func CreateAllIP(ctx context.Context, cl *client.Client) error {
+	dstips, err := net.LookupHost(ExternalURL)
+	if err != nil {
+		return err
+	}
+	dstip := dstips[0]
+	if err := CreateIP(ctx, cl.Consumer, dstip); err != nil {
+		return err
+	}
+	for k := range cl.Providers {
+		if err := CreateIP(ctx, cl.Providers[k], dstip); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// CreateIP creates an IP resource.
+func CreateIP(ctx context.Context, cl ctrlclient.Client, dstip string) error {
+	ip := ipamv1alpha1.IP{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      IPName,
+			Namespace: IPNamespace,
+			Labels: map[string]string{
+				remapping.IPCategoryTargetKey: remapping.IPCategoryTargetValueMapping,
+			},
+		},
+		Spec: ipamv1alpha1.IPSpec{
+			IP:         networkingv1alpha1.IP(dstip),
+			Masquerade: ptr.To(true),
+		},
+	}
+	if err := cl.Create(ctx, &ip); err != nil && ctrlclient.IgnoreAlreadyExists(err) != nil {
+		return err
+	}
+
+	return WaitIPRemapped(ctx, cl)
+}
+
+// WaitIPRemapped waits for the IP to be remapped.
+func WaitIPRemapped(ctx context.Context, cl ctrlclient.Client) error {
+	timeout, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	return wait.PollUntilContextCancel(timeout, time.Second, true, func(ctx context.Context) (done bool, err error) {
+		ip := ipamv1alpha1.IP{}
+		if err := cl.Get(ctx, ctrlclient.ObjectKey{Name: IPName, Namespace: IPNamespace}, &ip); err != nil {
+			return false, err
+		}
+		if len(ip.Status.IPMappings) == 0 {
+			return false, nil
+		}
+		return true, nil
+	})
+}

--- a/pkg/liqoctl/test/network/setup/kyverno.go
+++ b/pkg/liqoctl/test/network/setup/kyverno.go
@@ -1,0 +1,129 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package setup
+
+import (
+	"context"
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/liqotech/liqo/pkg/liqoctl/test/network/client"
+)
+
+// KyvernoPolicyGroupVersionResource specifies the group version resource used to register the objects.
+var KyvernoPolicyGroupVersionResource = schema.GroupVersionResource{Group: "kyverno.io", Version: "v1", Resource: "policies"}
+
+// KyvernoPolicyKind is the kind of the Kyverno policy.
+const KyvernoPolicyKind = "Policy"
+
+// CreatePolicy creates the Kyverno policies.
+func CreatePolicy(ctx context.Context, cl *client.Client) error {
+	policy := ForgeKyvernoPodAntiaffinityPolicy(cl.ConsumerName, false)
+	if _, err := cl.ConsumerDynamic.Resource(KyvernoPolicyGroupVersionResource).
+		Namespace(NamespaceName).Create(ctx, policy, metav1.CreateOptions{}); err != nil && !apierrors.IsAlreadyExists(err) {
+		return fmt.Errorf("consumer failed to create policy: %w", err)
+	}
+
+	policy = ForgeKyvernoPodAntiaffinityPolicy(cl.ConsumerName, true)
+	if _, err := cl.ConsumerDynamic.Resource(KyvernoPolicyGroupVersionResource).
+		Namespace(NamespaceName).Create(ctx, policy, metav1.CreateOptions{}); err != nil && !apierrors.IsAlreadyExists(err) {
+		return fmt.Errorf("consumer failed to create policy: %w", err)
+	}
+
+	for k := range cl.Providers {
+		policy := ForgeKyvernoPodAntiaffinityPolicy(k, false)
+		if _, err := cl.ProvidersDynamic[k].Resource(KyvernoPolicyGroupVersionResource).
+			Namespace(NamespaceName).Create(ctx, policy, metav1.CreateOptions{}); err != nil && !apierrors.IsAlreadyExists(err) {
+			return fmt.Errorf("producer %q failed to create policy: %w", k, err)
+		}
+		policy = ForgeKyvernoPodAntiaffinityPolicy(k, true)
+		if _, err := cl.ProvidersDynamic[k].Resource(KyvernoPolicyGroupVersionResource).
+			Namespace(NamespaceName).Create(ctx, policy, metav1.CreateOptions{}); err != nil && !apierrors.IsAlreadyExists(err) {
+			return fmt.Errorf("producer %q failed to create policy: %w", k, err)
+		}
+	}
+	return nil
+}
+
+// ForgeKyvernoPodAntiaffinityPolicy creates a Kyverno policy that enforces pod anti-affinity.
+func ForgeKyvernoPodAntiaffinityPolicy(suffix string, hostnetwork bool) *unstructured.Unstructured {
+	policy := &unstructured.Unstructured{}
+
+	policy.SetKind(KyvernoPolicyKind)
+	policy.SetAPIVersion(fmt.Sprintf("%s/%s", KyvernoPolicyGroupVersionResource.Group, KyvernoPolicyGroupVersionResource.Version))
+
+	deploymentName := DeploymentName
+	name := "pod-antiaffinity"
+	if hostnetwork {
+		deploymentName = DeploymentName + "-host"
+		name += "-host"
+	}
+
+	policy.SetName(name)
+	policy.SetNamespace(NamespaceName)
+
+	policy.Object["spec"] = map[string]interface{}{
+		"rules": []map[string]interface{}{
+			{
+				"name": name,
+				"match": map[string]interface{}{
+					"any": []map[string]interface{}{
+						{"resources": map[string]interface{}{
+							"kinds": []string{"Pod"},
+							"selector": map[string]interface{}{
+								"matchLabels": map[string]string{
+									PodLabelAppCluster: deploymentName + "-" + suffix,
+								},
+							},
+						}},
+					},
+				},
+				"mutate": map[string]interface{}{
+					"patchStrategicMerge": forgeRawPatchStrategicMerge(deploymentName+"-"+suffix, hostnetwork),
+				},
+			},
+		},
+	}
+	return policy
+}
+
+func forgeRawPatchStrategicMerge(labelValue string, hostnetwork bool) map[string]interface{} {
+	return map[string]interface{}{
+		"spec": map[string]interface{}{
+			"+(affinity)": map[string]interface{}{
+				"+(podAntiAffinity)": map[string]interface{}{
+					"+(preferredDuringSchedulingIgnoredDuringExecution)": []map[string]interface{}{
+						{
+							"weight": 100,
+							"podAffinityTerm": map[string]interface{}{
+								"labelSelector": map[string]interface{}{
+									"matchLabels": map[string]string{
+										PodLabelAppCluster: labelValue,
+									},
+								},
+								"topologyKey": "kubernetes.io/hostname",
+							},
+						},
+					},
+				},
+			},
+			"+(hostNetwork)": hostnetwork,
+		},
+	}
+}

--- a/pkg/liqoctl/test/network/setup/namespace.go
+++ b/pkg/liqoctl/test/network/setup/namespace.go
@@ -1,0 +1,86 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package setup
+
+import (
+	"context"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/liqotech/liqo/apis/offloading/v1alpha1"
+	"github.com/liqotech/liqo/pkg/consts"
+	"github.com/liqotech/liqo/pkg/liqoctl/test/network/client"
+)
+
+// CreateNamespace creates a namespace.
+func CreateNamespace(ctx context.Context, cl *client.Client) error {
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: NamespaceName,
+		},
+	}
+	if err := cl.Consumer.Create(ctx, ns); err != nil && ctrlclient.IgnoreAlreadyExists(err) != nil {
+		return err
+	}
+	return nil
+}
+
+// OffloadNamespace offloads the namespace.
+func OffloadNamespace(ctx context.Context, cl *client.Client) error {
+	nsoff := v1alpha1.NamespaceOffloading{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      consts.DefaultNamespaceOffloadingName,
+			Namespace: NamespaceName,
+		},
+		Spec: v1alpha1.NamespaceOffloadingSpec{
+			NamespaceMappingStrategy: v1alpha1.EnforceSameNameMappingStrategyType,
+			PodOffloadingStrategy:    v1alpha1.LocalAndRemotePodOffloadingStrategyType,
+			ClusterSelector: corev1.NodeSelector{
+				NodeSelectorTerms: []corev1.NodeSelectorTerm{},
+			},
+		},
+	}
+	if err := cl.Consumer.Create(ctx, &nsoff); err != nil && ctrlclient.IgnoreAlreadyExists(err) != nil {
+		return err
+	}
+	return nil
+}
+
+// RemoveNamespace removes the namespace.
+func RemoveNamespace(ctx context.Context, cl *client.Client) error {
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: NamespaceName,
+		},
+	}
+	if err := cl.Consumer.Delete(ctx, ns); err != nil {
+		return err
+	}
+	timeout, cancel := context.WithTimeout(ctx, 1*time.Minute)
+	defer cancel()
+	if err := wait.PollUntilContextCancel(timeout, 1*time.Second, true, func(ctx context.Context) (done bool, err error) {
+		if err := cl.Consumer.Get(ctx, ctrlclient.ObjectKeyFromObject(ns), ns); err != nil {
+			return ctrlclient.IgnoreNotFound(err) == nil, nil
+		}
+		return false, nil
+	}); err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/liqoctl/test/network/setup/node.go
+++ b/pkg/liqoctl/test/network/setup/node.go
@@ -1,0 +1,45 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package setup
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/liqotech/liqo/pkg/consts"
+	"github.com/liqotech/liqo/pkg/liqoctl/test/network/client"
+)
+
+// AddConsumerNodeLabels adds the consumer node labels.
+func AddConsumerNodeLabels(ctx context.Context, cl *client.Client) error {
+	nodes := corev1.NodeList{}
+	if err := cl.Consumer.List(ctx, &nodes); err != nil {
+		return err
+	}
+	for i := range nodes.Items {
+		if nodes.Items[i].Labels[consts.TypeLabel] == consts.TypeNode {
+			continue
+		}
+		if IsNodeControlPlane(nodes.Items[i].Spec.Taints) {
+			continue
+		}
+		nodes.Items[i].Labels[consts.RemoteClusterID] = cl.ConsumerName
+		if err := cl.Consumer.Update(ctx, &nodes.Items[i]); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/liqoctl/test/network/setup/service.go
+++ b/pkg/liqoctl/test/network/setup/service.go
@@ -1,0 +1,77 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package setup
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/liqotech/liqo/pkg/liqoctl/test/network/client"
+	"github.com/liqotech/liqo/pkg/liqoctl/test/network/flags"
+)
+
+// CreateService creates a service resource.
+func CreateService(ctx context.Context, cl *client.Client, opts *flags.Options) error {
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      DeploymentName,
+			Namespace: NamespaceName,
+		},
+		Spec: corev1.ServiceSpec{
+			Selector: map[string]string{PodLabelApp: DeploymentName},
+			Ports:    []corev1.ServicePort{{Port: 80, TargetPort: intstr.IntOrString{IntVal: 80}}},
+		},
+	}
+	if err := cl.Consumer.Create(ctx, svc); err != nil && ctrlclient.IgnoreAlreadyExists(err) != nil {
+		return err
+	}
+
+	svcnp := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      DeploymentName + "np",
+			Namespace: NamespaceName,
+		},
+		Spec: corev1.ServiceSpec{
+			Type:     corev1.ServiceTypeNodePort,
+			Selector: map[string]string{PodLabelApp: DeploymentName},
+			Ports:    []corev1.ServicePort{{Port: 80, TargetPort: intstr.IntOrString{IntVal: 80}}},
+		},
+	}
+	if err := cl.Consumer.Create(ctx, svcnp); err != nil && ctrlclient.IgnoreAlreadyExists(err) != nil {
+		return err
+	}
+
+	if opts.LoadBalancer {
+		svclb := &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      DeploymentName + "lb",
+				Namespace: NamespaceName,
+			},
+			Spec: corev1.ServiceSpec{
+				Type:     corev1.ServiceTypeLoadBalancer,
+				Selector: map[string]string{PodLabelApp: DeploymentName},
+				Ports:    []corev1.ServicePort{{Port: 80, TargetPort: intstr.IntOrString{IntVal: 80}}},
+			},
+		}
+		if err := cl.Consumer.Create(ctx, svclb); err != nil && ctrlclient.IgnoreAlreadyExists(err) != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/liqoctl/test/network/setup/setup.go
+++ b/pkg/liqoctl/test/network/setup/setup.go
@@ -1,0 +1,58 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package setup
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/liqotech/liqo/pkg/liqoctl/test/network/client"
+	"github.com/liqotech/liqo/pkg/liqoctl/test/network/flags"
+)
+
+// MakeInfrastructure sets up the infrastructure for the network tests.
+func MakeInfrastructure(ctx context.Context, cl *client.Client, opts *flags.Options) (totreplicas int32, err error) {
+	if err := AddConsumerNodeLabels(ctx, cl); err != nil {
+		return 0, fmt.Errorf("error adding consumer node labels: %w", err)
+	}
+
+	if err := CreateNamespace(ctx, cl); err != nil {
+		return 0, fmt.Errorf("error creating namespace: %w", err)
+	}
+
+	if err := OffloadNamespace(ctx, cl); err != nil {
+		return 0, fmt.Errorf("error offloading namespace: %w", err)
+	}
+
+	if err := CreatePolicy(ctx, cl); err != nil {
+		return 0, fmt.Errorf("error creating policy: %w", err)
+	}
+
+	if totreplicas, err = CreateAllDeployments(ctx, cl); err != nil {
+		return 0, fmt.Errorf("error creating deployments: %w", err)
+	}
+
+	if err := CreateService(ctx, cl, opts); err != nil {
+		return 0, fmt.Errorf("error creating service: %w", err)
+	}
+
+	if opts.IPRemapping {
+		if err := CreateAllIP(ctx, cl); err != nil {
+			return 0, fmt.Errorf("error creating ip: %w", err)
+		}
+	}
+
+	return totreplicas, nil
+}

--- a/pkg/liqoctl/test/network/setup/utils.go
+++ b/pkg/liqoctl/test/network/setup/utils.go
@@ -1,0 +1,54 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package setup
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/liqotech/liqo/pkg/consts"
+)
+
+// IsNodeControlPlane checks if the node is a control plane node.
+func IsNodeControlPlane(taints []corev1.Taint) bool {
+	for _, taint := range taints {
+		if taint.Key == ControlPlaneTaintKey {
+			return true
+		}
+	}
+	return false
+}
+
+func getReplicas(ctx context.Context, cl ctrlclient.Client) (int32, error) {
+	var replicas int32
+
+	nodes := corev1.NodeList{}
+	if err := cl.List(ctx, &nodes); err != nil {
+		return 0, err
+	}
+	for i := range nodes.Items {
+		if nodes.Items[i].Labels[consts.TypeLabel] == consts.TypeNode {
+			continue
+		}
+		if IsNodeControlPlane(nodes.Items[i].Spec.Taints) {
+			continue
+		}
+		replicas++
+	}
+
+	return replicas, nil
+}

--- a/pkg/liqoctl/test/options.go
+++ b/pkg/liqoctl/test/options.go
@@ -12,24 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package ipam
+package test
 
 import (
-	ipamv1alpha1 "github.com/liqotech/liqo/apis/ipam/v1alpha1"
-	networkingv1alpha1 "github.com/liqotech/liqo/apis/networking/v1alpha1"
-	"github.com/liqotech/liqo/pkg/consts"
+	"github.com/liqotech/liqo/pkg/liqoctl/factory"
 )
 
-// IsAPIServerIP checks if the resource is an IP of type API server.
-func IsAPIServerIP(ip *ipamv1alpha1.IP) bool {
-	ipType, ok := ip.Labels[consts.IPTypeLabelKey]
-	return ok && ipType == consts.IPTypeAPIServer
+// NewOptions returns a new Options struct.
+func NewOptions(f *factory.Factory) *Options {
+	return &Options{
+		LocalFactory: f,
+	}
 }
 
-// GetRemappedIP returns the remapped IP of the given IP resource.
-func GetRemappedIP(ip *ipamv1alpha1.IP) networkingv1alpha1.IP {
-	for _, ipremapped := range ip.Status.IPMappings {
-		return ipremapped
-	}
-	return ""
+// Options contains the options for the test commands.
+type Options struct {
+	LocalFactory *factory.Factory
+
+	Verbose  bool
+	FailFast bool
 }

--- a/pkg/liqoctl/test/utils/doc.go
+++ b/pkg/liqoctl/test/utils/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package utils contains common definition and utils used across liqoctl test
+package utils

--- a/pkg/liqoctl/test/utils/utils.go
+++ b/pkg/liqoctl/test/utils/utils.go
@@ -12,5 +12,29 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package util contains common definition and utils used across liqoctl
-package util
+package utils
+
+import "fmt"
+
+// ManageResults manages the results of the checks.
+func ManageResults(failfast bool, err error, ok bool,
+	successCount, errorCount int32) (successCountTot, errorCountTot int32, errReturn error) {
+	if err != nil {
+		errorCount++
+		if failfast {
+			return successCount, errorCount, err
+		}
+		return successCount, errorCount, nil
+	}
+
+	if !ok {
+		errorCount++
+		if failfast {
+			return successCount, errorCount, fmt.Errorf("check failed")
+		}
+		return successCount, errorCount, nil
+	}
+
+	successCount++
+	return successCount, errorCount, nil
+}

--- a/pkg/liqoctl/utils/doc.go
+++ b/pkg/liqoctl/utils/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package utils contains common definition and utils used across liqoctl
+package utils

--- a/pkg/liqoctl/utils/pod/doc.go
+++ b/pkg/liqoctl/utils/pod/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package pod provides utilities to work with pods.
+package pod

--- a/pkg/liqoctl/utils/pod/pod.go
+++ b/pkg/liqoctl/utils/pod/pod.go
@@ -1,0 +1,82 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pod
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/remotecommand"
+	"k8s.io/kubectl/pkg/scheme"
+)
+
+// ExecInPod executes a command in a pod.
+func ExecInPod(ctx context.Context, clset *kubernetes.Clientset, cfg *rest.Config,
+	pod *corev1.Pod, cmd string) (stdout, stderr string, err error) {
+	// Prepare the API URL used to execute the command
+	url := clset.CoreV1().RESTClient().Post().
+		Resource("pods").
+		Name(pod.Name).
+		Namespace(pod.Namespace).
+		SubResource("exec").
+		VersionedParams(&corev1.PodExecOptions{
+			Command:   strings.Split(cmd, " "),
+			Container: pod.Spec.Containers[0].Name,
+			Stdin:     false,
+			Stdout:    true,
+			Stderr:    true,
+			TTY:       false,
+		}, scheme.ParameterCodec).URL()
+
+	// Execute the command
+	exec, err := remotecommand.NewSPDYExecutor(cfg, "POST", url)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to initialize command executor: %w", err)
+	}
+
+	// Capture the output and error streams
+	var stdoutBuff, stderrBuff bytes.Buffer
+	if err = exec.StreamWithContext(ctx, remotecommand.StreamOptions{
+		Stdin:  nil,
+		Stdout: &stdoutBuff,
+		Stderr: &stderrBuff,
+		Tty:    false,
+	}); err != nil {
+		return "", "", fmt.Errorf("failed to execute command: %w", err)
+	}
+
+	return stdoutBuff.String(), stderrBuff.String(), nil
+}
+
+// TryFor tries to execute the function f for a maximum of maxRetries times.
+func TryFor(ctx context.Context, maxRetries int, f func() (bool, error)) (bool, error) {
+	var err error
+	var ok bool
+	for i := 0; i < maxRetries; i++ {
+		if ctx.Err() != nil {
+			return false, ctx.Err()
+		}
+		ok, err = f()
+		if ok {
+			return ok, nil
+		}
+	}
+	return ok, err
+}

--- a/pkg/liqoctl/utils/utils.go
+++ b/pkg/liqoctl/utils/utils.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package util
+package utils
 
 import (
 	"context"

--- a/pkg/utils/ipam/mapping/ips.go
+++ b/pkg/utils/ipam/mapping/ips.go
@@ -114,19 +114,19 @@ func MapAddressWithConfiguration(cfg *networkingv1alpha1.Configuration, address 
 
 	paddr := net.ParseIP(address)
 	if podNeedsRemap && podnet.Contains(paddr) {
-		return remapMask(paddr, *podnetMapped, podNetMaskLen).String(), nil
+		return RemapMask(paddr, *podnetMapped, podNetMaskLen).String(), nil
 	}
 	if extNeedsRemap && extnet.Contains(paddr) {
-		return remapMask(paddr, *extnetMapped, extNetMaskLen).String(), nil
+		return RemapMask(paddr, *extnetMapped, extNetMaskLen).String(), nil
 	}
 
 	return address, nil
 }
 
-// remapMask remaps the mask of the address.
+// RemapMask remaps the mask of the address.
 // Consider that net.IP is always a slice of 16 bytes (big-endian).
 // The mask is a slice of 4 or 16 bytes (big-endian).
-func remapMask(addr net.IP, mask net.IPNet, maskLen int) net.IP {
+func RemapMask(addr net.IP, mask net.IPNet, maskLen int) net.IP {
 	maskLenBytes := maskLen / 8
 	for i := 0; i < maskLenBytes; i++ {
 		// i+(len(addr)-len(mask.IP)) allows to start from the rightmost byte of the address.

--- a/pkg/virtualKubelet/reflection/exposition/endpointslice.go
+++ b/pkg/virtualKubelet/reflection/exposition/endpointslice.go
@@ -39,7 +39,7 @@ import (
 	vkv1alpha1clients "github.com/liqotech/liqo/pkg/client/clientset/versioned/typed/virtualkubelet/v1alpha1"
 	ipamv1alpha1listers "github.com/liqotech/liqo/pkg/client/listers/ipam/v1alpha1"
 	vkv1alpha1listers "github.com/liqotech/liqo/pkg/client/listers/virtualkubelet/v1alpha1"
-	"github.com/liqotech/liqo/pkg/liqo-controller-manager/networking/external-network/remapping"
+	ipamutils "github.com/liqotech/liqo/pkg/utils/ipam"
 	"github.com/liqotech/liqo/pkg/utils/virtualkubelet"
 	"github.com/liqotech/liqo/pkg/virtualKubelet/forge"
 	"github.com/liqotech/liqo/pkg/virtualKubelet/reflection/generic"
@@ -266,8 +266,9 @@ func (ner *NamespacedEndpointSliceReflector) MapEndpointIPFromIPResource(origina
 	}
 	for i := range ips {
 		if ips[i].Spec.IP.String() == original {
+			remappedIP := ipamutils.GetRemappedIP(ips[i])
 			if len(ips[i].Status.IPMappings) > 0 {
-				return remapping.GetFirstIPFromMapping(ips[i].Status.IPMappings), nil
+				return remappedIP.String(), nil
 			}
 			return "", fmt.Errorf("resource IP %s has not been mapped yet", ips[i].Name)
 		}

--- a/test/e2e/cruise/clusterlabels/cluster_labels_test.go
+++ b/test/e2e/cruise/clusterlabels/cluster_labels_test.go
@@ -35,7 +35,7 @@ import (
 	liqov1alpha1 "github.com/liqotech/liqo/apis/core/v1alpha1"
 	offloadingv1alpha1 "github.com/liqotech/liqo/apis/offloading/v1alpha1"
 	liqoconst "github.com/liqotech/liqo/pkg/consts"
-	liqoctlutil "github.com/liqotech/liqo/pkg/liqoctl/util"
+	liqoctlutil "github.com/liqotech/liqo/pkg/liqoctl/utils"
 	argsutils "github.com/liqotech/liqo/pkg/utils/args"
 	foreignclusterutils "github.com/liqotech/liqo/pkg/utils/foreigncluster"
 	"github.com/liqotech/liqo/test/e2e/testconsts"


### PR DESCRIPTION
# Description

This PR adds in liqoctl a new subsets of commands **"liqoctl test"** used to run E2E tests using liqoctl.

In this PR the network tests command have been added (**"liqoctl test network"**) which tests these scenarios:
- **Pod-to-Pod** connectivity
- **Pod-to-Node** connectivity
- **Pod-to-Service** connectivity (cluster-ip and nodeport)
- **External-to-LoadBalancer** connectivity
- **Pod-to-External** connectivity
- **Pod-To-External** (using IP resource remapping) connectivity
