### PR TITLE
Network: check kernel version

### DIFF
--- a/cmd/fabric/main.go
+++ b/cmd/fabric/main.go
@@ -43,6 +43,7 @@ import (
 	"github.com/liqotech/liqo/pkg/liqo-controller-manager/networking/external-network/remapping"
 	"github.com/liqotech/liqo/pkg/route"
 	flagsutils "github.com/liqotech/liqo/pkg/utils/flags"
+	kernelversion "github.com/liqotech/liqo/pkg/utils/kernel/version"
 	"github.com/liqotech/liqo/pkg/utils/mapper"
 	"github.com/liqotech/liqo/pkg/utils/restcfg"
 )
@@ -82,6 +83,13 @@ func main() {
 
 func run(cmd *cobra.Command, _ []string) error {
 	var err error
+
+	// Check if the minimum kernel version is satisfied.
+	if !options.DisableKernelVersionCheck {
+		if err := kernelversion.CheckKernelVersion(&options.MinimumKernelVersion); err != nil {
+			return fmt.Errorf("kernel version check failed: %w, disable this check with --%s", err, fabric.FlagNameDisableKernelVersionCheck)
+		}
+	}
 
 	// Set controller-runtime logger.
 	log.SetLogger(klog.NewKlogr())

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -40,6 +40,7 @@ import (
 	"github.com/liqotech/liqo/pkg/route"
 	flagsutils "github.com/liqotech/liqo/pkg/utils/flags"
 	"github.com/liqotech/liqo/pkg/utils/kernel"
+	kernelversion "github.com/liqotech/liqo/pkg/utils/kernel/version"
 	"github.com/liqotech/liqo/pkg/utils/mapper"
 	"github.com/liqotech/liqo/pkg/utils/restcfg"
 )
@@ -88,6 +89,13 @@ func main() {
 
 func run(cmd *cobra.Command, _ []string) error {
 	var err error
+
+	// Check if the minimum kernel version is satisfied.
+	if !connoptions.GwOptions.DisableKernelVersionCheck {
+		if err := kernelversion.CheckKernelVersion(&connoptions.GwOptions.MinimumKernelVersion); err != nil {
+			return fmt.Errorf("kernel version check failed: %w, disable this check with --%s", err, gateway.FlagNameDisableKernelVersionCheck)
+		}
+	}
 
 	// Enable ip_forwarding.
 	if err = kernel.EnableIPForwarding(); err != nil {

--- a/deployments/liqo/README.md
+++ b/deployments/liqo/README.md
@@ -155,6 +155,7 @@
 | proxy.service.annotations | object | `{}` |  |
 | proxy.service.type | string | `"ClusterIP"` |  |
 | pullPolicy | string | `"IfNotPresent"` | The pullPolicy for liqo pods. |
+| requirements.kernel.disabled | bool | `false` | Enable/Disable the kernel requirements check. |
 | storage.enable | bool | `true` | Enable/Disable the liqo virtual storage class on the local cluster. You will be able to offload your persistent volumes, while other clusters will be able to schedule their persistent workloads on the current cluster. |
 | storage.realStorageClassName | string | `""` | Name of the real storage class to use in the local cluster. |
 | storage.storageNamespace | string | `"liqo-storage"` | Namespace where liqo will deploy specific PVCs. Internal parameter, do not change. |

--- a/deployments/liqo/templates/liqo-fabric-daemonset.yaml
+++ b/deployments/liqo/templates/liqo-fabric-daemonset.yaml
@@ -44,7 +44,9 @@ spec:
           args:
           - --podname=$(POD_NAME)
           - --nodename=$(NODE_NAME)
-          - --enable-arp=true
+          {{- if .Values.requirements.kernel.disabled }}
+          - --disable-kernel-version-check
+          {{- end }}
           {{- if .Values.common.extraArgs }}
           {{- toYaml .Values.common.extraArgs | nindent 10 }}
           {{- end }}

--- a/deployments/liqo/templates/liqo-wireguard-gateway-client-template.yaml
+++ b/deployments/liqo/templates/liqo-wireguard-gateway-client-template.yaml
@@ -57,6 +57,9 @@ spec:
                 {{- if gt .Values.networking.gatewayTemplates.replicas 1.0 }}
                 - --leader-election=true
                 {{- end }}
+                {{- if .Values.requirements.kernel.disabled }}
+                - --disable-kernel-version-check
+                {{- end }}
                 {{- if .Values.metrics.enabled }}
                 ports:
                 - containerPort: 8080
@@ -117,7 +120,6 @@ spec:
                 - --metrics-address=:8084
                 {{- end }}
                 - --health-probe-bind-address=:8085
-                - --enable-arp=true
                 {{- if .Values.metrics.enabled }}
                 ports:
                 - containerPort: 8084

--- a/deployments/liqo/templates/liqo-wireguard-gateway-server-template-eks.yaml
+++ b/deployments/liqo/templates/liqo-wireguard-gateway-server-template-eks.yaml
@@ -73,7 +73,9 @@ spec:
                 - --node-name={{"$(NODE_NAME)"}}
                 - --gateway-uid={{"{{ .GatewayUID }}"}}
                 - --mode=server
+                {{- if .Values.metrics.enabled }}
                 - --metrics-address=:8080
+                {{- end }}
                 - --health-probe-bind-address=:8081
                 - --ping-enabled=true
                 - --ping-loss-threshold={{ .Values.networking.gatewayTemplates.ping.lossThreshold }}
@@ -81,6 +83,14 @@ spec:
                 - --ping-update-status-interval={{ .Values.networking.gatewayTemplates.ping.updateStatusInterval }}
                 {{- if gt .Values.networking.gatewayTemplates.replicas 1.0 }}
                 - --leader-election=true
+                {{- end }}
+                {{- if .Values.requirements.kernel.disabled }}
+                - --disable-kernel-version-check
+                {{- end }}
+                {{- if .Values.metrics.enabled }}
+                ports:
+                - containerPort: 8080
+                  name: gw-metrics
                 {{- end }}
                 env:
                 - name: NODE_NAME
@@ -104,9 +114,16 @@ spec:
                 - --mode=server
                 - --mtu={{"{{ .Spec.MTU }}"}}
                 - --listen-port={{"{{ .Spec.Endpoint.Port }}"}}
+                {{- if .Values.metrics.enabled }}
                 - --metrics-address=:8082
+                {{- end }}
                 - --health-probe-bind-address=:8083
                 - --implementation={{ .Values.networking.gatewayTemplates.wireguard.implementation }}
+                {{- if .Values.metrics.enabled }}
+                ports:
+                - containerPort: 8082
+                  name: wg-metrics
+                {{- end }}
                 securityContext:
                   capabilities:
                     add:
@@ -125,9 +142,15 @@ spec:
                 - --node-name={{"$(NODE_NAME)"}}
                 - --gateway-uid={{"{{ .GatewayUID }}"}}
                 - --mode=server
+                {{- if .Values.metrics.enabled }}
                 - --metrics-address=:8084
+                {{- end }}
                 - --health-probe-bind-address=:8085
-                - --enable-arp=true
+                {{- if .Values.metrics.enabled }}
+                ports:
+                - containerPort: 8084
+                  name: gv-metrics
+                {{- end }}
                 env:
                 - name: NODE_NAME
                   valueFrom:

--- a/deployments/liqo/templates/liqo-wireguard-gateway-server-template.yaml
+++ b/deployments/liqo/templates/liqo-wireguard-gateway-server-template.yaml
@@ -75,6 +75,9 @@ spec:
                 {{- if gt .Values.networking.gatewayTemplates.replicas 1.0 }}
                 - --leader-election=true
                 {{- end }}
+                {{- if .Values.requirements.kernel.disabled }}
+                - --disable-kernel-version-check
+                {{- end }}
                 {{- if .Values.metrics.enabled }}
                 ports:
                 - containerPort: 8080
@@ -134,7 +137,6 @@ spec:
                 - --metrics-address=:8084
                 {{- end }}
                 - --health-probe-bind-address=:8085
-                - --enable-arp=true
                 {{- if .Values.metrics.enabled }}
                 ports:
                 - containerPort: 8084

--- a/deployments/liqo/values.yaml
+++ b/deployments/liqo/values.yaml
@@ -10,6 +10,11 @@ nameOverride: ""
 # -- Override the standard full name used by Helm and associated to Kubernetes/Liqo resources.
 fullnameOverride: ""
 
+requirements:
+  kernel:
+    # -- Enable/Disable the kernel requirements check.
+    disabled: false
+
 metrics:
   # -- Enable/Disable the metrics server in every liqo component.
   enabled: false

--- a/pkg/fabric/flags.go
+++ b/pkg/fabric/flags.go
@@ -27,32 +27,40 @@ func (fn FlagName) String() string {
 }
 
 const (
-	// FlagNodeNameName is the name of the node where the pod is scheduled.
-	FlagNodeNameName FlagName = "nodename"
+	// FlagNameNodeName is the name of the node where the pod is scheduled.
+	FlagNameNodeName FlagName = "nodename"
 
 	// FlagNameMetricsAddress is the address for the metrics endpoint.
 	FlagNameMetricsAddress FlagName = "metrics-address"
 	// FlagNameProbeAddr is the address for the health probe endpoint.
 	FlagNameProbeAddr FlagName = "health-probe-bind-address"
 
-	// FlagEnableARP is the flag to enable ARP.
-	FlagEnableARP FlagName = "enable-arp"
+	// FlagNameDisableARP is the flag to enable ARP.
+	FlagNameDisableARP FlagName = "disable-arp"
+
+	// FlagNameDisableKernelVersionCheck is the flag to enable the kernel version check.
+	FlagNameDisableKernelVersionCheck FlagName = "disable-kernel-version-check"
+	// FlagNameMinimumKernelVersion is the minimum kernel version required to run the wireguard interface.
+	FlagNameMinimumKernelVersion FlagName = "minimum-kernel-version"
 )
 
 // RequiredFlags contains the list of the mandatory flags.
 var RequiredFlags = []FlagName{
-	FlagNodeNameName,
+	FlagNameNodeName,
 }
 
 // InitFlags initializes the flags for the wireguard tunnel.
 func InitFlags(flagset *pflag.FlagSet, opts *Options) {
-	flagset.StringVar(&opts.NodeName, FlagNodeNameName.String(), "", "Name of the node where the pod is scheduled")
+	flagset.StringVar(&opts.NodeName, FlagNameNodeName.String(), "", "Name of the node where the pod is scheduled")
 	flagset.StringVar(&opts.PodName, "podname", "", "Name of the pod")
 
 	flagset.StringVar(&opts.MetricsAddress, FlagNameMetricsAddress.String(), ":8080", "Address for the metrics endpoint")
 	flagset.StringVar(&opts.ProbeAddr, FlagNameProbeAddr.String(), ":8081", "Address for the health probe endpoint")
 
-	flagset.BoolVar(&opts.EnableARP, FlagEnableARP.String(), true, "Enable ARP")
+	flagset.BoolVar(&opts.DisableARP, FlagNameDisableARP.String(), false, "Disable ARP")
+
+	flagset.BoolVar(&opts.DisableKernelVersionCheck, FlagNameDisableKernelVersionCheck.String(), false, "Disable the kernel version check")
+	flagset.Var(&opts.MinimumKernelVersion, string(FlagNameMinimumKernelVersion), "Minimum kernel version required to run the wireguard interface")
 }
 
 // MarkFlagsRequired marks the flags as required.

--- a/pkg/fabric/internalfabric_controller.go
+++ b/pkg/fabric/internalfabric_controller.go
@@ -112,7 +112,7 @@ func (r *InternalFabricReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		internalnode.Spec.Interface.Node.IP.String(),
 		internalfabric.Spec.GatewayIP.String(),
 		id,
-		r.Options.EnableARP,
+		r.Options.DisableARP,
 	); err != nil {
 		return ctrl.Result{}, fmt.Errorf("unable to ensure the geneve interface presence: %w", err)
 	}

--- a/pkg/fabric/options.go
+++ b/pkg/fabric/options.go
@@ -14,6 +14,10 @@
 
 package fabric
 
+import (
+	kernelversion "github.com/liqotech/liqo/pkg/utils/kernel/version"
+)
+
 // Options contains the options for the wireguard interface.
 type Options struct {
 	NodeName string
@@ -22,10 +26,15 @@ type Options struct {
 	MetricsAddress string
 	ProbeAddr      string
 
-	EnableARP bool
+	DisableARP bool
+
+	DisableKernelVersionCheck bool
+	MinimumKernelVersion      kernelversion.KernelVersion
 }
 
 // NewOptions returns a new Options struct.
 func NewOptions() *Options {
-	return &Options{}
+	return &Options{
+		MinimumKernelVersion: kernelversion.MinimumKernelVersion,
+	}
 }

--- a/pkg/gateway/fabric/flag.go
+++ b/pkg/gateway/fabric/flag.go
@@ -26,11 +26,11 @@ func (fn FlagName) String() string {
 }
 
 const (
-	// FlagNameEnableARP is the flag to enable ARP.
-	FlagNameEnableARP FlagName = "enable-arp"
+	// FlagNameDisableARP is the flag to enable ARP.
+	FlagNameDisableARP FlagName = "disable-arp"
 )
 
 // InitFlags initializes the flags for the gateway.
 func InitFlags(flagset *pflag.FlagSet, opts *Options) {
-	flagset.BoolVar(&opts.EnableARP, FlagNameEnableARP.String(), false, "Enable ARP")
+	flagset.BoolVar(&opts.DisableARP, FlagNameDisableARP.String(), false, "Disable ARP")
 }

--- a/pkg/gateway/fabric/geneve/internalnode_controller.go
+++ b/pkg/gateway/fabric/geneve/internalnode_controller.go
@@ -102,7 +102,7 @@ func (r *InternalNodeReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		internalFabric.Spec.Interface.Gateway.IP.String(),
 		remoteIP.String(),
 		id,
-		r.Options.EnableARP,
+		r.Options.DisableARP,
 	); err != nil {
 		return ctrl.Result{}, fmt.Errorf("unable to ensure the geneve interface presence: %w", err)
 	}

--- a/pkg/gateway/flags.go
+++ b/pkg/gateway/flags.go
@@ -57,6 +57,11 @@ const (
 	FlagNameMetricsAddress FlagName = "metrics-address"
 	// FlagNameProbeAddr is the address for the health probe endpoint.
 	FlagNameProbeAddr FlagName = "health-probe-bind-address"
+
+	// FlagNameDisableKernelVersionCheck is the flag to enable the kernel version check.
+	FlagNameDisableKernelVersionCheck FlagName = "disable-kernel-version-check"
+	// FlagNameMinimumKernelVersion is the minimum kernel version required by Liqo.
+	FlagNameMinimumKernelVersion FlagName = "minimum-kernel-version"
 )
 
 // RequiredFlags contains the list of the mandatory flags.
@@ -90,6 +95,9 @@ func InitFlags(flagset *pflag.FlagSet, opts *Options) {
 
 	flagset.StringVar(&opts.MetricsAddress, FlagNameMetricsAddress.String(), "0", "Address for the metrics endpoint")
 	flagset.StringVar(&opts.ProbeAddr, FlagNameProbeAddr.String(), ":8081", "Address for the health probe endpoint")
+
+	flagset.BoolVar(&opts.DisableKernelVersionCheck, FlagNameDisableKernelVersionCheck.String(), false, "Disable the kernel version check")
+	flagset.Var(&opts.MinimumKernelVersion, FlagNameMinimumKernelVersion.String(), "Minimum kernel version required by Liqo")
 }
 
 // MarkFlagsRequired marks the flags as required.

--- a/pkg/gateway/options.go
+++ b/pkg/gateway/options.go
@@ -17,6 +17,8 @@ package gateway
 import (
 	"fmt"
 	"time"
+
+	kernelversion "github.com/liqotech/liqo/pkg/utils/kernel/version"
 )
 
 // Options contains the options for the wireguard interface.
@@ -37,11 +39,16 @@ type Options struct {
 
 	MetricsAddress string
 	ProbeAddr      string
+
+	DisableKernelVersionCheck bool
+	MinimumKernelVersion      kernelversion.KernelVersion
 }
 
 // NewOptions returns a new Options struct.
 func NewOptions() *Options {
-	return &Options{}
+	return &Options{
+		MinimumKernelVersion: kernelversion.MinimumKernelVersion,
+	}
 }
 
 // Mode is the mode in which the gateway is configured.

--- a/pkg/liqoctl/install/handler.go
+++ b/pkg/liqoctl/install/handler.go
@@ -98,6 +98,8 @@ type Options struct {
 	DisableAPIServerSanityChecks bool
 	DisableAPIServerDefaulting   bool
 	SkipValidation               bool
+
+	DisableKernelVersionCheck bool
 }
 
 // NewOptions returns a new Options struct.
@@ -348,6 +350,12 @@ func (o *Options) preProviderValues() map[string]interface{} {
 
 	return map[string]interface{}{
 		"tag": o.Version,
+
+		"requirements": map[string]interface{}{
+			"kernel": map[string]interface{}{
+				"disabled": o.DisableKernelVersionCheck,
+			},
+		},
 
 		"apiServer": map[string]interface{}{
 			"address": o.APIServer,

--- a/pkg/utils/kernel/version/const.go
+++ b/pkg/utils/kernel/version/const.go
@@ -12,21 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package fabric
+package version
 
-import (
-	"github.com/liqotech/liqo/pkg/gateway"
-)
-
-// Options contains the options for the wireguard interface.
-type Options struct {
-	GwOptions  *gateway.Options
-	DisableARP bool
-}
-
-// NewOptions returns a new Options struct.
-func NewOptions(options *gateway.Options) *Options {
-	return &Options{
-		GwOptions: options,
+var (
+	// MinimumKernelVersion is the minimum kernel version required by Liqo.
+	MinimumKernelVersion = KernelVersion{
+		Kernel: 5,
+		Major:  10,
+		Minor:  0,
 	}
-}
+)

--- a/pkg/utils/kernel/version/doc.go
+++ b/pkg/utils/kernel/version/doc.go
@@ -12,21 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package fabric
-
-import (
-	"github.com/liqotech/liqo/pkg/gateway"
-)
-
-// Options contains the options for the wireguard interface.
-type Options struct {
-	GwOptions  *gateway.Options
-	DisableARP bool
-}
-
-// NewOptions returns a new Options struct.
-func NewOptions(options *gateway.Options) *Options {
-	return &Options{
-		GwOptions: options,
-	}
-}
+// Package version provides functions to get kernel version and compare it with a given one.
+package version

--- a/pkg/utils/kernel/version/k8s.go
+++ b/pkg/utils/kernel/version/k8s.go
@@ -1,0 +1,75 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package version
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/liqotech/liqo/pkg/consts"
+)
+
+// CheckKernelVersionFromNodes checks if the current kernel version satisfies the minimum requirements from a list of nodes.
+func CheckKernelVersionFromNodes(ctx context.Context, cl client.Client, minimum *KernelVersion) error {
+	current, err := GetLowerKernelVersionFromNodes(ctx, cl)
+	if err != nil {
+		return fmt.Errorf("failed to get the current kernel version: %w", err)
+	}
+
+	if !current.CheckRequirements(minimum) {
+		return fmt.Errorf("kernel version %s does not satisfy the minimum requirements %s", current.String(), minimum.String())
+	}
+
+	klog.Infof("Kernel version %s satisfies the minimum requirements %s", current.String(), minimum.String())
+	return nil
+}
+
+// GetLowerKernelVersionFromNodes gets the lower kernel version from a list of nodes.
+func GetLowerKernelVersionFromNodes(ctx context.Context, cl client.Client) (*KernelVersion, error) {
+	nodes := corev1.NodeList{}
+	if err := cl.List(ctx, &nodes); err != nil {
+		return nil, err
+	}
+
+	var lowerKernelVersion *KernelVersion
+	for i := range nodes.Items {
+		node := nodes.Items[i]
+		if node.Status.NodeInfo.KernelVersion == "" {
+			continue
+		}
+		if l, ok := node.Labels[consts.TypeLabel]; ok && l == consts.VirtualNodeLabel {
+			continue
+		}
+		nodeKernelVersion, err := GetKernelVersionFromNode(&node)
+		if err != nil {
+			return nil, err
+		}
+
+		if lowerKernelVersion == nil || Compare(nodeKernelVersion, lowerKernelVersion) < 0 {
+			lowerKernelVersion = nodeKernelVersion
+		}
+	}
+
+	return lowerKernelVersion, nil
+}
+
+// GetKernelVersionFromNode gets the current kernel version from a node.
+func GetKernelVersionFromNode(node *corev1.Node) (*KernelVersion, error) {
+	return ParseRelease(node.Status.NodeInfo.KernelVersion)
+}

--- a/pkg/utils/kernel/version/unix.go
+++ b/pkg/utils/kernel/version/unix.go
@@ -1,0 +1,59 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux || freebsd || openbsd
+
+package version
+
+import (
+	"fmt"
+
+	"golang.org/x/sys/unix"
+	"k8s.io/klog/v2"
+)
+
+// CheckKernelVersion checks if the current kernel version satisfies the minimum requirements.
+func CheckKernelVersion(minimum *KernelVersion) error {
+	current, err := GetKernelVersion()
+	if err != nil {
+		return fmt.Errorf("failed to get the current kernel version: %w", err)
+	}
+
+	if !current.CheckRequirements(minimum) {
+		return fmt.Errorf("kernel version %s does not satisfy the minimum requirements %s", current.String(), minimum.String())
+	}
+
+	klog.Infof("Kernel version %s satisfies the minimum requirements %s", current.String(), minimum.String())
+	return nil
+}
+
+// GetKernelVersion gets the current kernel version.
+func GetKernelVersion() (*KernelVersion, error) {
+	uts, err := uname()
+	if err != nil {
+		return nil, err
+	}
+
+	// Remove the \x00 from the release for Atoi to parse correctly
+	return ParseRelease(unix.ByteSliceToString(uts.Release[:]))
+}
+
+func uname() (*unix.Utsname, error) {
+	uts := &unix.Utsname{}
+
+	if err := unix.Uname(uts); err != nil {
+		return nil, err
+	}
+	return uts, nil
+}

--- a/pkg/utils/kernel/version/version.go
+++ b/pkg/utils/kernel/version/version.go
@@ -1,0 +1,113 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package version
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/spf13/pflag"
+)
+
+var _ pflag.Value = &KernelVersion{}
+
+// KernelVersion holds information about the kernel.
+type KernelVersion struct {
+	Kernel int
+	Major  int
+	Minor  int
+	Flavor string
+}
+
+// String returns the string representation of the KernelVersion.
+func (kv *KernelVersion) String() string {
+	return fmt.Sprintf("%d.%d.%d%s", kv.Kernel, kv.Major, kv.Minor, kv.Flavor)
+}
+
+// Set parses a string and sets the KernelVersion.
+func (kv *KernelVersion) Set(s string) error {
+	newvi, err := ParseRelease(s)
+	if err != nil {
+		return err
+	}
+	kv.Kernel = newvi.Kernel
+	kv.Major = newvi.Major
+	kv.Minor = newvi.Minor
+	kv.Flavor = newvi.Flavor
+
+	return nil
+}
+
+// Type returns the type of the KernelVersion.
+func (kv *KernelVersion) Type() string {
+	return "string"
+}
+
+// CheckRequirements checks if the kernel version is compatible with the requirements.
+func (kv *KernelVersion) CheckRequirements(minimumkv *KernelVersion) bool {
+	return Compare(kv, minimumkv) >= 0
+}
+
+// Compare compares two kernel.VersionInfo structs.
+// Returns -1 if a < b, 0 if a == b, 1 it a > b.
+func Compare(a, b *KernelVersion) int {
+	if a.Kernel < b.Kernel {
+		return -1
+	} else if a.Kernel > b.Kernel {
+		return 1
+	}
+
+	if a.Major < b.Major {
+		return -1
+	} else if a.Major > b.Major {
+		return 1
+	}
+
+	if a.Minor < b.Minor {
+		return -1
+	} else if a.Minor > b.Minor {
+		return 1
+	}
+
+	return 0
+}
+
+// ParseRelease parses a string and creates a VersionInfo based on it.
+func ParseRelease(release string) (*KernelVersion, error) {
+	var (
+		kernel, major, minor, parsed int
+		flavor, partial              string
+	)
+
+	// Ignore error from Sscanf to allow an empty flavor.  Instead, just
+	// make sure we got all the version numbers.
+	parsed, _ = fmt.Sscanf(release, "%d.%d%s", &kernel, &major, &partial)
+	if parsed < 2 {
+		return nil, errors.New("Can't parse kernel version " + release)
+	}
+
+	// sometimes we have 3.12.25-gentoo, but sometimes we just have 3.12-1-amd64
+	parsed, _ = fmt.Sscanf(partial, ".%d%s", &minor, &flavor)
+	if parsed < 1 {
+		flavor = partial
+	}
+
+	return &KernelVersion{
+		Kernel: kernel,
+		Major:  major,
+		Minor:  minor,
+		Flavor: flavor,
+	}, nil
+}

--- a/pkg/utils/network/geneve/netlink.go
+++ b/pkg/utils/network/geneve/netlink.go
@@ -23,7 +23,7 @@ import (
 )
 
 // EnsureGeneveInterfacePresence ensures that a geneve interface exists for the given internal node.
-func EnsureGeneveInterfacePresence(interfaceName, localIP, remoteIP string, id uint32, enableARP bool) error {
+func EnsureGeneveInterfacePresence(interfaceName, localIP, remoteIP string, id uint32, disableARP bool) error {
 	remoteIPNet := net.ParseIP(remoteIP)
 	if remoteIPNet == nil {
 		remoteIPsNet, err := net.LookupIP(remoteIP)
@@ -36,7 +36,7 @@ func EnsureGeneveInterfacePresence(interfaceName, localIP, remoteIP string, id u
 		net.ParseIP(localIP),
 		remoteIPNet,
 		id,
-		enableARP,
+		disableARP,
 	)
 }
 
@@ -62,7 +62,7 @@ func ForgeGeneveInterface(name string, remote net.IP, id uint32) *netlink.Geneve
 }
 
 // CreateGeneveInterface creates a geneve interface with the given name, remote IP and ID.
-func CreateGeneveInterface(name string, local, remote net.IP, id uint32, enableARP bool) error {
+func CreateGeneveInterface(name string, local, remote net.IP, id uint32, disableARP bool) error {
 	var geneveLink *netlink.Geneve
 	link := ExistGeneveInterface(name)
 
@@ -86,7 +86,7 @@ func CreateGeneveInterface(name string, local, remote net.IP, id uint32, enableA
 		}
 	}
 
-	if !enableARP {
+	if disableARP {
 		if err := netlink.LinkSetARPOff(geneveLink); err != nil {
 			return fmt.Errorf("cannot set geneve link arp off: %w", err)
 		}

--- a/values.yaml
+++ b/values.yaml
@@ -1,0 +1,336 @@
+apiServer:
+    address: ""
+    ca: ""
+    trustedCA: false
+authentication:
+    awsConfig:
+        accessKeyId: ""
+        clusterName: ""
+        region: ""
+        secretAccessKey: ""
+        useExistingSecret: false
+    enabled: true
+common:
+    affinity: {}
+    extraArgs: []
+    nodeSelector: {}
+    tolerations: []
+controllerManager:
+    config:
+        defaultLimitsEnforcement: None
+        enableNodeFailureController: false
+        enableResourceEnforcement: true
+    image:
+        name: ghcr.io/liqotech/liqo-controller-manager
+        version: ""
+    metrics:
+        service:
+            annotations: {}
+            labels: {}
+        serviceMonitor:
+            enabled: false
+            interval: ""
+            labels: {}
+            scrapeTimeout: ""
+    pod:
+        annotations: {}
+        extraArgs: []
+        labels: {}
+        priorityClassName: ""
+        resources:
+            limits: {}
+            requests: {}
+    replicas: 1
+crdReplicator:
+    image:
+        name: ghcr.io/liqotech/crd-replicator
+        version: ""
+    metrics:
+        podMonitor:
+            enabled: false
+            interval: ""
+            labels: {}
+            scrapeTimeout: ""
+    pod:
+        annotations: {}
+        extraArgs: []
+        labels: {}
+        priorityClassName: ""
+        resources:
+            limits: {}
+            requests: {}
+discovery:
+    config:
+        clusterID: cheina-cluster1
+        clusterLabels:
+            liqo.io/provider: kind
+fullnameOverride: ""
+ipam:
+    additionalPools: []
+    external:
+        enabled: false
+        url: ""
+    externalCIDR: 10.70.0.0/16
+    internal:
+        image:
+            name: ghcr.io/liqotech/ipam
+            version: ""
+        pod:
+            annotations: {}
+            extraArgs: []
+            labels: {}
+            priorityClassName: ""
+            resources:
+                limits: {}
+                requests: {}
+        replicas: 1
+    internalCIDR: 10.80.0.0/16
+    podCIDR: 10.112.0.0/16
+    reservedSubnets: []
+    serviceCIDR: 10.111.0.0/16
+metricAgent:
+    config:
+        timeout:
+            read: 30s
+            write: 30s
+    enable: true
+    image:
+        name: ghcr.io/liqotech/metric-agent
+        version: ""
+    initContainer:
+        image:
+            name: ghcr.io/liqotech/cert-creator
+            version: ""
+    pod:
+        annotations: {}
+        extraArgs: []
+        labels: {}
+        priorityClassName: ""
+        resources:
+            limits: {}
+            requests: {}
+metrics:
+    enabled: false
+    prometheusOperator:
+        enabled: false
+nameOverride: ""
+networking:
+    clientResources:
+        - apiVersion: networking.liqo.io/v1alpha1
+          resource: wggatewayclients
+    enabled: true
+    fabric:
+        config:
+            fullMasquerade: false
+            gatewayMasqueradeBypass: true
+        image:
+            name: ghcr.io/liqotech/fabric
+            version: ""
+        pod:
+            annotations: {}
+            extraArgs: []
+            labels: {}
+            priorityClassName: ""
+            resources:
+                limits: {}
+                requests: {}
+        tolerations: []
+    gatewayTemplates:
+        container:
+            gateway:
+                image:
+                    name: ghcr.io/liqotech/gateway
+                    version: ""
+            geneve:
+                image:
+                    name: ghcr.io/liqotech/gateway/geneve
+                    version: ""
+            wireguard:
+                image:
+                    name: ghcr.io/liqotech/gateway/wireguard
+                    version: ""
+        ping:
+            interval: 2s
+            lossThreshold: 5
+            updateStatusInterval: 10s
+        replicas: 1
+        server:
+            service:
+                allocateLoadBalancerNodePorts: ""
+                annotations: null
+        wireguard:
+            implementation: kernel
+    reflectIPs: true
+    serverResources:
+        - apiVersion: networking.liqo.io/v1alpha1
+          resource: wggatewayservers
+offloading:
+    createNode: true
+    defaultNodeResources:
+        cpu: "4"
+        ephemeralStorage: 20Gi
+        memory: 8Gi
+        pods: "110"
+    disableNetworkCheck: false
+    enabled: true
+    reflection:
+        configmap:
+            type: DenyList
+            workers: 3
+        endpointslice:
+            workers: 10
+        event:
+            type: DenyList
+            workers: 3
+        ingress:
+            ingressClasses: []
+            type: DenyList
+            workers: 3
+        persistentvolumeclaim:
+            workers: 3
+        pod:
+            workers: 10
+        secret:
+            type: DenyList
+            workers: 3
+        service:
+            loadBalancerClasses: []
+            type: DenyList
+            workers: 3
+        serviceaccount:
+            workers: 3
+        skip:
+            annotations:
+                - cloud.google.com/neg
+                - cloud.google.com/neg-status
+                - kubernetes.digitalocean.com/load-balancer-id
+                - ingress.kubernetes.io/backends
+                - ingress.kubernetes.io/forwarding-rule
+                - ingress.kubernetes.io/target-proxy
+                - ingress.kubernetes.io/url-map
+                - metallb.universe.tf/address-pool
+                - metallb.universe.tf/ip-allocated-from-pool
+                - metallb.universe.tf/loadBalancerIPs
+                - loadbalancer.openstack.org/load-balancer-id
+            labels: []
+    runtimeClass:
+        annotations: {}
+        enable: false
+        handler: liqo
+        labels: {}
+        name: liqo
+        nodeSelector:
+            enable: true
+            labels:
+                liqo.io/type: virtual-node
+        tolerations:
+            enable: true
+            tolerations:
+                - effect: NoExecute
+                  key: virtual-node.liqo.io/not-allowed
+                  operator: Exists
+openshiftConfig:
+    enable: false
+    virtualKubeletSCCs:
+        - anyuid
+proxy:
+    config:
+        listeningPort: 8118
+    image:
+        name: ghcr.io/liqotech/proxy
+        version: ""
+    pod:
+        annotations: {}
+        extraArgs: []
+        labels: {}
+        priorityClassName: ""
+        resources:
+            limits: {}
+            requests: {}
+    service:
+        annotations: {}
+        type: ClusterIP
+pullPolicy: IfNotPresent
+requirements:
+    kernel:
+        disabled: true
+storage:
+    enable: true
+    realStorageClassName: ""
+    storageNamespace: liqo-storage
+    virtualStorageClassName: liqo
+tag: aaaa
+telemetry:
+    config:
+        schedule: ""
+    enable: false
+    image:
+        name: ghcr.io/liqotech/telemetry
+        version: ""
+    pod:
+        annotations: {}
+        extraArgs: []
+        labels: {}
+        resources:
+            limits: {}
+            requests: {}
+uninstaller:
+    image:
+        name: ghcr.io/liqotech/uninstaller
+        version: ""
+    pod:
+        annotations: {}
+        extraArgs: []
+        labels: {}
+        resources:
+            limits: {}
+            requests: {}
+virtualKubelet:
+    extra:
+        annotations: {}
+        args: []
+        labels: {}
+        resources:
+            limits: {}
+            requests: {}
+    image:
+        name: ghcr.io/liqotech/virtual-kubelet
+        version: ""
+    metrics:
+        enabled: false
+        podMonitor:
+            enabled: false
+            interval: ""
+            labels: {}
+            scrapeTimeout: ""
+        port: 5872
+    virtualNode:
+        extra:
+            annotations: {}
+            labels: {}
+webhook:
+    failurePolicy: Fail
+    image:
+        name: ghcr.io/liqotech/webhook
+        version: ""
+    metrics:
+        service:
+            annotations: {}
+            labels: {}
+        serviceMonitor:
+            enabled: false
+            interval: ""
+            labels: {}
+            scrapeTimeout: ""
+    patch:
+        image: k8s.gcr.io/ingress-nginx/kube-webhook-certgen:v1.1.1
+    pod:
+        annotations: {}
+        extraArgs: []
+        labels: {}
+        priorityClassName: ""
+        resources:
+            limits: {}
+            requests: {}
+    port: 9443
+    replicas: 1


### PR DESCRIPTION
# Description

Adds a check for kernel version inside the gateway and fabric.
By default, the kernel must be >=5.10.0
The minimum kernel version can be customized for each component or disabled through flags.
