### PR TITLE
add missing ClusterRole to liqo-webhook

### DIFF
--- a/deployments/liqo/files/liqo-webhook-ClusterRole.yaml
+++ b/deployments/liqo/files/liqo-webhook-ClusterRole.yaml
@@ -18,6 +18,18 @@ rules:
   - list
   - watch
 - apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - networking.liqo.io
   resources:
   - firewallconfigurations

--- a/pkg/webhooks/utils/permissions.go
+++ b/pkg/webhooks/utils/permissions.go
@@ -1,0 +1,18 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// package utils contains the utility functions used by the webhooks and permissions.
+package utils
+
+// +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;watch;create;update;patch;delete


### PR DESCRIPTION
# Description

When running more than one replicas of the liqo-webhook nothing is working without those permissions here
They may be too much, and there may be other permissions missing in other places, I only know I managed to get things working by adding those
