### PR TITLE
New `liqoctl info` command

### DIFF
--- a/cmd/liqoctl/cmd/info.go
+++ b/cmd/liqoctl/cmd/info.go
@@ -1,0 +1,129 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cmd
+
+import (
+	"context"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/liqotech/liqo/pkg/liqoctl/completion"
+	"github.com/liqotech/liqo/pkg/liqoctl/factory"
+	"github.com/liqotech/liqo/pkg/liqoctl/info"
+	"github.com/liqotech/liqo/pkg/liqoctl/info/localstatus"
+	"github.com/liqotech/liqo/pkg/liqoctl/output"
+	"github.com/liqotech/liqo/pkg/utils/args"
+)
+
+var outputFormat = args.NewEnum([]string{"json", "yaml"}, "")
+
+const liqoctlInfoLongHelp = `Show info about the current Liqo instance.
+
+Liqoctl provides a set of commands to verify the status of the Liqo control
+plane, its configuration, as well as the characteristics of the currently
+active peerings, and reports the outcome in human-readable or
+machine-readable format (either JSON or YAML).
+Additionally, via '--get', it allows to retrieve each single field of the reports
+using a query in dot notation (e.g. '--get field.subfield')
+
+This command shows information about the local cluster and checks the presence
+and the sanity of the Liqo namespace and the Liqo pods and some brief info about
+the active peerings and their status.
+
+Examples:
+  $ {{ .Executable }} info
+  $ {{ .Executable }} info --namespace liqo-system
+show the output in YAML format
+  $ {{ .Executable }} info -o yaml
+get a specific field
+  $ {{ .Executable }} info --get clusterid
+  $ {{ .Executable }} info --get network.podcidr
+`
+
+func infoPreRun(options *info.Options) {
+	// When the output is redirected to a file is desiderable that errors ends in the stderr output.
+	options.Printer.Error.Writer = os.Stderr
+	options.Printer.Warning.Writer = os.Stderr
+	// Configure output according to the provided parameter
+	options.Format = info.OutputFormat(outputFormat.Value)
+	// Force verbose when `get` is used to allow to retrieve also
+	// the info in the verbose output also when "--verbose" is not provided
+	if options.GetQuery != "" {
+		options.Verbose = true
+	}
+}
+
+func newPeerInfoCommand(ctx context.Context, f *factory.Factory, options *info.Options) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:               "peer",
+		Short:             "Show additional info about one or more specific peerings",
+		Long:              WithTemplate(""),
+		Args:              cobra.MinimumNArgs(1),
+		ValidArgsFunction: completion.ClusterIDs(ctx, f, completion.NoLimit),
+
+		PreRun: func(_ *cobra.Command, _ []string) {
+			infoPreRun(options)
+		},
+
+		Run: func(_ *cobra.Command, clusterIds []string) {
+			output.ExitOnErr(options.RunPeerInfo(ctx, clusterIds))
+		},
+	}
+
+	return cmd
+}
+
+func newInfoCommand(ctx context.Context, f *factory.Factory) *cobra.Command {
+	options := info.NewOptions(f)
+
+	maincmd := &cobra.Command{
+		Use:   "info",
+		Short: "Show info about the current Liqo instance",
+		Long:  WithTemplate(liqoctlInfoLongHelp),
+		Args:  cobra.NoArgs,
+
+		PreRun: func(_ *cobra.Command, _ []string) {
+			infoPreRun(options)
+		},
+
+		Run: func(_ *cobra.Command, _ []string) {
+			// Set up checkers
+			checkers := []info.Checker{
+				&localstatus.InstallationChecker{},
+				&localstatus.HealthChecker{},
+			}
+			if options.Verbose {
+				checkers = append(checkers, &localstatus.NetworkChecker{})
+			}
+			checkers = append(checkers, &localstatus.PeeringChecker{})
+			output.ExitOnErr(options.RunInfo(ctx, checkers))
+		},
+	}
+
+	f.AddLiqoNamespaceFlag(maincmd.PersistentFlags())
+	maincmd.PersistentFlags().BoolVarP(&options.Verbose, "verbose", "v", false, "Make info more verbose")
+	maincmd.PersistentFlags().VarP(outputFormat, "output", "o", "Output format. Supported formats: json, yaml")
+	maincmd.PersistentFlags().StringVarP(&options.GetQuery, "get", "g", "",
+		"Path to the desired subfield in dot notation. Each part of the path corresponds to a key of the output structure")
+
+	f.Printer.CheckErr(maincmd.RegisterFlagCompletionFunc(factory.FlagNamespace, completion.Namespaces(ctx, f, completion.NoLimit)))
+	f.Printer.CheckErr(maincmd.RegisterFlagCompletionFunc("output", completion.Enumeration(outputFormat.Allowed)))
+
+	maincmd.AddCommand(newPeerInfoCommand(ctx, f, options))
+
+	return maincmd
+}

