### PR TITLE
[Test] Virtual-kubelet reflection counters for each resource

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,8 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.67.0
 	github.com/prometheus/client_golang v1.18.0
+	github.com/prometheus/client_model v0.5.0
+	github.com/prometheus/common v0.45.0
 	github.com/pterm/pterm v0.12.79
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/pflag v1.0.5
@@ -201,8 +203,6 @@ require (
 	github.com/pjbgf/sha1cd v0.3.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/pquerna/otp v1.3.0 // indirect
-	github.com/prometheus/client_model v0.5.0 // indirect
-	github.com/prometheus/common v0.45.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/rivo/uniseg v0.4.4 // indirect
 	github.com/rubenv/sql-migrate v1.6.0 // indirect

--- a/test/e2e/cruise/resourceenforcement/resourceenforcement_test.go
+++ b/test/e2e/cruise/resourceenforcement/resourceenforcement_test.go
@@ -41,7 +41,7 @@ const (
 	// clustersRequired is the number of clusters required in this E2E test.
 	clustersRequired = 2
 	// testName is the name of this E2E test.
-	testName = "RESOURCEENFORCEMENT"
+	testName = "RESOURCE_ENFORCEMENT"
 )
 
 func TestE2E(t *testing.T) {

--- a/test/e2e/testutils/http/doc.go
+++ b/test/e2e/testutils/http/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package http provides utilities to handle http requests.
+package http

--- a/test/e2e/testutils/http/http.go
+++ b/test/e2e/testutils/http/http.go
@@ -1,0 +1,59 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package http
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// Client struct to handle http requests.
+type Client struct {
+	Client *http.Client
+}
+
+// NewHTTPClient creates a new HttpClient with a specified timeout.
+func NewHTTPClient(timeout time.Duration) *Client {
+	return &Client{
+		Client: &http.Client{
+			Timeout: timeout,
+		},
+	}
+}
+
+// Curl executes a curl command to the specified target.
+// It returns the response and the body of the response, or an error if the request fails.
+func (hc *Client) Curl(ctx context.Context, url string) (*http.Response, []byte, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", url, http.NoBody)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create HTTP request: %w", err)
+	}
+
+	resp, err := hc.Client.Do(req)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to execute curl command: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	return resp, body, nil
+}

--- a/test/e2e/testutils/metrics/doc.go
+++ b/test/e2e/testutils/metrics/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package metrics provides utilities to handle metrics.
+package metrics

--- a/test/e2e/testutils/metrics/metrics.go
+++ b/test/e2e/testutils/metrics/metrics.go
@@ -1,0 +1,68 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"fmt"
+	"strings"
+
+	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/expfmt"
+)
+
+// ParseMetrics parses a Prometheus metrics file and returns a map of metric families.
+func ParseMetrics(body string) (map[string]*dto.MetricFamily, error) {
+	parser := expfmt.TextParser{}
+	return parser.TextToMetricFamilies(strings.NewReader(body))
+}
+
+// RetrieveCounter retrieves a metric of type counter from a metric family, given the metric name and a set of key-value selectors.
+func RetrieveCounter(metricFamilies map[string]*dto.MetricFamily, metricName string, keyValueSelectors map[string]string) (float64, error) {
+	// Find the metric family
+	if metricFamilies == nil {
+		return 0, fmt.Errorf("metric families not found")
+	}
+
+	mf, ok := metricFamilies[metricName]
+	if !ok {
+		return 0, fmt.Errorf("metric family %s not found", metricName)
+	}
+
+	// Find the specific metric
+	for _, metric := range mf.Metric {
+		entry := make(map[string]string)
+		for _, pair := range metric.Label {
+			entry[pair.GetName()] = pair.GetValue()
+		}
+
+		match := true
+		for key, value := range keyValueSelectors {
+			if entry[key] != value {
+				match = false
+				break
+			}
+		}
+
+		if match {
+			counter := metric.GetCounter()
+			if counter == nil {
+				return 0, fmt.Errorf("metric %s is not a counter", metricName)
+			}
+			return counter.GetValue(), nil
+		}
+	}
+
+	return 0, fmt.Errorf("metric %s not found", metricName)
+}

--- a/test/e2e/testutils/portforward/doc.go
+++ b/test/e2e/testutils/portforward/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package portforward provides a util functions to portforward resources in K8s.
+package portforward

