### PR TITLE
E2E tests: multiple virtual-nodes

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -162,7 +162,7 @@ func main() {
 	mgr.GetWebhookServer().Register("/mutate/pod", podwh.New(mgr.GetClient(), *addVirtualNodeTolerationOnOffloadedPods))
 	mgr.GetWebhookServer().Register("/mutate/virtualnodes", virtualnodewh.New(
 		mgr.GetClient(), clusterID, *podcidr, *liqoNamespace, vkOptsDefaultTemplateRef))
-	mgr.GetWebhookServer().Register("/validate/resourceslices", resourceslicewh.NewValidator())
+	mgr.GetWebhookServer().Register("/validate/resourceslices", resourceslicewh.NewValidator(mgr.GetClient()))
 	mgr.GetWebhookServer().Register("/validate/firewallconfigurations", fwcfgwh.NewValidator(mgr.GetClient()))
 	mgr.GetWebhookServer().Register("/mutate/firewallconfigurations", fwcfgwh.NewMutator())
 	mgr.GetWebhookServer().Register("/validate/routeconfigurations", routecfgwh.NewValidator(mgr.GetClient()))

--- a/deployments/liqo/files/liqo-webhook-ClusterRole.yaml
+++ b/deployments/liqo/files/liqo-webhook-ClusterRole.yaml
@@ -1,5 +1,13 @@
 rules:
 - apiGroups:
+  - authentication.liqo.io
+  resources:
+  - resourceslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - ""
   resources:
   - namespaces

--- a/deployments/liqo/templates/webhooks/liqo-validating-webhook.yaml
+++ b/deployments/liqo/templates/webhooks/liqo-validating-webhook.yaml
@@ -86,7 +86,7 @@ webhooks:
         path: "/validate/resourceslices"
         port: {{ .Values.webhook.port }}
     rules:
-      - operations: ["UPDATE"]
+      - operations: ["CREATE", "UPDATE"]
         apiGroups: ["authentication.liqo.io"]
         apiVersions: ["v1alpha1"]
         resources: ["resourceslices"]

--- a/internal/crdReplicator/reflection/reflector.go
+++ b/internal/crdReplicator/reflection/reflector.go
@@ -264,5 +264,9 @@ func ReplicatedResourcesLabelSelector() metav1.LabelSelector {
 
 // IsReplicated returns whether the given object is replicated by the CRD replicator.
 func IsReplicated(obj metav1.Object) bool {
+	if obj.GetLabels() == nil {
+		return false
+	}
+
 	return obj.GetLabels()[consts.ReplicationStatusLabel] == strconv.FormatBool(true)
 }

--- a/pkg/liqo-controller-manager/virtualnodecreator-controller/virtualnodecreator_controller.go
+++ b/pkg/liqo-controller-manager/virtualnodecreator-controller/virtualnodecreator_controller.go
@@ -121,6 +121,10 @@ func (r *VirtualNodeCreatorReconciler) Reconcile(ctx context.Context, req ctrl.R
 		if err := forge.MutateVirtualNode(virtualNode, identity.Spec.ClusterID, vnOpts, nil, nil); err != nil {
 			return err
 		}
+		if virtualNode.Labels == nil {
+			virtualNode.Labels = map[string]string{}
+		}
+		virtualNode.Labels[consts.ResourceSliceNameLabelKey] = resourceSlice.Name
 		return controllerutil.SetControllerReference(&resourceSlice, virtualNode, r.Scheme)
 	}); err != nil {
 		klog.Errorf("Unable to create or update the VirtualNode for resourceslice %q: %s", req.NamespacedName, err)

--- a/pkg/utils/getters/k8sGetters.go
+++ b/pkg/utils/getters/k8sGetters.go
@@ -787,6 +787,22 @@ func ListPhysicalNodes(ctx context.Context, cl client.Client) (*corev1.NodeList,
 	return list, nil
 }
 
+// ListLiqoNodes returns the list of nodes of type virtual-node.
+func ListLiqoNodes(ctx context.Context, cl client.Client) (*corev1.NodeList, error) {
+	req, err := labels.NewRequirement(consts.TypeLabel, selection.Equals, []string{consts.TypeNode})
+	if err != nil {
+		return nil, err
+	}
+
+	lSelector := labels.NewSelector().Add(*req)
+
+	list := new(corev1.NodeList)
+	if err := cl.List(ctx, list, &client.ListOptions{LabelSelector: lSelector}); err != nil {
+		return nil, err
+	}
+	return list, nil
+}
+
 // ListInternalNodesByLabels returns the list of internalnodes resources. (i.e. nodes created by Liqo).
 func ListInternalNodesByLabels(ctx context.Context, cl client.Client,
 	lSelector labels.Selector) (*networkingv1alpha1.InternalNodeList, error) {

--- a/pkg/webhooks/virtualnode/virtualnode.go
+++ b/pkg/webhooks/virtualnode/virtualnode.go
@@ -95,7 +95,7 @@ func (w *vnwh) Handle(ctx context.Context, req admission.Request) admission.Resp
 	if req.Operation == admissionv1.Create {
 		// VirtualNode name and the created Node have the same name.
 		// This checks if the Node already exists in the cluster to avoid duplicates.
-		err := checkNodeDubplicate(ctx, w, virtualnode)
+		err := checkNodeDuplicate(ctx, w, virtualnode)
 		if err != nil {
 			klog.Errorf("Failed checking node duplicate: %v", err)
 			return admission.Denied(err.Error())
@@ -124,8 +124,8 @@ func (w *vnwh) Handle(ctx context.Context, req admission.Request) admission.Resp
 	return w.CreatePatchResponse(&req, virtualnode)
 }
 
-// checkNodeDubplicate checks if the node already exists in the cluster.
-func checkNodeDubplicate(ctx context.Context, w *vnwh, virtualnode *offloadingv1alpha1.VirtualNode) error {
+// checkNodeDuplicate checks if the node already exists in the cluster.
+func checkNodeDuplicate(ctx context.Context, w *vnwh, virtualnode *offloadingv1alpha1.VirtualNode) error {
 	node := &corev1.Node{}
 	err := w.client.Get(ctx, client.ObjectKey{Name: virtualnode.Name}, node)
 	if err != nil {

--- a/test/e2e/cruise/apiserverinteraction/apiserver_interaction_test.go
+++ b/test/e2e/cruise/apiserverinteraction/apiserver_interaction_test.go
@@ -54,7 +54,7 @@ var (
 )
 
 var _ = Describe("Liqo E2E", func() {
-	Context("E2E API server interaction Testing", func() {
+	Context("API server interaction Testing", func() {
 		const (
 			retries             = 60
 			sleepBetweenRetries = 1 * time.Second

--- a/test/e2e/cruise/multiplevirtualnodes/multiple_virtualnodes_test.go
+++ b/test/e2e/cruise/multiplevirtualnodes/multiple_virtualnodes_test.go
@@ -1,0 +1,286 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multiplevirtualnodes
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	authv1alpha1 "github.com/liqotech/liqo/apis/authentication/v1alpha1"
+	liqov1alpha1 "github.com/liqotech/liqo/apis/core/v1alpha1"
+	offv1alpha1 "github.com/liqotech/liqo/apis/offloading/v1alpha1"
+	"github.com/liqotech/liqo/pkg/consts"
+	"github.com/liqotech/liqo/pkg/liqo-controller-manager/authentication/forge"
+	tenantnamespace "github.com/liqotech/liqo/pkg/tenantNamespace"
+	"github.com/liqotech/liqo/pkg/utils"
+	"github.com/liqotech/liqo/pkg/utils/getters"
+	liqolabels "github.com/liqotech/liqo/pkg/utils/labels"
+	"github.com/liqotech/liqo/test/e2e/testutils/config"
+	"github.com/liqotech/liqo/test/e2e/testutils/tester"
+	"github.com/liqotech/liqo/test/e2e/testutils/util"
+)
+
+const (
+	// clustersRequired is the number of clusters required in this E2E test.
+	clustersRequired = 3
+	// testName is the name of this E2E test.
+	testName = "MULTIPLE_VIRTUALNODES"
+)
+
+func TestE2E(t *testing.T) {
+	util.CheckIfTestIsSkipped(t, clustersRequired, testName)
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Liqo E2E Suite")
+}
+
+var (
+	ctx         = context.Background()
+	testContext = tester.GetTester(ctx)
+	interval    = config.Interval
+	timeout     = config.Timeout
+
+	testResSliceLabel = "liqo.io/test-resourceslice"
+
+	testResourceRequirement = func() labels.Requirement {
+		req, err := labels.NewRequirement(testResSliceLabel, selection.Exists, []string{})
+		Expect(err).To(Not(HaveOccurred()))
+		return *req
+	}
+
+	createTestResourceSlice = func(cl client.Client, name string, providerClusterID liqov1alpha1.ClusterID, createVirtualNode bool) {
+		tenantNs := tenantnamespace.GetNameForNamespace(providerClusterID)
+		resSlice := forge.ResourceSlice(name, tenantNs)
+		if resSlice.Labels == nil {
+			resSlice.Labels = map[string]string{}
+		}
+		resSlice.Labels[testResSliceLabel] = "true"
+		Expect(forge.MutateResourceSlice(resSlice, providerClusterID, &forge.ResourceSliceOptions{
+			Class: authv1alpha1.ResourceSliceClassDefault,
+		}, createVirtualNode)).To(Succeed())
+		Expect(cl.Create(ctx, resSlice)).To(Succeed())
+	}
+
+	deleteTestResourceSlices = func(cl client.Client) {
+		resSlices, err := getters.ListResourceSlicesByLabel(ctx, cl,
+			corev1.NamespaceAll, liqolabels.LocalLabelSelector().Add(testResourceRequirement()))
+		Expect(err).To(Not(HaveOccurred()))
+		for j := range resSlices {
+			Expect(client.IgnoreNotFound(cl.Delete(ctx, &resSlices[j]))).To(Succeed())
+		}
+	}
+
+	checkCleanUp = func(cl client.Client, role liqov1alpha1.RoleType, numPeeredProviders int) error {
+		resSlices, err := getters.ListResourceSlicesByLabel(ctx, cl,
+			corev1.NamespaceAll, labels.NewSelector().Add(testResourceRequirement()))
+		if err != nil {
+			return err
+		}
+		if len(resSlices) != 0 {
+			return fmt.Errorf("ResourceSlices not deleted yet")
+		}
+
+		// Number of expected VirtualNodes/Nodes after cleanup.
+		var expectedNum int
+		switch role {
+		case liqov1alpha1.ConsumerRole:
+			expectedNum = numPeeredProviders
+		default:
+			expectedNum = 0
+		}
+
+		// Number of virtual nodes should equal the number of peered providers.
+		vNodes, err := getters.ListVirtualNodesByLabels(ctx, cl, labels.Everything())
+		if err != nil {
+			return err
+		}
+		if len(vNodes.Items) != expectedNum {
+			return fmt.Errorf("Found %d VirtualNodes after cleanup, expected %d", len(vNodes.Items), expectedNum)
+		}
+
+		nodes, err := getters.ListLiqoNodes(ctx, cl)
+		if err != nil {
+			return err
+		}
+		if len(nodes.Items) != expectedNum {
+			return fmt.Errorf("Found %d Liqo nodes after cleanup, expected %d", len(nodes.Items), expectedNum)
+		}
+
+		return nil
+	}
+)
+
+var _ = Describe("Liqo E2E", func() {
+	Context("Multiple VirtualNodes and ResourceSlices", func() {
+		AfterEach(func() {
+			for i := range testContext.Clusters {
+				deleteTestResourceSlices(testContext.Clusters[i].ControllerClient)
+			}
+
+			for i := range testContext.Clusters {
+				Eventually(func() error {
+					return checkCleanUp(testContext.Clusters[i].ControllerClient,
+						testContext.Clusters[i].Role, testContext.Clusters[i].NumPeeredProviders)
+				}, timeout, interval).Should(Succeed())
+			}
+		})
+
+		When("Peerings are established", func() {
+			It("Should have the right number of resourceslices", func() {
+				for i := range testContext.Clusters {
+					cluster := testContext.Clusters[i]
+					switch cluster.Role {
+					case liqov1alpha1.ConsumerRole:
+						resSlices, err := getters.ListResourceSlicesByLabel(ctx, cluster.ControllerClient,
+							corev1.NamespaceAll, liqolabels.LocalLabelSelector())
+						Expect(err).To(Not(HaveOccurred()))
+						Expect(len(resSlices)).To(Equal(cluster.NumPeeredProviders))
+					case liqov1alpha1.ProviderRole:
+						resSlices, err := getters.ListResourceSlicesByLabel(ctx, cluster.ControllerClient,
+							corev1.NamespaceAll, liqolabels.RemoteLabelSelector())
+						Expect(err).To(Not(HaveOccurred()))
+						Expect(len(resSlices)).To(Equal(cluster.NumPeeredConsumers))
+					default:
+						resSlices, err := getters.ListResourceSlicesByLabel(ctx, cluster.ControllerClient, corev1.NamespaceAll, labels.Everything())
+						Expect(err).To(Not(HaveOccurred()))
+						Expect(len(resSlices)).To(BeZero())
+					}
+				}
+			})
+		})
+
+		When("Adding multiple ResourceSlices for each providers on multiple providers", func() {
+
+			It("Should replicate the ResourceSlices to the provider, and create VirtualNodes and Nodes", func() {
+				// On every consumer cluster, create a ResourceSlice for each provider cluster.
+				for i := range testContext.Clusters {
+					if testContext.Clusters[i].Role == liqov1alpha1.ConsumerRole {
+						consumer := testContext.Clusters[i]
+						for j := range testContext.Clusters {
+							if testContext.Clusters[j].Role == liqov1alpha1.ProviderRole {
+								provider := testContext.Clusters[j]
+								createTestResourceSlice(consumer.ControllerClient, fmt.Sprintf("rs-test-%s", provider.Cluster), provider.Cluster, true)
+							}
+						}
+					}
+				}
+
+				// Test that every ResourceSlices, VirtualNodes and Nodes are created.
+				for i := range testContext.Clusters {
+					switch testContext.Clusters[i].Role {
+					// CONSUMERS
+					case liqov1alpha1.ConsumerRole:
+						consumer := testContext.Clusters[i]
+
+						var resSlices []authv1alpha1.ResourceSlice
+
+						// List all ResourceSlices created by the consumer
+						// (filtering out the resourceslices from the original peering)
+						// and test if the number of ResourceSlices is correct.
+						Eventually(func() error {
+							var err error
+							resSlices, err = getters.ListResourceSlicesByLabel(ctx, consumer.ControllerClient,
+								corev1.NamespaceAll, liqolabels.LocalLabelSelector().Add(testResourceRequirement()))
+							if err != nil {
+								return err
+							}
+							if len(resSlices) != consumer.NumPeeredProviders {
+								return fmt.Errorf("Found %d ResourceSlices, expected %d", len(resSlices), consumer.NumPeeredProviders)
+							}
+							return nil
+						}, timeout, interval).Should(Succeed())
+
+						for j := range resSlices {
+							var vNodes *offv1alpha1.VirtualNodeList
+
+							// Test if every resourceSlice has the associated VirtualNode.
+							Eventually(func() error {
+								var err error
+								vNodes, err = getters.ListVirtualNodesByLabels(ctx, consumer.ControllerClient,
+									labels.Set{consts.ResourceSliceNameLabelKey: resSlices[j].Name}.AsSelector())
+								if err != nil {
+									return err
+								}
+								if len(vNodes.Items) != 1 {
+									return fmt.Errorf("Found %d VirtualNodes for ResourceSlice %s, expected 1", len(vNodes.Items), resSlices[j].Name)
+								}
+								return nil
+							}, timeout, interval).Should(Succeed())
+
+							// Test if every VirtualNode has the associated Node and that it is Ready.
+							Eventually(func() error {
+								node, err := getters.GetNodeFromVirtualNode(ctx, consumer.ControllerClient, &vNodes.Items[0])
+								if err != nil {
+									return fmt.Errorf("Unable to get Node for VirtualNode %s: %w", vNodes.Items[0].Name, err)
+								}
+								if !utils.IsNodeReady(node) {
+									return fmt.Errorf("Node %s is not ready", node.Name)
+								}
+								return nil
+							}, timeout, interval).Should(Succeed())
+						}
+
+					// PROVIDERS
+					case liqov1alpha1.ProviderRole:
+						provider := testContext.Clusters[i]
+
+						var resSlices []authv1alpha1.ResourceSlice
+
+						// List all ResourceSlices replicated on the provider
+						// (filtering out the resourceslices from the original peering)
+						// and test if the number of ResourceSlices is correct.
+						Eventually(func() error {
+							var err error
+							resSlices, err = getters.ListResourceSlicesByLabel(ctx, provider.ControllerClient,
+								corev1.NamespaceAll, liqolabels.RemoteLabelSelector().Add(testResourceRequirement()))
+							if err != nil {
+								return err
+							}
+							if len(resSlices) != provider.NumPeeredConsumers {
+								return fmt.Errorf("Found %d ResourceSlices, expected %d", len(resSlices), provider.NumPeeredConsumers)
+							}
+							return nil
+						}, timeout, interval).Should(Succeed())
+
+						// Test that a VirtualNode has not been created for the remote ResourceSlice.
+						for j := range resSlices {
+							Eventually(func() error {
+								vNodes, err := getters.ListVirtualNodesByLabels(ctx, provider.ControllerClient,
+									labels.Set{consts.ResourceSliceNameLabelKey: resSlices[j].Name}.AsSelector())
+								if err != nil {
+									return err
+								}
+								if len(vNodes.Items) != 0 {
+									return fmt.Errorf("Found %d VirtualNodes for ResourceSlice %s, expected 0", len(vNodes.Items), resSlices[j].Name)
+								}
+								return nil
+							}, timeout, interval).Should(Succeed())
+						}
+
+					default:
+						// Do nothing.
+					}
+				}
+			})
+		})
+	})
+})

--- a/test/e2e/cruise/resourceenforcement/resourceenforcement_test.go
+++ b/test/e2e/cruise/resourceenforcement/resourceenforcement_test.go
@@ -105,7 +105,7 @@ var (
 )
 
 var _ = Describe("Liqo E2E", func() {
-	Context("E2E Resource Enforcement", func() {
+	Context("Resource Enforcement", func() {
 
 		var (
 			deploymentName = "nginx"

--- a/test/e2e/cruise/storage/storage_test.go
+++ b/test/e2e/cruise/storage/storage_test.go
@@ -59,7 +59,7 @@ var (
 )
 
 var _ = Describe("Liqo E2E", func() {
-	Context("E2E Storage Testing", func() {
+	Context("Storage Testing", func() {
 		var (
 			replica1Name = fmt.Sprintf("%v-1", storage.StatefulSetName)
 			options      *k8s.KubectlOptions


### PR DESCRIPTION
# Description

This PR adds e2e tests that checks the correct creation of multiple resourceslices and virtualnodes.

It also modify the resourceslice validating wehbhook to prevent the creation if a resourceslice with the same name already exists on the cluster.