--- a/cmd/liqoctl/cmd/root.go
+++ b/cmd/liqoctl/cmd/root.go
@@ -141,6 +141,7 @@ func NewRootCommand(ctx context.Context) *cobra.Command {
 	cmd.AddCommand(generate.NewGenerateCommand(ctx, liqoResources, f))
 	cmd.AddCommand(get.NewGetCommand(ctx, liqoResources, f))
 	cmd.AddCommand(delete.NewDeleteCommand(ctx, liqoResources, f))
+	cmd.AddCommand(newInfoCommand(ctx, f))
 	cmd.AddCommand(newTestCommand(ctx, f))
 
 	return cmd

--- a/go.mod
+++ b/go.mod
@@ -58,6 +58,7 @@ require (
 	sigs.k8s.io/aws-iam-authenticator v0.6.19
 	sigs.k8s.io/controller-runtime v0.18.5
 	sigs.k8s.io/sig-storage-lib-external-provisioner/v7 v7.0.1
+	sigs.k8s.io/yaml v1.4.0
 )
 
 require (
@@ -258,5 +259,4 @@ require (
 	sigs.k8s.io/kustomize/api v0.16.0 // indirect
 	sigs.k8s.io/kustomize/kyaml v0.16.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
-	sigs.k8s.io/yaml v1.4.0 // indirect
 )

--- a/pkg/liqoctl/info/checker.go
+++ b/pkg/liqoctl/info/checker.go
@@ -1,0 +1,50 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package info
+
+import "context"
+
+// Checker is the interface to be implemented by all the checkers that
+// collect info about the current instance of Liqo.
+type Checker interface {
+	// Collect the data from the Liqo installation
+	Collect(ctx context.Context, options Options)
+	// Return the collected data using a user friendly output
+	Format(options Options) string
+	// Get the title of the section retrieve by the checker
+	GetTitle() string
+	// Get the id to be shown of machine readable output
+	GetID() string
+	// Get the data collected by the checker
+	GetData() interface{}
+	// Return the errors occurred during the collection of the data.
+	GetCollectionErrors() []error
+}
+
+// CheckerBase contains the common attributes and functions of the checkers.
+type CheckerBase struct {
+	collectionErrors []error
+}
+
+// AddCollectionError adds an error to the list of errors occurred while
+// collecting the info about a Liqo component.
+func (c *CheckerBase) AddCollectionError(err error) {
+	c.collectionErrors = append(c.collectionErrors, err)
+}
+
+// GetCollectionErrors returns the errors occurred during the collection of the data.
+func (c *CheckerBase) GetCollectionErrors() []error {
+	return c.collectionErrors
+}

--- a/pkg/liqoctl/info/doc.go
+++ b/pkg/liqoctl/info/doc.go
@@ -1,0 +1,17 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+// Package info contains the logic to show info about the current Liqo instance
+package info

--- a/pkg/liqoctl/info/handler.go
+++ b/pkg/liqoctl/info/handler.go
@@ -1,0 +1,100 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package info
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/liqotech/liqo/pkg/liqoctl/factory"
+)
+
+// OutputFormat represents the format of the output of the command.
+type OutputFormat string
+
+const (
+	// JSON indicates that the output will be in JSON format.
+	JSON OutputFormat = "json"
+	// YAML indicates that the output will be in YAML format.
+	YAML OutputFormat = "yaml"
+)
+
+// LocalInfoQueryShortcuts contains shortcuts for the paths in the local info data.
+var LocalInfoQueryShortcuts = map[string]string{
+	"clusterid": "local.clusterid",
+}
+
+// Options encapsulates the arguments of the info command.
+type Options struct {
+	*factory.Factory
+
+	Verbose  bool
+	Format   OutputFormat
+	GetQuery string
+}
+
+// NewOptions returns a new Options struct.
+func NewOptions(f *factory.Factory) *Options {
+	return &Options{
+		Factory: f,
+	}
+}
+
+// RunInfo execute the `info` command.
+func (o *Options) RunInfo(ctx context.Context, checkers []Checker) error {
+	// Check whether Liqo is installed in the current cluster
+	if err := o.installationCheck(ctx); err != nil {
+		return err
+	}
+
+	// Start collecting the data via the checkers
+	for i := range checkers {
+		checkers[i].Collect(ctx, *o)
+		for _, err := range checkers[i].GetCollectionErrors() {
+			o.Printer.Warning.Println(err)
+		}
+	}
+
+	var err error
+	var output string
+	switch {
+	// If no format is specified, format and print a user-friendly output
+	case o.Format == "" && o.GetQuery == "":
+		for i := range checkers {
+			o.Printer.BoxSetTitle(checkers[i].GetTitle())
+			o.Printer.BoxPrintln(checkers[i].Format(*o))
+		}
+		return nil
+	// If query specified try to retrieve the field from the output
+	case o.GetQuery != "":
+		output, err = o.sPrintField(o.GetQuery, checkers, LocalInfoQueryShortcuts)
+	default:
+		output, err = o.sPrintMachineReadable(checkers)
+	}
+
+	if err != nil {
+		o.Printer.Error.Println(err)
+	} else {
+		fmt.Println(output)
+	}
+
+	return err
+}
+
+// RunPeerInfo execute the `info peer` command.
+func (o *Options) RunPeerInfo(_ context.Context, _ []string) error {
+	panic("Not implemented")
+}

--- a/pkg/liqoctl/info/localstatus/doc.go
+++ b/pkg/liqoctl/info/localstatus/doc.go
@@ -1,0 +1,17 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+// Package localstatus contains the logic to retrieve info about the local Liqo instance
+package localstatus

--- a/pkg/liqoctl/info/localstatus/health.go
+++ b/pkg/liqoctl/info/localstatus/health.go
@@ -1,0 +1,121 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package localstatus
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/liqotech/liqo/pkg/liqoctl/info"
+	"github.com/liqotech/liqo/pkg/liqoctl/output"
+	podutils "github.com/liqotech/liqo/pkg/utils/pod"
+)
+
+// PodHealthInfo represents the current status of a Liqo pod.
+type PodHealthInfo struct {
+	Status          corev1.PodPhase `json:"status"`
+	ReadyContainers int             `json:"readyContainers"`
+	TotalContainers int             `json:"totalContainers"`
+	Restarts        int32           `json:"restarts"`
+}
+
+// Health represents the current status of a Liqo instance.
+type Health struct {
+	// Healthy is true whenever all the Liqo pods are up and running.
+	Healthy       bool                     `json:"healthy"`
+	UnhealthyPods map[string]PodHealthInfo `json:"unhealthyPods,omitempty"`
+}
+
+// HealthChecker collects the info about the local instance of Liqo.
+type HealthChecker struct {
+	info.CheckerBase
+	data Health
+}
+
+// Collect data about the health of the local instance of Liqo.
+func (l *HealthChecker) Collect(ctx context.Context, options info.Options) {
+	var liqoPodsList corev1.PodList
+	if err := options.CRClient.List(ctx, &liqoPodsList, client.InNamespace(options.LiqoNamespace)); err != nil {
+		l.AddCollectionError(fmt.Errorf("unable to get Liqo pods: %w", err))
+		return
+	}
+
+	// Check the status of each pods
+	l.data.Healthy = true
+	l.data.UnhealthyPods = map[string]PodHealthInfo{}
+	liqoPods := liqoPodsList.Items
+	for i := range liqoPods {
+		pod := &liqoPods[i]
+		// Check if one of the pods is not ready, in that case declare Liqo installation as Unhealthy
+		if ok, _ := podutils.IsPodReady(pod); !ok {
+			l.data.Healthy = false
+			healthInfo := PodHealthInfo{
+				Status:          pod.Status.Phase,
+				TotalContainers: len(pod.Status.ContainerStatuses),
+			}
+
+			// Populate the info about restarts and running containers
+			for i := range pod.Status.ContainerStatuses {
+				containerStatus := &pod.Status.ContainerStatuses[i]
+				healthInfo.Restarts += containerStatus.RestartCount
+				if containerStatus.Ready {
+					healthInfo.ReadyContainers++
+				}
+			}
+			l.data.UnhealthyPods[pod.Name] = healthInfo
+		}
+	}
+}
+
+// Format returns the collected data using a user friendly output.
+func (l *HealthChecker) Format(options info.Options) string {
+	main := output.NewRootSection()
+	if l.data.Healthy {
+		main.AddSectionSuccess(fmt.Sprintf("%s    Liqo is healthy", output.CheckMark))
+	} else {
+		main.AddSectionFailure(fmt.Sprintf("%s    Liqo is unhealthy", output.Cross))
+	}
+
+	if len(l.data.UnhealthyPods) > 0 {
+		podsSection := main.AddSection("Unhealthy pods")
+		for podName, podInfo := range l.data.UnhealthyPods {
+			podsSection.AddEntryWithoutStyle(
+				podName,
+				fmt.Sprintf("Status: %v, Ready: %v/%v, Restarts: %v", podInfo.Status, podInfo.ReadyContainers, podInfo.TotalContainers, podInfo.Restarts),
+			)
+		}
+	}
+
+	return main.SprintForBox(options.Printer)
+}
+
+// GetData returns the data collected by the checker.
+func (l *HealthChecker) GetData() interface{} {
+	return l.data
+}
+
+// GetID returns the id of the section collected by the checker.
+func (l *HealthChecker) GetID() string {
+	return "health"
+}
+
+// GetTitle returns the title of the section collected by the checker.
+func (l *HealthChecker) GetTitle() string {
+	return "Installation health"
+}

