### PR TITLE
Docs: hide kbd from search bar

### DIFF
--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -8,6 +8,11 @@ div {
     scrollbar-color: hsl(var(--muted-foreground)) hsl(var(--background));
 }
 
+/* Hide search kbd */
+header kbd {
+    display: none !important;
+}
+
 /* Add a background to all the images in the documentation body */
 #content img {
     background: #fff;


### PR DESCRIPTION
# Description

As the search shortcut are currently not working, this patch hides the kbd.
