### PR TITLE
fix: retrieve GatewayServer/GatewayClient resources by labels

### DIFF
--- a/docs/advanced/peering/inter-cluster-network.md
+++ b/docs/advanced/peering/inter-cluster-network.md
@@ -453,7 +453,7 @@ Resuming, these are the steps to be followed by the administrators of each of th
 3. **Cluster client**: applies the server configuration:
 
    ```bash
-   kubectl apply -f server-client.yaml
+   kubectl apply -f conf-server.yaml
    ```
 
 4. **Cluster server**: sets up the `GatewayServer` and provides to the cluster client administrator port and address where the server is reachable:

--- a/pkg/liqo-controller-manager/networking/forge/gatewayclient.go
+++ b/pkg/liqo-controller-manager/networking/forge/gatewayclient.go
@@ -32,8 +32,8 @@ const (
 	DefaultGwClientTemplateName = "wireguard-client"
 )
 
-// DefaultGatewayClientName returns the default name for a GatewayClient.
-func DefaultGatewayClientName(remoteClusterID liqov1beta1.ClusterID) string {
+// defaultGatewayClientName returns the default name for a GatewayClient.
+func defaultGatewayClientName(remoteClusterID liqov1beta1.ClusterID) string {
 	return string(remoteClusterID)
 }
 
@@ -51,14 +51,14 @@ type GwClientOptions struct {
 }
 
 // GatewayClient forges a GatewayClient.
-func GatewayClient(name, namespace string, o *GwClientOptions) (*networkingv1beta1.GatewayClient, error) {
+func GatewayClient(namespace string, name *string, o *GwClientOptions) (*networkingv1beta1.GatewayClient, error) {
 	gwClient := &networkingv1beta1.GatewayClient{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       networkingv1beta1.GatewayClientKind,
 			APIVersion: networkingv1beta1.GroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
+			Name:      ptr.Deref(name, defaultGatewayClientName(o.RemoteClusterID)),
 			Namespace: namespace,
 			Labels: map[string]string{
 				liqoconsts.RemoteClusterID: string(o.RemoteClusterID),

--- a/pkg/liqo-controller-manager/networking/forge/gatewayserver.go
+++ b/pkg/liqo-controller-manager/networking/forge/gatewayserver.go
@@ -18,6 +18,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/utils/ptr"
 
 	liqov1beta1 "github.com/liqotech/liqo/apis/core/v1beta1"
 	networkingv1beta1 "github.com/liqotech/liqo/apis/networking/v1beta1"
@@ -33,8 +34,8 @@ const (
 	DefaultGwServerPort         = 51840
 )
 
-// DefaultGatewayServerName returns the default name for a GatewayServer.
-func DefaultGatewayServerName(remoteClusterID liqov1beta1.ClusterID) string {
+// defaultGatewayServerName returns the default name for a GatewayServer.
+func defaultGatewayServerName(remoteClusterID liqov1beta1.ClusterID) string {
 	return string(remoteClusterID)
 }
 
@@ -53,14 +54,14 @@ type GwServerOptions struct {
 }
 
 // GatewayServer forges a GatewayServer.
-func GatewayServer(name, namespace string, o *GwServerOptions) (*networkingv1beta1.GatewayServer, error) {
+func GatewayServer(namespace string, name *string, o *GwServerOptions) (*networkingv1beta1.GatewayServer, error) {
 	gwServer := &networkingv1beta1.GatewayServer{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       networkingv1beta1.GatewayServerKind,
 			APIVersion: networkingv1beta1.GroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
+			Name:      ptr.Deref(name, defaultGatewayServerName(o.RemoteClusterID)),
 			Namespace: namespace,
 			Labels: map[string]string{
 				liqoconsts.RemoteClusterID: string(o.RemoteClusterID),

--- a/pkg/liqoctl/network/handler.go
+++ b/pkg/liqoctl/network/handler.go
@@ -190,9 +190,7 @@ func (o *Options) RunConnect(ctx context.Context) error {
 	}
 
 	// Create gateway server on cluster 2
-	gwServer, err := cluster2.EnsureGatewayServer(ctx,
-		forge.DefaultGatewayServerName(cluster1.localClusterID),
-		o.newGatewayServerForgeOptions(o.RemoteFactory.KubeClient, cluster1.localClusterID))
+	gwServer, err := cluster2.EnsureGatewayServer(ctx, o.newGatewayServerForgeOptions(o.RemoteFactory.KubeClient, cluster1.localClusterID))
 	if err != nil {
 		return err
 	}
@@ -209,7 +207,6 @@ func (o *Options) RunConnect(ctx context.Context) error {
 
 	// Create gateway client on cluster 1
 	gwClient, err := cluster1.EnsureGatewayClient(ctx,
-		forge.DefaultGatewayClientName(cluster2.localClusterID),
 		o.newGatewayClientForgeOptions(o.LocalFactory.KubeClient, cluster2.localClusterID, gwServer.Status.Endpoint))
 	if err != nil {
 		return err
@@ -303,22 +300,22 @@ func (o *Options) RunDisconnect(ctx context.Context, cluster1, cluster2 *Cluster
 	}
 
 	// Delete gateway client on cluster 1
-	if err := cluster1.DeleteGatewayClient(ctx, forge.DefaultGatewayClientName(cluster2.localClusterID)); err != nil {
+	if err := cluster1.DeleteGatewayClient(ctx, cluster2.localClusterID); err != nil {
 		return err
 	}
 
 	// Delete gateway client on cluster 2
-	if err := cluster2.DeleteGatewayClient(ctx, forge.DefaultGatewayClientName(cluster1.localClusterID)); err != nil {
+	if err := cluster2.DeleteGatewayClient(ctx, cluster1.localClusterID); err != nil {
 		return err
 	}
 
 	// Delete gateway server on cluster 1
-	if err := cluster1.DeleteGatewayServer(ctx, forge.DefaultGatewayServerName(cluster2.localClusterID)); err != nil {
+	if err := cluster1.DeleteGatewayServer(ctx, cluster2.localClusterID); err != nil {
 		return err
 	}
 
 	// Delete gateway server on cluster 2
-	return cluster2.DeleteGatewayServer(ctx, forge.DefaultGatewayServerName(cluster1.localClusterID))
+	return cluster2.DeleteGatewayServer(ctx, cluster1.localClusterID)
 }
 
 func (o *Options) newGatewayServerForgeOptions(kubeClient kubernetes.Interface, remoteClusterID liqov1beta1.ClusterID) *forge.GwServerOptions {

--- a/pkg/liqoctl/rest/gatewayclient/create.go
+++ b/pkg/liqoctl/rest/gatewayclient/create.go
@@ -95,7 +95,7 @@ func (o *Options) Create(ctx context.Context, options *rest.CreateOptions) *cobr
 func (o *Options) handleCreate(ctx context.Context) error {
 	opts := o.createOptions
 
-	gwClient, err := forge.GatewayClient(opts.Name, opts.Namespace, o.getForgeOptions())
+	gwClient, err := forge.GatewayClient(opts.Namespace, &opts.Name, o.getForgeOptions())
 	if err != nil {
 		opts.Printer.CheckErr(err)
 		return err

--- a/pkg/liqoctl/rest/gatewayserver/create.go
+++ b/pkg/liqoctl/rest/gatewayserver/create.go
@@ -98,7 +98,7 @@ func (o *Options) Create(ctx context.Context, options *rest.CreateOptions) *cobr
 func (o *Options) handleCreate(ctx context.Context) error {
 	opts := o.createOptions
 
-	gwServer, err := forge.GatewayServer(opts.Name, opts.Namespace, o.getForgeOptions())
+	gwServer, err := forge.GatewayServer(opts.Namespace, &opts.Name, o.getForgeOptions())
 	if err != nil {
 		opts.Printer.CheckErr(err)
 		return err


### PR DESCRIPTION
# Description

This PR fixes a bug in Liqoctl where GatewayServer and GatewayClient resources were retrieved by name instead of labels.