--- a/pkg/liqoctl/info/localstatus/health_test.go
+++ b/pkg/liqoctl/info/localstatus/health_test.go
@@ -1,0 +1,191 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package localstatus_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/pterm/pterm"
+	corev1 "k8s.io/api/core/v1"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	liqoconsts "github.com/liqotech/liqo/pkg/consts"
+	"github.com/liqotech/liqo/pkg/liqoctl/factory"
+	"github.com/liqotech/liqo/pkg/liqoctl/info"
+	"github.com/liqotech/liqo/pkg/liqoctl/info/localstatus"
+	"github.com/liqotech/liqo/pkg/liqoctl/output"
+	"github.com/liqotech/liqo/pkg/utils/testutil"
+)
+
+var _ = Describe("HealthChecker tests", func() {
+
+	type TestArgs struct {
+		totalPods int
+		readyPods int
+	}
+
+	const unhealthyRestartCount = 10
+	var (
+		clientBuilder    fake.ClientBuilder
+		hc               *localstatus.HealthChecker
+		ctx              context.Context
+		options          info.Options
+		healthyPodStatus = corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			Conditions: []corev1.PodCondition{
+				{
+					Type:   corev1.PodReady,
+					Status: corev1.ConditionTrue,
+				}},
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name:         "fake-container",
+					RestartCount: 0,
+					Ready:        false,
+				},
+			},
+		}
+		unhealthyPodStatus = corev1.PodStatus{
+			Phase: corev1.PodPending,
+			Conditions: []corev1.PodCondition{
+				{
+					Type:   corev1.PodReady,
+					Status: corev1.ConditionFalse,
+				}},
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name:         "fake-container",
+					RestartCount: unhealthyRestartCount,
+					Ready:        false,
+				},
+			},
+		}
+	)
+
+	getPodName := func(n int) string {
+		return pterm.Sprintf("liqo-pod-%d", n)
+	}
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		clientBuilder = *fake.NewClientBuilder().WithScheme(scheme.Scheme)
+
+		options = info.Options{Factory: factory.NewForLocal()}
+		options.Printer = output.NewFakePrinter(GinkgoWriter)
+		options.KubeClient = k8sfake.NewSimpleClientset()
+	})
+
+	Describe("Testing the HealthChecker", func() {
+		Context("Collecting and retrieving the data", func() {
+			DescribeTable("should collect the data and return the right result", func(args TestArgs) {
+
+				// Set up the fake clients creating some fake Liqo pods
+				nUnhealthyPods := args.totalPods - args.readyPods
+				shouldBeHealthy := args.totalPods == args.readyPods
+				podsList := []client.Object{}
+
+				for i := range args.totalPods {
+					pod := testutil.FakePodWithSingleContainer(
+						liqoconsts.DefaultLiqoNamespace,
+						getPodName(i),
+						"fake-image",
+					)
+					if nUnhealthyPods > 0 && i < nUnhealthyPods {
+						pod.Status = unhealthyPodStatus
+					} else {
+						pod.Status = healthyPodStatus
+					}
+					podsList = append(podsList, pod)
+				}
+
+				clientBuilder.WithObjects(podsList...)
+				options.CRClient = clientBuilder.Build()
+				options.LiqoNamespace = liqoconsts.DefaultLiqoNamespace
+
+				By("Collecting the data")
+				hc = &localstatus.HealthChecker{}
+				hc.Collect(ctx, options)
+
+				By("Verifying that no errors have been raised")
+				Expect(hc.GetCollectionErrors()).To(BeEmpty())
+
+				By("Checking the correctness of the data in the struct")
+				data := hc.GetData().(localstatus.Health)
+
+				Expect(data.Healthy).To(Equal(shouldBeHealthy), "Unexpected installation status")
+				if !shouldBeHealthy {
+					Expect(data.UnhealthyPods).NotTo(BeEmpty(), "Installation is unhealthy but unhealthy pod list is empty")
+
+					for i := range nUnhealthyPods {
+						currentPod := data.UnhealthyPods[getPodName(i)]
+						Expect(currentPod.TotalContainers).To(Equal(1))
+
+						restarts := 0
+						readyContainers := 1
+						podStatus := healthyPodStatus.Phase
+						if nUnhealthyPods > 0 && i < nUnhealthyPods {
+							restarts = unhealthyRestartCount
+							readyContainers = 0
+							podStatus = unhealthyPodStatus.Phase
+						}
+
+						Expect(currentPod.Restarts).To(Equal(int32(restarts)), "Not matching restarts")
+						Expect(currentPod.ReadyContainers).To(Equal(readyContainers), "Not matching ready containers")
+						Expect(currentPod.Status).To(Equal(podStatus), "Not matching pod statuses")
+					}
+				}
+
+				By("Checking the formatted output")
+				text := hc.Format(options)
+				text = pterm.RemoveColorFromString(text)
+				text = testutil.SqueezeWhitespaces(text)
+
+				if shouldBeHealthy {
+					Expect(text).To(ContainSubstring("Liqo is healthy"))
+				} else {
+					Expect(text).To(ContainSubstring("Liqo is unhealthy"))
+					for i := range nUnhealthyPods {
+						Expect(text).To(ContainSubstring(
+							pterm.Sprintf(
+								"%s: Status: Pending, Ready: 0/1, Restarts: %d",
+								getPodName(i),
+								unhealthyRestartCount,
+							),
+						))
+					}
+				}
+			},
+				Entry("Healthy installation", TestArgs{
+					totalPods: 3,
+					readyPods: 3,
+				}),
+				Entry("Unhealthy installation", TestArgs{
+					totalPods: 3,
+					readyPods: 2,
+				}),
+				Entry("Unhealthy installation - No pods running", TestArgs{
+					totalPods: 3,
+					readyPods: 0,
+				}),
+			)
+		})
+	})
+})

--- a/pkg/liqoctl/info/localstatus/local_info.go
+++ b/pkg/liqoctl/info/localstatus/local_info.go
@@ -1,0 +1,143 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package localstatus
+
+import (
+	"context"
+	"fmt"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+
+	liqov1beta1 "github.com/liqotech/liqo/apis/core/v1beta1"
+	"github.com/liqotech/liqo/pkg/liqoctl/info"
+	"github.com/liqotech/liqo/pkg/liqoctl/output"
+	liqoctlutils "github.com/liqotech/liqo/pkg/liqoctl/utils"
+	"github.com/liqotech/liqo/pkg/utils"
+	"github.com/liqotech/liqo/pkg/utils/apiserver"
+	"github.com/liqotech/liqo/pkg/utils/getters"
+)
+
+// Installation contains the info about the local Liqo installation.
+type Installation struct {
+	ClusterID     liqov1beta1.ClusterID `json:"clusterID"`
+	Version       string                `json:"version"`
+	Labels        map[string]string     `json:"labels"`
+	APIServerAddr string
+}
+
+// InstallationChecker collects the info about the local Liqo installation.
+type InstallationChecker struct {
+	info.CheckerBase
+	data Installation
+}
+
+const (
+	ctrlManagerContainerName = "controller-manager"
+)
+
+// Collect data about the local installation of Liqo.
+func (l *InstallationChecker) Collect(ctx context.Context, options info.Options) {
+	// Get the cluster ID of the local cluster
+	clusterID, err := utils.GetClusterID(ctx, options.KubeClient, options.LiqoNamespace)
+	if err != nil {
+		l.AddCollectionError(fmt.Errorf("unable to get cluster id: %w", err))
+	}
+	l.data.ClusterID = clusterID
+
+	// Collect Liqo version and cluster labels from the controller manager deployment
+	ctrlDeployment, err := getters.GetControllerManagerDeployment(ctx, options.CRClient, options.LiqoNamespace)
+	if err != nil {
+		l.AddCollectionError(fmt.Errorf("unable to get Liqo version and cluster labels: %w", err))
+	} else {
+		if err := l.collectLiqoVersion(ctrlDeployment); err != nil {
+			l.AddCollectionError(fmt.Errorf("unable to get Liqo version: %w", err))
+		}
+
+		if err := l.collectClusterLabels(ctrlDeployment); err != nil {
+			l.AddCollectionError(fmt.Errorf("unable to get cluster labels: %w", err))
+		}
+	}
+
+	// Get the URL of the K8s API
+	apiAddr, err := apiserver.GetURL(ctx, options.CRClient, "")
+	if err != nil {
+		l.AddCollectionError(fmt.Errorf("unable to get K8s API server: %w", err))
+	}
+	l.data.APIServerAddr = apiAddr
+}
+
+// Format returns the collected data using a user friendly output.
+func (l *InstallationChecker) Format(options info.Options) string {
+	main := output.NewRootSection()
+	main.AddEntry("Cluster ID", string(l.data.ClusterID))
+	main.AddEntry("Version", l.data.Version)
+	main.AddEntry("K8s API server", l.data.APIServerAddr)
+	labelsSection := main.AddSection("Cluster labels")
+	for key, val := range l.data.Labels {
+		labelsSection.AddEntry(key, val)
+	}
+	return main.SprintForBox(options.Printer)
+}
+
+// GetData returns the data collected by the checker.
+func (l *InstallationChecker) GetData() interface{} {
+	return l.data
+}
+
+// GetID returns the id of the section collected by the checker.
+func (l *InstallationChecker) GetID() string {
+	return "local"
+}
+
+// GetTitle returns the title of the section collected by the checker.
+func (l *InstallationChecker) GetTitle() string {
+	return "Local installation info"
+}
+
+func (l *InstallationChecker) collectClusterLabels(ctrlDeployment *appsv1.Deployment) error {
+	var ctrlContainer corev1.Container
+
+	// Get the container of the controller manager
+	containers := ctrlDeployment.Spec.Template.Spec.Containers
+	for i := range containers {
+		if containers[i].Name == ctrlManagerContainerName {
+			ctrlContainer = containers[i]
+		}
+	}
+
+	clusterLabelsArg, err := liqoctlutils.ExtractValuesFromArgumentList("--cluster-labels", ctrlContainer.Args)
+	if err != nil {
+		return err
+	}
+
+	clusterLabels, err := liqoctlutils.ParseArgsMultipleValues(clusterLabelsArg, ",")
+	if err != nil {
+		return err
+	}
+
+	l.data.Labels = clusterLabels
+	return nil
+}
+
+func (l *InstallationChecker) collectLiqoVersion(ctrlDeployment *appsv1.Deployment) error {
+	version, err := getters.GetContainerImageVersion(ctrlDeployment.Spec.Template.Spec.Containers, ctrlManagerContainerName)
+	if err != nil {
+		return err
+	}
+	l.data.Version = version
+	return nil
+}

