### PR TITLE
[Feat] Gateway HA

### DIFF
--- a/cmd/gateway/wireguard/main.go
+++ b/cmd/gateway/wireguard/main.go
@@ -24,7 +24,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
@@ -37,7 +36,7 @@ import (
 	ipamv1alpha1 "github.com/liqotech/liqo/apis/ipam/v1alpha1"
 	networkingv1beta1 "github.com/liqotech/liqo/apis/networking/v1beta1"
 	"github.com/liqotech/liqo/pkg/gateway"
-	"github.com/liqotech/liqo/pkg/gateway/forge"
+	"github.com/liqotech/liqo/pkg/gateway/concurrent"
 	"github.com/liqotech/liqo/pkg/gateway/tunnel/wireguard"
 	flagsutils "github.com/liqotech/liqo/pkg/utils/flags"
 	"github.com/liqotech/liqo/pkg/utils/mapper"
@@ -102,17 +101,7 @@ func run(cmd *cobra.Command, _ []string) error {
 			BindAddress: options.GwOptions.MetricsAddress,
 		},
 		HealthProbeBindAddress: options.GwOptions.ProbeAddr,
-		LeaderElection:         options.GwOptions.LeaderElection,
-		LeaderElectionID: fmt.Sprintf(
-			"%s.%s.%s.wgtunnel.liqo.io",
-			forge.GatewayResourceName(options.GwOptions.Name), options.GwOptions.Namespace, options.GwOptions.Mode,
-		),
-		LeaderElectionNamespace:       options.GwOptions.Namespace,
-		LeaderElectionReleaseOnCancel: true,
-		LeaderElectionResourceLock:    resourcelock.LeasesResourceLock,
-		LeaseDuration:                 &options.GwOptions.LeaderElectionLeaseDuration,
-		RenewDeadline:                 &options.GwOptions.LeaderElectionRenewDeadline,
-		RetryPeriod:                   &options.GwOptions.LeaderElectionRetryPeriod,
+		LeaderElection:         false,
 	})
 	if err != nil {
 		return fmt.Errorf("unable to create manager: %w", err)
@@ -167,6 +156,15 @@ func run(cmd *cobra.Command, _ []string) error {
 	if err := metrics.Registry.Register(promcollect); err != nil {
 		return fmt.Errorf("unable to register prometheus collector: %w", err)
 	}
+
+	runnable, err := concurrent.NewRunnableGuest(options.GwOptions.ContainerName)
+	if err != nil {
+		return fmt.Errorf("unable to create runnable guest: %w", err)
+	}
+	if err := runnable.Start(cmd.Context()); err != nil {
+		return fmt.Errorf("unable to start runnable guest: %w", err)
+	}
+	defer runnable.Close()
 
 	// Start the manager.
 	return mgr.Start(cmd.Context())

--- a/deployments/liqo/files/liqo-gateway-ClusterRole.yaml
+++ b/deployments/liqo/files/liqo-gateway-ClusterRole.yaml
@@ -12,6 +12,16 @@ rules:
   - update
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - coordination.k8s.io
   resources:
   - leases

--- a/deployments/liqo/templates/_helpers.tpl
+++ b/deployments/liqo/templates/_helpers.tpl
@@ -97,6 +97,9 @@ helm.sh/chart: {{ quote (include "liqo.chart" .) }}
 app.kubernetes.io/version: {{ quote (include "liqo.version" .) }}
 app.kubernetes.io/managed-by: {{ quote .Release.Service }}
 networking.liqo.io/component: "gateway"
+{{- if .isService }}
+networking.liqo.io/active: "true"
+{{- end }}
 {{- end }}
 
 {{/*

--- a/deployments/liqo/templates/liqo-wireguard-gateway-client-template.yaml
+++ b/deployments/liqo/templates/liqo-wireguard-gateway-client-template.yaml
@@ -47,7 +47,10 @@ spec:
                 - --remote-cluster-id={{"{{ .ClusterID }}"}}
                 - --gateway-uid={{"{{ .GatewayUID }}"}}
                 - --node-name={{"$(NODE_NAME)"}}
+                - --pod-name={{"$(POD_NAME)"}}
                 - --mode=client
+                - --container-name=gateway
+                - --concurrent-containers-names=wireguard,geneve
                 {{- if .Values.metrics.enabled }}
                 - --metrics-address=:8080
                 {{- end }}
@@ -56,12 +59,13 @@ spec:
                 - --ping-loss-threshold={{ .Values.networking.gatewayTemplates.ping.lossThreshold }}
                 - --ping-interval={{ .Values.networking.gatewayTemplates.ping.interval }}
                 - --ping-update-status-interval={{ .Values.networking.gatewayTemplates.ping.updateStatusInterval }}
-                {{- if gt .Values.networking.gatewayTemplates.replicas 1.0 }}
                 - --leader-election=true
-                {{- end }}
                 {{- if .Values.requirements.kernel.disabled }}
                 - --disable-kernel-version-check
                 {{- end }}
+                volumeMounts: 
+                - name: ipc 
+                  mountPath: /ipc
                 {{- if .Values.metrics.enabled }}
                 ports:
                 - containerPort: 8080
@@ -72,6 +76,10 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: spec.nodeName
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
                 securityContext:
                   privileged: true
                   capabilities:
@@ -87,6 +95,7 @@ spec:
                 - --remote-cluster-id={{"{{ .ClusterID }}"}}
                 - --gateway-uid={{"{{ .GatewayUID }}"}}
                 - --mode=client
+                - --container-name=wireguard
                 - --mtu={{"{{ .Spec.MTU }}"}}
                 - --endpoint-address={{"{{ index .Spec.Endpoint.Addresses 0 }}"}}
                 - --endpoint-port={{"{{ .Spec.Endpoint.Port }}"}}
@@ -109,6 +118,8 @@ spec:
                   privileged: true
                   {{ end }}
                 volumeMounts:
+                - name: ipc 
+                  mountPath: /ipc
                 - name: wireguard-config
                   mountPath: /etc/wireguard/keys
               - name: geneve
@@ -120,12 +131,17 @@ spec:
                 - --remote-cluster-id={{"{{ .ClusterID }}"}}
                 - --gateway-uid={{"{{ .GatewayUID }}"}}
                 - --node-name={{"$(NODE_NAME)"}}
+                - --pod-name={{"$(POD_NAME)"}}
                 - --mode=server
+                - --container-name=geneve
                 - --geneve-port={{ .Values.networking.genevePort }}
                 {{- if .Values.metrics.enabled }}
                 - --metrics-address=:8084
                 {{- end }}
                 - --health-probe-bind-address=:8085
+                volumeMounts: 
+                - name: ipc 
+                  mountPath: /ipc
                 {{- if .Values.metrics.enabled }}
                 ports:
                 - containerPort: 8084
@@ -136,6 +152,10 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: spec.nodeName
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
                 securityContext:
                   capabilities:
                     add:
@@ -147,4 +167,6 @@ spec:
               - name: wireguard-config
                 secret:
                   secretName: "{{"{{ .SecretName }}"}}"
+              - name: ipc 
+                emptyDir: {}   
 {{- end }}

--- a/deployments/liqo/templates/liqo-wireguard-gateway-server-template-eks.yaml
+++ b/deployments/liqo/templates/liqo-wireguard-gateway-server-template-eks.yaml
@@ -39,7 +39,7 @@ spec:
           {{- end }}
         spec:
           selector:
-            {{- include "liqo.labelsTemplate" $templateConfig | nindent 12 }}
+            {{- include "liqo.labelsTemplate" (merge (dict "isService" true) $templateConfig) | nindent 12 }}
           type: "{{"{{ .Spec.Endpoint.ServiceType }}"}}"
           ports:
           - port: "{{"{{ .Spec.Endpoint.Port }}"}}"
@@ -73,8 +73,11 @@ spec:
                 - --namespace={{"{{ .Namespace }}"}}
                 - --remote-cluster-id={{"{{ .ClusterID }}"}}
                 - --node-name={{"$(NODE_NAME)"}}
+                - --pod-name={{"$(POD_NAME)"}}
                 - --gateway-uid={{"{{ .GatewayUID }}"}}
                 - --mode=server
+                - --container-name=gateway
+                - --concurrent-containers-names=wireguard,geneve
                 {{- if .Values.metrics.enabled }}
                 - --metrics-address=:8080
                 {{- end }}
@@ -83,12 +86,13 @@ spec:
                 - --ping-loss-threshold={{ .Values.networking.gatewayTemplates.ping.lossThreshold }}
                 - --ping-interval={{ .Values.networking.gatewayTemplates.ping.interval }}
                 - --ping-update-status-interval={{ .Values.networking.gatewayTemplates.ping.updateStatusInterval }}
-                {{- if gt .Values.networking.gatewayTemplates.replicas 1.0 }}
                 - --leader-election=true
-                {{- end }}
                 {{- if .Values.requirements.kernel.disabled }}
                 - --disable-kernel-version-check
                 {{- end }}
+                volumeMounts: 
+                - name: ipc 
+                  mountPath: /ipc
                 {{- if .Values.metrics.enabled }}
                 ports:
                 - containerPort: 8080
@@ -99,6 +103,10 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: spec.nodeName
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
                 securityContext:
                   privileged: true
                   capabilities:
@@ -114,6 +122,7 @@ spec:
                 - --remote-cluster-id={{"{{ .ClusterID }}"}}
                 - --gateway-uid={{"{{ .GatewayUID }}"}}
                 - --mode=server
+                - --container-name=wireguard
                 - --mtu={{"{{ .Spec.MTU }}"}}
                 - --listen-port={{"{{ .Spec.Endpoint.Port }}"}}
                 {{- if .Values.metrics.enabled }}
@@ -135,6 +144,8 @@ spec:
                   privileged: true
                   {{ end }}
                 volumeMounts:
+                - name: ipc 
+                  mountPath: /ipc
                 - name: wireguard-config
                   mountPath: /etc/wireguard/keys
               - name: geneve
@@ -145,13 +156,18 @@ spec:
                 - --namespace={{"{{ .Namespace }}"}}
                 - --remote-cluster-id={{"{{ .ClusterID }}"}}
                 - --node-name={{"$(NODE_NAME)"}}
+                - --pod-name={{"$(POD_NAME)"}}
                 - --gateway-uid={{"{{ .GatewayUID }}"}}
                 - --mode=server
+                - --container-name=geneve
                 - --geneve-port={{ .Values.networking.genevePort }}
                 {{- if .Values.metrics.enabled }}
                 - --metrics-address=:8084
                 {{- end }}
                 - --health-probe-bind-address=:8085
+                volumeMounts: 
+                - name: ipc 
+                  mountPath: /ipc
                 {{- if .Values.metrics.enabled }}
                 ports:
                 - containerPort: 8084
@@ -162,6 +178,10 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: spec.nodeName
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
                 securityContext:
                   capabilities:
                     add:
@@ -175,4 +195,6 @@ spec:
               - name: wireguard-config
                 secret:
                   secretName: "{{"{{ .SecretName }}"}}"
+              - name: ipc 
+                emptyDir: {} 
 {{- end }}

--- a/deployments/liqo/templates/liqo-wireguard-gateway-server-template.yaml
+++ b/deployments/liqo/templates/liqo-wireguard-gateway-server-template.yaml
@@ -30,7 +30,7 @@ spec:
           {{- end }}
         spec:
           selector:
-            {{- include "liqo.labelsTemplate" $templateConfig | nindent 12 }}
+            {{- include "liqo.labelsTemplate" (merge (dict "isService" true) $templateConfig) | nindent 12 }}
           type: "{{"{{ .Spec.Endpoint.ServiceType }}"}}"
           ports:
           - port: "{{"{{ .Spec.Endpoint.Port }}"}}"
@@ -64,8 +64,11 @@ spec:
                 - --namespace={{"{{ .Namespace }}"}}
                 - --remote-cluster-id={{"{{ .ClusterID }}"}}
                 - --node-name={{"$(NODE_NAME)"}}
+                - --pod-name={{"$(POD_NAME)"}}
                 - --gateway-uid={{"{{ .GatewayUID }}"}}
                 - --mode=server
+                - --container-name=gateway
+                - --concurrent-containers-names=wireguard,geneve
                 {{- if .Values.metrics.enabled }}
                 - --metrics-address=:8080
                 {{- end }}
@@ -74,12 +77,13 @@ spec:
                 - --ping-loss-threshold={{ .Values.networking.gatewayTemplates.ping.lossThreshold }}
                 - --ping-interval={{ .Values.networking.gatewayTemplates.ping.interval }}
                 - --ping-update-status-interval={{ .Values.networking.gatewayTemplates.ping.updateStatusInterval }}
-                {{- if gt .Values.networking.gatewayTemplates.replicas 1.0 }}
                 - --leader-election=true
-                {{- end }}
                 {{- if .Values.requirements.kernel.disabled }}
                 - --disable-kernel-version-check
                 {{- end }}
+                volumeMounts: 
+                - name: ipc 
+                  mountPath: /ipc
                 {{- if .Values.metrics.enabled }}
                 ports:
                 - containerPort: 8080
@@ -90,6 +94,10 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: spec.nodeName
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
                 securityContext:
                   privileged: true
                   capabilities:
@@ -105,6 +113,7 @@ spec:
                 - --remote-cluster-id={{"{{ .ClusterID }}"}}
                 - --gateway-uid={{"{{ .GatewayUID }}"}}
                 - --mode=server
+                - --container-name=wireguard
                 - --mtu={{"{{ .Spec.MTU }}"}}
                 - --listen-port={{"{{ .Spec.Endpoint.Port }}"}}
                 {{- if .Values.metrics.enabled }}
@@ -126,6 +135,8 @@ spec:
                   privileged: true
                   {{ end }}
                 volumeMounts:
+                - name: ipc 
+                  mountPath: /ipc
                 - name: wireguard-config
                   mountPath: /etc/wireguard/keys
               - name: geneve
@@ -136,13 +147,18 @@ spec:
                 - --namespace={{"{{ .Namespace }}"}}
                 - --remote-cluster-id={{"{{ .ClusterID }}"}}
                 - --node-name={{"$(NODE_NAME)"}}
+                - --pod-name={{"$(POD_NAME)"}}
                 - --gateway-uid={{"{{ .GatewayUID }}"}}
                 - --mode=server
+                - --container-name=geneve
                 - --geneve-port={{ .Values.networking.genevePort }}
                 {{- if .Values.metrics.enabled }}
                 - --metrics-address=:8084
                 {{- end }}
                 - --health-probe-bind-address=:8085
+                volumeMounts: 
+                - name: ipc 
+                  mountPath: /ipc
                 {{- if .Values.metrics.enabled }}
                 ports:
                 - containerPort: 8084
@@ -153,6 +169,10 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: spec.nodeName
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
                 securityContext:
                   capabilities:
                     add:
@@ -164,4 +184,6 @@ spec:
               - name: wireguard-config
                 secret:
                   secretName: "{{"{{ .SecretName }}"}}"
+              - name: ipc 
+                emptyDir: {} 
 {{- end }}

--- a/pkg/fabric/source-detector/gateway_controller.go
+++ b/pkg/fabric/source-detector/gateway_controller.go
@@ -109,7 +109,7 @@ func (r *GatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 func (r *GatewayReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	filterByLabelsGatewayPods, err := predicate.LabelSelectorPredicate(
 		metav1.LabelSelector{
-			MatchLabels: gateway.ForgeGatewayPodLabels(),
+			MatchLabels: gateway.ForgeActiveGatewayPodLabels(),
 		},
 	)
 	if err != nil {

--- a/pkg/gateway/concurrent/const.go
+++ b/pkg/gateway/concurrent/const.go
@@ -1,0 +1,18 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package concurrent
+
+// UnixSocketPath is the path of the Unix socket.
+const unixSocketPath string = "/ipc/leader.sock"

--- a/pkg/gateway/concurrent/doc.go
+++ b/pkg/gateway/concurrent/doc.go
@@ -1,0 +1,21 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package concurrent contains the logic to manage same gateway replicas.
+// They are managed using an active/passive approach.
+// The gateway container try to acquire the active role using the controller manager lease.
+// Then, the active gateway is labeled with the ActiveGatewayKey and ActiveGatewayValue, and the passive gateways are unlabeled.
+// The gateway service target the active gateway using the ActiveGatewayKey and ActiveGatewayValue labels.
+// In order to cohordinate the sidecar containers, the gateway uses a unix socket to manage the IPC, and to start the sidecars when it becomes leader.
+package concurrent

--- a/pkg/gateway/concurrent/gateway.go
+++ b/pkg/gateway/concurrent/gateway.go
@@ -1,0 +1,102 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package concurrent
+
+import (
+	"context"
+	"net"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	"github.com/liqotech/liqo/pkg/utils/ipc"
+)
+
+var _ manager.Runnable = &RunnableGateway{}
+
+// RunnableGateway is a RunnableGateway that manages concurrency.
+type RunnableGateway struct {
+	Client client.Client
+
+	PodName        string
+	DeploymentName string
+	Namespace      string
+
+	Socket           net.Listener
+	GuestConnections ipc.GuestConnections
+}
+
+// NewRunnableGateway creates a new Runnable.
+func NewRunnableGateway(cl client.Client, podName, deploymentName, namespace string, containerNames []string) (*RunnableGateway, error) {
+	guestConnections := ipc.NewGuestConnections(containerNames)
+
+	socket, err := ipc.CreateListenSocket(unixSocketPath)
+	if err != nil {
+		return nil, err
+	}
+
+	err = ipc.WaitAllGuestsConnections(guestConnections, socket)
+	if err != nil {
+		return nil, err
+	}
+
+	return &RunnableGateway{
+		Client:           cl,
+		PodName:          podName,
+		DeploymentName:   deploymentName,
+		Namespace:        namespace,
+		Socket:           socket,
+		GuestConnections: guestConnections,
+	}, nil
+}
+
+// Start starts the ConcurrentRunnable.
+func (rg *RunnableGateway) Start(ctx context.Context) error {
+	defer rg.Close()
+
+	pods, err := ListAllGatewaysReplicas(ctx, rg.Client, rg.Namespace, rg.DeploymentName)
+	if err != nil {
+		return err
+	}
+
+	var activePod *corev1.Pod
+
+	for i := range pods {
+		if pods[i].GetName() == rg.PodName {
+			activePod = &pods[i]
+		} else {
+			if err := RemoveActiveGatewayLabel(ctx, rg.Client, client.ObjectKeyFromObject(&pods[i])); err != nil {
+				return err
+			}
+		}
+	}
+
+	if err := AddActiveGatewayLabel(ctx, rg.Client, client.ObjectKeyFromObject(activePod)); err != nil {
+		return err
+	}
+
+	if err := ipc.StartAllGuestsConnections(rg.GuestConnections); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Close closes the Runnable.
+func (rg *RunnableGateway) Close() {
+	ipc.CloseListenSocket(rg.Socket)
+	ipc.CloseAllGuestsConnections(rg.GuestConnections)
+}

--- a/pkg/gateway/concurrent/guest.go
+++ b/pkg/gateway/concurrent/guest.go
@@ -1,0 +1,77 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package concurrent
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	"github.com/liqotech/liqo/pkg/utils/ipc"
+)
+
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var _ manager.Runnable = &RunnableGuest{}
+
+// RunnableGuest is a RunnableGuest that manages concurrency.
+type RunnableGuest struct {
+	GuestID    string
+	Connection net.Conn
+}
+
+// NewRunnableGuest creates a new Runnable.
+func NewRunnableGuest(guestID string) (*RunnableGuest, error) {
+	conn, err := ipc.Connect(unixSocketPath, guestID)
+	if err != nil {
+		return nil, err
+	}
+
+	return &RunnableGuest{
+		GuestID:    guestID,
+		Connection: conn,
+	}, nil
+}
+
+// Start starts the ConcurrentRunnable.
+func (rg *RunnableGuest) Start(_ context.Context) error {
+	if err := ipc.WaitForStart(rg.GuestID, rg.Connection); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Close closes the Runnable.
+func (rg *RunnableGuest) Close() {
+	if err := rg.Connection.Close(); err != nil {
+		fmt.Printf("Error closing connection: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/pkg/gateway/concurrent/k8s.go
+++ b/pkg/gateway/concurrent/k8s.go
@@ -1,0 +1,89 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package concurrent
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/liqotech/liqo/pkg/consts"
+)
+
+// AddActiveGatewayLabel adds the active gateway label to the pod.
+func AddActiveGatewayLabel(ctx context.Context, cl client.Client, key client.ObjectKey) error {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      key.Name,
+			Namespace: key.Namespace,
+		},
+	}
+	if err := cl.Get(ctx, key, pod); err != nil {
+		return err
+	}
+
+	labels := pod.GetLabels()
+	if labels == nil {
+		labels = map[string]string{}
+	}
+	labels[ActiveGatewayKey] = ActiveGatewayValue
+	pod.SetLabels(labels)
+
+	if err := cl.Update(ctx, pod); err != nil {
+		return err
+	}
+	klog.Infof("Pod %s/%s is now the active gateway", pod.Namespace, pod.Name)
+	return nil
+}
+
+// RemoveActiveGatewayLabel removes the active gateway label from the pod.
+func RemoveActiveGatewayLabel(ctx context.Context, cl client.Client, key client.ObjectKey) error {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      key.Name,
+			Namespace: key.Namespace,
+		},
+	}
+	if err := cl.Get(ctx, key, pod); err != nil {
+		return err
+	}
+
+	labels := pod.GetLabels()
+	if labels == nil {
+		return nil
+	}
+	delete(labels, ActiveGatewayKey)
+	pod.SetLabels(labels)
+
+	if err := cl.Update(ctx, pod); err != nil {
+		return err
+	}
+	klog.Infof("Pod %s/%s is no longer the active gateway", pod.Namespace, pod.Name)
+	return nil
+}
+
+// ListAllGatewaysReplicas returns the list of all the gateways replicas of the same deployment.
+func ListAllGatewaysReplicas(ctx context.Context, cl client.Client, namespace, deploymentName string) ([]corev1.Pod, error) {
+	podList := &corev1.PodList{}
+	if err := cl.List(ctx, podList, client.InNamespace(namespace), client.MatchingLabels{
+		consts.K8sAppNameKey: deploymentName,
+	}); err != nil {
+		return nil, err
+	}
+	return podList.Items, nil
+}

--- a/pkg/gateway/concurrent/label.go
+++ b/pkg/gateway/concurrent/label.go
@@ -1,0 +1,22 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package concurrent
+
+const (
+	// ActiveGatewayKey is the key used to label the active pod gateway.
+	ActiveGatewayKey = "networking.liqo.io/active"
+	// ActiveGatewayValue is the value used to label the active pod gateway.
+	ActiveGatewayValue = "true"
+)

--- a/pkg/gateway/flags.go
+++ b/pkg/gateway/flags.go
@@ -37,12 +37,19 @@ const (
 	FlagNameRemoteClusterID FlagName = "remote-cluster-id"
 	// FlagNameNodeName is the name of the node.
 	FlagNameNodeName FlagName = "node-name"
+	// FlagNamePodName is the name of the pod.
+	FlagNamePodName FlagName = "pod-name"
+	// FlagContainerName is the name of the container.
+	FlagContainerName FlagName = "container-name"
 
 	// FlagNameGatewayUID is the UID of the Gateway resource.
 	FlagNameGatewayUID FlagName = "gateway-uid"
 
 	// FlagNameMode is the mode in which the gateway is configured.
 	FlagNameMode FlagName = "mode"
+
+	// FlagConcurrentContainersNames is the names of the containers that the gateway container must wait for.
+	FlagConcurrentContainersNames FlagName = "concurrent-containers-names"
 
 	// FlagNameLeaderElection is the flag to enable leader election.
 	FlagNameLeaderElection FlagName = "leader-election"
@@ -72,6 +79,8 @@ var RequiredFlags = []FlagName{
 	FlagNameMode,
 	FlagNameGatewayUID,
 	FlagNameNodeName,
+	FlagNamePodName,
+	FlagContainerName,
 }
 
 // InitFlags initializes the flags for the gateway.
@@ -80,10 +89,15 @@ func InitFlags(flagset *pflag.FlagSet, opts *Options) {
 	flagset.StringVar(&opts.Namespace, FlagNameNamespace.String(), "", "Parent gateway namespace")
 	flagset.StringVar(&opts.RemoteClusterID, FlagNameRemoteClusterID.String(), "", "ClusterID of the remote cluster")
 	flagset.StringVar(&opts.NodeName, FlagNameNodeName.String(), "", "Node name")
+	flagset.StringVar(&opts.PodName, FlagNamePodName.String(), "", "Pod name")
+	flagset.StringVar(&opts.ContainerName, FlagContainerName.String(), "", "Container name")
 
 	flagset.StringVar(&opts.GatewayUID, FlagNameGatewayUID.String(), "", "Parent gateway resource UID")
 
 	flagset.Var(&opts.Mode, FlagNameMode.String(), "Parent gateway mode")
+
+	flagset.StringSliceVar(&opts.ConcurrentContainersNames, FlagConcurrentContainersNames.String(),
+		[]string{}, "the container list that gateway container must wait for")
 
 	flagset.BoolVar(&opts.LeaderElection, FlagNameLeaderElection.String(), false, "Enable leader election")
 	flagset.DurationVar(&opts.LeaderElectionLeaseDuration, FlagNameLeaderElectionLeaseDuration.String(), 15*time.Second,
@@ -107,5 +121,12 @@ func MarkFlagsRequired(cmd *cobra.Command) error {
 			return err
 		}
 	}
+
+	if cmd.Name() == "liqo-gateway" {
+		if err := cmd.MarkFlagRequired(FlagConcurrentContainersNames.String()); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }

--- a/pkg/gateway/label.go
+++ b/pkg/gateway/label.go
@@ -16,6 +16,7 @@ package gateway
 
 import (
 	"github.com/liqotech/liqo/pkg/firewall"
+	"github.com/liqotech/liqo/pkg/gateway/concurrent"
 	"github.com/liqotech/liqo/pkg/route"
 )
 
@@ -42,10 +43,11 @@ const (
 	FirewallSubCategoryFabricTargetValue = "fabric"
 )
 
-// ForgeGatewayPodLabels returns the labels for the gateway pod.
-func ForgeGatewayPodLabels() map[string]string {
+// ForgeActiveGatewayPodLabels returns the labels for the gateway pod.
+func ForgeActiveGatewayPodLabels() map[string]string {
 	return map[string]string{
-		GatewayComponentKey: GatewayComponentGateway,
+		concurrent.ActiveGatewayKey: concurrent.ActiveGatewayValue,
+		GatewayComponentKey:         GatewayComponentGateway,
 	}
 }
 

--- a/pkg/gateway/options.go
+++ b/pkg/gateway/options.go
@@ -27,10 +27,14 @@ type Options struct {
 	Namespace       string
 	RemoteClusterID string
 	NodeName        string
+	PodName         string
+	ContainerName   string
 
 	GatewayUID string
 
 	Mode Mode
+
+	ConcurrentContainersNames []string
 
 	LeaderElection              bool
 	LeaderElectionLeaseDuration time.Duration

--- a/pkg/liqo-controller-manager/networking/internal-network/gw-masq-bypass/pod_controller.go
+++ b/pkg/liqo-controller-manager/networking/internal-network/gw-masq-bypass/pod_controller.go
@@ -111,9 +111,7 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 // SetupWithManager register the PodReconciler to the manager.
 func (r *PodReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	p, err := predicate.LabelSelectorPredicate(v1.LabelSelector{
-		MatchLabels: map[string]string{
-			gateway.GatewayComponentKey: gateway.GatewayComponentGateway,
-		},
+		MatchLabels: gateway.ForgeActiveGatewayPodLabels(),
 	})
 	if err != nil {
 		return err

--- a/pkg/utils/ipc/client.go
+++ b/pkg/utils/ipc/client.go
@@ -1,0 +1,64 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ipc
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog/v2"
+)
+
+// Connect connects to the Unix domain socket at the given path and sends the given ID.
+func Connect(path, id string) (net.Conn, error) {
+	var c net.Conn
+	var err error
+	klog.Infof("Connecting to %s socket", path)
+	if err := wait.PollUntilContextTimeout(context.Background(), time.Millisecond*100, time.Second*30, false, func(context.Context) (bool, error) {
+		c, err = net.Dial("unix", path)
+		if err != nil {
+			return false, nil
+		}
+		return true, nil
+	}); err != nil {
+		return nil, err
+	}
+
+	klog.Infof("Sending message to %s", path)
+	if _, err := c.Write([]byte(id)); err != nil {
+		return nil, err
+	}
+	return c, nil
+}
+
+// WaitForStart waits for the start signal from the given ID.
+func WaitForStart(id string, conn net.Conn) error {
+	klog.Infof("Waiting for start message")
+	buf := make([]byte, 4096)
+	n, err := conn.Read(buf)
+	if err != nil {
+		return err
+	}
+	msg := string(buf[:n])
+
+	if msg != ForgeStartMessage(id) {
+		return fmt.Errorf("unexpected message: %s", msg)
+	}
+	klog.Infof("Received start message")
+	return nil
+}

--- a/pkg/utils/ipc/common.go
+++ b/pkg/utils/ipc/common.go
@@ -1,0 +1,22 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ipc
+
+import "fmt"
+
+// ForgeStartMessage creates a start message.
+func ForgeStartMessage(id string) string {
+	return fmt.Sprintf("Start %s", id)
+}

--- a/pkg/utils/ipc/doc.go
+++ b/pkg/utils/ipc/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package ipc contains the logic to manage the Inter-Process Communication (IPC) between the gateway replicas.
+package ipc

--- a/pkg/utils/ipc/server.go
+++ b/pkg/utils/ipc/server.go
@@ -1,0 +1,121 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ipc
+
+import (
+	"net"
+	"os"
+
+	"k8s.io/klog/v2"
+)
+
+// GuestConnections is a map of guest IDs to connections.
+type GuestConnections map[string]net.Conn
+
+// NewGuestConnections creates a new GuestConnections map from string slice.
+func NewGuestConnections(guests []string) GuestConnections {
+	guestsConnections := make(GuestConnections)
+	for _, guest := range guests {
+		guestsConnections[guest] = nil
+	}
+	return guestsConnections
+}
+
+// checkAllGuestsConnected checks if all guests are connected.
+func checkAllGuestsConnected(guestsConnections GuestConnections) bool {
+	for _, connected := range guestsConnections {
+		if connected == nil {
+			return false
+		}
+	}
+	return true
+}
+
+// addGuestConnection adds a new connection to the guestsConnections map.
+func addGuestConnection(guestsConnections GuestConnections, guest string, connection net.Conn) {
+	guestsConnections[guest] = connection
+}
+
+// CreateListenSocket creates a Unix domain socket and listens for incoming connections.
+func CreateListenSocket(path string) (net.Listener, error) {
+	if err := os.RemoveAll(path); err != nil {
+		return nil, err
+	}
+
+	// Create a Unix domain socket and listen for incoming connections.
+	klog.Infof("Listening on %s socket", path)
+	socket, err := net.Listen("unix", path)
+	if err != nil {
+		return nil, err
+	}
+	return socket, nil
+}
+
+// CloseListenSocket closes the listen socket.
+func CloseListenSocket(socket net.Listener) {
+	if err := socket.Close(); err != nil {
+		klog.Errorf("Error closing socket: %v", err)
+		os.Exit(1)
+	}
+}
+
+// WaitAllGuestsConnections waits for all guests to connect to the socket.
+func WaitAllGuestsConnections(guestsConnections GuestConnections, socket net.Listener) error {
+	for !checkAllGuestsConnected(guestsConnections) {
+		// Accept an incoming connection.
+		conn, err := socket.Accept()
+		if err != nil {
+			return err
+		}
+
+		// Create a buffer for incoming data.
+		buf := make([]byte, 4096)
+
+		// Read data from the connection.
+		n, err := conn.Read(buf)
+		if err != nil {
+			return err
+		}
+		id := string(buf[:n])
+
+		addGuestConnection(guestsConnections, id, conn)
+
+		klog.Infof("Guest %s connected\n", id)
+	}
+	return nil
+}
+
+// CloseAllGuestsConnections closes all connections in the guestsConnections map.
+func CloseAllGuestsConnections(guestsConnections GuestConnections) {
+	for _, conn := range guestsConnections {
+		if conn != nil {
+			if err := conn.Close(); err != nil {
+				klog.Errorf("Error closing connection: %v", err)
+				os.Exit(1)
+			}
+		}
+	}
+}
+
+// StartAllGuestsConnections sends a start message to all connections in the guestsConnections map.
+func StartAllGuestsConnections(guestsConnections GuestConnections) error {
+	for guest, conn := range guestsConnections {
+		if _, err := conn.Write([]byte(ForgeStartMessage(guest))); err != nil {
+			return err
+		}
+	}
+	klog.Infof("Sent start message to all guests")
+	return nil
+}

--- a/test/e2e/pipeline/installer/liqoctl/setup.sh
+++ b/test/e2e/pipeline/installer/liqoctl/setup.sh
@@ -63,6 +63,7 @@ LIQO_VERSION="${LIQO_VERSION:-$(git rev-parse HEAD)}"
 export SERVICE_CIDR=10.100.0.0/16
 export POD_CIDR=10.200.0.0/16
 export POD_CIDR_OVERLAPPING=${POD_CIDR_OVERLAPPING:-"false"}
+export HA_REPLICAS=3
 
 for i in $(seq 1 "${CLUSTER_NUMBER}");
 do
@@ -109,7 +110,7 @@ do
 
   if [[ "${INFRA}" == "cluster-api" ]]; then
     LIQO_PROVIDER="kubeadm"
-    COMMON_ARGS=("${COMMON_ARGS[@]}")
+    COMMON_ARGS=("${COMMON_ARGS[@]}" --set "networking.gatewayTemplates.replicas=$HA_REPLICAS" )
   else
     LIQO_PROVIDER="${INFRA}"
   fi

--- a/test/e2e/testutils/util/pod.go
+++ b/test/e2e/testutils/util/pod.go
@@ -83,7 +83,7 @@ func NumPodsInTenantNs(networkingEnabled bool, role liqov1beta1.RoleType) int {
 	count := 0
 	// If the network is enabled, it should have the gateway pod.
 	if networkingEnabled {
-		count++
+		count += 3
 	}
 	// If the cluster is a consumer, it should have the virtual-kubelet pod.
 	if fcutils.IsConsumer(role) {


### PR DESCRIPTION
# Description

This PR adds support for HA (active/passive) in liqo gateways. The "gateway" container is now the only responsible for the lease acquisition and can start the "geneve" and "wireguard" containers using IPC.

The main changes are:
- added a "label" to target the active gateway pod (useful for gateway server services and to create internal network tunnels)
- added a "runnable" to add and remove the "label" from the active pod when it becomes the leader (using k8s lease)
- added an IPC (inter process communication) based on UNIX sockets shared between gateway containers

