### PR TITLE
[Feat] support cluster ip in gateway services

### DIFF
--- a/cmd/liqoctl/cmd/network.go
+++ b/cmd/liqoctl/cmd/network.go
@@ -156,7 +156,9 @@ func newNetworkConnectCommand(ctx context.Context, options *network.Options) *co
 	cmd.Flags().StringVar(&options.ServerTemplateNamespace, "server-template-namespace", "",
 		"Namespace of the Gateway Server template")
 	cmd.Flags().Var(options.ServerServiceType, "server-service-type",
-		fmt.Sprintf("Service type of the Gateway Server. Default: %s", forge.DefaultGwServerServiceType))
+		fmt.Sprintf("Service type of the Gateway Server. Default: %s."+
+			" Note: use ClusterIP only if you know what you are doing and you have a proper network configuration",
+			forge.DefaultGwServerServiceType))
 	cmd.Flags().Int32Var(&options.ServerPort, "server-port", forge.DefaultGwServerPort,
 		fmt.Sprintf("Port of the Gateway Server. Default: %d", forge.DefaultGwServerPort))
 	cmd.Flags().Int32Var(&options.ServerNodePort, "node-port", 0,

--- a/cmd/liqoctl/cmd/peer.go
+++ b/cmd/liqoctl/cmd/peer.go
@@ -90,7 +90,9 @@ func newPeerCommand(ctx context.Context, f *factory.Factory) *cobra.Command {
 	// Networking flags
 	cmd.Flags().BoolVar(&options.NetworkingDisabled, "networking-disabled", false, "Disable networking between the two clusters")
 	cmd.Flags().Var(options.ServerServiceType, "server-service-type",
-		fmt.Sprintf("Service type of the Gateway Server. Default: %s", nwforge.DefaultGwServerServiceType))
+		fmt.Sprintf("Service type of the Gateway Server. Default: %s."+
+			" Note: use ClusterIP only if you know what you are doing and you have a proper network configuration",
+			nwforge.DefaultGwServerServiceType))
 	cmd.Flags().Int32Var(&options.ServerPort, "server-port", nwforge.DefaultGwServerPort,
 		fmt.Sprintf("Port of the Gateway Server. Default: %d", nwforge.DefaultGwServerPort))
 	cmd.Flags().IntVar(&options.MTU, "mtu", nwforge.DefaultMTU,

--- a/pkg/liqoctl/network/handler.go
+++ b/pkg/liqoctl/network/handler.go
@@ -59,7 +59,8 @@ func NewOptions(localFactory *factory.Factory) *Options {
 	return &Options{
 		LocalFactory: localFactory,
 		ServerServiceType: argsutils.NewEnum(
-			[]string{string(corev1.ServiceTypeLoadBalancer), string(corev1.ServiceTypeNodePort)}, string(forge.DefaultGwServerServiceType)),
+			[]string{string(corev1.ServiceTypeLoadBalancer), string(corev1.ServiceTypeNodePort), string(corev1.ServiceTypeClusterIP)},
+			string(forge.DefaultGwServerServiceType)),
 	}
 }
 

--- a/pkg/liqoctl/peer/handler.go
+++ b/pkg/liqoctl/peer/handler.go
@@ -62,7 +62,8 @@ func NewOptions(localFactory *factory.Factory) *Options {
 	return &Options{
 		LocalFactory: localFactory,
 		ServerServiceType: argsutils.NewEnum(
-			[]string{string(corev1.ServiceTypeLoadBalancer), string(corev1.ServiceTypeNodePort)}, string(nwforge.DefaultGwServerServiceType)),
+			[]string{string(corev1.ServiceTypeLoadBalancer), string(corev1.ServiceTypeNodePort), string(corev1.ServiceTypeClusterIP)},
+			string(nwforge.DefaultGwServerServiceType)),
 	}
 }
 


### PR DESCRIPTION
# Description

This pr adds the cluster to the list of the gateways-supported services. It can be helpful for particular use cases where service addresses are discoverable from the other cluster.