--- a/pkg/liqoctl/info/localstatus/local_info_test.go
+++ b/pkg/liqoctl/info/localstatus/local_info_test.go
@@ -1,0 +1,121 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package localstatus_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/pterm/pterm"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	liqoconsts "github.com/liqotech/liqo/pkg/consts"
+	"github.com/liqotech/liqo/pkg/liqoctl/factory"
+	"github.com/liqotech/liqo/pkg/liqoctl/info"
+	"github.com/liqotech/liqo/pkg/liqoctl/info/localstatus"
+	"github.com/liqotech/liqo/pkg/liqoctl/output"
+	liqoctlutils "github.com/liqotech/liqo/pkg/liqoctl/utils"
+	"github.com/liqotech/liqo/pkg/utils/testutil"
+)
+
+var _ = Describe("InstallationChecker tests", func() {
+	const (
+		clusterID = "fake"
+	)
+
+	var (
+		clientBuilder     fake.ClientBuilder
+		ic                *localstatus.InstallationChecker
+		ctx               context.Context
+		options           info.Options
+		argsClusterLabels []string
+		baseObjects       = []client.Object{
+			testutil.FakeNode(),
+			testutil.FakeClusterIDConfigMap(liqoconsts.DefaultLiqoNamespace, clusterID),
+		}
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		clientBuilder = *fake.NewClientBuilder().WithScheme(scheme.Scheme)
+		for k, v := range testutil.ClusterLabels {
+			argsClusterLabels = append(argsClusterLabels, fmt.Sprintf("%s=%s", k, v))
+		}
+
+		options = info.Options{Factory: factory.NewForLocal()}
+		options.Printer = output.NewFakePrinter(GinkgoWriter)
+		options.KubeClient = k8sfake.NewSimpleClientset()
+	})
+
+	Describe("Testing the InstallationChecker", func() {
+		Context("Collecting and retrieving the data", func() {
+			It("should collect the data and return the right result", func() {
+				objects := append([]client.Object{}, baseObjects...)
+
+				fakectrlman := testutil.FakeControllerManagerDeployment(argsClusterLabels, true)
+				objects = append(objects, fakectrlman)
+
+				// Set up the fake clients
+				clientBuilder.WithObjects(objects...)
+				options.CRClient = clientBuilder.Build()
+				options.LiqoNamespace = liqoconsts.DefaultLiqoNamespace
+
+				// The configmap is retrieved with the native client, so mock the kubeclient
+				options.KubeClient = k8sfake.NewSimpleClientset(baseObjects[1])
+
+				By("Collecting the data")
+				ic = &localstatus.InstallationChecker{}
+				ic.Collect(ctx, options)
+
+				By("Verifying that no errors have been raised")
+				Expect(ic.GetCollectionErrors()).To(BeEmpty())
+
+				By("Checking the correctness of the data in the struct")
+				data := ic.GetData().(localstatus.Installation)
+
+				Expect(string(data.ClusterID)).To(Equal(clusterID))
+				Expect(data.Version).To(Equal(testutil.FakeLiqoVersion))
+				Expect(data.APIServerAddr).To(Equal(fmt.Sprintf("https://%v:6443", testutil.EndpointIP)))
+
+				// Check if the cluster labels are the expected ones
+				labels, _ := liqoctlutils.ParseArgsMultipleValues(strings.Join(argsClusterLabels, ","), ",")
+				Expect(data.Labels).To(Equal(labels))
+
+				By("Checking the formatted output")
+				text := ic.Format(options)
+				text = pterm.RemoveColorFromString(text)
+				text = testutil.SqueezeWhitespaces(text)
+
+				Expect(text).To(ContainSubstring(
+					pterm.Sprintf("Cluster ID: %s", clusterID),
+				))
+				Expect(text).To(ContainSubstring(
+					pterm.Sprintf("Version: %s", testutil.FakeLiqoVersion),
+				))
+
+				for _, v := range testutil.ClusterLabels {
+					Expect(text).To(ContainSubstring(v))
+				}
+			})
+		})
+	})
+})

--- a/pkg/liqoctl/info/localstatus/local_suite_test.go
+++ b/pkg/liqoctl/info/localstatus/local_suite_test.go
@@ -1,0 +1,42 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package localstatus
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+
+	corev1beta1 "github.com/liqotech/liqo/apis/core/v1beta1"
+	ipamv1alpha1 "github.com/liqotech/liqo/apis/ipam/v1alpha1"
+	networkingv1beta1 "github.com/liqotech/liqo/apis/networking/v1beta1"
+)
+
+func TestLocal(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Local Suite")
+}
+
+var _ = BeforeSuite(func() {
+	utilruntime.Must(corev1.AddToScheme(scheme.Scheme))
+	utilruntime.Must(networkingv1beta1.AddToScheme(scheme.Scheme))
+	utilruntime.Must(ipamv1alpha1.AddToScheme(scheme.Scheme))
+	utilruntime.Must(corev1beta1.AddToScheme(scheme.Scheme))
+})

