### PR TITLE
Avoid retrieval of tenant namespace by name

### DIFF
--- a/pkg/liqoctl/authenticate/cluster.go
+++ b/pkg/liqoctl/authenticate/cluster.go
@@ -73,11 +73,12 @@ func (c *Cluster) EnsureTenantNamespace(ctx context.Context, remoteClusterID liq
 
 	c.RemoteClusterID = remoteClusterID
 
-	if _, err := c.localNamespaceManager.CreateNamespace(ctx, c.RemoteClusterID); err != nil {
+	tenantNs, err := c.localNamespaceManager.CreateNamespace(ctx, c.RemoteClusterID)
+	if err != nil {
 		s.Fail(fmt.Sprintf("An error occurred while ensuring tenant namespace: %v", output.PrettyErr(err)))
 		return err
 	}
-	c.TenantNamespace = tenantnamespace.GetNameForNamespace(c.RemoteClusterID)
+	c.TenantNamespace = tenantNs.Name
 
 	s.Success("Tenant namespace correctly ensured")
 


### PR DESCRIPTION
# Description

This PR refactors some liqoctl commands to not rely on the metadata name to retrieve a tenant namespace. Retrieval by naming is unsafe as tenant namespace names can be customized and one should rely only on labels to retrieve the correct tenant namespace.

The PR makes the function that generates the default tenant namespace name private and modifies liqoctl commands to only rely on the `NamespaceManager` interface to retrieve the correct namespace.