### PR TITLE
Bump golangci-lint and gci

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,10 +21,10 @@ jobs:
           cache: false
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6.0.1
+        uses: golangci/golangci-lint-action@v6.1.0
         with:
           only-new-issues: true
-          version: v1.59.1
+          version: v1.60.3
           args: --timeout=900s
 
   gomodtidy:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 -   repo: https://github.com/golangci/golangci-lint
-    rev: v1.59.1
+    rev: v1.60.3
     hooks:
     - id: golangci-lint
       name: golangci-lint

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ rbacs: controller-gen
 # Install gci if not available
 gci:
 ifeq (, $(shell which gci))
-	@go install github.com/daixiang0/gci@v0.11.2
+	@go install github.com/daixiang0/gci@v0.13.4
 GCI=$(GOBIN)/gci
 else
 GCI=$(shell which gci)
@@ -100,7 +100,7 @@ fmt: gci addlicense
 # Install golangci-lint if not available
 golangci-lint:
 ifeq (, $(shell which golangci-lint))
-	@go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.59.1
+	@go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.60.3
 GOLANGCILINT=$(GOBIN)/golangci-lint
 else
 GOLANGCILINT=$(shell which golangci-lint)


### PR DESCRIPTION
# Description

This PR bumps:
- `golangci-lint` binary to v1.60.3 and action to v6.1.0
- `gci` to v0.13.4