--- a/pkg/liqoctl/info/localstatus/network.go
+++ b/pkg/liqoctl/info/localstatus/network.go
@@ -1,0 +1,90 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package localstatus
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/liqotech/liqo/pkg/liqoctl/info"
+	"github.com/liqotech/liqo/pkg/liqoctl/output"
+	"github.com/liqotech/liqo/pkg/utils/ipam"
+)
+
+// Network represents the status of the network of the local Liqo installation.
+type Network struct {
+	PodCIDR      string `json:"podCIDR"`
+	ServiceCIDR  string `json:"serviceCIDR"`
+	ExternalCIDR string `json:"externalCIDR"`
+	InternalCIDR string `json:"internalCIDR"`
+}
+
+func (l *Network) setProperty(propName, propValue string) {
+	reflect.ValueOf(l).Elem().FieldByName(propName).Set(reflect.ValueOf(propValue))
+}
+
+// NetworkChecker collects info about the local installation of Liqo.
+type NetworkChecker struct {
+	info.CheckerBase
+	data Network
+}
+
+// Collect data about the network of the local installation of Liqo.
+func (l *NetworkChecker) Collect(ctx context.Context, options info.Options) {
+	fields := map[string]func(ctx context.Context, cl client.Client) (string, error){
+		"PodCIDR":      ipam.GetPodCIDR,
+		"ServiceCIDR":  ipam.GetServiceCIDR,
+		"ExternalCIDR": ipam.GetExternalCIDR,
+		"InternalCIDR": ipam.GetInternalCIDR,
+	}
+
+	for key, fn := range fields {
+		val, err := fn(ctx, options.CRClient)
+		if err != nil {
+			l.AddCollectionError(fmt.Errorf("unable to get %s: %w", key, err))
+		}
+		l.data.setProperty(key, val)
+	}
+}
+
+// Format returns the collected data using a user friendly output.
+func (l *NetworkChecker) Format(options info.Options) string {
+	main := output.NewRootSection()
+	main.AddEntry("Pod CIDR", l.data.PodCIDR)
+	main.AddEntry("Service CIDR", l.data.ServiceCIDR)
+	main.AddEntry("External CIDR", l.data.ExternalCIDR)
+	main.AddEntry("Internal CIDR", l.data.InternalCIDR)
+
+	return main.SprintForBox(options.Printer)
+}
+
+// GetData returns the data collected by the checker.
+func (l *NetworkChecker) GetData() interface{} {
+	return l.data
+}
+
+// GetID returns the id of the section collected by the checker.
+func (l *NetworkChecker) GetID() string {
+	return "network"
+}
+
+// GetTitle returns the title of the section collected by the checker.
+func (l *NetworkChecker) GetTitle() string {
+	return "Network"
+}

--- a/pkg/liqoctl/info/localstatus/network_test.go
+++ b/pkg/liqoctl/info/localstatus/network_test.go
@@ -1,0 +1,105 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package localstatus_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/pterm/pterm"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	liqoconsts "github.com/liqotech/liqo/pkg/consts"
+	"github.com/liqotech/liqo/pkg/liqoctl/factory"
+	"github.com/liqotech/liqo/pkg/liqoctl/info"
+	"github.com/liqotech/liqo/pkg/liqoctl/info/localstatus"
+	"github.com/liqotech/liqo/pkg/liqoctl/output"
+	"github.com/liqotech/liqo/pkg/utils/testutil"
+)
+
+var _ = Describe("NetworkChecker tests", func() {
+
+	var (
+		clientBuilder fake.ClientBuilder
+		nc            *localstatus.NetworkChecker
+		ctx           context.Context
+		options       info.Options
+		baseObjects   = []client.Object{
+			testutil.FakeNetworkPodCIDR(),
+			testutil.FakeNetworkServiceCIDR(),
+			testutil.FakeNetworkInternalCIDR(),
+			testutil.FakeNetworkExternalCIDR(),
+		}
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		clientBuilder = *fake.NewClientBuilder().WithScheme(scheme.Scheme)
+
+		options = info.Options{Factory: factory.NewForLocal()}
+		options.Printer = output.NewFakePrinter(GinkgoWriter)
+		options.KubeClient = k8sfake.NewSimpleClientset()
+	})
+
+	Describe("Testing the NetworkChecker", func() {
+		Context("Collecting and retrieving the data", func() {
+			It("should collect the data and return the right result", func() {
+
+				// Set up the fake clients
+				clientBuilder.WithObjects(baseObjects...)
+				options.CRClient = clientBuilder.Build()
+				options.LiqoNamespace = liqoconsts.DefaultLiqoNamespace
+
+				By("Collecting the data")
+				nc = &localstatus.NetworkChecker{}
+				nc.Collect(ctx, options)
+
+				By("Verifying that no errors have been raised")
+				Expect(nc.GetCollectionErrors()).To(BeEmpty())
+
+				By("Checking the correctness of the data in the struct")
+				data := nc.GetData().(localstatus.Network)
+
+				Expect(data.PodCIDR).To(Equal(testutil.PodCIDR))
+				Expect(data.ServiceCIDR).To(Equal(testutil.ServiceCIDR))
+				Expect(data.ExternalCIDR).To(Equal(testutil.ExternalCIDR))
+				Expect(data.InternalCIDR).To(Equal(testutil.InternalCIDR))
+
+				By("Checking the formatted output")
+				text := nc.Format(options)
+				text = pterm.RemoveColorFromString(text)
+				text = testutil.SqueezeWhitespaces(text)
+
+				Expect(text).To(ContainSubstring(
+					pterm.Sprintf("Pod CIDR: %s", testutil.PodCIDR),
+				))
+				Expect(text).To(ContainSubstring(
+					pterm.Sprintf("Service CIDR: %s", testutil.ServiceCIDR),
+				))
+				Expect(text).To(ContainSubstring(
+					pterm.Sprintf("External CIDR: %s", testutil.ExternalCIDR),
+				))
+				Expect(text).To(ContainSubstring(
+					pterm.Sprintf("Internal CIDR: %s", testutil.InternalCIDR),
+				))
+			})
+		})
+	})
+})

