### PR TITLE
Fix providers overwrite flags liqoctl install

### DIFF
--- a/cmd/liqoctl/cmd/docs.go
+++ b/cmd/liqoctl/cmd/docs.go
@@ -32,7 +32,7 @@ func newDocsCommand(ctx context.Context) *cobra.Command {
 		Long:  WithTemplate("Generate {{ .Executable }} documentation"),
 		Args:  cobra.NoArgs,
 
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(cmd *cobra.Command, _ []string) {
 			options.Root = cmd.Root()
 			util.CheckErr(options.Run(ctx))
 		},

--- a/cmd/liqoctl/cmd/drain.go
+++ b/cmd/liqoctl/cmd/drain.go
@@ -60,11 +60,11 @@ func newDrainTenantCommand(ctx context.Context, f *factory.Factory) *cobra.Comma
 		Args:              cobra.ExactArgs(1),
 		ValidArgsFunction: completion.Tenants(ctx, f, 1),
 
-		PreRun: func(cmd *cobra.Command, args []string) {
+		PreRun: func(_ *cobra.Command, _ []string) {
 			output.ExitOnErr(options.Printer.AskConfirm("drain", options.SkipConfirm))
 		},
 
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, args []string) {
 			options.Name = args[0]
 			output.ExitOnErr(options.RunDrainTenant(ctx))
 		},

--- a/cmd/liqoctl/cmd/install.go
+++ b/cmd/liqoctl/cmd/install.go
@@ -182,19 +182,22 @@ func newInstallCommand(ctx context.Context, f *factory.Factory) *cobra.Command {
 	f.AddLiqoNamespaceFlag(cmd.PersistentFlags())
 
 	base.RegisterFlags(cmd)
-	cmd.AddCommand(newInstallProviderCommand(ctx, options, aks.New))
-	cmd.AddCommand(newInstallProviderCommand(ctx, options, eks.New))
-	cmd.AddCommand(newInstallProviderCommand(ctx, options, gke.New))
-	cmd.AddCommand(newInstallProviderCommand(ctx, options, k3s.New))
-	cmd.AddCommand(newInstallProviderCommand(ctx, options, kind.New))
-	cmd.AddCommand(newInstallProviderCommand(ctx, options, kubeadm.New))
-	cmd.AddCommand(newInstallProviderCommand(ctx, options, openshift.New))
+	cmd.AddCommand(newInstallProviderCommand(ctx, options.CommonOptions, aks.New))
+	cmd.AddCommand(newInstallProviderCommand(ctx, options.CommonOptions, eks.New))
+	cmd.AddCommand(newInstallProviderCommand(ctx, options.CommonOptions, gke.New))
+	cmd.AddCommand(newInstallProviderCommand(ctx, options.CommonOptions, k3s.New))
+	cmd.AddCommand(newInstallProviderCommand(ctx, options.CommonOptions, kind.New))
+	cmd.AddCommand(newInstallProviderCommand(ctx, options.CommonOptions, kubeadm.New))
+	cmd.AddCommand(newInstallProviderCommand(ctx, options.CommonOptions, openshift.New))
 
 	return cmd
 }
 
-func newInstallProviderCommand(ctx context.Context, options *install.Options, creator func(*install.Options) install.Provider) *cobra.Command {
-	provider := creator(options)
+func newInstallProviderCommand(ctx context.Context, commonOpts *install.CommonOptions,
+	creator func(*install.Options) install.Provider) *cobra.Command {
+	options := install.Options{CommonOptions: commonOpts}
+	provider := creator(&options)
+
 	cmd := &cobra.Command{
 		Use:   provider.Name(),
 		Short: fmt.Sprintf("Install Liqo in the selected %s cluster", provider.Name()),

--- a/cmd/liqoctl/cmd/move.go
+++ b/cmd/liqoctl/cmd/move.go
@@ -76,14 +76,14 @@ func newMoveVolumeCommand(ctx context.Context, f *factory.Factory) *cobra.Comman
 		Args:              cobra.ExactArgs(1),
 		ValidArgsFunction: completion.PVCs(ctx, f, 1),
 
-		PreRun: func(cmd *cobra.Command, args []string) {
+		PreRun: func(_ *cobra.Command, _ []string) {
 			options.ContainersCPURequests = containersCPURequests.Quantity
 			options.ContainersCPULimits = containersCPULimits.Quantity
 			options.ContainersRAMRequests = containersRAMRequests.Quantity
 			options.ContainersRAMLimits = containersRAMLimits.Quantity
 		},
 
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, args []string) {
 			options.VolumeName = args[0]
 			output.ExitOnErr(options.Run(ctx))
 		},

--- a/cmd/liqoctl/cmd/offload.go
+++ b/cmd/liqoctl/cmd/offload.go
@@ -104,7 +104,7 @@ func newOffloadNamespaceCommand(ctx context.Context, f *factory.Factory) *cobra.
 		Args:              cobra.ExactArgs(1),
 		ValidArgsFunction: completion.Namespaces(ctx, f, 1),
 
-		PreRun: func(cmd *cobra.Command, args []string) {
+		PreRun: func(_ *cobra.Command, _ []string) {
 			options.PodOffloadingStrategy = offloadingv1beta1.PodOffloadingStrategyType(podOffloadingStrategy.Value)
 			options.NamespaceMappingStrategy = offloadingv1beta1.NamespaceMappingStrategyType(namespaceMappingStrategy.Value)
 			options.RemoteNamespaceName = remoteNamespaceName
@@ -112,7 +112,7 @@ func newOffloadNamespaceCommand(ctx context.Context, f *factory.Factory) *cobra.
 			options.Printer.CheckErr(options.ParseClusterSelectors(selectors))
 		},
 
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, args []string) {
 			options.Namespace = args[0]
 			output.ExitOnErr(options.Run(ctx))
 		},

--- a/cmd/liqoctl/cmd/root.go
+++ b/cmd/liqoctl/cmd/root.go
@@ -103,7 +103,7 @@ func NewRootCommand(ctx context.Context) *cobra.Command {
 		// The behavior can be customized in subcommands defining an appropriate PersistentPreRun function.
 		// Yet, the initialization is skipped for the __complete command, as characterized by a peculiar behavior
 		// in terms of flags parsing (https://github.com/spf13/cobra/issues/1291#issuecomment-739056690).
-		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		PersistentPreRun: func(cmd *cobra.Command, _ []string) {
 			if cmd != nil && cmd.Name() != cobra.ShellCompRequestCmd {
 				singleClusterPersistentPreRun(cmd, f)
 			}

--- a/cmd/liqoctl/cmd/uninstall.go
+++ b/cmd/liqoctl/cmd/uninstall.go
@@ -50,11 +50,11 @@ func newUninstallCommand(ctx context.Context, f *factory.Factory) *cobra.Command
 		Long:  WithTemplate(liqoctlUninstallLongHelp),
 		Args:  cobra.NoArgs,
 
-		PreRun: func(cmd *cobra.Command, args []string) {
+		PreRun: func(_ *cobra.Command, _ []string) {
 			output.ExitOnErr(options.Printer.AskConfirm("uninstall", f.SkipConfirm))
 		},
 
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, _ []string) {
 			output.ExitOnErr(options.Run(ctx))
 		},
 	}

--- a/cmd/liqoctl/cmd/unoffload.go
+++ b/cmd/liqoctl/cmd/unoffload.go
@@ -59,11 +59,11 @@ func newUnoffloadNamespaceCommand(ctx context.Context, f *factory.Factory) *cobr
 		Args:              cobra.ExactArgs(1),
 		ValidArgsFunction: completion.OffloadedNamespaces(ctx, f, 1),
 
-		PreRun: func(cmd *cobra.Command, args []string) {
+		PreRun: func(_ *cobra.Command, _ []string) {
 			output.ExitOnErr(f.Printer.AskConfirm("unoffload", f.SkipConfirm))
 		},
 
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, args []string) {
 			options.Namespace = args[0]
 			output.ExitOnErr(options.Run(ctx))
 		},

--- a/pkg/liqoctl/install/aks/aks_test.go
+++ b/pkg/liqoctl/install/aks/aks_test.go
@@ -36,7 +36,11 @@ var _ = Describe("Extract elements from AKS", func() {
 	var options Options
 
 	BeforeEach(func() {
-		options = Options{Options: &install.Options{ClusterLabels: map[string]string{}}}
+		options = Options{Options: &install.Options{
+			CommonOptions: &install.CommonOptions{
+				ClusterLabels: map[string]string{},
+			},
+		}}
 	})
 
 	It("test parse values", func() {

--- a/pkg/liqoctl/install/aks/provider.go
+++ b/pkg/liqoctl/install/aks/provider.go
@@ -34,7 +34,7 @@ import (
 
 var _ install.Provider = (*Options)(nil)
 
-// Options encapsulates the arguments of the install command.
+// Options encapsulates the arguments of the install aks command.
 type Options struct {
 	*install.Options
 

--- a/pkg/liqoctl/install/eks/eks_test.go
+++ b/pkg/liqoctl/install/eks/eks_test.go
@@ -36,7 +36,11 @@ var _ = Describe("Extract elements from EKS", func() {
 	var options Options
 
 	BeforeEach(func() {
-		options = Options{Options: &install.Options{ClusterLabels: map[string]string{}}}
+		options = Options{Options: &install.Options{
+			CommonOptions: &install.CommonOptions{
+				ClusterLabels: map[string]string{},
+			},
+		}}
 	})
 
 	It("test parse values", func() {

--- a/pkg/liqoctl/install/eks/provider.go
+++ b/pkg/liqoctl/install/eks/provider.go
@@ -28,7 +28,7 @@ import (
 
 var _ install.Provider = (*Options)(nil)
 
-// Options encapsulates the arguments of the install command.
+// Options encapsulates the arguments of the install eks command.
 type Options struct {
 	*install.Options
 

--- a/pkg/liqoctl/install/generic/provider.go
+++ b/pkg/liqoctl/install/generic/provider.go
@@ -52,7 +52,7 @@ func (o *Options) RegisterFlags(cmd *cobra.Command) {
 }
 
 // Initialize performs the initialization tasks to retrieve the provider-specific parameters.
-func (o *Options) Initialize(ctx context.Context) error { return nil }
+func (o *Options) Initialize(_ context.Context) error { return nil }
 
 // Values returns the customized provider-specifc values file parameters.
 func (o *Options) Values() map[string]interface{} {

--- a/pkg/liqoctl/install/gke/gke_test.go
+++ b/pkg/liqoctl/install/gke/gke_test.go
@@ -34,7 +34,11 @@ var _ = Describe("Extract elements from GKE", func() {
 	var options Options
 
 	BeforeEach(func() {
-		options = Options{Options: &install.Options{ClusterLabels: map[string]string{}}}
+		options = Options{Options: &install.Options{
+			CommonOptions: &install.CommonOptions{
+				ClusterLabels: map[string]string{},
+			},
+		}}
 	})
 
 	It("test parse values", func() {

--- a/pkg/liqoctl/install/gke/provider.go
+++ b/pkg/liqoctl/install/gke/provider.go
@@ -32,7 +32,7 @@ import (
 
 var _ install.Provider = (*Options)(nil)
 
-// Options encapsulates the arguments of the install command.
+// Options encapsulates the arguments of the install gke command.
 type Options struct {
 	*install.Options
 

--- a/pkg/liqoctl/install/handler.go
+++ b/pkg/liqoctl/install/handler.go
@@ -63,6 +63,15 @@ type Provider interface {
 
 // Options encapsulates the arguments of the install command.
 type Options struct {
+	*CommonOptions
+
+	APIServer   string
+	PodCIDR     string
+	ServiceCIDR string
+}
+
+// CommonOptions encapsulates common arguments (not modified by providers) of the install command.
+type CommonOptions struct {
 	*factory.Factory
 	CommandName string
 
@@ -85,13 +94,10 @@ type Options struct {
 	ClusterID     liqov1beta1.ClusterID
 	ClusterLabels map[string]string
 
-	APIServer        string
 	EnableHA         bool
 	EnableMetrics    bool
 	DisableTelemetry bool
 
-	PodCIDR         string
-	ServiceCIDR     string
 	ReservedSubnets []string
 
 	DisableAPIServerSanityChecks bool
@@ -104,8 +110,10 @@ type Options struct {
 // NewOptions returns a new Options struct.
 func NewOptions(f *factory.Factory, commandName string) *Options {
 	return &Options{
-		CommandName: commandName,
-		Factory:     f,
+		CommonOptions: &CommonOptions{
+			CommandName: commandName,
+			Factory:     f,
+		},
 	}
 }
 

--- a/pkg/liqoctl/install/k3s/provider.go
+++ b/pkg/liqoctl/install/k3s/provider.go
@@ -24,7 +24,7 @@ import (
 
 var _ install.Provider = (*Options)(nil)
 
-// Options encapsulates the arguments of the install command.
+// Options encapsulates the arguments of the install k3s command.
 type Options struct {
 	*install.Options
 }
@@ -59,7 +59,7 @@ func (o *Options) RegisterFlags(cmd *cobra.Command) {
 }
 
 // Initialize performs the initialization tasks to retrieve the provider-specific parameters.
-func (o *Options) Initialize(ctx context.Context) error {
+func (o *Options) Initialize(_ context.Context) error {
 	// Typically, the URL refers to a localhost address.
 	o.DisableAPIServerSanityChecks = true
 	return nil

--- a/pkg/liqoctl/install/kind/provider.go
+++ b/pkg/liqoctl/install/kind/provider.go
@@ -23,7 +23,7 @@ import (
 
 var _ install.Provider = (*Options)(nil)
 
-// Options encapsulates the arguments of the install command.
+// Options encapsulates the arguments of the install kind command.
 type Options struct {
 	*kubeadm.Options
 }

--- a/pkg/liqoctl/install/kubeadm/kubeadm_test.go
+++ b/pkg/liqoctl/install/kubeadm/kubeadm_test.go
@@ -84,10 +84,14 @@ var _ = Describe("Extract elements from apiServer", func() {
 	)
 
 	JustBeforeEach(func() {
-		options = Options{Options: &install.Options{Factory: &factory.Factory{
-			KubeClient: fake.NewSimpleClientset(pods...),
-			Printer:    output.NewFakePrinter(GinkgoWriter),
-		}}}
+		options = Options{Options: &install.Options{
+			CommonOptions: &install.CommonOptions{
+				Factory: &factory.Factory{
+					KubeClient: fake.NewSimpleClientset(pods...),
+					Printer:    output.NewFakePrinter(GinkgoWriter),
+				},
+			},
+		}}
 	})
 
 	When("no kube-controller-manager pods is present", func() {

--- a/pkg/liqoctl/install/kubeadm/provider.go
+++ b/pkg/liqoctl/install/kubeadm/provider.go
@@ -30,7 +30,7 @@ var _ install.Provider = (*Options)(nil)
 
 var kubeControllerManagerLabels = map[string]string{"component": "kube-controller-manager", "tier": "control-plane"}
 
-// Options encapsulates the arguments of the install k3s command.
+// Options encapsulates the arguments of the install kubeadm command.
 type Options struct {
 	*install.Options
 }
@@ -52,7 +52,7 @@ func (o *Options) Examples() string {
 }
 
 // RegisterFlags registers the flags for the given provider.
-func (o *Options) RegisterFlags(cmd *cobra.Command) {}
+func (o *Options) RegisterFlags(_ *cobra.Command) {}
 
 // Initialize performs the initialization tasks to retrieve the provider-specific parameters.
 func (o *Options) Initialize(ctx context.Context) error {

--- a/pkg/liqoctl/install/openshift/provider.go
+++ b/pkg/liqoctl/install/openshift/provider.go
@@ -28,7 +28,7 @@ import (
 
 var _ install.Provider = (*Options)(nil)
 
-// Options encapsulates the arguments of the install k3s command.
+// Options encapsulates the arguments of the install openshift command.
 type Options struct {
 	*install.Options
 }
@@ -50,7 +50,7 @@ func (o *Options) Examples() string {
 }
 
 // RegisterFlags registers the flags for the given provider.
-func (o *Options) RegisterFlags(cmd *cobra.Command) {}
+func (o *Options) RegisterFlags(_ *cobra.Command) {}
 
 // Initialize performs the initialization tasks to retrieve the provider-specific parameters.
 func (o *Options) Initialize(ctx context.Context) error {

--- a/pkg/liqoctl/install/validation_test.go
+++ b/pkg/liqoctl/install/validation_test.go
@@ -43,7 +43,11 @@ var _ = Describe("Validation", func() {
 	)
 
 	BeforeEach(func() {
-		options = Options{Factory: &factory.Factory{}}
+		options = Options{
+			CommonOptions: &CommonOptions{
+				Factory: &factory.Factory{},
+			},
+		}
 		ctx = context.Background()
 	})
 


### PR DESCRIPTION
# Description

This PR fixes a bug causing providers in `liqoctl` installer to overwrite some flags between each other.
