### PR TITLE
Fix forge auth params in tenant reconciler

### DIFF
--- a/pkg/liqo-controller-manager/authentication/tenant-controller/tenant_controller.go
+++ b/pkg/liqo-controller-manager/authentication/tenant-controller/tenant_controller.go
@@ -201,6 +201,10 @@ func (r *TenantReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res
 		IdentityType:    authv1alpha1.ControlPlaneIdentityType,
 		Name:            tenant.Name,
 		SigningRequest:  tenant.Spec.CSR,
+
+		APIServerAddressOverride: r.APIServerAddressOverride,
+		CAOverride:               r.CAOverride,
+		TrustedCA:                r.TrustedCA,
 	})
 	if err != nil {
 		klog.Errorf("Unable to forge the AuthParams for the Tenant %q: %s", req.Name, err)


### PR DESCRIPTION
# Description

This PR fixes the forge of auth params in the tenant reconciler