--- a/pkg/liqoctl/info/localstatus/peerings.go
+++ b/pkg/liqoctl/info/localstatus/peerings.go
@@ -1,0 +1,148 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package localstatus
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pterm/pterm"
+
+	liqov1beta1 "github.com/liqotech/liqo/apis/core/v1beta1"
+	"github.com/liqotech/liqo/pkg/liqoctl/info"
+	"github.com/liqotech/liqo/pkg/liqoctl/output"
+)
+
+// ModuleStatus represents the status of each of the modules.
+type ModuleStatus string
+
+const (
+	// Healthy indicates a module that works as expected.
+	Healthy ModuleStatus = "Healthy"
+	// Unhealthy indicates that there are issues with the module.
+	Unhealthy ModuleStatus = "Unhealthy"
+	// Disabled indicates that the modules is not currently used.
+	Disabled ModuleStatus = "Disabled"
+)
+
+// PeeringInfo represents the peering with another cluster.
+type PeeringInfo struct {
+	liqov1beta1.ClusterID `json:"clusterID"`
+	Role                  liqov1beta1.RoleType `json:"role"`
+	NetworkingStatus      ModuleStatus         `json:"networkingStatus"`
+	AuthenticationStatus  ModuleStatus         `json:"authenticationStatus"`
+	OffloadingStatus      ModuleStatus         `json:"offloadingStatus"`
+}
+
+// Peerings contains some brief data about the active peering of the local cluster.
+type Peerings struct {
+	Peers []PeeringInfo `json:"peers"`
+}
+
+// PeeringChecker collects the data about the active peering of the local cluster.
+type PeeringChecker struct {
+	info.CheckerBase
+	data Peerings
+}
+
+// Collect some brief data about the active peering of the local Liqo installation.
+func (p *PeeringChecker) Collect(ctx context.Context, options info.Options) {
+	var peeringsList liqov1beta1.ForeignClusterList
+	if err := options.CRClient.List(ctx, &peeringsList); err != nil {
+		p.AddCollectionError(fmt.Errorf("unable to retrieve peerings: %w", err))
+		return
+	}
+
+	p.data.Peers = []PeeringInfo{}
+	for i := range peeringsList.Items {
+		peer := &peeringsList.Items[i]
+
+		moduleStatus := map[string]ModuleStatus{}
+
+		modules := map[string]liqov1beta1.Module{
+			"networking":     peer.Status.Modules.Networking,
+			"authentication": peer.Status.Modules.Authentication,
+			"offloading":     peer.Status.Modules.Offloading,
+		}
+
+		for moduleName, moduleInfo := range modules {
+			if moduleInfo.Enabled {
+				for i := range moduleInfo.Conditions {
+					condition := &moduleInfo.Conditions[i]
+
+					if condition.Status == liqov1beta1.ConditionStatusEstablished || condition.Status == liqov1beta1.ConditionStatusReady {
+						moduleStatus[moduleName] = Healthy
+					} else {
+						moduleStatus[moduleName] = Unhealthy
+					}
+				}
+			} else {
+				moduleStatus[moduleName] = Disabled
+			}
+		}
+
+		p.data.Peers = append(p.data.Peers, PeeringInfo{
+			ClusterID:            peer.Spec.ClusterID,
+			Role:                 peer.Status.Role,
+			NetworkingStatus:     moduleStatus["networking"],
+			AuthenticationStatus: moduleStatus["authentication"],
+			OffloadingStatus:     moduleStatus["offloading"],
+		})
+	}
+}
+
+// Format returns the collected data using a user friendly output.
+func (p *PeeringChecker) Format(options info.Options) string {
+	main := output.NewRootSection()
+	for i := range p.data.Peers {
+		peer := &p.data.Peers[i]
+		peerSection := main.AddSectionInfo(string(peer.ClusterID))
+		peerSection.AddEntry("Role", string(peer.Role))
+		peerSection.AddEntry("Networking status", p.formatStatus(peer.NetworkingStatus))
+		peerSection.AddEntry("Authentication status", p.formatStatus(peer.AuthenticationStatus))
+		peerSection.AddEntry("Offloading status", p.formatStatus(peer.OffloadingStatus))
+	}
+
+	return main.SprintForBox(options.Printer)
+}
+
+// GetData returns the data collected by the checker.
+func (p *PeeringChecker) GetData() interface{} {
+	return p.data
+}
+
+// GetID returns the id of the section collected by the checker.
+func (p *PeeringChecker) GetID() string {
+	return "peerings"
+}
+
+// GetTitle returns the title of the section collected by the checker.
+func (p *PeeringChecker) GetTitle() string {
+	return "Active peerings"
+}
+
+func (p *PeeringChecker) formatStatus(moduleStatus ModuleStatus) string {
+	var color pterm.Color
+	switch moduleStatus {
+	case Healthy:
+		color = pterm.FgGreen
+	case Disabled:
+		color = pterm.FgLightCyan
+	default:
+		color = pterm.FgRed
+	}
+	return pterm.NewStyle(color, pterm.Bold).Sprint(moduleStatus)
+}

--- a/pkg/liqoctl/info/localstatus/peerings_test.go
+++ b/pkg/liqoctl/info/localstatus/peerings_test.go
@@ -1,0 +1,200 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package localstatus_test
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/pterm/pterm"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	liqov1beta1 "github.com/liqotech/liqo/apis/core/v1beta1"
+	liqoconsts "github.com/liqotech/liqo/pkg/consts"
+	"github.com/liqotech/liqo/pkg/liqoctl/factory"
+	"github.com/liqotech/liqo/pkg/liqoctl/info"
+	"github.com/liqotech/liqo/pkg/liqoctl/info/localstatus"
+	"github.com/liqotech/liqo/pkg/liqoctl/output"
+	"github.com/liqotech/liqo/pkg/utils/testutil"
+)
+
+var _ = Describe("PeeringChecker tests", func() {
+
+	getFakeModuleFromStatus := func(status localstatus.ModuleStatus) liqov1beta1.Module {
+		var conditions []liqov1beta1.Condition
+		if status == localstatus.Disabled {
+			return liqov1beta1.Module{
+				Enabled: false,
+			}
+		} else if status == localstatus.Healthy {
+			conditions = append(conditions,
+				liqov1beta1.Condition{
+					Type:   "fake1",
+					Status: liqov1beta1.ConditionStatusEstablished,
+				},
+				liqov1beta1.Condition{
+					Type:   "fake2",
+					Status: liqov1beta1.ConditionStatusReady,
+				},
+			)
+		} else {
+			conditions = append(conditions,
+				liqov1beta1.Condition{
+					Type:   "fake1",
+					Status: liqov1beta1.ConditionStatusError,
+				},
+			)
+		}
+
+		return liqov1beta1.Module{
+			Enabled:    true,
+			Conditions: conditions,
+		}
+	}
+
+	getFakeForeignClusterID := func(n int) string {
+		return fmt.Sprintf("cluster-%d", n)
+	}
+
+	type ForeignClusterDescription struct {
+		Authentication localstatus.ModuleStatus
+		Networking     localstatus.ModuleStatus
+		Offloading     localstatus.ModuleStatus
+	}
+
+	type TestArgs struct {
+		foreignClusterDescriptions []ForeignClusterDescription
+	}
+
+	var (
+		clientBuilder fake.ClientBuilder
+		pc            *localstatus.PeeringChecker
+		ctx           context.Context
+		options       info.Options
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		clientBuilder = *fake.NewClientBuilder().WithScheme(scheme.Scheme)
+
+		options = info.Options{Factory: factory.NewForLocal()}
+		options.Printer = output.NewFakePrinter(GinkgoWriter)
+		options.KubeClient = k8sfake.NewSimpleClientset()
+	})
+
+	Describe("Testing the PeeringChecker", func() {
+		Context("Collecting and retrieving the data", func() {
+			DescribeTable("should collect the data and return the right result", func(args TestArgs) {
+				// Set up the fake foreign clusters
+				var clustersList []client.Object
+
+				for i, d := range args.foreignClusterDescriptions {
+					clustersList = append(clustersList, testutil.FakeForeignCluster(
+						liqov1beta1.ClusterID(getFakeForeignClusterID(i)),
+						&liqov1beta1.Modules{
+							Authentication: getFakeModuleFromStatus(d.Authentication),
+							Networking:     getFakeModuleFromStatus(d.Networking),
+							Offloading:     getFakeModuleFromStatus(d.Offloading),
+						},
+					))
+				}
+
+				clientBuilder.WithObjects(clustersList...)
+				options.CRClient = clientBuilder.Build()
+				options.LiqoNamespace = liqoconsts.DefaultLiqoNamespace
+
+				By("Collecting the data")
+				pc = &localstatus.PeeringChecker{}
+				pc.Collect(ctx, options)
+
+				By("Verifying that no errors have been raised")
+				Expect(pc.GetCollectionErrors()).To(BeEmpty())
+
+				By("Checking the correctness of the data in the struct")
+				data := pc.GetData().(localstatus.Peerings)
+
+				// Checking that the number of active peerings match the number of ForeignCluster resources
+				Expect(len(data.Peers)).To(Equal(len(args.foreignClusterDescriptions)),
+					"The number of active peerings reported is not the expected one",
+				)
+
+				for i, clusterInfo := range data.Peers {
+					expectedClusterRes := &args.foreignClusterDescriptions[i]
+					Expect(clusterInfo.ClusterID).To(Equal(liqov1beta1.ClusterID(getFakeForeignClusterID(i))),
+						"Unexpected ClusterID",
+					)
+					Expect(clusterInfo.AuthenticationStatus).To(Equal(expectedClusterRes.Authentication))
+					Expect(clusterInfo.NetworkingStatus).To(Equal(expectedClusterRes.Networking))
+					Expect(clusterInfo.OffloadingStatus).To(Equal(expectedClusterRes.Offloading))
+				}
+
+				By("Checking the formatted output")
+				text := pc.Format(options)
+				text = pterm.RemoveColorFromString(text)
+				text = testutil.SqueezeWhitespaces(text)
+				for i, clusterInfo := range data.Peers {
+					Expect(text).To(ContainSubstring(
+						pterm.Sprintf(
+							"%s Role: Unknown Networking status: %v Authentication status: %v Offloading status: %v",
+							getFakeForeignClusterID(i),
+							clusterInfo.NetworkingStatus,
+							clusterInfo.AuthenticationStatus,
+							clusterInfo.OffloadingStatus,
+						),
+					))
+				}
+			},
+				Entry("Healthy 1 peering", TestArgs{
+					foreignClusterDescriptions: []ForeignClusterDescription{
+						{
+							Authentication: localstatus.Healthy,
+							Networking:     localstatus.Healthy,
+							Offloading:     localstatus.Healthy,
+						},
+					},
+				}),
+				Entry("Healthy and Unhealthy peerings", TestArgs{
+					foreignClusterDescriptions: []ForeignClusterDescription{
+						{
+							Authentication: localstatus.Healthy,
+							Networking:     localstatus.Healthy,
+							Offloading:     localstatus.Healthy,
+						},
+						{
+							Authentication: localstatus.Healthy,
+							Networking:     localstatus.Unhealthy,
+							Offloading:     localstatus.Healthy,
+						},
+					},
+				}),
+				Entry("Unhealthy peering with disable module", TestArgs{
+					foreignClusterDescriptions: []ForeignClusterDescription{
+						{
+							Authentication: localstatus.Healthy,
+							Networking:     localstatus.Disabled,
+							Offloading:     localstatus.Unhealthy,
+						},
+					},
+				}),
+			)
+		})
+	})
+})

