### PR TITLE
Fix liqoctl disconnect on bidirectional peering

### DIFF
--- a/cmd/liqoctl/cmd/network.go
+++ b/cmd/liqoctl/cmd/network.go
@@ -196,7 +196,7 @@ func newNetworkDisconnectCommand(ctx context.Context, options *network.Options) 
 		},
 
 		Run: func(_ *cobra.Command, _ []string) {
-			output.ExitOnErr(options.RunDisconnect(ctx))
+			output.ExitOnErr(options.RunDisconnect(ctx, nil, nil))
 		},
 	}
 


### PR DESCRIPTION
# Description

This PR fixes the `liqoctl disconnect` command in case of bidirectional peering.
