### PR TITLE
Telemetry: nodes and modules

### DIFF
--- a/cmd/telemetry/main.go
+++ b/cmd/telemetry/main.go
@@ -30,6 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
+	authv1alpha1 "github.com/liqotech/liqo/apis/authentication/v1alpha1"
 	liqov1alpha1 "github.com/liqotech/liqo/apis/core/v1alpha1"
 	ipamv1alpha1 "github.com/liqotech/liqo/apis/ipam/v1alpha1"
 	offloadingv1alpha1 "github.com/liqotech/liqo/apis/offloading/v1alpha1"
@@ -48,6 +49,7 @@ func init() {
 	_ = liqov1alpha1.AddToScheme(scheme)
 	_ = offloadingv1alpha1.AddToScheme(scheme)
 	_ = ipamv1alpha1.AddToScheme(scheme)
+	_ = authv1alpha1.AddToScheme(scheme)
 }
 
 // cluster-role
@@ -55,6 +57,7 @@ func init() {
 // +kubebuilder:rbac:groups=core.liqo.io,resources=foreignclusters,verbs=get;list;watch
 // +kubebuilder:rbac:groups=offloading.liqo.io,resources=namespaceoffloadings,verbs=get;list;watch
 // +kubebuilder:rbac:groups=offloading.liqo.io,resources=virtualnodes,verbs=get;list;watch
+// +kubebuilder:rbac:groups=authentication.liqo.io,resources=resourceslices,verbs=get;list;watch
 
 func main() {
 	var clusterLabels argsutils.StringMap

--- a/deployments/liqo/files/liqo-telemetry-ClusterRole.yaml
+++ b/deployments/liqo/files/liqo-telemetry-ClusterRole.yaml
@@ -1,5 +1,13 @@
 rules:
 - apiGroups:
+  - authentication.liqo.io
+  resources:
+  - resourceslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - ""
   resources:
   - configmaps

--- a/pkg/telemetry/doc.go
+++ b/pkg/telemetry/doc.go
@@ -20,15 +20,24 @@
 //   - Cluster ID
 //   - Liqo version
 //   - Kubernetes version
+//   - Node info
+//     -- Kernel version
+//     -- OS image
 //   - Security mode
 //   - Provider (e.g. GKE, EKS, AKS, ...)
 //   - Peering info
 //     -- RemoteClusterID
-//     -- PeeringType (OutOfBand/InBand)
-//     -- DiscoveryType (LAN/Manual/IncomingPeering)
+//     -- Modules
+//     ---- Networking
+//     ------ Enabled
+//     ---- Authentication
+//     ------ Enabled
+//     ---- Offloading
+//     ------ Enabled
+//     -- Role
 //     -- Latency
-//     -- Incoming (enabled, resources)
-//     -- Outgoing (enabled, resources)
+//     -- NodesNumber
+//     -- VirtualNodesNumber
 //   - Namespaces info
 //     -- UID
 //     -- MappingStrategy (EnforceSameName/DefaultName)

--- a/pkg/telemetry/types.go
+++ b/pkg/telemetry/types.go
@@ -24,6 +24,13 @@ import (
 	offloadingv1alpha1 "github.com/liqotech/liqo/apis/offloading/v1alpha1"
 )
 
+// NodeInfo contains information about a node.
+type NodeInfo struct {
+	KernelVersion string `json:"kernelVersion,omitempty"`
+	OsImage       string `json:"osImage,omitempty"`
+	Architecture  string `json:"architecture,omitempty"`
+}
+
 // NamespaceInfo contains information about an offloaded namespace.
 type NamespaceInfo struct {
 	UID                string                                          `json:"uid,omitempty"`
@@ -39,21 +46,38 @@ type PeeringDetails struct {
 	Resources corev1.ResourceList `json:"resources,omitempty"`
 }
 
+// ModuleInfo contains information about a module.
+type ModuleInfo struct {
+	Enabled bool `json:"enabled"`
+}
+
+// ModulesInfo contains information about the modules.
+type ModulesInfo struct {
+	Networking     ModuleInfo `json:"networking"`
+	Authentication ModuleInfo `json:"authentication"`
+	Offloading     ModuleInfo `json:"offloading"`
+}
+
 // PeeringInfo contains information about a peering.
 type PeeringInfo struct {
-	RemoteClusterID liqov1alpha1.ClusterID `json:"remoteClusterID"`
-	Role            liqov1alpha1.RoleType  `json:"role,omitempty"`
-	Latency         time.Duration          `json:"latency,omitempty"`
+	RemoteClusterID     liqov1alpha1.ClusterID `json:"remoteClusterID"`
+	Modules             ModulesInfo            `json:"modules,omitempty"`
+	Role                liqov1alpha1.RoleType  `json:"role,omitempty"`
+	Latency             time.Duration          `json:"latency,omitempty"`
+	NodesNumber         int                    `json:"nodesNumber"`
+	VirtualNodesNumber  int                    `json:"virtualNodesNumber"`
+	ResourceSliceNumber int                    `json:"resourceSliceNumber"`
 }
 
 // Telemetry contains information about the cluster.
 type Telemetry struct {
-	ClusterID         string          `json:"clusterID"`
-	LiqoVersion       string          `json:"liqoVersion,omitempty"`
-	KubernetesVersion string          `json:"kubernetesVersion,omitempty"`
-	Provider          string          `json:"provider,omitempty"`
-	PeeringInfo       []PeeringInfo   `json:"peeringInfo,omitempty"`
-	NamespacesInfo    []NamespaceInfo `json:"namespacesInfo,omitempty"`
+	ClusterID         string              `json:"clusterID"`
+	LiqoVersion       string              `json:"liqoVersion,omitempty"`
+	KubernetesVersion string              `json:"kubernetesVersion,omitempty"`
+	NodesInfo         map[string]NodeInfo `json:"nodesInfo,omitempty"`
+	Provider          string              `json:"provider,omitempty"`
+	PeeringInfo       []PeeringInfo       `json:"peeringInfo,omitempty"`
+	NamespacesInfo    []NamespaceInfo     `json:"namespacesInfo,omitempty"`
 }
 
 // Builder is the constructor for the Telemetry struct.

--- a/pkg/utils/getters/k8sGetters.go
+++ b/pkg/utils/getters/k8sGetters.go
@@ -840,6 +840,22 @@ func ListLiqoNodes(ctx context.Context, cl client.Client) (*corev1.NodeList, err
 	return list, nil
 }
 
+// ListNotLiqoNodes returns the list of nodes not created by Liqo.
+func ListNotLiqoNodes(ctx context.Context, cl client.Client) (*corev1.NodeList, error) {
+	req, err := labels.NewRequirement(consts.TypeLabel, selection.DoesNotExist, []string{})
+	if err != nil {
+		return nil, err
+	}
+
+	lSelector := labels.NewSelector().Add(*req)
+
+	list := new(corev1.NodeList)
+	if err := cl.List(ctx, list, &client.ListOptions{LabelSelector: lSelector}); err != nil {
+		return nil, err
+	}
+	return list, nil
+}
+
 // ListInternalNodesByLabels returns the list of internalnodes resources. (i.e. nodes created by Liqo).
 func ListInternalNodesByLabels(ctx context.Context, cl client.Client,
 	lSelector labels.Selector) (*networkingv1alpha1.InternalNodeList, error) {


### PR DESCRIPTION
# Description

This PR refactors the telemetry.

The new metrics monitored are:

- Peers
	- Enabled Modules (network,auth,offloading)
	- Number of VirtualNodes
	- Number of Nodes created by a VirtualNode
- Nodes Kernel Version
- Nodes OS Image