--- a/pkg/liqoctl/info/suite_test.go
+++ b/pkg/liqoctl/info/suite_test.go
@@ -1,0 +1,66 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package info
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+type dummyChecker struct {
+	CheckerBase
+	title string
+	id    string
+	data  interface{}
+
+	nCollectCalls int
+}
+
+func (d *dummyChecker) Collect(_ context.Context, _ Options) {
+	d.nCollectCalls++
+}
+
+func (d *dummyChecker) Format(options Options) string {
+	return ""
+}
+
+func (d *dummyChecker) GetData() interface{} {
+	return d.data
+}
+
+// GetID returns the id of the section collected by the checker.
+func (d *dummyChecker) GetID() string {
+	if d.id != "" {
+		return d.id
+	}
+	return "dummy"
+}
+
+// GetTitle returns the title of the section collected by the checker.
+func (d *dummyChecker) GetTitle() string {
+	if d.id != "" {
+		return d.title
+	}
+	return "Dummy"
+}
+
+func TestLocal(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Local Suite")
+}

--- a/pkg/liqoctl/info/utils.go
+++ b/pkg/liqoctl/info/utils.go
@@ -1,0 +1,131 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package info
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
+)
+
+// collectData collect the data retrieved by the checkers in a map.
+func (o *Options) collectData(checkers []Checker) map[string]interface{} {
+	data := map[string]interface{}{}
+
+	for i := range checkers {
+		data[checkers[i].GetID()] = checkers[i].GetData()
+	}
+
+	return data
+}
+
+// installationCheck checks if Liqo is installed in the cluster.
+func (o *Options) installationCheck(ctx context.Context) error {
+	_, err := o.KubeClient.CoreV1().Namespaces().Get(ctx, o.LiqoNamespace, metav1.GetOptions{})
+
+	switch {
+	case client.IgnoreNotFound(err) != nil:
+		o.Printer.Error.Printfln("Unable to check if Liqo is installed: %v", err)
+		return err
+	case kerrors.IsNotFound(err):
+		o.Printer.Error.Println("Liqo is not installed in the current cluster! \n\n" +
+			"You can install liqo via the 'liqoctl install' command.\n" +
+			"Check 'liqoctl install --help' for further information.")
+		return err
+	}
+
+	return nil
+}
+
+// sPrintField returns a specific field from the data collected from the checkers
+// given a query in dot notation.
+func (o *Options) sPrintField(query string, checkers []Checker, queryShortcuts map[string]string) (string, error) {
+	data := o.collectData(checkers)
+
+	// Check whether the query is actually a shortcut
+	if shortcut, ok := queryShortcuts[strings.ToLower(query)]; ok {
+		query = shortcut
+	}
+
+	query = strings.TrimPrefix(query, ".")
+	fields := strings.Split(query, ".")
+
+	currData, ok := data[fields[0]]
+	if !ok {
+		return "", fmt.Errorf("invalid query %q: %q not found", query, fields[0])
+	}
+
+	for i, f := range fields[1:] {
+		if reflect.ValueOf(currData).Kind() != reflect.Struct {
+			// We need to report that the previous field is not an object.
+			// We use fields[i] as we iterate over `fields[1:]` so "i" is already pointing to the value before "f"
+			return "", fmt.Errorf("invalid query %q: %q is not an object", query, fields[i])
+		}
+
+		gotData := reflect.ValueOf(currData).FieldByNameFunc(func(fieldName string) bool {
+			return strings.EqualFold(fieldName, f)
+		})
+
+		if !gotData.IsValid() || (gotData.IsValid() && gotData.IsZero()) {
+			return "", fmt.Errorf("invalid query %q: %q not found", query, f)
+		}
+		currData = gotData.Interface()
+	}
+
+	// Check the type of returned data to correctly print the output
+	kind := reflect.ValueOf(currData).Kind()
+	if kind != reflect.Struct && kind != reflect.Slice && kind != reflect.Map {
+		return fmt.Sprint(currData), nil
+	}
+
+	return o.sPrintOutput(currData)
+}
+
+// sPrintMachineReadable returns the output collected by the checkers in a machine readable format. Either JSON or YAML,
+// according to the output format.
+func (o *Options) sPrintMachineReadable(checkers []Checker) (string, error) {
+	data := o.collectData(checkers)
+
+	return o.sPrintOutput(data)
+}
+
+// sPrintOutput format the data as the output format.
+func (o *Options) sPrintOutput(data interface{}) (string, error) {
+	var output string
+	if o.Format == JSON {
+		jsonRes, err := json.MarshalIndent(data, "", "  ")
+		if err != nil {
+			return "", err
+		}
+		output = string(jsonRes)
+	} else {
+		// if not json, print the output in yaml format
+		yamlRes, err := yaml.Marshal(data)
+		if err != nil {
+			return "", err
+		}
+		output = string(yamlRes)
+	}
+
+	return output, nil
+}

