### PR TITLE
`liqoctl create nonce` namespace is not created when output specified

### DIFF
--- a/pkg/tenantNamespace/interface.go
+++ b/pkg/tenantNamespace/interface.go
@@ -17,7 +17,7 @@ package tenantnamespace
 import (
 	"context"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -27,8 +27,9 @@ import (
 // Manager provides the methods to handle the creation and
 // the management of tenant namespaces.
 type Manager interface {
-	CreateNamespace(ctx context.Context, cluster liqov1alpha1.ClusterID) (*v1.Namespace, error)
-	GetNamespace(ctx context.Context, cluster liqov1alpha1.ClusterID) (*v1.Namespace, error)
+	CreateNamespace(ctx context.Context, cluster liqov1alpha1.ClusterID) (*corev1.Namespace, error)
+	ForgeNamespace(cluster liqov1alpha1.ClusterID, name *string) *corev1.Namespace
+	GetNamespace(ctx context.Context, cluster liqov1alpha1.ClusterID) (*corev1.Namespace, error)
 	BindClusterRoles(ctx context.Context, cluster liqov1alpha1.ClusterID,
 		owner metav1.Object, clusterRoles ...*rbacv1.ClusterRole) ([]*rbacv1.RoleBinding, error)
 	UnbindClusterRoles(ctx context.Context, cluster liqov1alpha1.ClusterID, clusterRoles ...string) error

--- a/pkg/tenantNamespace/tenantNamespaceManager_test.go
+++ b/pkg/tenantNamespace/tenantNamespaceManager_test.go
@@ -52,6 +52,15 @@ var _ = Describe("TenantNamespace", func() {
 		Expect(ns2).To(Equal(ns))
 	})
 
+	It("Should forge a namespace with a custom name", func() {
+		By("Forging a new namespace providing the name")
+		nsname := "custom-cluster-name"
+		ns := namespaceManager.ForgeNamespace(homeCluster, &nsname)
+		Expect(ns).NotTo(BeNil())
+		Expect(ns.Name).To(Equal(nsname))
+		Expect(ns.Labels).NotTo(BeNil())
+	})
+
 	It("Get Namespace", func() {
 		ns, err := namespaceManager.GetNamespace(ctx, homeCluster)
 		Expect(err).To(BeNil())


### PR DESCRIPTION
# Description

Previously when to the `liqoctl create nonce` the output was specified, a namespace was created in the cluster. With this patch, when the output is specified, the command does not perform any change to the cluster, and the Namespace resource is added to the output. If a tenant namespace already esists, the Namespace resource of the output will have the same name of the existing Namespace.
