### PR TITLE
Disable docker artifacts in CI

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -134,6 +134,8 @@ jobs:
 
       - name: Build (and Publish) ${{ matrix.component }} image
         uses: docker/build-push-action@v6
+        env:
+          DOCKER_BUILD_RECORD_UPLOAD: false
         with:
           context: .
           platforms: ${{ needs.configure.outputs.architectures }}


### PR DESCRIPTION
# Description

This PR disable the upload of artifact created by https://github.com/docker/build-push-action from version 6.9.0