--- a/pkg/liqoctl/info/utils_test.go
+++ b/pkg/liqoctl/info/utils_test.go
@@ -1,0 +1,193 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package info
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	"sigs.k8s.io/yaml"
+
+	"github.com/liqotech/liqo/pkg/liqoctl/factory"
+	"github.com/liqotech/liqo/pkg/liqoctl/output"
+	"github.com/liqotech/liqo/pkg/utils/testutil"
+)
+
+var _ = Describe("Info utilities functions tests", func() {
+	Context("sPrintField function tests", func() {
+		It("gets a string and a number from a struct", func() {
+			o := Options{}
+			type Dummy struct {
+				Key string
+				N   int
+			}
+
+			expectedVal := "value"
+			expectedN := 48
+			data := Dummy{Key: expectedVal, N: expectedN}
+
+			By("getting a string value with a dotted query")
+			checker := &dummyChecker{data: data, id: "dummy"}
+			text, err := o.sPrintField("dummy.key", []Checker{checker}, nil)
+			Expect(err).To(BeNil())
+			Expect(text).To(Equal(expectedVal), "Unexpected string retrieved")
+
+			By("getting a number value with a dotted query")
+			text, err = o.sPrintField("dummy.n", []Checker{checker}, nil)
+			Expect(err).To(BeNil())
+			Expect(text).To(Equal(fmt.Sprint(expectedN)), "Unexpected number retrieved")
+
+			By("getting a string value with a dotted query (trailing dot)")
+			text, err = o.sPrintField(".dummy.key", []Checker{checker}, nil)
+			Expect(err).To(BeNil())
+			Expect(text).To(Equal(expectedVal), "Unexpected string retrieved")
+
+			By("getting a string value with a dotted query (capitalized field)")
+			text, err = o.sPrintField(".dummy.KEY", []Checker{checker}, nil)
+			Expect(err).To(BeNil())
+			Expect(text).To(Equal(expectedVal), "Unexpected string retrieved")
+
+			By("getting a string with query shortcut")
+			text, err = o.sPrintField("key", []Checker{checker}, map[string]string{"key": "dummy.key"})
+			Expect(err).To(BeNil())
+			Expect(text).To(Equal(expectedVal), "Unexpected string retrieved")
+		})
+
+		It("gets more complex data structures", func() {
+			o := Options{Format: YAML}
+			type NestedDummy struct {
+				Key1 string
+				Key2 string
+			}
+
+			type Dummy struct {
+				Nested NestedDummy
+				Slice  []string
+				Map    map[string]string
+			}
+
+			expectedNested := NestedDummy{
+				Key1: "hello",
+				Key2: "Liqo",
+			}
+			expectedSlice := []string{"Slice", "Liqo"}
+			expectedMap := map[string]string{"Map": "Liqo"}
+			data := Dummy{
+				Nested: expectedNested,
+				Slice:  expectedSlice,
+				Map:    expectedMap,
+			}
+
+			checker := &dummyChecker{data: data, id: "dummy"}
+
+			By("getting a string a nested data structure")
+			text, err := o.sPrintField("dummy.nested.key1", []Checker{checker}, nil)
+			Expect(err).To(BeNil())
+			Expect(text).To(Equal(expectedNested.Key1), "Unexpected string retrieved")
+
+			By("getting the entire nested struct (YAML)")
+			text, err = o.sPrintField("dummy.nested", []Checker{checker}, nil)
+			expectedNestedYaml, _ := yaml.Marshal(expectedNested)
+			Expect(err).To(BeNil())
+			Expect(text).To(Equal(
+				string(expectedNestedYaml),
+			), "Unexpected YAML data structure")
+
+			By("getting a slice (YAML)")
+			text, err = o.sPrintField("dummy.slice", []Checker{checker}, nil)
+			expectedSliceYaml, _ := yaml.Marshal(expectedSlice)
+			Expect(err).To(BeNil())
+			Expect(text).To(Equal(
+				string(expectedSliceYaml),
+			), "Unexpected YAML when getting a slice")
+
+			By("getting a map (YAML)")
+			text, err = o.sPrintField("dummy.map", []Checker{checker}, nil)
+			expectedMapYaml, _ := yaml.Marshal(expectedMap)
+			Expect(err).To(BeNil())
+			Expect(text).To(Equal(
+				string(expectedMapYaml),
+			), "Unexpected YAML when getting a map")
+
+			By("getting the entire nested struct changin output to JSON")
+			o.Format = JSON
+			text, err = o.sPrintField("dummy.nested", []Checker{checker}, nil)
+			expectedNestedJSON, _ := json.MarshalIndent(expectedNested, "", "  ")
+			Expect(err).To(BeNil())
+			Expect(text).To(Equal(
+				string(expectedNestedJSON),
+			), "Unexpected JSON data structure")
+		})
+
+		It("tries to get invalid fields", func() {
+			o := Options{}
+			type Dummy struct {
+				Key string
+				N   int
+			}
+
+			data := Dummy{Key: "val", N: 11}
+			checker := &dummyChecker{data: data, id: "dummy"}
+
+			By("getting invalid field (first field of the query)")
+			_, err := o.sPrintField("invalid", []Checker{checker}, nil)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("not found"))
+
+			By("getting invalid field (second field of the query)")
+			_, err = o.sPrintField("dummy.invalid", []Checker{checker}, nil)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("not found"))
+
+			By("trying to access a subfield of a non-object field")
+			_, err = o.sPrintField("dummy.key.subfield", []Checker{checker}, nil)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("not an object"))
+		})
+	})
+
+	Context("installationCheck function tests", func() {
+		var ctx context.Context
+
+		BeforeEach(func() {
+			ctx = context.Background()
+		})
+
+		It("check whether the Liqo namespace exists (existing namespace)", func() {
+			o := Options{Factory: factory.NewForLocal()}
+			o.LiqoNamespace = "liqo"
+			o.KubeClient = k8sfake.NewSimpleClientset(testutil.FakeLiqoNamespace(o.LiqoNamespace))
+
+			err := o.installationCheck(ctx)
+			Expect(err).NotTo(HaveOccurred(), "Existing Liqo namespace but failed check")
+		})
+
+		It("check whether the Liqo namespace exists (not existing namespace)", func() {
+			o := Options{Factory: factory.NewForLocal()}
+			o.LiqoNamespace = "fakens"
+			o.KubeClient = k8sfake.NewSimpleClientset()
+			o.Printer = output.NewFakePrinter(GinkgoWriter)
+
+			err := o.installationCheck(ctx)
+			Expect(err).To(HaveOccurred(), "Existing Liqo namespace but failed check")
+			Expect(err.Error()).To(ContainSubstring("not found"))
+		})
+	})
+})

--- a/pkg/utils/testutil/kubernetes.go
+++ b/pkg/utils/testutil/kubernetes.go
@@ -23,6 +23,18 @@ import (
 	liqoconsts "github.com/liqotech/liqo/pkg/consts"
 )
 
+// FakeLiqoNamespace returns a fake Liqo namespace.
+func FakeLiqoNamespace(name string) *corev1.Namespace {
+	return &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				"kubernetes.io/metadata.name": "liqo",
+			},
+		},
+	}
+}
+
 // FakeClusterIDConfigMap returns a fake ClusterID ConfigMap.
 func FakeClusterIDConfigMap(namespace, clusterID string) *corev1.ConfigMap {
 	return &corev1.ConfigMap{


### PR DESCRIPTION
# Description

With the new version of Liqo the liqoctl status command has been removed because of some issues with the mantainabilty of the command, indeed it used to get the info from multiple CR and as with the new version of Liqo, a major refactoring of the resources has been done and complete rework on it was necessary.

The status command was a good way to check the:

- Health of the installation
- Current configuration
- Status of the peerings

This PR introduces the new `liqoctl info` command as a replacement for the status command. It not only shows the current status of the local Liqo instance, but provides some brief info about the active peerings. 
By default the output is presented in a human-readable form. However, to simplify automate retrieval of the data, via the `-o` option it is possible to format the output in `JSON` or `YAML`  and, via the `--get field.subfield` argument, each field of the reports can be individually retrieved.

E.g.
Get the output in YAML format
```
liqoctl info -o json
```

Get the podCIDR of the local Liqo instance:
```
liqoctl info --get network.podcidr
```

This PR add the boilerplate for the `liqoctl info peer <CLUSTED_ID>` command, **which is still not implemented**.

# How Has This Been Tested?

Test suite provided.