--- a/test/e2e/testutils/portforward/portforward.go
+++ b/test/e2e/testutils/portforward/portforward.go
@@ -1,0 +1,131 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package portforward
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/portforward"
+	"k8s.io/client-go/transport/spdy"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// RunPortForwardContext implements all the necessary functionality for port-forward cmd.
+// It ends portforwarding when an error is received from the backend, or an interrupt
+// signal is received, or the provided context is done.
+func RunPortForwardContext(ctx context.Context, cfg *rest.Config, cl client.Client, podName, podNamespace string, localPort, targetPort int) error {
+	ppf := NewPodPortForwarderOptions(cfg, cl, podName, podNamespace, localPort, targetPort)
+
+	// Managing termination signal from the terminal.
+	// The stopCh gets closed to gracefully handle its termination.
+	signals := make(chan os.Signal, 1)
+	signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM)
+	defer signal.Stop(signals)
+
+	returnCtx, returnCtxCancel := context.WithCancel(ctx)
+	defer returnCtxCancel()
+
+	go func() {
+		select {
+		case <-signals:
+		case <-returnCtx.Done():
+		}
+		if ppf.StopCh != nil {
+			close(ppf.StopCh)
+		}
+	}()
+
+	return ppf.PortForwardPod(ctx)
+}
+
+// NewPodPortForwarderOptions creates a new PodPortForwarderOptions.
+func NewPodPortForwarderOptions(cfg *rest.Config, cl client.Client,
+	podName, podNamespace string, localPort, targetPort int) *PodPortForwarderOptions {
+	return &PodPortForwarderOptions{
+		Config:       cfg,
+		Client:       cl,
+		PodName:      podName,
+		PodNamespace: podNamespace,
+		LocalPort:    localPort,
+		TargetPort:   targetPort,
+		Streams:      genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr},
+		StopCh:       make(chan struct{}, 1),
+		ReadyCh:      make(chan struct{}),
+	}
+}
+
+// PodPortForwarderOptions contains the options for the port forwarding a pod.
+type PodPortForwarderOptions struct {
+	// RestConfig is the kubernetes config
+	Config *rest.Config
+	// Client is the controller-runtime client
+	Client client.Client
+	// PodName is the name of the pod to port forward
+	PodName string
+	// PodNamespace is the namespace of the pod to port forward
+	PodNamespace string
+	// LocalPort is the local port that will be selected to expose the PodPort
+	LocalPort int
+	// TargetPort is the target port for the pod
+	TargetPort int
+	// Steams configures where to write or read input from
+	Streams genericclioptions.IOStreams
+	// StopCh is the channel used to manage the port forward lifecycle
+	StopCh chan struct{}
+	// ReadyCh communicates when the tunnel is ready to receive traffic
+	ReadyCh chan struct{}
+}
+
+// PortForwardPod port forwards the pod.
+func (o *PodPortForwarderOptions) PortForwardPod(ctx context.Context) error {
+	// Check if pod is in Running phase
+	var pod corev1.Pod
+	if err := o.Client.Get(ctx, client.ObjectKey{Namespace: o.PodNamespace, Name: o.PodName}, &pod); err != nil {
+		return err
+	}
+	if pod.Status.Phase != corev1.PodRunning {
+		return fmt.Errorf("unable to forward port because pod is not running. Current status=%v", pod.Status.Phase)
+	}
+
+	path := fmt.Sprintf("/api/v1/namespaces/%s/pods/%s/portforward", o.PodNamespace, o.PodName)
+	hostIP := strings.TrimLeft(o.Config.Host, "htps:/")
+
+	transport, upgrader, err := spdy.RoundTripperFor(o.Config)
+	if err != nil {
+		return err
+	}
+
+	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: transport}, http.MethodPost, &url.URL{Scheme: "https", Path: path, Host: hostIP})
+
+	fw, err := portforward.New(dialer,
+		[]string{fmt.Sprintf("%d:%d", o.LocalPort, o.TargetPort)},
+		o.StopCh, o.ReadyCh,
+		o.Streams.Out, o.Streams.ErrOut)
+	if err != nil {
+		return err
+	}
+
+	return fw.ForwardPorts()
+}


### PR DESCRIPTION
# Description

This PR adds e2e tests that check that the number of reflections for each resource is reasonably low. These metrics are retrieved from the metric server for the virtual-kubelet using port-forwarding on localhost.
