### PR TITLE
Fix bug deletion routine of virtualnodes with createNode=false

### DIFF
--- a/pkg/liqo-controller-manager/offloading/virtualnode-controller/deletion-routine.go
+++ b/pkg/liqo-controller-manager/offloading/virtualnode-controller/deletion-routine.go
@@ -176,8 +176,8 @@ func (dr *DeletionRoutine) handle(ctx context.Context, key string) (err error) {
 			return err
 		}
 	} else {
-		// Node is being deleted, but the VirtualNode resource is not.
-		// The VirtualNode .Spec.CreateNode field is set to false.
+		// Node is deleting/deleted, but the VirtualNode resource is not
+		// (the virtualNode .Spec.CreateNode field is set to false).
 		ForgeCondition(vn, VnConditionMap{
 			offloadingv1beta1.NodeConditionType: VnCondition{
 				Status: offloadingv1beta1.NoneConditionStatusType,
@@ -185,7 +185,7 @@ func (dr *DeletionRoutine) handle(ctx context.Context, key string) (err error) {
 	}
 
 	klog.Infof("Deletion routine completed for virtual node %s", vn.Name)
-	return err
+	return nil
 }
 
 // deleteNode deletes the Node created by VirtualNode.

--- a/pkg/liqo-controller-manager/offloading/virtualnode-controller/virtualnode_controller.go
+++ b/pkg/liqo-controller-manager/offloading/virtualnode-controller/virtualnode_controller.go
@@ -98,7 +98,7 @@ func (r *VirtualNodeReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	virtualNode := &offloadingv1beta1.VirtualNode{}
 	if err := r.Get(ctx, req.NamespacedName, virtualNode); err != nil {
 		if apierrors.IsNotFound(err) {
-			klog.Infof("There is no a virtual-node called '%s' in '%s'", req.Name, req.Namespace)
+			klog.Infof("There is no virtual-node called %q in %q", req.Name, req.Namespace)
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, fmt.Errorf("unable to get the virtual-node %q: %w", req.NamespacedName, err)


### PR DESCRIPTION
# Description

This PR fixes a bug that prevented virtualnodes with the option `createNode` set to False from being correctly evicted by the deletion-routine.
