### PR TITLE
[Feat] New `liqoctl info peer` command

### DIFF
--- a/pkg/liqo-controller-manager/networking/external-network/route/k8s.go
+++ b/pkg/liqo-controller-manager/networking/external-network/route/k8s.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -141,13 +140,8 @@ func forgeMutateRouteConfiguration(cfg *networkingv1beta1.Configuration,
 
 // GetGatewayMode returns the mode of the Gateway related to the Configuration.
 func GetGatewayMode(ctx context.Context, cl client.Client, remoteClusterID liqov1beta1.ClusterID) (gateway.Mode, error) {
-	gwclient, err := getters.GetGatewayClientByClusterID(ctx, cl, remoteClusterID)
-	if err != nil && !kerrors.IsNotFound(err) {
-		return "", err
-	}
-
-	gwserver, err := getters.GetGatewayServerByClusterID(ctx, cl, remoteClusterID)
-	if err != nil && !kerrors.IsNotFound(err) {
+	gwserver, gwclient, err := getters.GetGatewaysByClusterID(ctx, cl, remoteClusterID)
+	if err != nil {
 		return "", err
 	}
 

--- a/pkg/liqoctl/info/checker.go
+++ b/pkg/liqoctl/info/checker.go
@@ -14,37 +14,56 @@
 
 package info
 
-import "context"
+import (
+	"context"
 
-// Checker is the interface to be implemented by all the checkers that
-// collect info about the current instance of Liqo.
-type Checker interface {
+	liqov1beta1 "github.com/liqotech/liqo/apis/core/v1beta1"
+)
+
+// CheckerBase is the base interface for the multiple types of checkers.
+type CheckerBase interface {
 	// Collect the data from the Liqo installation
 	Collect(ctx context.Context, options Options)
-	// Return the collected data using a user friendly output
-	Format(options Options) string
 	// Get the title of the section retrieve by the checker
 	GetTitle() string
 	// Get the id to be shown of machine readable output
 	GetID() string
-	// Get the data collected by the checker
-	GetData() interface{}
 	// Return the errors occurred during the collection of the data.
 	GetCollectionErrors() []error
 }
 
-// CheckerBase contains the common attributes and functions of the checkers.
-type CheckerBase struct {
+// Checker is the interface to be implemented by all the checkers that
+// collect info about the current instance of Liqo.
+type Checker interface {
+	CheckerBase
+	// Return the collected data using a user friendly output
+	Format(options Options) string
+	// Get the data collected by the checker
+	GetData() interface{}
+}
+
+// MultiClusterChecker is the interface to be implemented by all the checkers that
+// collect info from multiple clusters.
+type MultiClusterChecker interface {
+	CheckerBase
+	// Get the data collected by the checker for the specified clusterID
+	GetDataByClusterID(clusterID liqov1beta1.ClusterID) (interface{}, error)
+	// Return the collected data for the specified clusterID using a user friendly output
+	FormatForClusterID(clusterID liqov1beta1.ClusterID, options Options) string
+}
+
+// CheckerCommon contains the common attributes and functions of the checkers.
+type CheckerCommon struct {
 	collectionErrors []error
 }
 
 // AddCollectionError adds an error to the list of errors occurred while
 // collecting the info about a Liqo component.
-func (c *CheckerBase) AddCollectionError(err error) {
+func (c *CheckerCommon) AddCollectionError(err error) {
 	c.collectionErrors = append(c.collectionErrors, err)
 }
 
 // GetCollectionErrors returns the errors occurred during the collection of the data.
-func (c *CheckerBase) GetCollectionErrors() []error {
+func (c *CheckerCommon) GetCollectionErrors() []error {
 	return c.collectionErrors
 }

--- a/pkg/liqoctl/info/common/doc.go
+++ b/pkg/liqoctl/info/common/doc.go
@@ -1,0 +1,17 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+// Package common contains the utilities and the types common to the checkers
+package common

--- a/pkg/liqoctl/info/common/types.go
+++ b/pkg/liqoctl/info/common/types.go
@@ -1,0 +1,28 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package common
+
+// ModuleStatus represents the status of each of the modules.
+type ModuleStatus string
+
+const (
+	// ModuleHealthy indicates a module that works as expected.
+	ModuleHealthy ModuleStatus = "Healthy"
+	// ModuleUnhealthy indicates that there are issues with the module.
+	ModuleUnhealthy ModuleStatus = "Unhealthy"
+	// ModuleDisabled indicates that the modules is not currently used.
+	ModuleDisabled ModuleStatus = "Disabled"
+)

--- a/pkg/liqoctl/info/common/utils.go
+++ b/pkg/liqoctl/info/common/utils.go
@@ -1,0 +1,71 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package common
+
+import (
+	"github.com/pterm/pterm"
+
+	liqov1beta1 "github.com/liqotech/liqo/apis/core/v1beta1"
+)
+
+var statusStyles = map[ModuleStatus]*pterm.Style{
+	ModuleHealthy:   pterm.NewStyle(pterm.FgGreen, pterm.Bold),
+	ModuleUnhealthy: pterm.NewStyle(pterm.FgRed, pterm.Bold),
+	ModuleDisabled:  pterm.NewStyle(pterm.FgLightCyan, pterm.Bold),
+}
+
+// CheckModuleStatusAndAlerts returns the status and the alerts of the given module.
+func CheckModuleStatusAndAlerts(module liqov1beta1.Module) (status ModuleStatus, alerts []string) {
+	status = CheckModuleStatus(module)
+	// Collect the alerts if status if module is not healthy
+	if status == ModuleUnhealthy {
+		alerts = GetModuleAlerts(module)
+	}
+	return
+}
+
+// CheckModuleStatus based on the conditions of a module returns its status.
+func CheckModuleStatus(module liqov1beta1.Module) ModuleStatus {
+	if module.Enabled {
+		for i := range module.Conditions {
+			condition := &module.Conditions[i]
+
+			if condition.Status != liqov1beta1.ConditionStatusEstablished && condition.Status != liqov1beta1.ConditionStatusReady {
+				return ModuleUnhealthy
+			}
+		}
+		return ModuleHealthy
+	}
+
+	return ModuleDisabled
+}
+
+// GetModuleAlerts returns the alerts for the given module.
+func GetModuleAlerts(module liqov1beta1.Module) []string {
+	alerts := []string{}
+	for _, condition := range module.Conditions {
+		if condition.Status != liqov1beta1.ConditionStatusEstablished && condition.Status != liqov1beta1.ConditionStatusReady {
+			alerts = append(alerts, condition.Message)
+		}
+	}
+	return alerts
+}
+
+// FormatStatus returns a formatted string with the provided status.
+func FormatStatus(moduleStatus ModuleStatus) string {
+	style := statusStyles[moduleStatus]
+	return style.Sprint(moduleStatus)
+}

--- a/pkg/liqoctl/info/localstatus/health.go
+++ b/pkg/liqoctl/info/localstatus/health.go
@@ -44,7 +44,7 @@ type Health struct {
 
 // HealthChecker collects the info about the local instance of Liqo.
 type HealthChecker struct {
-	info.CheckerBase
+	info.CheckerCommon
 	data Health
 }
 

--- a/pkg/liqoctl/info/localstatus/local_info.go
+++ b/pkg/liqoctl/info/localstatus/local_info.go
@@ -41,7 +41,7 @@ type Installation struct {
 
 // InstallationChecker collects the info about the local Liqo installation.
 type InstallationChecker struct {
-	info.CheckerBase
+	info.CheckerCommon
 	data Installation
 }
 

--- a/pkg/liqoctl/info/localstatus/network.go
+++ b/pkg/liqoctl/info/localstatus/network.go
@@ -41,7 +41,7 @@ func (l *Network) setProperty(propName, propValue string) {
 
 // NetworkChecker collects info about the local installation of Liqo.
 type NetworkChecker struct {
-	info.CheckerBase
+	info.CheckerCommon
 	data Network
 }
 

--- a/pkg/liqoctl/info/localstatus/peerings_test.go
+++ b/pkg/liqoctl/info/localstatus/peerings_test.go
@@ -31,6 +31,7 @@ import (
 	liqoconsts "github.com/liqotech/liqo/pkg/consts"
 	"github.com/liqotech/liqo/pkg/liqoctl/factory"
 	"github.com/liqotech/liqo/pkg/liqoctl/info"
+	"github.com/liqotech/liqo/pkg/liqoctl/info/common"
 	"github.com/liqotech/liqo/pkg/liqoctl/info/localstatus"
 	"github.com/liqotech/liqo/pkg/liqoctl/output"
 	"github.com/liqotech/liqo/pkg/utils/testutil"
@@ -38,13 +39,13 @@ import (
 
 var _ = Describe("PeeringChecker tests", func() {
 
-	getFakeModuleFromStatus := func(status localstatus.ModuleStatus) liqov1beta1.Module {
+	getFakeModuleFromStatus := func(status common.ModuleStatus) liqov1beta1.Module {
 		var conditions []liqov1beta1.Condition
-		if status == localstatus.Disabled {
+		if status == common.ModuleDisabled {
 			return liqov1beta1.Module{
 				Enabled: false,
 			}
-		} else if status == localstatus.Healthy {
+		} else if status == common.ModuleHealthy {
 			conditions = append(conditions,
 				liqov1beta1.Condition{
 					Type:   "fake1",
@@ -75,9 +76,9 @@ var _ = Describe("PeeringChecker tests", func() {
 	}
 
 	type ForeignClusterDescription struct {
-		Authentication localstatus.ModuleStatus
-		Networking     localstatus.ModuleStatus
-		Offloading     localstatus.ModuleStatus
+		Authentication common.ModuleStatus
+		Networking     common.ModuleStatus
+		Offloading     common.ModuleStatus
 	}
 
 	type TestArgs struct {
@@ -165,32 +166,32 @@ var _ = Describe("PeeringChecker tests", func() {
 				Entry("Healthy 1 peering", TestArgs{
 					foreignClusterDescriptions: []ForeignClusterDescription{
 						{
-							Authentication: localstatus.Healthy,
-							Networking:     localstatus.Healthy,
-							Offloading:     localstatus.Healthy,
+							Authentication: common.ModuleHealthy,
+							Networking:     common.ModuleHealthy,
+							Offloading:     common.ModuleHealthy,
 						},
 					},
 				}),
 				Entry("Healthy and Unhealthy peerings", TestArgs{
 					foreignClusterDescriptions: []ForeignClusterDescription{
 						{
-							Authentication: localstatus.Healthy,
-							Networking:     localstatus.Healthy,
-							Offloading:     localstatus.Healthy,
+							Authentication: common.ModuleHealthy,
+							Networking:     common.ModuleHealthy,
+							Offloading:     common.ModuleHealthy,
 						},
 						{
-							Authentication: localstatus.Healthy,
-							Networking:     localstatus.Unhealthy,
-							Offloading:     localstatus.Healthy,
+							Authentication: common.ModuleHealthy,
+							Networking:     common.ModuleUnhealthy,
+							Offloading:     common.ModuleHealthy,
 						},
 					},
 				}),
 				Entry("Unhealthy peering with disable module", TestArgs{
 					foreignClusterDescriptions: []ForeignClusterDescription{
 						{
-							Authentication: localstatus.Healthy,
-							Networking:     localstatus.Disabled,
-							Offloading:     localstatus.Unhealthy,
+							Authentication: common.ModuleHealthy,
+							Networking:     common.ModuleDisabled,
+							Offloading:     common.ModuleUnhealthy,
 						},
 					},
 				}),

--- a/pkg/liqoctl/info/peer/auth.go
+++ b/pkg/liqoctl/info/peer/auth.go
@@ -1,0 +1,216 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package peer
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	authv1beta1 "github.com/liqotech/liqo/apis/authentication/v1beta1"
+	liqov1beta1 "github.com/liqotech/liqo/apis/core/v1beta1"
+	"github.com/liqotech/liqo/pkg/consts"
+	"github.com/liqotech/liqo/pkg/liqoctl/info"
+	"github.com/liqotech/liqo/pkg/liqoctl/info/common"
+	"github.com/liqotech/liqo/pkg/liqoctl/output"
+	"github.com/liqotech/liqo/pkg/utils/getters"
+)
+
+// ResourceSliceAction tells whether the cluster is consuming or providing the resources.
+type ResourceSliceAction string
+
+const (
+	// ConsumingAction tells that the cluster is requesting and consuming the resources.
+	ConsumingAction ResourceSliceAction = "Consuming"
+	// ProvidingAction tells that the cluster is providing the resources.
+	ProvidingAction ResourceSliceAction = "Providing"
+)
+
+// ResourceSliceStatus contains info about a ResourceSliceStatus CR.
+type ResourceSliceStatus struct {
+	Name      string              `json:"name"`
+	Action    ResourceSliceAction `json:"action"`
+	Accepted  bool                `json:"accepted"`
+	Alerts    []string            `json:"alerts,omitempty"`
+	Resources corev1.ResourceList `json:"resources"`
+}
+
+// Auth contains some info about the current status of the authentication module.
+type Auth struct {
+	Status         common.ModuleStatus `json:"status"`
+	Alerts         []string            `json:"alerts,omitempty"`
+	APIServerAddr  string
+	ResourceSlices []ResourceSliceStatus `json:"resourceSlices"`
+}
+
+// AuthChecker collects some info about the current status of the authentication module.
+type AuthChecker struct {
+	info.CheckerCommon
+
+	// In this case data is a mapping between ClusterID and peer Authentication info
+	data map[liqov1beta1.ClusterID]Auth
+}
+
+// Collect some info about the current status of the authentication module.
+func (ac *AuthChecker) Collect(ctx context.Context, options info.Options) {
+	ac.data = map[liqov1beta1.ClusterID]Auth{}
+	for clusterID := range options.ClustersInfo {
+		authStatus := Auth{}
+		ac.collectStatusInfo(clusterID, options.ClustersInfo, &authStatus)
+
+		if options.ClustersInfo[clusterID].Status.Role == liqov1beta1.ProviderRole {
+			if err := ac.collectAPIAddress(ctx, options.CRClient, clusterID, &authStatus); err != nil {
+				ac.AddCollectionError(fmt.Errorf("unable to get API server address of cluster %q: %w", clusterID, err))
+			}
+		}
+
+		// Get the ResourceSlices related to the given remote clusterID
+		resSlices, err := getters.ListResourceSlicesByClusterID(ctx, options.CRClient, clusterID)
+		if err != nil {
+			ac.AddCollectionError(fmt.Errorf("unable to get ResourceSlices of cluster %q: %w", clusterID, err))
+		} else {
+			ac.collectResourceSlices(resSlices, &authStatus)
+		}
+
+		ac.data[clusterID] = authStatus
+	}
+}
+
+// FormatForClusterID returns the collected data for the specified clusterID using a user friendly output.
+func (ac *AuthChecker) FormatForClusterID(clusterID liqov1beta1.ClusterID, options info.Options) string {
+	if data, ok := ac.data[clusterID]; ok {
+		main := output.NewRootSection()
+		main.AddEntry("Status", common.FormatStatus(data.Status))
+
+		if data.Status != common.ModuleDisabled {
+			// Show alerts if any
+			if len(data.Alerts) > 0 {
+				main.AddEntryWarning("Alerts", data.Alerts...)
+			}
+
+			if data.APIServerAddr != "" {
+				main.AddEntry("API server", data.APIServerAddr)
+			}
+
+			// Show resource slices
+			slicesSection := main.AddSection("Resource slices")
+			for i := range data.ResourceSlices {
+				slice := &data.ResourceSlices[i]
+				currSliceSection := slicesSection.AddSection(slice.Name)
+				if slice.Accepted {
+					currSliceSection.AddSectionSuccess("Resource slice accepted")
+				} else {
+					currSliceSection.AddSectionFailure("Resource slice not accepted")
+				}
+				if len(slice.Alerts) > 0 {
+					main.AddEntryWarning("Alerts", slice.Alerts...)
+				}
+				currSliceSection.AddEntry("Action", string(slice.Action))
+
+				resourcesSection := currSliceSection.AddSection("Resources")
+				for resource, quantity := range slice.Resources {
+					resourcesSection.AddEntry(string(resource), quantity.String())
+				}
+			}
+		}
+
+		return main.SprintForBox(options.Printer)
+	}
+	return ""
+}
+
+// GetData returns the data collected by the checker.
+func (ac *AuthChecker) GetData() interface{} {
+	return ac.data
+}
+
+// GetDataByClusterID returns the data collected by the checker for the cluster with the give ClusterID.
+func (ac *AuthChecker) GetDataByClusterID(clusterID liqov1beta1.ClusterID) (interface{}, error) {
+	if res, ok := ac.data[clusterID]; ok {
+		return res, nil
+	}
+	return nil, fmt.Errorf("no data collected for cluster %q", clusterID)
+}
+
+// GetID returns the id of the section collected by the checker.
+func (ac *AuthChecker) GetID() string {
+	return "authentication"
+}
+
+// GetTitle returns the title of the section collected by the checker.
+func (ac *AuthChecker) GetTitle() string {
+	return "Authentication"
+}
+
+// collectStatusInfo collects the info about the status of the network between the local cluster and the one with the given ClusterID.
+func (ac *AuthChecker) collectStatusInfo(clusterID liqov1beta1.ClusterID,
+	clusterInfo map[liqov1beta1.ClusterID]*liqov1beta1.ForeignCluster, authStatus *Auth) {
+	cluster := clusterInfo[clusterID]
+	authStatus.Status, authStatus.Alerts = common.CheckModuleStatusAndAlerts(cluster.Status.Modules.Authentication)
+}
+
+// collectResourceSlices collect the data from the list of ResourceSlice CRs.
+func (ac *AuthChecker) collectResourceSlices(resourceSlices []authv1beta1.ResourceSlice, authStatus *Auth) {
+	authStatus.ResourceSlices = []ResourceSliceStatus{}
+	for i := range resourceSlices {
+		resSlice := &resourceSlices[i]
+
+		// Check the status of the ResourceSlice
+		// If no condition is present in the status, it means that the operator has not already reconciled the
+		// resource, so the resource is not accepted. Otherwise, we initialize the variable to `true` and we set
+		// it to false if we find a condition not accepted.
+		accepted := len(resSlice.Status.Conditions) > 0
+		alerts := []string{}
+		for _, condition := range resSlice.Status.Conditions {
+			isConditionAccepted := condition.Status == authv1beta1.ResourceSliceConditionAccepted
+			if !isConditionAccepted {
+				accepted = false
+				alerts = append(alerts, condition.Message)
+			}
+		}
+
+		// To check who is the provider of the ResourceSlice we can verify whether the CR has been replicated from the cluster consumer
+		action := ConsumingAction
+		if value, isProvider := resSlice.ObjectMeta.Labels[consts.ReplicationStatusLabel]; isProvider && strings.EqualFold(value, "true") {
+			action = ProvidingAction
+		}
+
+		authStatus.ResourceSlices = append(authStatus.ResourceSlices, ResourceSliceStatus{
+			Name:      resSlice.Name,
+			Action:    action,
+			Accepted:  accepted,
+			Alerts:    alerts,
+			Resources: resSlice.Status.Resources,
+		})
+	}
+}
+
+func (ac *AuthChecker) collectAPIAddress(ctx context.Context, cl client.Client, clusterID liqov1beta1.ClusterID, authStatus *Auth) error {
+	identity, err := getters.GetControlPlaneIdentityByClusterID(ctx, cl, clusterID)
+	if err != nil {
+		return err
+	}
+
+	if identity.Spec.AuthParams.ProxyURL != nil {
+		authStatus.APIServerAddr = *identity.Spec.AuthParams.ProxyURL
+	} else {
+		authStatus.APIServerAddr = identity.Spec.AuthParams.APIServer
+	}
+	return nil
+}

--- a/pkg/liqoctl/info/peer/auth_test.go
+++ b/pkg/liqoctl/info/peer/auth_test.go
@@ -1,0 +1,245 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package peer
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/pterm/pterm"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	authv1beta1 "github.com/liqotech/liqo/apis/authentication/v1beta1"
+	liqov1beta1 "github.com/liqotech/liqo/apis/core/v1beta1"
+	"github.com/liqotech/liqo/pkg/consts"
+	"github.com/liqotech/liqo/pkg/liqoctl/factory"
+	"github.com/liqotech/liqo/pkg/liqoctl/info"
+	"github.com/liqotech/liqo/pkg/liqoctl/info/common"
+	"github.com/liqotech/liqo/pkg/liqoctl/output"
+	"github.com/liqotech/liqo/pkg/utils/testutil"
+)
+
+var _ = Describe("AuthChecker tests", func() {
+	remoteClusterID := "fake-remote"
+	localClusterID := "fake-local"
+	expectedResourceList := corev1.ResourceList{
+		corev1.ResourceCPU:    resource.MustParse("2"),
+		corev1.ResourceMemory: resource.MustParse("2Gi"),
+	}
+
+	var (
+		clientBuilder fake.ClientBuilder
+		ac            *AuthChecker
+		ctx           context.Context
+		options       info.Options
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		clientBuilder = *fake.NewClientBuilder().WithScheme(scheme.Scheme)
+
+		options = info.Options{Factory: factory.NewForLocal()}
+		options.Printer = output.NewFakePrinter(GinkgoWriter)
+		options.KubeClient = k8sfake.NewSimpleClientset()
+	})
+
+	Describe("Testing the AuthChecker", func() {
+		Context("Collecting and retrieving the data", func() {
+			It("should collect the data and return the right result", func() {
+				identityRes := testutil.FakeIdentity(liqov1beta1.ClusterID(remoteClusterID), authv1beta1.ControlPlaneIdentityType)
+				resourceSlices := []client.Object{
+					testutil.FakeResourceSlice("rs01", liqov1beta1.ClusterID(localClusterID), liqov1beta1.ClusterID(remoteClusterID),
+						authv1beta1.ResourceSliceConditionAccepted, expectedResourceList),
+					testutil.FakeResourceSlice("rs02", liqov1beta1.ClusterID(localClusterID), liqov1beta1.ClusterID(remoteClusterID),
+						authv1beta1.ResourceSliceConditionDenied, expectedResourceList),
+				}
+				foreignclusterRes := testutil.FakeForeignCluster(liqov1beta1.ClusterID(remoteClusterID), &liqov1beta1.Modules{
+					Networking:     liqov1beta1.Module{Enabled: true},
+					Authentication: liqov1beta1.Module{Enabled: true},
+					Offloading:     liqov1beta1.Module{Enabled: true},
+				})
+				foreignclusterRes.Status.Role = liqov1beta1.ProviderRole
+
+				// Set up the fake clients
+				resources := []client.Object{identityRes}
+				resources = append(resources, resourceSlices...)
+				clientBuilder.WithObjects(resources...)
+				options.CRClient = clientBuilder.Build()
+
+				options.ClustersInfo = map[liqov1beta1.ClusterID]*liqov1beta1.ForeignCluster{
+					liqov1beta1.ClusterID(remoteClusterID): foreignclusterRes,
+				}
+
+				By("Collecting the data")
+				ac = &AuthChecker{}
+				ac.Collect(ctx, options)
+
+				By("Verifying that no errors have been raised")
+				Expect(ac.GetCollectionErrors()).To(BeEmpty(), "Unexpected collection errors detected")
+
+				By("Checking the correctness of the data in the struct")
+				rawData, err := ac.GetDataByClusterID(liqov1beta1.ClusterID(remoteClusterID))
+				Expect(err).NotTo(HaveOccurred(), "An error occurred while getting the data")
+
+				data := rawData.(Auth)
+				Expect(data.Status).To(Equal(common.ModuleHealthy), "Unexpected status")
+
+				Expect(data.APIServerAddr).To(Equal(identityRes.Spec.AuthParams.APIServer), "Unexpected API server address")
+
+				// Check resource slices
+				Expect(len(data.ResourceSlices)).To(Equal(len(resourceSlices)), "Unexpected number of resource slices")
+				Expect(data.ResourceSlices[0].Accepted).To(BeTrue(), "First resource slice is expected to be accepted")
+				Expect(data.ResourceSlices[1].Accepted).To(BeFalse(), "Second resource slice is expected to be rejected")
+				for _, slice := range data.ResourceSlices {
+					Expect(slice.Resources).To(Equal(expectedResourceList))
+				}
+			})
+
+			It("tests ResourceSlice collection of data", func() {
+				ac = &AuthChecker{}
+
+				By("Checking that ResourceSlice status is corrently retrieved when one of the conditions is Denied")
+				rs := testutil.FakeResourceSlice("rs01", liqov1beta1.ClusterID(localClusterID), liqov1beta1.ClusterID(remoteClusterID),
+					authv1beta1.ResourceSliceConditionAccepted, expectedResourceList)
+
+				// Add error to resource slice
+				expectedAlert := "This is an error"
+				rs.Status.Conditions = append(rs.Status.Conditions, authv1beta1.ResourceSliceCondition{
+					Type:    authv1beta1.ResourceSliceConditionTypeAuthentication,
+					Status:  authv1beta1.ResourceSliceConditionDenied,
+					Message: expectedAlert,
+				})
+
+				authStatus := Auth{}
+				ac.collectResourceSlices([]authv1beta1.ResourceSlice{*rs}, &authStatus)
+
+				Expect(len(authStatus.ResourceSlices)).To(Equal(1), "One single resource slice expected")
+				Expect(authStatus.ResourceSlices[0].Accepted).To(BeFalse(), "One condition denied, expected resource slice to be denied")
+				Expect(authStatus.ResourceSlices[0].Action).To(Equal(ConsumingAction),
+					"Unexpected ResourceSlice action: originated by the same cluster")
+				Expect(authStatus.ResourceSlices[0].Alerts).To(ContainElements(expectedAlert), "Alert not found in ResourceSlice alerts")
+
+				By("Checking that the checker detects a replicated ResourceSlice")
+				rs = testutil.FakeResourceSlice("rs01", liqov1beta1.ClusterID(localClusterID), liqov1beta1.ClusterID(remoteClusterID),
+					authv1beta1.ResourceSliceConditionAccepted, expectedResourceList)
+				rs.ObjectMeta.Labels[consts.ReplicationStatusLabel] = "TRUE"
+
+				authStatus = Auth{}
+				ac.collectResourceSlices([]authv1beta1.ResourceSlice{*rs}, &authStatus)
+				Expect(len(authStatus.ResourceSlices)).To(Equal(1), "One single resource slice expected")
+				Expect(authStatus.ResourceSlices[0].Action).To(Equal(ProvidingAction),
+					"Unexpected action: ResourceSlice has replication status label set to true")
+			})
+		})
+
+		DescribeTable("FormatForClusterID function test", func(testCase Auth) {
+			ac = &AuthChecker{}
+			ac.data = map[liqov1beta1.ClusterID]Auth{
+				liqov1beta1.ClusterID(remoteClusterID): testCase,
+			}
+
+			text := ac.FormatForClusterID(liqov1beta1.ClusterID(remoteClusterID), options)
+			text = pterm.RemoveColorFromString(text)
+			text = strings.TrimSpace(testutil.SqueezeWhitespaces(text))
+
+			if testCase.Status == common.ModuleDisabled {
+				Expect(text).To(Equal("Status: Disabled"))
+			} else {
+				Expect(text).To(ContainSubstring(
+					pterm.Sprintf("Status: %s", testCase.Status),
+				), "Unexpected status shown")
+
+				// Check that alerts are shown when list is not empty
+				for _, alert := range testCase.Alerts {
+					Expect(text).To(ContainSubstring(alert), "Alert not shown")
+				}
+
+				if testCase.APIServerAddr != "" {
+					Expect(text).To(ContainSubstring(pterm.Sprintf("API server: %s", testCase.APIServerAddr)), "Unexpected API server")
+				}
+
+				// This test expects that all the ResourceSlice names starts with "rs-"
+				if len(testCase.ResourceSlices) > 0 {
+					outSections := strings.Split(text, "Resource slices")
+					Expect(len(outSections)).To(Equal(2), "Invalid output: expected a section with name 'Resource slices'")
+					rsSection := strings.TrimSpace(outSections[1])
+					rsNamesRegex := regexp.MustCompile(`rs-\d+\s+`)
+					rsSplittedSections := rsNamesRegex.Split(rsSection, -1)[1:]
+
+					Expect(len(rsSplittedSections)).To(Equal(len(testCase.ResourceSlices)),
+						"The number of ResourseSlices does not match the one shown in output")
+
+					for i, rs := range testCase.ResourceSlices {
+						sectionText := rsSplittedSections[i]
+
+						// Check RS action
+						Expect(sectionText).To(ContainSubstring(pterm.Sprintf("Action: %s", rs.Action)),
+							fmt.Sprintf("Unexpected action in RS section %q", rs.Name))
+
+						// Check that the status of the ResourceSlice is correctly shown
+						statusCondition := ContainSubstring("Resource slice not accepted")
+						if rs.Accepted {
+							statusCondition = ContainSubstring("Resource slice accepted")
+						}
+						Expect(sectionText).To(statusCondition, fmt.Sprintf("Unexpected status in RS section %q", rs.Name))
+
+						// Check that all the resources are correctly shown
+						for resName, resValue := range rs.Resources {
+							resString := fmt.Sprintf("%s: %s", resName, &resValue)
+							Expect(sectionText).To(ContainSubstring(resString),
+								fmt.Sprintf("Unexpected resources shown in RS section %q", rs.Name))
+						}
+					}
+				}
+			}
+		},
+			Entry("Disabled module", Auth{Status: common.ModuleDisabled}),
+			Entry("Healthy module", Auth{
+				Status:        common.ModuleHealthy,
+				APIServerAddr: "http://192.166.0.5",
+				ResourceSlices: []ResourceSliceStatus{
+					{
+						Name:      "rs-01",
+						Action:    ConsumingAction,
+						Accepted:  false,
+						Alerts:    []string{"rs01 error"},
+						Resources: expectedResourceList,
+					},
+					{
+						Name:      "rs-02",
+						Action:    ProvidingAction,
+						Accepted:  true,
+						Resources: expectedResourceList,
+					},
+				},
+			}),
+			Entry("Unhealthy module", Auth{
+				Status: common.ModuleUnhealthy,
+				Alerts: []string{"This is an error"},
+			}),
+		)
+
+	})
+})

--- a/pkg/liqoctl/info/peer/doc.go
+++ b/pkg/liqoctl/info/peer/doc.go
@@ -1,0 +1,17 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+// Package peer contains the logic to retrieve detailed info about active peerings
+package peer

--- a/pkg/liqoctl/info/peer/network.go
+++ b/pkg/liqoctl/info/peer/network.go
@@ -1,0 +1,190 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package peer
+
+import (
+	"context"
+	"fmt"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	liqov1beta1 "github.com/liqotech/liqo/apis/core/v1beta1"
+	networkingv1beta1 "github.com/liqotech/liqo/apis/networking/v1beta1"
+	"github.com/liqotech/liqo/pkg/liqoctl/info"
+	"github.com/liqotech/liqo/pkg/liqoctl/info/common"
+	"github.com/liqotech/liqo/pkg/liqoctl/output"
+	"github.com/liqotech/liqo/pkg/utils/getters"
+)
+
+// GatewayType represents the type of network gateway (Client or Server).
+type GatewayType string
+
+const (
+	// GatewayClientType indicates that the gateway acts as a client.
+	GatewayClientType GatewayType = "Client"
+	// GatewayServerType indicates that the gateway acts as a server.
+	GatewayServerType GatewayType = "Server"
+)
+
+// CIDRInfo contains info about CIDR and its remapping.
+type CIDRInfo struct {
+	Remote   networkingv1beta1.ClusterConfigCIDR  `json:"remote"`
+	Remapped *networkingv1beta1.ClusterConfigCIDR `json:"remapped,omitempty"`
+}
+
+// GatewayInfo contains info about the network gateway.
+type GatewayInfo struct {
+	Address []string    `json:"address"`
+	Port    int32       `json:"port"`
+	Role    GatewayType `json:"role"`
+}
+
+// Network contains some info and the status of the network between the local cluster and a peer.
+type Network struct {
+	Status  common.ModuleStatus `json:"status"`
+	Alerts  []string            `json:"alerts,omitempty"`
+	CIDRs   CIDRInfo
+	Gateway GatewayInfo `json:"gateway"`
+}
+
+// NetworkChecker collects some info about the status of the network between the local cluster and the active peers.
+type NetworkChecker struct {
+	info.CheckerCommon
+
+	// In this case data is a mapping between ClusterID and Network info
+	data map[liqov1beta1.ClusterID]Network
+}
+
+// Collect some info about the status of the network between the local cluster and the active peers.
+func (nc *NetworkChecker) Collect(ctx context.Context, options info.Options) {
+	nc.data = map[liqov1beta1.ClusterID]Network{}
+	for clusterID := range options.ClustersInfo {
+		peerNetwork := Network{}
+
+		// Collect info about the status of the network module
+		nc.collectStatusInfo(clusterID, options.ClustersInfo, &peerNetwork)
+
+		// If the module is disabled we do not need to collect any additional info
+		if peerNetwork.Status != common.ModuleDisabled {
+			// Get the network CIDRs
+			config, err := getters.GetConfigurationByClusterID(ctx, options.CRClient, clusterID)
+			if err != nil {
+				nc.AddCollectionError(fmt.Errorf("unable to get network configuration for cluster %q: %w", clusterID, err))
+			} else {
+				peerNetwork.CIDRs = CIDRInfo{
+					Remote:   config.Spec.Remote.CIDR,
+					Remapped: &config.Status.Remote.CIDR,
+				}
+			}
+
+			// Collect info about the gateway
+			if err := nc.collectGatewayInfo(ctx, options.CRClient, clusterID, &peerNetwork); err != nil {
+				nc.AddCollectionError(fmt.Errorf("unable to get network gateway info for cluster %q: %w", clusterID, err))
+			}
+		}
+
+		nc.data[clusterID] = peerNetwork
+	}
+}
+
+// FormatForClusterID returns the collected data for the specified clusterID using a user friendly output.
+func (nc *NetworkChecker) FormatForClusterID(clusterID liqov1beta1.ClusterID, options info.Options) string {
+	if data, ok := nc.data[clusterID]; ok {
+		main := output.NewRootSection()
+		main.AddEntry("Status", common.FormatStatus(data.Status))
+		if data.Status != common.ModuleDisabled {
+			// Show alerts if any
+			if len(data.Alerts) > 0 {
+				main.AddEntryWarning("Alerts", data.Alerts...)
+			}
+
+			// Print info about CIDR
+			cidrSection := main.AddSection("CIDR")
+
+			remoteCIDRSection := cidrSection.AddSection("Remote")
+			if data.CIDRs.Remapped != nil {
+				remoteCIDRSection.AddEntry("Pod CIDR",
+					fmt.Sprintf("%s → Remapped to %s", data.CIDRs.Remote.Pod, data.CIDRs.Remapped.Pod))
+				remoteCIDRSection.AddEntry("External CIDR",
+					fmt.Sprintf("%s → Remapped to %s", data.CIDRs.Remote.External, data.CIDRs.Remapped.External))
+			} else {
+				remoteCIDRSection.AddEntry("Pod CIDR", string(data.CIDRs.Remote.Pod))
+				remoteCIDRSection.AddEntry("External CIDR", string(data.CIDRs.Remote.External))
+			}
+
+			// Print info about Gateway
+			gatewaySection := main.AddSection("Gateway")
+			gatewaySection.AddEntry("Role", string(data.Gateway.Role))
+			gatewaySection.AddEntry("Address", data.Gateway.Address...)
+			gatewaySection.AddEntry("Port", fmt.Sprint(data.Gateway.Port))
+		}
+
+		return main.SprintForBox(options.Printer)
+	}
+	return ""
+}
+
+// GetDataByClusterID returns the data collected by the checker for the cluster with the give ClusterID.
+func (nc *NetworkChecker) GetDataByClusterID(clusterID liqov1beta1.ClusterID) (interface{}, error) {
+	if res, ok := nc.data[clusterID]; ok {
+		return res, nil
+	}
+	return nil, fmt.Errorf("no data collected for cluster %q", clusterID)
+}
+
+// GetID returns the id of the section collected by the checker.
+func (nc *NetworkChecker) GetID() string {
+	return "network"
+}
+
+// GetTitle returns the title of the section collected by the checker.
+func (nc *NetworkChecker) GetTitle() string {
+	return "Network"
+}
+
+// collectStatusInfo collects the info about the status of the network between the local cluster and the one with the given ClusterID.
+func (nc *NetworkChecker) collectStatusInfo(clusterID liqov1beta1.ClusterID,
+	clusterInfo map[liqov1beta1.ClusterID]*liqov1beta1.ForeignCluster, peerNetwork *Network) {
+	cluster := clusterInfo[clusterID]
+	peerNetwork.Status, peerNetwork.Alerts = common.CheckModuleStatusAndAlerts(cluster.Status.Modules.Networking)
+}
+
+// collectGatewayInfo collects the info about the local gateway connected to the peer cluster gateway.
+func (nc *NetworkChecker) collectGatewayInfo(ctx context.Context, cl client.Client, clusterID liqov1beta1.ClusterID, peerNetwork *Network) error {
+	gwServer, gwClient, err := getters.GetGatewaysByClusterID(ctx, cl, clusterID)
+	if err != nil {
+		return err
+	}
+
+	switch {
+	case gwClient != nil && gwServer != nil:
+		return fmt.Errorf("multiple Gateways found")
+	case gwClient != nil:
+		// We are reflecting the status of the peer cluster. So, if locally there is a client, the peer
+		// cluester has a server.
+		peerNetwork.Gateway.Role = GatewayServerType
+		peerNetwork.Gateway.Address = gwClient.Spec.Endpoint.Addresses
+		peerNetwork.Gateway.Port = gwClient.Spec.Endpoint.Port
+	case gwServer != nil:
+		peerNetwork.Gateway.Role = GatewayClientType
+		peerNetwork.Gateway.Address = gwServer.Status.Endpoint.Addresses
+		peerNetwork.Gateway.Port = gwServer.Status.Endpoint.Port
+	default:
+		return fmt.Errorf("no gateways found")
+	}
+
+	return nil
+}

--- a/pkg/liqoctl/info/peer/network_test.go
+++ b/pkg/liqoctl/info/peer/network_test.go
@@ -1,0 +1,252 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package peer
+
+import (
+	"context"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/pterm/pterm"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	liqov1beta1 "github.com/liqotech/liqo/apis/core/v1beta1"
+	networkingv1beta1 "github.com/liqotech/liqo/apis/networking/v1beta1"
+	"github.com/liqotech/liqo/pkg/liqoctl/factory"
+	"github.com/liqotech/liqo/pkg/liqoctl/info"
+	"github.com/liqotech/liqo/pkg/liqoctl/info/common"
+	"github.com/liqotech/liqo/pkg/liqoctl/output"
+	"github.com/liqotech/liqo/pkg/utils/testutil"
+)
+
+var _ = Describe("NetworkChecker tests", func() {
+	remoteClusterID := "fake"
+	expectedAlerts := []string{"This is an alert", "this another"}
+
+	var (
+		clientBuilder fake.ClientBuilder
+		nc            *NetworkChecker
+		ctx           context.Context
+		options       info.Options
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		clientBuilder = *fake.NewClientBuilder().WithScheme(scheme.Scheme)
+
+		options = info.Options{Factory: factory.NewForLocal()}
+		options.Printer = output.NewFakePrinter(GinkgoWriter)
+		options.KubeClient = k8sfake.NewSimpleClientset()
+	})
+
+	Describe("Testing the NetworkChecker", func() {
+		Context("Collecting and retrieving the data", func() {
+			It("should collect the data and return the right result", func() {
+				expectedPodCIDR := "10.0.0.0/24"
+				expectedRemappedPod := "11.0.0.0/24"
+				expectedExternalCIDR := "10.0.1.0/24"
+				expectedRemappedExternal := "11.0.1.0/24"
+
+				foreignclusterRes := testutil.FakeForeignCluster(liqov1beta1.ClusterID(remoteClusterID), &liqov1beta1.Modules{
+					Networking: liqov1beta1.Module{
+						Enabled: true,
+						Conditions: []liqov1beta1.Condition{
+							{
+								Status: liqov1beta1.ConditionStatusEstablished,
+							},
+						},
+					},
+					Authentication: liqov1beta1.Module{Enabled: true},
+					Offloading:     liqov1beta1.Module{Enabled: true},
+				})
+				configurationRes := testutil.FakeConfiguration(
+					remoteClusterID, expectedPodCIDR, expectedExternalCIDR, expectedPodCIDR, expectedExternalCIDR,
+					expectedRemappedPod, expectedRemappedExternal)
+
+				gatewayRes := testutil.FakeGatewayClient(remoteClusterID)
+
+				// Set up the fake clients
+				clientBuilder.WithObjects(configurationRes, gatewayRes)
+				options.CRClient = clientBuilder.Build()
+
+				options.ClustersInfo = map[liqov1beta1.ClusterID]*liqov1beta1.ForeignCluster{
+					liqov1beta1.ClusterID(remoteClusterID): foreignclusterRes,
+				}
+
+				By("Collecting the data")
+				nc = &NetworkChecker{}
+				nc.Collect(ctx, options)
+
+				By("Verifying that no errors have been raised")
+				Expect(nc.GetCollectionErrors()).To(BeEmpty(), "Unexpected collection errors detected")
+
+				By("Checking the correctness of the data in the struct")
+				rawData, err := nc.GetDataByClusterID(liqov1beta1.ClusterID(remoteClusterID))
+				Expect(err).NotTo(HaveOccurred(), "An error occurred while getting the data")
+
+				data := rawData.(Network)
+
+				Expect(data.Status).To(Equal(common.ModuleHealthy), "Unexpected status")
+
+				Expect(data.CIDRs.Remote.Pod).To(Equal(networkingv1beta1.CIDR(expectedPodCIDR)), "Unexpected remote Pod CIDR")
+				Expect(data.CIDRs.Remote.External).To(Equal(networkingv1beta1.CIDR(expectedExternalCIDR)), "Unexpected remote external CIDR")
+				Expect(data.CIDRs.Remapped).NotTo(BeNil(), "Expected remapped CIDRs but empty received")
+				Expect(data.CIDRs.Remapped.Pod).To(Equal(networkingv1beta1.CIDR(expectedRemappedPod)), "Unexpected remapped Pod CIDR")
+				Expect(data.CIDRs.Remapped.External).To(Equal(networkingv1beta1.CIDR(expectedRemappedExternal)), "Unexpected remapped external CIDR")
+
+				// Check gateway parameters
+				Expect(data.Gateway.Role).To(Equal(GatewayServerType), "Unexpected Gateway type")
+				Expect(data.Gateway.Address).To(Equal(gatewayRes.Spec.Endpoint.Addresses), "Unexpected gateway addresses")
+				Expect(data.Gateway.Port).To(Equal(gatewayRes.Spec.Endpoint.Port), "Unexpected gateway addresses")
+			})
+		})
+
+		DescribeTable("collectGatewayInfo function test", func(gatewayType GatewayType) {
+			var objects []client.Object
+			switch gatewayType {
+			case GatewayServerType:
+				objects = append(objects, testutil.FakeGatewayClient(remoteClusterID))
+			case GatewayClientType:
+				objects = append(objects, testutil.FakeGatewayServer(remoteClusterID))
+			default:
+				objects = append(objects,
+					testutil.FakeGatewayClient(remoteClusterID), testutil.FakeGatewayServer(remoteClusterID))
+			}
+			// Set up the fake clients
+			clientBuilder.WithObjects(objects...)
+			options.CRClient = clientBuilder.Build()
+			peerNetwork := Network{}
+
+			nc = &NetworkChecker{}
+			err := nc.collectGatewayInfo(ctx, options.CRClient, liqov1beta1.ClusterID(remoteClusterID), &peerNetwork)
+
+			if gatewayType == "" {
+				// Both gateway present so an error should have been raised
+				Expect(err).To(HaveOccurred(), "Expected error as multiple gateways present")
+			} else {
+				Expect(err).NotTo(HaveOccurred(), "Unexpected error occurred")
+				Expect(peerNetwork.Gateway.Role).To(Equal(gatewayType), "Unexpected gateway type")
+				var endpoint networkingv1beta1.EndpointStatus
+				if gatewayType == GatewayServerType {
+					gateway, _ := objects[0].(*networkingv1beta1.GatewayClient)
+					endpoint = gateway.Spec.Endpoint
+				} else {
+					gateway, _ := objects[0].(*networkingv1beta1.GatewayServer)
+					endpoint = *gateway.Status.Endpoint
+				}
+				Expect(endpoint.Addresses).To(Equal(peerNetwork.Gateway.Address), "Unexpected gateway address")
+				Expect(endpoint.Port).To(Equal(peerNetwork.Gateway.Port), "Unexpected gateway port")
+			}
+		},
+			Entry("Gateway server", GatewayServerType),
+			Entry("Gateway client", GatewayClientType),
+			Entry("Both gateways present", GatewayType("")),
+		)
+
+		DescribeTable("FormatForClusterID function test", func(testCase Network) {
+			nc = &NetworkChecker{}
+			nc.data = map[liqov1beta1.ClusterID]Network{
+				liqov1beta1.ClusterID(remoteClusterID): testCase,
+			}
+
+			text := nc.FormatForClusterID(liqov1beta1.ClusterID(remoteClusterID), options)
+			text = pterm.RemoveColorFromString(text)
+			text = strings.TrimSpace(testutil.SqueezeWhitespaces(text))
+
+			if testCase.Status == common.ModuleDisabled {
+				Expect(text).To(Equal("Status: Disabled"))
+			} else {
+				Expect(text).To(ContainSubstring(
+					pterm.Sprintf("Status: %s", testCase.Status),
+				), "Unexpected status shown")
+
+				// Check that alerts are shown when list is not empty
+				for _, alert := range testCase.Alerts {
+					Expect(text).To(ContainSubstring(alert), "Alert not shown")
+				}
+
+				// Check CIDRs
+				if testCase.CIDRs.Remapped != nil {
+					Expect(text).To(ContainSubstring(
+						pterm.Sprintf("Pod CIDR: %s → Remapped to %s", testCase.CIDRs.Remote.Pod, testCase.CIDRs.Remapped.Pod)),
+						"Unexpected POD CIDR shown",
+					)
+					Expect(text).To(ContainSubstring(
+						pterm.Sprintf("External CIDR: %s → Remapped to %s", testCase.CIDRs.Remote.External, testCase.CIDRs.Remapped.External)),
+						"Unexpected External CIDR shown",
+					)
+				} else {
+					Expect(text).To(ContainSubstring(
+						pterm.Sprintf("Pod CIDR: %s", testCase.CIDRs.Remote.Pod)), "Unexpected POD CIDR shown",
+					)
+					Expect(text).To(ContainSubstring(
+						pterm.Sprintf("External CIDR: %s", testCase.CIDRs.Remote.External)),
+						"Unexpected External CIDR shown",
+					)
+				}
+
+				// Check Gateway visualization
+				Expect(text).To(ContainSubstring(pterm.Sprintf("Role: %s", testCase.Gateway.Role)), "Unexpected gateway role")
+				for _, address := range testCase.Gateway.Address {
+					Expect(text).To(ContainSubstring(address), "Unexpected gateway address")
+				}
+				Expect(text).To(ContainSubstring(pterm.Sprintf("Port: %d", testCase.Gateway.Port)), "Unexpected gateway port")
+			}
+		},
+			Entry("Disabled module", Network{Status: common.ModuleDisabled}),
+			Entry("Healthy module remapped CIDR", Network{
+				Status: common.ModuleHealthy,
+				CIDRs: CIDRInfo{
+					Remote: networkingv1beta1.ClusterConfigCIDR{
+						Pod:      "fakepod",
+						External: "fakeexternal",
+					},
+					Remapped: &networkingv1beta1.ClusterConfigCIDR{
+						Pod:      "fakeremappedpod",
+						External: "fakeremappedexternal",
+					},
+				},
+				Gateway: GatewayInfo{
+					Address: []string{"fakeaddress", "fakeaddress2"},
+					Port:    4310,
+					Role:    GatewayServerType,
+				},
+			}),
+			Entry("Healthy module", Network{
+				Status: common.ModuleHealthy,
+				CIDRs: CIDRInfo{
+					Remote: networkingv1beta1.ClusterConfigCIDR{
+						Pod:      "fakepod",
+						External: "fakeexternal",
+					},
+				},
+				Gateway: GatewayInfo{
+					Address: []string{"10.0.0.0/24"},
+					Port:    4320,
+					Role:    GatewayClientType,
+				},
+			}),
+			Entry("Healthy module CIDR", Network{
+				Status: common.ModuleUnhealthy,
+				Alerts: expectedAlerts,
+			}),
+		)
+	})
+})

--- a/pkg/liqoctl/info/peer/offloading.go
+++ b/pkg/liqoctl/info/peer/offloading.go
@@ -1,0 +1,166 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package peer
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+
+	liqov1beta1 "github.com/liqotech/liqo/apis/core/v1beta1"
+	offloadingv1beta1 "github.com/liqotech/liqo/apis/offloading/v1beta1"
+	"github.com/liqotech/liqo/pkg/consts"
+	"github.com/liqotech/liqo/pkg/liqoctl/info"
+	"github.com/liqotech/liqo/pkg/liqoctl/info/common"
+	"github.com/liqotech/liqo/pkg/liqoctl/output"
+	"github.com/liqotech/liqo/pkg/utils/getters"
+)
+
+// VirtualNodeStatus contains info about a VirtualNodeStatus CR.
+type VirtualNodeStatus struct {
+	Name          string              `json:"name"`
+	Status        common.ModuleStatus `json:"status"`
+	Secret        string              `json:"secret"`
+	ResourceSlice string              `json:"resourceSlice,omitempty"`
+	Resources     corev1.ResourceList `json:"resources"`
+}
+
+// Offloading contains info about offloaded resources and virtual nodes.
+type Offloading struct {
+	Status       common.ModuleStatus `json:"status"`
+	Alerts       []string            `json:"alerts,omitempty"`
+	VirtualNodes []VirtualNodeStatus `json:"virtualNodes"`
+}
+
+// OffloadingChecker collects info about offloaded resources and virtual nodes.
+type OffloadingChecker struct {
+	info.CheckerCommon
+
+	// In this case data is a mapping between ClusterID and Offloading info
+	data map[liqov1beta1.ClusterID]Offloading
+}
+
+// Collect some info about the status of the network between the local cluster and the active peers.
+func (oc *OffloadingChecker) Collect(ctx context.Context, options info.Options) {
+	oc.data = map[liqov1beta1.ClusterID]Offloading{}
+	for clusterID := range options.ClustersInfo {
+		offloadingState := Offloading{}
+
+		// Collect the status of the offloading module
+		oc.collectStatusInfo(clusterID, options.ClustersInfo, &offloadingState)
+
+		// Get the VirtualNode resources pointing to the given remote clusterID
+		virtualNodes, err := getters.ListVirtualNodesByClusterID(ctx, options.CRClient, clusterID)
+		if err != nil {
+			oc.AddCollectionError(fmt.Errorf("unable to get VirtualNodes pointing to cluster %q: %w", clusterID, err))
+		} else {
+			oc.collectVirtualNodes(virtualNodes, &offloadingState)
+		}
+		oc.data[clusterID] = offloadingState
+	}
+}
+
+// FormatForClusterID returns the collected data for the specified clusterID using a user friendly output.
+func (oc *OffloadingChecker) FormatForClusterID(clusterID liqov1beta1.ClusterID, options info.Options) string {
+	if data, ok := oc.data[clusterID]; ok {
+		main := output.NewRootSection()
+		main.AddEntry("Status", common.FormatStatus(data.Status))
+		if data.Status != common.ModuleDisabled {
+			// Show alerts if any
+			if len(data.Alerts) > 0 {
+				main.AddEntryWarning("Alerts", data.Alerts...)
+			}
+
+			// Show virtual nodes
+			nodesSection := main.AddSection("Virtual nodes")
+			for i := range data.VirtualNodes {
+				vNode := &data.VirtualNodes[i]
+				currNodeSection := nodesSection.AddSection(vNode.Name)
+				currNodeSection.AddEntry("Status", common.FormatStatus(vNode.Status))
+				currNodeSection.AddEntry("Secret", vNode.Secret)
+				currNodeSection.AddEntry("Resource slice", vNode.ResourceSlice)
+				resourcesSection := currNodeSection.AddSection("Resources")
+				for resource, quantity := range vNode.Resources {
+					resourcesSection.AddEntry(string(resource), quantity.String())
+				}
+			}
+		}
+		return main.SprintForBox(options.Printer)
+	}
+	return ""
+}
+
+// GetDataByClusterID returns the data collected by the checker for the cluster with the give ClusterID.
+func (oc *OffloadingChecker) GetDataByClusterID(clusterID liqov1beta1.ClusterID) (interface{}, error) {
+	if res, ok := oc.data[clusterID]; ok {
+		return res, nil
+	}
+	return nil, fmt.Errorf("no data collected for cluster %q", clusterID)
+}
+
+// GetID returns the id of the section collected by the checker.
+func (oc *OffloadingChecker) GetID() string {
+	return "offloading"
+}
+
+// GetTitle returns the title of the section collected by the checker.
+func (oc *OffloadingChecker) GetTitle() string {
+	return "Offloading"
+}
+
+// collectStatusInfo collects the info about the status of the offloading module.
+func (oc *OffloadingChecker) collectStatusInfo(clusterID liqov1beta1.ClusterID,
+	clusterInfo map[liqov1beta1.ClusterID]*liqov1beta1.ForeignCluster, offloadingState *Offloading) {
+	cluster := clusterInfo[clusterID]
+	offloadingState.Status, offloadingState.Alerts = common.CheckModuleStatusAndAlerts(cluster.Status.Modules.Offloading)
+}
+
+// collectVirtualNodes collects the data from the list of VirtualNode CRs.
+func (oc *OffloadingChecker) collectVirtualNodes(virtualNodes []offloadingv1beta1.VirtualNode, offloadingState *Offloading) {
+	offloadingState.VirtualNodes = []VirtualNodeStatus{}
+	for i := range virtualNodes {
+		vNode := &virtualNodes[i]
+
+		// Check the status of the virtual node
+		status := common.ModuleUnhealthy
+		for _, condition := range vNode.Status.Conditions {
+			if condition.Status == offloadingv1beta1.RunningConditionStatusType || condition.Status == offloadingv1beta1.NoneConditionStatusType {
+				status = common.ModuleHealthy
+			} else {
+				status = common.ModuleUnhealthy
+				break
+			}
+		}
+
+		// Get the ResourceSlice assigned to VirtualNode secret
+		resourceSlice := vNode.ObjectMeta.Labels[consts.ResourceSliceNameLabelKey]
+
+		// Get the secret configured in the virtual node
+		secretName := ""
+		if vNode.Spec.KubeconfigSecretRef != nil {
+			secretName = vNode.Spec.KubeconfigSecretRef.Name
+		}
+
+		offloadingState.VirtualNodes = append(offloadingState.VirtualNodes, VirtualNodeStatus{
+			Name:          vNode.Name,
+			Status:        status,
+			ResourceSlice: resourceSlice,
+			Secret:        secretName,
+			Resources:     vNode.Spec.ResourceQuota.Hard,
+		})
+	}
+}

--- a/pkg/liqoctl/info/peer/offloading_test.go
+++ b/pkg/liqoctl/info/peer/offloading_test.go
@@ -1,0 +1,220 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package peer
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/pterm/pterm"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	liqov1beta1 "github.com/liqotech/liqo/apis/core/v1beta1"
+	offloadingv1beta1 "github.com/liqotech/liqo/apis/offloading/v1beta1"
+	"github.com/liqotech/liqo/pkg/liqoctl/factory"
+	"github.com/liqotech/liqo/pkg/liqoctl/info"
+	"github.com/liqotech/liqo/pkg/liqoctl/info/common"
+	"github.com/liqotech/liqo/pkg/liqoctl/output"
+	"github.com/liqotech/liqo/pkg/utils/testutil"
+)
+
+var _ = Describe("OffloadingChecker tests", func() {
+	clusterID := "fake-clusterid"
+	expectedResourceList := corev1.ResourceList{
+		corev1.ResourceCPU:    resource.MustParse("2"),
+		corev1.ResourceMemory: resource.MustParse("2Gi"),
+	}
+
+	var (
+		clientBuilder fake.ClientBuilder
+		oc            *OffloadingChecker
+		ctx           context.Context
+		options       info.Options
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		clientBuilder = *fake.NewClientBuilder().WithScheme(scheme.Scheme)
+
+		options = info.Options{Factory: factory.NewForLocal()}
+		options.Printer = output.NewFakePrinter(GinkgoWriter)
+		options.KubeClient = k8sfake.NewSimpleClientset()
+	})
+
+	Describe("Testing the OffloadingChecker", func() {
+		Context("Collecting and retrieving the data", func() {
+			It("should collect the data and return the right result", func() {
+				virtualNodes := []client.Object{
+					testutil.FakeVirtualNode("vn01", liqov1beta1.ClusterID(clusterID),
+						offloadingv1beta1.RunningConditionStatusType, expectedResourceList),
+					testutil.FakeVirtualNode("vn02", liqov1beta1.ClusterID(clusterID),
+						offloadingv1beta1.CreatingConditionStatusType, expectedResourceList),
+				}
+
+				foreignclusterRes := testutil.FakeForeignCluster(liqov1beta1.ClusterID(clusterID), &liqov1beta1.Modules{
+					Networking:     liqov1beta1.Module{Enabled: true},
+					Authentication: liqov1beta1.Module{Enabled: true},
+					Offloading:     liqov1beta1.Module{Enabled: true},
+				})
+				foreignclusterRes.Status.Role = liqov1beta1.ProviderRole
+
+				clientBuilder.WithObjects(virtualNodes...)
+				options.CRClient = clientBuilder.Build()
+
+				options.ClustersInfo = map[liqov1beta1.ClusterID]*liqov1beta1.ForeignCluster{
+					liqov1beta1.ClusterID(clusterID): foreignclusterRes,
+				}
+
+				By("Collecting the data")
+				oc = &OffloadingChecker{}
+				oc.Collect(ctx, options)
+
+				By("Verifying that no errors have been raised")
+				Expect(oc.GetCollectionErrors()).To(BeEmpty(), "Unexpected collection errors detected")
+
+				By("Checking the correctness of the data in the struct")
+				rawData, err := oc.GetDataByClusterID(liqov1beta1.ClusterID(clusterID))
+				Expect(err).NotTo(HaveOccurred(), "An error occurred while getting the data")
+
+				data := rawData.(Offloading)
+				Expect(data.Status).To(Equal(common.ModuleHealthy), "Unexpected status")
+
+				// Check the correctness of VirtualNodes data
+				Expect(len(data.VirtualNodes)).To(Equal(len(virtualNodes)), "Unexpected number of VirtualNodes")
+				Expect(data.VirtualNodes[0].Status).To(Equal(common.ModuleHealthy), "First VirtualNode is expected to be ready")
+				Expect(data.VirtualNodes[1].Status).To(Equal(common.ModuleUnhealthy), "Second VirtualNode is expected to be NOT ready")
+
+				for i, vnStatus := range data.VirtualNodes {
+					virtualNode := virtualNodes[i].(*offloadingv1beta1.VirtualNode)
+					Expect(vnStatus.ResourceSlice).To(Equal(virtualNode.Name), "Unexpected VirtualNode ResourceSlice name")
+					Expect(vnStatus.Secret).To(Equal(fmt.Sprintf("%s-secret", virtualNode.Name)), "Unexpected VirtualNode secret name")
+					Expect(vnStatus.Resources).To(Equal(expectedResourceList), "Unexpected resources")
+				}
+			})
+
+			It("tests ResourceSlice collection of data", func() {
+				oc = &OffloadingChecker{}
+
+				By("Checking that ResourceSlice status is corrently retrieved when one of the conditions is Denied")
+				vn := testutil.FakeVirtualNode("vn01", liqov1beta1.ClusterID(clusterID),
+					offloadingv1beta1.RunningConditionStatusType, expectedResourceList)
+
+				// Add error to virtual node
+				vn.Status.Conditions = append(vn.Status.Conditions, offloadingv1beta1.VirtualNodeCondition{
+					Status: offloadingv1beta1.CreatingConditionStatusType,
+				})
+				offloadingStatus := Offloading{}
+				oc.collectVirtualNodes([]offloadingv1beta1.VirtualNode{*vn}, &offloadingStatus)
+
+				Expect(len(offloadingStatus.VirtualNodes)).To(Equal(1), "One single virtual node expected")
+				Expect(offloadingStatus.VirtualNodes[0].Status).To(Equal(common.ModuleUnhealthy),
+					"One condition unhealthy, expected virtual node to be unhealthy")
+			})
+		})
+
+		DescribeTable("FormatForClusterID function test", func(testCase Offloading) {
+			oc = &OffloadingChecker{}
+			oc.data = map[liqov1beta1.ClusterID]Offloading{
+				liqov1beta1.ClusterID(clusterID): testCase,
+			}
+
+			text := oc.FormatForClusterID(liqov1beta1.ClusterID(clusterID), options)
+			text = pterm.RemoveColorFromString(text)
+			text = strings.TrimSpace(testutil.SqueezeWhitespaces(text))
+
+			if testCase.Status == common.ModuleDisabled {
+				Expect(text).To(Equal("Status: Disabled"))
+			} else {
+				Expect(text).To(ContainSubstring(
+					pterm.Sprintf("Status: %s", testCase.Status),
+				), "Unexpected status shown")
+
+				// Check that alerts are shown when list is not empty
+				for _, alert := range testCase.Alerts {
+					Expect(text).To(ContainSubstring(alert), "Alert not shown")
+				}
+
+				// This test expects that all the ResourceSlice names starts with "rs-"
+				if len(testCase.VirtualNodes) > 0 {
+					outSections := strings.Split(text, "Virtual nodes")
+					Expect(len(outSections)).To(Equal(2), "Invalid output: expected a section with name 'Resource slices'")
+					rsSection := strings.TrimSpace(outSections[1])
+					rsNamesRegex := regexp.MustCompile(`vn-\d+\s+`)
+					rsSplittedSections := rsNamesRegex.Split(rsSection, -1)[1:]
+
+					Expect(len(rsSplittedSections)).To(Equal(len(testCase.VirtualNodes)),
+						"The number of ResourseSlices does not match the one shown in output")
+
+					for i, vn := range testCase.VirtualNodes {
+						sectionText := rsSplittedSections[i]
+
+						// Check RS action
+						Expect(sectionText).To(ContainSubstring(pterm.Sprintf("Status: %s", vn.Status)),
+							fmt.Sprintf("Unexpected health in VirtualNode section %q", vn.Name))
+
+						Expect(sectionText).To(ContainSubstring(pterm.Sprintf("Secret: %s", vn.Secret)),
+							fmt.Sprintf("Unexpected secret in VirtualNode section %q", vn.Name))
+
+						Expect(sectionText).To(ContainSubstring(pterm.Sprintf("Resource slice: %s", vn.ResourceSlice)),
+							fmt.Sprintf("Unexpected ResourceSlice in VirtualNode section %q", vn.Name))
+
+						// Check that all the resources are correctly shown
+						for resName, resValue := range vn.Resources {
+							resString := fmt.Sprintf("%s: %s", resName, &resValue)
+							Expect(sectionText).To(ContainSubstring(resString),
+								fmt.Sprintf("Unexpected resources shown in RS section %q", vn.Name))
+						}
+					}
+				}
+			}
+		},
+			Entry("Disabled module", Offloading{Status: common.ModuleDisabled}),
+			Entry("Healthy module", Offloading{
+				Status: common.ModuleHealthy,
+				VirtualNodes: []VirtualNodeStatus{
+					{
+						Name:          "vn-01",
+						Status:        common.ModuleHealthy,
+						Secret:        "secret",
+						ResourceSlice: "slice",
+						Resources:     expectedResourceList,
+					},
+					{
+						Name:          "vn-02",
+						Status:        common.ModuleUnhealthy,
+						Secret:        "secret",
+						ResourceSlice: "slice",
+						Resources:     expectedResourceList,
+					},
+				},
+			}),
+			Entry("Unhealthy module", Offloading{
+				Status: common.ModuleUnhealthy,
+				Alerts: []string{"This is an error"},
+			}),
+		)
+
+	})
+})

--- a/pkg/liqoctl/info/peer/peer_info.go
+++ b/pkg/liqoctl/info/peer/peer_info.go
@@ -1,0 +1,80 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package peer
+
+import (
+	"context"
+	"fmt"
+
+	liqov1beta1 "github.com/liqotech/liqo/apis/core/v1beta1"
+	"github.com/liqotech/liqo/pkg/liqoctl/info"
+	"github.com/liqotech/liqo/pkg/liqoctl/output"
+)
+
+// Info contains some info about the identity and the role of a peer cluster.
+type Info struct {
+	liqov1beta1.ClusterID `json:"clusterID"`
+	Role                  liqov1beta1.RoleType `json:"role"`
+}
+
+// InfoChecker collects some info about the identity and the role of a peer cluster.
+type InfoChecker struct {
+	info.CheckerCommon
+
+	// In this case data is a mapping between ClusterID and peer Info
+	data map[liqov1beta1.ClusterID]Info
+}
+
+// Collect some data about the identity and the role of the peer cluster.
+func (ic *InfoChecker) Collect(_ context.Context, options info.Options) {
+	ic.data = map[liqov1beta1.ClusterID]Info{}
+	for clusterID := range options.ClustersInfo {
+		ic.data[clusterID] = Info{
+			ClusterID: clusterID,
+			Role:      options.ClustersInfo[clusterID].Status.Role,
+		}
+	}
+}
+
+// FormatForClusterID returns the collected data for the specified clusterID using a user friendly output.
+func (ic *InfoChecker) FormatForClusterID(clusterID liqov1beta1.ClusterID, options info.Options) string {
+	if data, ok := ic.data[clusterID]; ok {
+		main := output.NewRootSection()
+		main.AddEntry("Cluster ID", string(data.ClusterID))
+		main.AddEntry("Role", string(data.Role))
+
+		return main.SprintForBox(options.Printer)
+	}
+	return ""
+}
+
+// GetDataByClusterID returns the data collected by the checker for the cluster with the give ClusterID.
+func (ic *InfoChecker) GetDataByClusterID(clusterID liqov1beta1.ClusterID) (interface{}, error) {
+	if res, ok := ic.data[clusterID]; ok {
+		return res, nil
+	}
+	return nil, fmt.Errorf("no data collected for cluster %q", clusterID)
+}
+
+// GetID returns the id of the section collected by the checker.
+func (ic *InfoChecker) GetID() string {
+	return "info"
+}
+
+// GetTitle returns the title of the section collected by the checker.
+func (ic *InfoChecker) GetTitle() string {
+	return "Peer cluster info"
+}

--- a/pkg/liqoctl/info/peer/peer_info_test.go
+++ b/pkg/liqoctl/info/peer/peer_info_test.go
@@ -1,0 +1,93 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package peer_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/pterm/pterm"
+
+	liqov1beta1 "github.com/liqotech/liqo/apis/core/v1beta1"
+	"github.com/liqotech/liqo/pkg/liqoctl/factory"
+	"github.com/liqotech/liqo/pkg/liqoctl/info"
+	"github.com/liqotech/liqo/pkg/liqoctl/info/peer"
+	"github.com/liqotech/liqo/pkg/liqoctl/output"
+	"github.com/liqotech/liqo/pkg/utils/testutil"
+)
+
+var _ = Describe("InfoChecker tests", func() {
+	var (
+		ic      *peer.InfoChecker
+		ctx     context.Context
+		options info.Options
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+
+		options = info.Options{Factory: factory.NewForLocal()}
+		options.Printer = output.NewFakePrinter(GinkgoWriter)
+	})
+
+	Describe("Testing the InfoChecker", func() {
+		Context("Collecting and retrieving the data", func() {
+			It("should collect the data and return the right result", func() {
+				expectedClusterRole := liqov1beta1.ConsumerAndProviderRole
+				expectedClusterID := liqov1beta1.ClusterID("cl01")
+
+				fakeForeignCluster := testutil.FakeForeignCluster(expectedClusterID, &liqov1beta1.Modules{
+					Networking:     liqov1beta1.Module{},
+					Authentication: liqov1beta1.Module{},
+					Offloading:     liqov1beta1.Module{},
+				})
+				fakeForeignCluster.Status.Role = expectedClusterRole
+				options.ClustersInfo = map[liqov1beta1.ClusterID]*liqov1beta1.ForeignCluster{
+					expectedClusterID: fakeForeignCluster,
+				}
+
+				By("Collecting the data")
+				ic = &peer.InfoChecker{}
+				ic.Collect(ctx, options)
+
+				By("Verifying that no errors have been raised")
+				Expect(ic.GetCollectionErrors()).To(BeEmpty(), "Unexpected collection errors detected")
+
+				By("Checking the correctness of the data in the struct")
+				rawData, err := ic.GetDataByClusterID(expectedClusterID)
+				Expect(err).NotTo(HaveOccurred(), "An error occurred while getting the data")
+
+				data := rawData.(peer.Info)
+
+				Expect(data.ClusterID).To(Equal(expectedClusterID))
+				Expect(data.Role).To(Equal(expectedClusterRole))
+
+				By("Checking the formatted output")
+				text := ic.FormatForClusterID(expectedClusterID, options)
+				text = pterm.RemoveColorFromString(text)
+				text = testutil.SqueezeWhitespaces(text)
+
+				Expect(text).To(ContainSubstring(
+					pterm.Sprintf("Cluster ID: %s", expectedClusterID),
+				))
+				Expect(text).To(ContainSubstring(
+					pterm.Sprintf("Role: %s", expectedClusterRole),
+				))
+			})
+		})
+	})
+})

--- a/pkg/liqoctl/info/peer/peer_suite_test.go
+++ b/pkg/liqoctl/info/peer/peer_suite_test.go
@@ -1,0 +1,44 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package peer
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+
+	authv1beta1 "github.com/liqotech/liqo/apis/authentication/v1beta1"
+	corev1beta1 "github.com/liqotech/liqo/apis/core/v1beta1"
+	networkingv1beta1 "github.com/liqotech/liqo/apis/networking/v1beta1"
+	offloadingv1beta1 "github.com/liqotech/liqo/apis/offloading/v1beta1"
+)
+
+func TestLocal(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Peer Suite")
+}
+
+var _ = BeforeSuite(func() {
+	utilruntime.Must(corev1.AddToScheme(scheme.Scheme))
+	utilruntime.Must(authv1beta1.AddToScheme(scheme.Scheme))
+	utilruntime.Must(corev1beta1.AddToScheme(scheme.Scheme))
+	utilruntime.Must(networkingv1beta1.AddToScheme(scheme.Scheme))
+	utilruntime.Must(offloadingv1beta1.AddToScheme(scheme.Scheme))
+})

--- a/pkg/liqoctl/info/utils_test.go
+++ b/pkg/liqoctl/info/utils_test.go
@@ -23,8 +23,12 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/yaml"
 
+	liqov1beta1 "github.com/liqotech/liqo/apis/core/v1beta1"
 	"github.com/liqotech/liqo/pkg/liqoctl/factory"
 	"github.com/liqotech/liqo/pkg/liqoctl/output"
 	"github.com/liqotech/liqo/pkg/utils/testutil"
@@ -45,27 +49,32 @@ var _ = Describe("Info utilities functions tests", func() {
 
 			By("getting a string value with a dotted query")
 			checker := &dummyChecker{data: data, id: "dummy"}
-			text, err := o.sPrintField("dummy.key", []Checker{checker}, nil)
+			collectedData := o.collectDataFromCheckers([]Checker{checker})
+			text, err := o.sPrintField("dummy.key", collectedData, nil)
 			Expect(err).To(BeNil())
 			Expect(text).To(Equal(expectedVal), "Unexpected string retrieved")
 
 			By("getting a number value with a dotted query")
-			text, err = o.sPrintField("dummy.n", []Checker{checker}, nil)
+			collectedData = o.collectDataFromCheckers([]Checker{checker})
+			text, err = o.sPrintField("dummy.n", collectedData, nil)
 			Expect(err).To(BeNil())
 			Expect(text).To(Equal(fmt.Sprint(expectedN)), "Unexpected number retrieved")
 
 			By("getting a string value with a dotted query (trailing dot)")
-			text, err = o.sPrintField(".dummy.key", []Checker{checker}, nil)
+			collectedData = o.collectDataFromCheckers([]Checker{checker})
+			text, err = o.sPrintField(".dummy.key", collectedData, nil)
 			Expect(err).To(BeNil())
 			Expect(text).To(Equal(expectedVal), "Unexpected string retrieved")
 
 			By("getting a string value with a dotted query (capitalized field)")
-			text, err = o.sPrintField(".dummy.KEY", []Checker{checker}, nil)
+			collectedData = o.collectDataFromCheckers([]Checker{checker})
+			text, err = o.sPrintField(".dummy.KEY", collectedData, nil)
 			Expect(err).To(BeNil())
 			Expect(text).To(Equal(expectedVal), "Unexpected string retrieved")
 
 			By("getting a string with query shortcut")
-			text, err = o.sPrintField("key", []Checker{checker}, map[string]string{"key": "dummy.key"})
+			collectedData = o.collectDataFromCheckers([]Checker{checker})
+			text, err = o.sPrintField("key", collectedData, map[string]string{"key": "dummy.key"})
 			Expect(err).To(BeNil())
 			Expect(text).To(Equal(expectedVal), "Unexpected string retrieved")
 		})
@@ -98,12 +107,14 @@ var _ = Describe("Info utilities functions tests", func() {
 			checker := &dummyChecker{data: data, id: "dummy"}
 
 			By("getting a string a nested data structure")
-			text, err := o.sPrintField("dummy.nested.key1", []Checker{checker}, nil)
+			collectedData := o.collectDataFromCheckers([]Checker{checker})
+			text, err := o.sPrintField("dummy.nested.key1", collectedData, nil)
 			Expect(err).To(BeNil())
 			Expect(text).To(Equal(expectedNested.Key1), "Unexpected string retrieved")
 
 			By("getting the entire nested struct (YAML)")
-			text, err = o.sPrintField("dummy.nested", []Checker{checker}, nil)
+			collectedData = o.collectDataFromCheckers([]Checker{checker})
+			text, err = o.sPrintField("dummy.nested", collectedData, nil)
 			expectedNestedYaml, _ := yaml.Marshal(expectedNested)
 			Expect(err).To(BeNil())
 			Expect(text).To(Equal(
@@ -111,7 +122,8 @@ var _ = Describe("Info utilities functions tests", func() {
 			), "Unexpected YAML data structure")
 
 			By("getting a slice (YAML)")
-			text, err = o.sPrintField("dummy.slice", []Checker{checker}, nil)
+			collectedData = o.collectDataFromCheckers([]Checker{checker})
+			text, err = o.sPrintField("dummy.slice", collectedData, nil)
 			expectedSliceYaml, _ := yaml.Marshal(expectedSlice)
 			Expect(err).To(BeNil())
 			Expect(text).To(Equal(
@@ -119,7 +131,8 @@ var _ = Describe("Info utilities functions tests", func() {
 			), "Unexpected YAML when getting a slice")
 
 			By("getting a map (YAML)")
-			text, err = o.sPrintField("dummy.map", []Checker{checker}, nil)
+			collectedData = o.collectDataFromCheckers([]Checker{checker})
+			text, err = o.sPrintField("dummy.map", collectedData, nil)
 			expectedMapYaml, _ := yaml.Marshal(expectedMap)
 			Expect(err).To(BeNil())
 			Expect(text).To(Equal(
@@ -128,7 +141,8 @@ var _ = Describe("Info utilities functions tests", func() {
 
 			By("getting the entire nested struct changin output to JSON")
 			o.Format = JSON
-			text, err = o.sPrintField("dummy.nested", []Checker{checker}, nil)
+			collectedData = o.collectDataFromCheckers([]Checker{checker})
+			text, err = o.sPrintField("dummy.nested", collectedData, nil)
 			expectedNestedJSON, _ := json.MarshalIndent(expectedNested, "", "  ")
 			Expect(err).To(BeNil())
 			Expect(text).To(Equal(
@@ -147,19 +161,85 @@ var _ = Describe("Info utilities functions tests", func() {
 			checker := &dummyChecker{data: data, id: "dummy"}
 
 			By("getting invalid field (first field of the query)")
-			_, err := o.sPrintField("invalid", []Checker{checker}, nil)
+			collectedData := o.collectDataFromCheckers([]Checker{checker})
+			_, err := o.sPrintField("invalid", collectedData, nil)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("not found"))
 
 			By("getting invalid field (second field of the query)")
-			_, err = o.sPrintField("dummy.invalid", []Checker{checker}, nil)
+			collectedData = o.collectDataFromCheckers([]Checker{checker})
+			_, err = o.sPrintField("dummy.invalid", collectedData, nil)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("not found"))
 
 			By("trying to access a subfield of a non-object field")
-			_, err = o.sPrintField("dummy.key.subfield", []Checker{checker}, nil)
+			collectedData = o.collectDataFromCheckers([]Checker{checker})
+			_, err = o.sPrintField("dummy.key.subfield", collectedData, nil)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("not an object"))
+		})
+	})
+
+	Context("getForeignClusters function tests", func() {
+		var (
+			clientBuilder   fake.ClientBuilder
+			ctx             context.Context
+			foreignClusters = []client.Object{
+				testutil.FakeForeignCluster("cl01", &liqov1beta1.Modules{
+					Networking:     liqov1beta1.Module{},
+					Authentication: liqov1beta1.Module{},
+					Offloading:     liqov1beta1.Module{},
+				}),
+				testutil.FakeForeignCluster("cl02", &liqov1beta1.Modules{
+					Networking:     liqov1beta1.Module{},
+					Authentication: liqov1beta1.Module{},
+					Offloading:     liqov1beta1.Module{},
+				}),
+			}
+			options Options
+		)
+
+		BeforeEach(func() {
+			ctx = context.Background()
+			clientBuilder = *fake.NewClientBuilder().WithScheme(scheme.Scheme)
+			options = Options{Factory: factory.NewForLocal()}
+			options.Printer = output.NewFakePrinter(GinkgoWriter)
+			// Define the ForeignCluster CRs to be returned
+			clientBuilder.WithObjects(foreignClusters...)
+			options.CRClient = clientBuilder.Build()
+		})
+
+		It("check that only the requested clusters are retrieved", func() {
+			var expectedClusterID liqov1beta1.ClusterID = "cl01"
+
+			err := options.getForeignClusters(ctx, []string{string(expectedClusterID)})
+			Expect(err).NotTo(HaveOccurred(), "An error occurred while getting foreign clusters")
+			Expect(len(options.ClustersInfo)).To(Equal(1), "Expected one single cluster in list")
+			Expect(options.ClustersInfo).To(HaveKey(expectedClusterID), "Unexpected cluster info content")
+			Expect(options.ClustersInfo[expectedClusterID].Spec.ClusterID).To(Equal(expectedClusterID),
+				"Unexpected ForeignCluster object in cluster info")
+
+		})
+
+		It("check that an error is raised if a cluster does not exist", func() {
+			var expectedClusterID liqov1beta1.ClusterID = "notexisting"
+
+			err := options.getForeignClusters(ctx, []string{string(expectedClusterID)})
+			Expect(err).To(MatchError(ContainSubstring("not found in active")), "No errors raised when target cluster does not exist")
+		})
+
+		It("check that when no IDs are provided all the clusters are retrieved", func() {
+			expectedClusterIDs := []liqov1beta1.ClusterID{"cl01", "cl02"}
+
+			err := options.getForeignClusters(ctx, []string{})
+			Expect(err).NotTo(HaveOccurred(), "An error occurred while getting foreign clusters")
+			Expect(len(options.ClustersInfo)).To(Equal(len(expectedClusterIDs)), "Expected all the peers to be retrieved")
+
+			for _, clusterID := range expectedClusterIDs {
+				Expect(options.ClustersInfo).To(HaveKey(clusterID), "Unexpected cluster info content")
+				Expect(options.ClustersInfo[clusterID].Spec.ClusterID).To(Equal(clusterID),
+					"Unexpected ForeignCluster object in cluster info")
+			}
 		})
 	})
 
@@ -188,6 +268,91 @@ var _ = Describe("Info utilities functions tests", func() {
 			err := o.installationCheck(ctx)
 			Expect(err).To(HaveOccurred(), "Existing Liqo namespace but failed check")
 			Expect(err.Error()).To(ContainSubstring("not found"))
+		})
+	})
+
+	Context("Retrieving the cluster name from a query", func() {
+		var options Options
+
+		BeforeEach(func() {
+			options = Options{Factory: factory.NewForLocal()}
+		})
+
+		It("checks that the proper clusterID and truncated query is returned", func() {
+			clusters := []liqov1beta1.ClusterID{"cl01", "cl02"}
+			query := "network.status"
+			expectedCluster := "cl02"
+			gotQuery, gotCluster := options.getClusterFromQuery(fmt.Sprintf("%s.%s", expectedCluster, query), clusters)
+
+			Expect(query).To(Equal(gotQuery), "Unexpected query received")
+			Expect(expectedCluster).To(Equal(gotCluster), "Unexpected cluster received")
+		})
+
+		It("check that query is NOT truncated and the proper cluster ID returned with a single cluster", func() {
+			clusters := []liqov1beta1.ClusterID{"cl01"}
+			query := "network.cidr"
+			expectedCluster := "cl01"
+			gotQuery, gotCluster := options.getClusterFromQuery(query, clusters)
+
+			Expect(query).To(Equal(gotQuery), "Unexpected query received")
+			Expect(expectedCluster).To(Equal(gotCluster), "Unexpected cluster received")
+		})
+	})
+
+	Context("collectDataFromMultiClusterCheckers function test", func() {
+		var options Options
+
+		BeforeEach(func() {
+			options = Options{Factory: factory.NewForLocal()}
+		})
+
+		It("Checks that data is collected correctly for each clusterID", func() {
+			// There is no need to access to the ForeignCluster structs, so, for simplicity, keep them nil
+			options.ClustersInfo = map[liqov1beta1.ClusterID]*liqov1beta1.ForeignCluster{
+				"cl01": nil,
+				"cl02": nil,
+			}
+
+			type Data1 struct {
+				ClusterID liqov1beta1.ClusterID
+			}
+			type Data2 struct {
+				shoe string
+			}
+
+			clusterIDs := []liqov1beta1.ClusterID{"cl01", "cl02"}
+			checkers := []MultiClusterChecker{}
+			expectedData := map[liqov1beta1.ClusterID]map[string]interface{}{}
+			checker1Data := map[liqov1beta1.ClusterID]interface{}{}
+			checker2Data := map[liqov1beta1.ClusterID]interface{}{}
+
+			for i, clusterID := range clusterIDs {
+				expectedData[clusterID] = map[string]interface{}{}
+				data1 := Data1{clusterID}
+				data2 := Data2{fmt.Sprintf("shirt %d", i)}
+
+				expectedData[clusterID]["c1"] = data1
+				expectedData[clusterID]["c2"] = data2
+				checker1Data[clusterID] = data1
+				checker2Data[clusterID] = data2
+			}
+
+			checkers = append(checkers,
+				&dummyMultiClusterChecker{
+					id:    "c1",
+					title: "C1",
+					data:  checker1Data,
+				},
+				&dummyMultiClusterChecker{
+					id:    "c2",
+					title: "C2",
+					data:  checker2Data,
+				},
+			)
+
+			data, err := options.collectDataFromMultiClusterCheckers(checkers)
+			Expect(err).NotTo(HaveOccurred(), "An error occurred while collecting data")
+			Expect(data).To(Equal(expectedData), "Unexpected collected data")
 		})
 	})
 })

--- a/pkg/liqoctl/output/info.go
+++ b/pkg/liqoctl/output/info.go
@@ -28,6 +28,7 @@ type Section interface {
 	AddSectionInfo(title string) Section
 	AddSectionWithDetail(title, detail string) Section
 	AddEntry(key string, values ...string) Section
+	AddEntryWarning(key string, values ...string) Section
 	AddEntryWithoutStyle(key, value string) Section
 	SprintForBox(printer *Printer) string
 }
@@ -99,6 +100,12 @@ func (s *section) AddEntry(key string, values ...string) Section {
 	return s
 }
 
+// AddEntryWarning add a new entry with warning style.
+func (s *section) AddEntryWarning(key string, values ...string) Section {
+	s.entries = append(s.entries, &entry{key: key, values: values, style: StatusWarningStyle})
+	return s
+}
+
 // AddEntryWithoutStyle add a new entry without style.
 func (s *section) AddEntryWithoutStyle(key, value string) Section {
 	s.entries = append(s.entries, &entry{key: key, values: []string{value}, style: pterm.NewStyle(pterm.FgDefault)})
@@ -166,7 +173,7 @@ func (e *entry) print(level int, printer *Printer, longestKey int) {
 		)
 	case 1:
 		printer.BulletListAddItemWithoutBullet(pterm.Sprintf("%s: %s%s",
-			pterm.Bold.Sprint(e.key),
+			pterm.Sprint(e.key),
 			strings.Repeat(" ", longestKey-len(e.key)),
 			e.style.Sprint(e.values[0]),
 		),
@@ -174,7 +181,7 @@ func (e *entry) print(level int, printer *Printer, longestKey int) {
 		)
 	default:
 		printer.BulletListAddItemWithoutBullet(
-			pterm.Bold.Sprint(e.key),
+			pterm.Sprint(e.key),
 			level,
 		)
 		for _, v := range e.values {

--- a/pkg/liqoctl/output/output.go
+++ b/pkg/liqoctl/output/output.go
@@ -63,9 +63,11 @@ var (
 	// StatusSectionInfoStyle is the style of the info status section.
 	StatusSectionInfoStyle = pterm.NewStyle(pterm.FgDefault, pterm.Bold)
 	// StatusDataStyle is the style of the status data.
-	StatusDataStyle = pterm.NewStyle(pterm.FgLightYellow, pterm.Bold)
+	StatusDataStyle = pterm.NewStyle(pterm.FgDefault, pterm.Bold)
 	// StatusInfoStyle is the style of the status info.
 	StatusInfoStyle = pterm.NewStyle(pterm.FgCyan, pterm.Bold)
+	// StatusWarningStyle is the style of the status info.
+	StatusWarningStyle = pterm.NewStyle(pterm.FgYellow, pterm.Bold)
 	// BoxTitleStyle is the style of the box.
 	BoxTitleStyle = pterm.NewStyle(pterm.FgMagenta, pterm.Bold)
 )


### PR DESCRIPTION
# Description

This completes the work done in #2718 implementing the `liqoctl info peer` command, which provides detailed info about the current active peerings:

- Peer identity and role
- Status and info about each of the modules
- Amount of resources offloaded and shared
- Details about the currently configured virtual nodes

By default the output is presented in a human-readable form. However, to simplify automate retrieval of the data, via the `-o` option, it is possible to format the output in JSON or YAML and, via the `--get clusterID.field.subfield` argument, each field of the reports can be individually retrieved (when data about a single peer is returned, the clusterID can be omitted).

E.g.
Get info about all the currently active peerings in a human readable form:

```
liqoctl info peer
```

dump the result in json form:

```
liqoctl info peer -o json
```