### PR TITLE
Flags package refactoring: from "flag" to "pflag"

### DIFF
--- a/cmd/crd-replicator/main.go
+++ b/cmd/crd-replicator/main.go
@@ -15,10 +15,10 @@
 package main
 
 import (
-	"flag"
 	"os"
 	"time"
 
+	"github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
@@ -34,6 +34,7 @@ import (
 	identitymanager "github.com/liqotech/liqo/pkg/identityManager"
 	tenantnamespace "github.com/liqotech/liqo/pkg/tenantNamespace"
 	"github.com/liqotech/liqo/pkg/utils/args"
+	flagsutils "github.com/liqotech/liqo/pkg/utils/flags"
 	"github.com/liqotech/liqo/pkg/utils/mapper"
 	"github.com/liqotech/liqo/pkg/utils/restcfg"
 )
@@ -47,13 +48,13 @@ func init() {
 
 func main() {
 	clusterFlags := args.NewClusterIDFlags(true, nil)
-	resyncPeriod := flag.Duration("resync-period", 10*time.Hour, "The resync period for the informers")
-	workers := flag.Uint("workers", 1, "The number of workers managing the reflection of each remote cluster")
+	resyncPeriod := pflag.Duration("resync-period", 10*time.Hour, "The resync period for the informers")
+	workers := pflag.Uint("workers", 1, "The number of workers managing the reflection of each remote cluster")
 
 	restcfg.InitFlags(nil)
-	klog.InitFlags(nil)
+	flagsutils.InitKlogFlags(nil)
 
-	flag.Parse()
+	pflag.Parse()
 
 	log.SetLogger(klog.NewKlogr())
 

--- a/cmd/fabric/main.go
+++ b/cmd/fabric/main.go
@@ -16,7 +16,6 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"os"
 
@@ -64,12 +63,10 @@ func main() {
 		RunE: run,
 	}
 
-	legacyflags := flag.NewFlagSet("legacy", flag.ExitOnError)
-	restcfg.InitFlags(legacyflags)
-	klog.InitFlags(legacyflags)
-	flagsutils.FromFlagToPflag(legacyflags, cmd.Flags())
-
+	flagsutils.InitKlogFlags(cmd.Flags())
+	restcfg.InitFlags(cmd.Flags())
 	fabric.InitFlags(cmd.Flags(), options)
+
 	if err := fabric.MarkFlagsRequired(&cmd); err != nil {
 		klog.Error(err)
 		os.Exit(1)

--- a/cmd/gateway/geneve/main.go
+++ b/cmd/gateway/geneve/main.go
@@ -16,7 +16,6 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"os"
 
@@ -58,11 +57,8 @@ func main() {
 		RunE: run,
 	}
 
-	legacyflags := flag.NewFlagSet("legacy", flag.ExitOnError)
-	restcfg.InitFlags(legacyflags)
-	klog.InitFlags(legacyflags)
-	flagsutils.FromFlagToPflag(legacyflags, cmd.Flags())
-
+	flagsutils.InitKlogFlags(cmd.Flags())
+	restcfg.InitFlags(cmd.Flags())
 	fabric.InitFlags(cmd.Flags(), options)
 
 	gateway.InitFlags(cmd.Flags(), options.GwOptions)

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -16,7 +16,6 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"os"
 
@@ -62,10 +61,8 @@ func main() {
 		RunE: run,
 	}
 
-	legacyflags := flag.NewFlagSet("legacy", flag.ExitOnError)
-	restcfg.InitFlags(legacyflags)
-	klog.InitFlags(legacyflags)
-	flagsutils.FromFlagToPflag(legacyflags, cmd.Flags())
+	flagsutils.InitKlogFlags(cmd.Flags())
+	restcfg.InitFlags(cmd.Flags())
 
 	gwoptions := gateway.NewOptions()
 	connoptions = connection.NewOptions(

--- a/cmd/gateway/wireguard/main.go
+++ b/cmd/gateway/wireguard/main.go
@@ -16,7 +16,6 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"net"
 	"os"
@@ -66,10 +65,8 @@ func main() {
 		RunE: run,
 	}
 
-	legacyflags := flag.NewFlagSet("legacy", flag.ExitOnError)
-	restcfg.InitFlags(legacyflags)
-	klog.InitFlags(legacyflags)
-	flagsutils.FromFlagToPflag(legacyflags, cmd.Flags())
+	flagsutils.InitKlogFlags(cmd.Flags())
+	restcfg.InitFlags(cmd.Flags())
 
 	gateway.InitFlags(cmd.Flags(), options.GwOptions)
 	wireguard.InitFlags(cmd.Flags(), options)

--- a/cmd/ipam/main.go
+++ b/cmd/ipam/main.go
@@ -16,7 +16,6 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"os"
 
@@ -66,10 +65,8 @@ func main() {
 		RunE: run,
 	}
 
-	legacyflags := flag.NewFlagSet("legacy", flag.ExitOnError)
-	restcfg.InitFlags(legacyflags)
-	klog.InitFlags(legacyflags)
-	flagsutils.FromFlagToPflag(legacyflags, cmd.Flags())
+	flagsutils.InitKlogFlags(cmd.Flags())
+	restcfg.InitFlags(cmd.Flags())
 
 	liqoipam.InitFlags(cmd.Flags(), options)
 	if err := liqoipam.MarkFlagsRequired(&cmd, options); err != nil {

--- a/cmd/liqoctl/cmd/root.go
+++ b/cmd/liqoctl/cmd/root.go
@@ -17,7 +17,6 @@ package cmd
 import (
 	"bytes"
 	"context"
-	"flag"
 	"fmt"
 	"html/template"
 	"os"
@@ -26,8 +25,6 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/klog/v2"
 	"k8s.io/kubectl/pkg/cmd/util"
 
 	"github.com/liqotech/liqo/pkg/liqoctl/create"
@@ -109,16 +106,6 @@ func NewRootCommand(ctx context.Context) *cobra.Command {
 			}
 		},
 	}
-
-	// Since we cannot access internal klog configuration, we create a new flagset, let klog to install
-	// its flags, and we only set the ones we are intrested in.
-	klogFlagset := flag.NewFlagSet("klog", flag.PanicOnError)
-	klog.InitFlags(klogFlagset)
-	// These settings is required to silence the Helm library messages.
-	utilruntime.Must(klogFlagset.Set("stderrthreshold", "FATAL"))
-	klog.LogToStderr(false)
-	buffer := &bytes.Buffer{}
-	klog.SetOutput(buffer)
 
 	// In case liqoctl is used as a kubectl plugin, let's set a custom usage template with kubectl
 	// hardcoded in it, since Cobra does not allow to specify a two word command (i.e., "kubectl liqo")

--- a/cmd/metric-agent/main.go
+++ b/cmd/metric-agent/main.go
@@ -17,11 +17,11 @@ package main
 
 import (
 	"context"
-	"flag"
 	"fmt"
 	"net/http"
 	"os"
 
+	"github.com/spf13/pflag"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -36,6 +36,7 @@ import (
 	"github.com/liqotech/liqo/pkg/consts"
 	"github.com/liqotech/liqo/pkg/remotemetrics"
 	clientutils "github.com/liqotech/liqo/pkg/utils/clients"
+	flagsutils "github.com/liqotech/liqo/pkg/utils/flags"
 	"github.com/liqotech/liqo/pkg/utils/mapper"
 	"github.com/liqotech/liqo/pkg/utils/restcfg"
 )
@@ -47,15 +48,16 @@ import (
 func main() {
 	ctx := context.Background()
 
-	keyPath := flag.String("key-path", "server.key", "Path to the key file")
-	certPath := flag.String("cert-path", "server.crt", "Path to the certificate file")
-	readTimeout := flag.Duration("read-timeout", 0, "Read timeout")
-	writeTimeout := flag.Duration("write-timeout", 0, "Write timeout")
-	port := flag.Int("port", 8443, "Port to listen on")
+	keyPath := pflag.String("key-path", "server.key", "Path to the key file")
+	certPath := pflag.String("cert-path", "server.crt", "Path to the certificate file")
+	readTimeout := pflag.Duration("read-timeout", 0, "Read timeout")
+	writeTimeout := pflag.Duration("write-timeout", 0, "Write timeout")
+	port := pflag.Int("port", 8443, "Port to listen on")
 
-	klog.InitFlags(nil)
-	restcfg.InitFlags(nil)
-	flag.Parse()
+	flagsutils.InitKlogFlags(pflag.CommandLine)
+	restcfg.InitFlags(pflag.CommandLine)
+
+	pflag.Parse()
 
 	log.SetLogger(klog.NewKlogr())
 

--- a/cmd/telemetry/main.go
+++ b/cmd/telemetry/main.go
@@ -16,13 +16,13 @@ package main
 
 import (
 	"context"
-	"flag"
 	"fmt"
 	"os"
 	"os/signal"
 	"syscall"
 	"time"
 
+	"github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/klog/v2"
@@ -37,6 +37,7 @@ import (
 	"github.com/liqotech/liqo/pkg/consts"
 	"github.com/liqotech/liqo/pkg/telemetry"
 	argsutils "github.com/liqotech/liqo/pkg/utils/args"
+	flagsutils "github.com/liqotech/liqo/pkg/utils/flags"
 	"github.com/liqotech/liqo/pkg/utils/json"
 	"github.com/liqotech/liqo/pkg/utils/mapper"
 	"github.com/liqotech/liqo/pkg/utils/restcfg"
@@ -62,16 +63,18 @@ func init() {
 func main() {
 	var clusterLabels argsutils.StringMap
 
-	telemetryEndpoint := flag.String("telemetry-endpoint", "https://api.telemetry.liqo.io/v1", "telemetry endpoint")
-	timeout := flag.Duration("timeout", 10*time.Second, "timeout for requests")
-	namespace := flag.String("namespace", "liqo", "the namespace where liqo is deployed")
-	liqoVersion := flag.String("liqo-version", "", "the liqo version")
-	kubernetesVersion := flag.String("kubernetes-version", "", "the kubernetes version")
-	dryRun := flag.Bool("dry-run", false, "if true, do not send the telemetry item and print it on stdout")
-	flag.Var(&clusterLabels, consts.ClusterLabelsParameter,
+	telemetryEndpoint := pflag.String("telemetry-endpoint", "https://api.telemetry.liqo.io/v1", "telemetry endpoint")
+	timeout := pflag.Duration("timeout", 10*time.Second, "timeout for requests")
+	namespace := pflag.String("namespace", "liqo", "the namespace where liqo is deployed")
+	liqoVersion := pflag.String("liqo-version", "", "the liqo version")
+	kubernetesVersion := pflag.String("kubernetes-version", "", "the kubernetes version")
+	dryRun := pflag.Bool("dry-run", false, "if true, do not send the telemetry item and print it on stdout")
+	pflag.Var(&clusterLabels, consts.ClusterLabelsParameter,
 		"The set of labels which characterizes the local cluster when exposed remotely as a virtual node")
 
-	flag.Parse()
+	flagsutils.InitKlogFlags(nil)
+
+	pflag.Parse()
 
 	log.SetLogger(klog.NewKlogr())
 

--- a/cmd/virtual-kubelet/root/flag.go
+++ b/cmd/virtual-kubelet/root/flag.go
@@ -87,6 +87,8 @@ func InstallFlags(flags *pflag.FlagSet, o *Opts) {
 	flags.DurationVar(&o.VirtualKubeletLeaseRetryPeriod, "vk-lease-retry-period", 5*time.Second,
 		"the duration the LeaderElector clients should wait between tries of actions.")
 
+	restcfg.InitFlags(flags)
+
 	flagset := flag.NewFlagSet("klog", flag.PanicOnError)
 	klog.InitFlags(flagset)
 	flagset.VisitAll(func(f *flag.Flag) {
@@ -95,7 +97,6 @@ func InstallFlags(flags *pflag.FlagSet, o *Opts) {
 	})
 
 	flagset = flag.NewFlagSet("restcfg", flag.PanicOnError)
-	restcfg.InitFlags(flagset)
 	flags.AddGoFlagSet(flagset)
 }
 

--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -16,10 +16,10 @@
 package main
 
 import (
-	"flag"
 	"os"
 	"time"
 
+	"github.com/spf13/pflag"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -40,7 +40,7 @@ import (
 	offloadingv1beta1 "github.com/liqotech/liqo/apis/offloading/v1beta1"
 	"github.com/liqotech/liqo/pkg/consts"
 	argsutils "github.com/liqotech/liqo/pkg/utils/args"
-	liqoerrors "github.com/liqotech/liqo/pkg/utils/errors"
+	flagsutils "github.com/liqotech/liqo/pkg/utils/flags"
 	"github.com/liqotech/liqo/pkg/utils/indexer"
 	"github.com/liqotech/liqo/pkg/utils/mapper"
 	"github.com/liqotech/liqo/pkg/utils/restcfg"
@@ -70,28 +70,28 @@ func init() {
 
 func main() {
 	// Manager flags
-	webhookPort := flag.Uint("webhook-port", 9443, "The port the webhook server binds to")
-	metricsAddr := flag.String("metrics-address", ":8080", "The address the metric endpoint binds to")
-	probeAddr := flag.String("health-probe-address", ":8081", "The address the health probe endpoint binds to")
-	leaderElection := flag.Bool("enable-leader-election", false, "Enable leader election for controller manager")
+	webhookPort := pflag.Uint("webhook-port", 9443, "The port the webhook server binds to")
+	metricsAddr := pflag.String("metrics-address", ":8080", "The address the metric endpoint binds to")
+	probeAddr := pflag.String("health-probe-address", ":8081", "The address the health probe endpoint binds to")
+	leaderElection := pflag.Bool("enable-leader-election", false, "Enable leader election for controller manager")
 
 	// Global parameters
 	clusterIDFlags := argsutils.NewClusterIDFlags(true, nil)
-	liqoNamespace := flag.String("liqo-namespace", consts.DefaultLiqoNamespace,
+	liqoNamespace := pflag.String("liqo-namespace", consts.DefaultLiqoNamespace,
 		"Name of the namespace where the liqo components are running")
-	podcidr := flag.String("podcidr", "", "The CIDR to use for the pod network")
-	vkOptsDefaultTemplate := flag.String("vk-options-default-template", "", "Namespaced name of the virtual-kubelet options template")
-	enableResourceValidation := flag.Bool("enable-resource-enforcement", false,
+	podcidr := pflag.String("podcidr", "", "The CIDR to use for the pod network")
+	vkOptsDefaultTemplate := pflag.String("vk-options-default-template", "", "Namespaced name of the virtual-kubelet options template")
+	enableResourceValidation := pflag.Bool("enable-resource-enforcement", false,
 		"Enforce offerer-side that offloaded pods do not exceed offered resources (based on container limits)")
-	refreshInterval := flag.Duration("resource-validator-refresh-interval",
+	refreshInterval := pflag.Duration("resource-validator-refresh-interval",
 		5*time.Minute, "The interval at which the resource validator cache is refreshed")
-	addVirtualNodeTolerationOnOffloadedPods := flag.Bool("add-virtual-node-toleration-on-offloaded-pods", false,
+	addVirtualNodeTolerationOnOffloadedPods := pflag.Bool("add-virtual-node-toleration-on-offloaded-pods", false,
 		"Automatically add the virtual node toleration on offloaded pods")
 
-	liqoerrors.InitFlags(nil)
-	restcfg.InitFlags(nil)
-	klog.InitFlags(nil)
-	flag.Parse()
+	flagsutils.InitKlogFlags(pflag.CommandLine)
+	restcfg.InitFlags(pflag.CommandLine)
+
+	pflag.Parse()
 
 	log.SetLogger(klog.NewKlogr())
 

--- a/pkg/utils/apiserver/config.go
+++ b/pkg/utils/apiserver/config.go
@@ -17,9 +17,9 @@ package apiserver
 import (
 	"context"
 	"encoding/base64"
-	"flag"
 	"os"
 
+	"github.com/spf13/pflag"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -41,9 +41,9 @@ type Config struct {
 }
 
 // InitFlags initializes the flags to configure the API server parameters.
-func InitFlags(flagset *flag.FlagSet) {
+func InitFlags(flagset *pflag.FlagSet) {
 	if flagset == nil {
-		flagset = flag.CommandLine
+		flagset = pflag.CommandLine
 	}
 
 	flagset.StringVar(&config.Address, "advertise-api-server-address", "",

--- a/pkg/utils/apiserver/config_test.go
+++ b/pkg/utils/apiserver/config_test.go
@@ -16,11 +16,11 @@ package apiserver_test
 
 import (
 	"encoding/base64"
-	"flag"
 	"strconv"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/spf13/pflag"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -35,10 +35,10 @@ var _ = Describe("The API server configuration", func() {
 
 	Describe("the GetConfig function", func() {
 		Context("configuring the API server parameters", func() {
-			var fs flag.FlagSet
+			var fs pflag.FlagSet
 
 			BeforeEach(func() {
-				fs = *flag.NewFlagSet("test-flags", flag.PanicOnError)
+				fs = *pflag.NewFlagSet("test-flags", pflag.PanicOnError)
 				apiserver.InitFlags(&fs)
 			})
 			JustBeforeEach(func() { cfg = apiserver.GetConfig() })

--- a/pkg/utils/args/args_test.go
+++ b/pkg/utils/args/args_test.go
@@ -15,13 +15,13 @@
 package args
 
 import (
-	"flag"
 	"net"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
+	"github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
@@ -219,7 +219,7 @@ var _ = Describe("ParseArguments", func() {
 
 		DescribeTable("ClusterID table",
 			func(c parseClusterIDTestCase) {
-				flagset := flag.NewFlagSet("test", flag.ContinueOnError)
+				flagset := pflag.NewFlagSet("test", pflag.ContinueOnError)
 				flags := NewClusterIDFlags(true, flagset)
 				Expect(flagset.Parse(c.args)).To(Succeed())
 				_, err := flags.Read()

--- a/pkg/utils/args/cluster-identity.go
+++ b/pkg/utils/args/cluster-identity.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/klog/v2"
 
@@ -42,7 +43,7 @@ var _ flag.Value = &ClusterIDFlags{}
 //	fcFlags := NewClusterIDFlags(false, nil)
 //	flag.Parse()
 //	foreignClusterID := fcFlags.Read()
-func NewClusterIDFlags(local bool, flags *flag.FlagSet) ClusterIDFlags {
+func NewClusterIDFlags(local bool, flags *pflag.FlagSet) ClusterIDFlags {
 	var prefix, description string
 	if local {
 		prefix = "cluster" //nolint:goconst // No need to make the word "cluster" a const...
@@ -52,7 +53,7 @@ func NewClusterIDFlags(local bool, flags *flag.FlagSet) ClusterIDFlags {
 		description = "The %s of the foreign cluster"
 	}
 	if flags == nil {
-		flags = flag.CommandLine
+		flags = pflag.CommandLine
 	}
 	return ClusterIDFlags{
 		local:     local,

--- a/pkg/utils/errors/errors.go
+++ b/pkg/utils/errors/errors.go
@@ -15,9 +15,9 @@
 package errors
 
 import (
-	"flag"
 	"strings"
 
+	"github.com/spf13/pflag"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/klog/v2"
@@ -26,9 +26,9 @@ import (
 var panicOnErrorMode = false
 
 // InitFlags initializes the flags to configure the errormanagement parameter.
-func InitFlags(flagset *flag.FlagSet) {
+func InitFlags(flagset *pflag.FlagSet) {
 	if flagset == nil {
-		flagset = flag.CommandLine
+		flagset = pflag.CommandLine
 	}
 
 	flagset.BoolVar(&panicOnErrorMode, "panic-on-unexpected-errors", panicOnErrorMode,
@@ -47,10 +47,9 @@ func Must(err error) bool {
 	if err != nil {
 		if panicOnErrorMode {
 			panic(err)
-		} else {
-			klog.Errorf("%s", err)
-			return false
 		}
+		klog.Errorf("%s", err)
+		return false
 	}
 	return true
 }

--- a/pkg/utils/flags/flags.go
+++ b/pkg/utils/flags/flags.go
@@ -18,11 +18,19 @@ import (
 	"flag"
 
 	"github.com/spf13/pflag"
+	"k8s.io/klog/v2"
 )
 
-// FromFlagToPflag copies the flags from a flag.FlagSet to a pflag.FlagSet.
-func FromFlagToPflag(flags *flag.FlagSet, pflags *pflag.FlagSet) {
-	flags.VisitAll(func(f *flag.Flag) {
-		pflags.AddGoFlag(f)
+// InitKlogFlags initializes the klog flags.
+func InitKlogFlags(flags *pflag.FlagSet) {
+	if flags == nil {
+		flags = pflag.CommandLine
+	}
+
+	legacyflags := flag.NewFlagSet("legacy", flag.ExitOnError)
+	klog.InitFlags(legacyflags)
+	legacyflags.VisitAll(func(f *flag.Flag) {
+		f.Name = "klog." + f.Name
+		flags.AddGoFlag(f)
 	})
 }

--- a/pkg/utils/kernel/version/k8s.go
+++ b/pkg/utils/kernel/version/k8s.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/liqotech/liqo/pkg/consts"
@@ -35,8 +34,6 @@ func CheckKernelVersionFromNodes(ctx context.Context, cl client.Client, minimum 
 	if !current.CheckRequirements(minimum) {
 		return fmt.Errorf("kernel version %s does not satisfy the minimum requirements %s", current.String(), minimum.String())
 	}
-
-	klog.Infof("Kernel version %s satisfies the minimum requirements %s", current.String(), minimum.String())
 	return nil
 }
 

--- a/pkg/utils/restcfg/ratelimiting.go
+++ b/pkg/utils/restcfg/ratelimiting.go
@@ -15,9 +15,9 @@
 package restcfg
 
 import (
-	"flag"
 	"time"
 
+	"github.com/spf13/pflag"
 	"k8s.io/client-go/rest"
 )
 
@@ -37,9 +37,9 @@ var (
 )
 
 // InitFlags initializes the flags to configure the rate limiter parameters.
-func InitFlags(flagset *flag.FlagSet) {
+func InitFlags(flagset *pflag.FlagSet) {
 	if flagset == nil {
-		flagset = flag.CommandLine
+		flagset = pflag.CommandLine
 	}
 
 	flagset.DurationVar(&timeout, "client-timeout", DefaultClientTimeout,

--- a/pkg/utils/restcfg/ratelimiting_test.go
+++ b/pkg/utils/restcfg/ratelimiting_test.go
@@ -15,14 +15,15 @@
 package restcfg_test
 
 import (
-	"flag"
 	"strconv"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/spf13/pflag"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/rest"
 
+	flagsutils "github.com/liqotech/liqo/pkg/utils/flags"
 	"github.com/liqotech/liqo/pkg/utils/restcfg"
 )
 
@@ -41,11 +42,12 @@ var _ = Describe("The rate limiting utility functions", func() {
 
 	Describe("the SetRateLimiter function", func() {
 		Context("configuring the rate limiting parameters", func() {
-			var fs flag.FlagSet
+			var fs pflag.FlagSet
 
 			BeforeEach(func() {
-				fs = *flag.NewFlagSet("test-flags", flag.PanicOnError)
+				fs = *pflag.NewFlagSet("test-flags", pflag.PanicOnError)
 				restcfg.InitFlags(&fs)
+				flagsutils.InitKlogFlags(&fs)
 			})
 			JustBeforeEach(func() { output = restcfg.SetRateLimiter(&cfg) })
 

--- a/pkg/utils/testutil/log.go
+++ b/pkg/utils/testutil/log.go
@@ -15,20 +15,23 @@
 package testutil
 
 import (
-	"flag"
-
 	"github.com/onsi/ginkgo/v2"
+	"github.com/spf13/pflag"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/klog/v2"
+
+	flagsutils "github.com/liqotech/liqo/pkg/utils/flags"
 )
 
 // LogsToGinkgoWriter configures klog to output the logs to GinkgoWriter, instead of stdout.
 // This allows to output the logs only in case of failing tests, simplifying troubleshooting.
 func LogsToGinkgoWriter() {
 	klog.SetOutput(ginkgo.GinkgoWriter)
-	flagset := flag.NewFlagSet("klog", flag.PanicOnError)
-	klog.InitFlags(flagset)
-	utilruntime.Must(flagset.Set("v", "5"))
-	utilruntime.Must(flagset.Set("stderrthreshold", "FATAL"))
+	flagset := pflag.NewFlagSet("klog", pflag.PanicOnError)
+
+	flagsutils.InitKlogFlags(flagset)
+
+	utilruntime.Must(flagset.Set("klog.v", "5"))
+	utilruntime.Must(flagset.Set("klog.stderrthreshold", "FATAL"))
 	klog.LogToStderr(false)
 }

--- a/pkg/utils/trace/trace_test.go
+++ b/pkg/utils/trace/trace_test.go
@@ -15,30 +15,30 @@
 package trace_test
 
 import (
-	"flag"
 	"strconv"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/spf13/pflag"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/klog/v2"
 
+	flagsutils "github.com/liqotech/liqo/pkg/utils/flags"
 	"github.com/liqotech/liqo/pkg/utils/trace"
 )
 
 var _ = Describe("Trace utilities", func() {
 
-	var fs flag.FlagSet
+	var fs pflag.FlagSet
 
 	BeforeEach(func() {
-		fs = *flag.NewFlagSet("test-flags", flag.PanicOnError)
-		klog.InitFlags(&fs)
+		fs = *pflag.NewFlagSet("test-flags", pflag.PanicOnError)
+		flagsutils.InitKlogFlags(&fs)
 	})
 
 	DescribeTable("The LongThreshold function",
 		func(level int, expected time.Duration) {
-			utilruntime.Must(fs.Set("v", strconv.FormatInt(int64(level), 10)))
+			utilruntime.Must(fs.Set("klog.v", strconv.FormatInt(int64(level), 10)))
 			Expect(trace.LongThreshold()).To(Equal(expected))
 		},
 		Entry("with log level 0", 0, time.Second),


### PR DESCRIPTION
# Description

This PR refactors the flags used by liqo, changing the default package from **flag** to **pflag**