### PR TITLE
[Network] skip second connect in bidirectional peering

### DIFF
--- a/pkg/liqoctl/network/cluster.go
+++ b/pkg/liqoctl/network/cluster.go
@@ -400,3 +400,25 @@ func (c *Cluster) DeleteGatewayClient(ctx context.Context, name string) error {
 
 	return nil
 }
+
+// CheckAlreadyEstablishedForGwServer checks if a GatewayServer is already established.
+func (c *Cluster) CheckAlreadyEstablishedForGwServer(ctx context.Context) (bool, error) {
+	_, err := c.GetGatewayServer(ctx, forge.DefaultGatewayServerName(c.remoteClusterID))
+	if err == nil {
+		return true, nil
+	} else if client.IgnoreNotFound(err) != nil {
+		return false, err
+	}
+	return false, nil
+}
+
+// CheckAlreadyEstablishedForGwClient checks if a GatewayClient is already established.
+func (c *Cluster) CheckAlreadyEstablishedForGwClient(ctx context.Context) (bool, error) {
+	_, err := c.GetGatewayClient(ctx, forge.DefaultGatewayClientName(c.remoteClusterID))
+	if err == nil {
+		return true, nil
+	} else if client.IgnoreNotFound(err) != nil {
+		return false, err
+	}
+	return false, nil
+}

--- a/pkg/liqoctl/network/handler.go
+++ b/pkg/liqoctl/network/handler.go
@@ -179,6 +179,20 @@ func (o *Options) RunConnect(ctx context.Context) error {
 		return err
 	}
 
+	// Check if the reverse Networking is already established on cluster 1
+	if established, err := cluster1.CheckAlreadyEstablishedForGwServer(ctx); err != nil {
+		return err
+	} else if established {
+		return nil
+	}
+
+	// Check if the reverse Networking is already established on cluster 2
+	if established, err := cluster2.CheckAlreadyEstablishedForGwClient(ctx); err != nil {
+		return err
+	} else if established {
+		return nil
+	}
+
 	// Create gateway server on cluster 2
 	gwServer, err := cluster2.EnsureGatewayServer(ctx,
 		forge.DefaultGatewayServerName(cluster1.localClusterID),


### PR DESCRIPTION
# Description

This PR disable a second connection establishment in case of a bidirectional peering.