### PR TITLE
fix: retrieve configuration resources by labels

### DIFF
--- a/pkg/liqo-controller-manager/authentication/forge/kubeconfig.go
+++ b/pkg/liqo-controller-manager/authentication/forge/kubeconfig.go
@@ -26,8 +26,8 @@ import (
 	identitymanager "github.com/liqotech/liqo/pkg/identityManager"
 )
 
-// GenerateKubeconfigSecretName generates the name of the kubeconfig secret associated to an identity.
-func GenerateKubeconfigSecretName(identity *authv1beta1.Identity) string {
+// generateKubeconfigSecretName generates the name of the kubeconfig secret associated to an identity.
+func generateKubeconfigSecretName(identity *authv1beta1.Identity) string {
 	return "kubeconfig-" + identity.Name
 }
 
@@ -39,7 +39,7 @@ func KubeconfigSecret(identity *authv1beta1.Identity) *corev1.Secret {
 			Kind:       "Secret",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      GenerateKubeconfigSecretName(identity),
+			Name:      generateKubeconfigSecretName(identity),
 			Namespace: identity.Namespace,
 		},
 	}

--- a/pkg/liqo-controller-manager/authentication/forge/nonce.go
+++ b/pkg/liqo-controller-manager/authentication/forge/nonce.go
@@ -22,8 +22,8 @@ import (
 	"github.com/liqotech/liqo/pkg/consts"
 )
 
-// GenerateNonceSecretName generates the name of the Secret object to store the nonce.
-func GenerateNonceSecretName() string {
+// generateNonceSecretName generates the name of the Secret object to store the nonce.
+func generateNonceSecretName() string {
 	return "liqo-nonce"
 }
 
@@ -35,7 +35,7 @@ func Nonce(tenantNamespace string) *corev1.Secret {
 			Kind:       "Secret",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      GenerateNonceSecretName(),
+			Name:      generateNonceSecretName(),
 			Namespace: tenantNamespace,
 		},
 	}

--- a/pkg/liqo-controller-manager/authentication/forge/signednonce.go
+++ b/pkg/liqo-controller-manager/authentication/forge/signednonce.go
@@ -22,8 +22,8 @@ import (
 	"github.com/liqotech/liqo/pkg/consts"
 )
 
-// GenerateSignedNonceSecretName generates the name of the Secret object to store the signed nonce.
-func GenerateSignedNonceSecretName() string {
+// generateSignedNonceSecretName generates the name of the Secret object to store the signed nonce.
+func generateSignedNonceSecretName() string {
 	return "liqo-signed-nonce"
 }
 
@@ -35,7 +35,7 @@ func SignedNonce(remoteClusterID liqov1beta1.ClusterID, tenantNamespace, nonce s
 			Kind:       "Secret",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      GenerateSignedNonceSecretName(),
+			Name:      generateSignedNonceSecretName(),
 			Namespace: tenantNamespace,
 			Labels: map[string]string{
 				consts.SignedNonceSecretLabelKey: "true",

--- a/pkg/liqo-controller-manager/networking/forge/configuration.go
+++ b/pkg/liqo-controller-manager/networking/forge/configuration.go
@@ -29,8 +29,8 @@ import (
 	ipamutils "github.com/liqotech/liqo/pkg/utils/ipam"
 )
 
-// DefaultConfigurationName returns the default name for a Configuration.
-func DefaultConfigurationName(remoteClusterID liqov1beta1.ClusterID) string {
+// defaultConfigurationName returns the default name for a Configuration.
+func defaultConfigurationName(remoteClusterID liqov1beta1.ClusterID) string {
 	return string(remoteClusterID)
 }
 
@@ -91,7 +91,7 @@ func ConfigurationForRemoteCluster(ctx context.Context, cl client.Client,
 			APIVersion: networkingv1beta1.GroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: DefaultConfigurationName(clusterID),
+			Name: defaultConfigurationName(clusterID),
 			Labels: map[string]string{
 				consts.RemoteClusterID: string(clusterID),
 			},

--- a/pkg/liqo-controller-manager/networking/utils/configuration.go
+++ b/pkg/liqo-controller-manager/networking/utils/configuration.go
@@ -12,26 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package configuration
+package utils
 
 import (
-	"context"
-
-	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
 	networkingv1beta1 "github.com/liqotech/liqo/apis/networking/v1beta1"
 )
 
 // IsConfigurationStatusSet check if a Configuration is ready by checking if its status is correctly set.
-func IsConfigurationStatusSet(ctx context.Context, cl client.Client, name, namespace string) (bool, error) {
-	conf := &networkingv1beta1.Configuration{}
-	if err := cl.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, conf); err != nil {
-		return false, err
-	}
-
-	return conf.Status.Remote != nil &&
-			conf.Status.Remote.CIDR.Pod.String() != "" &&
-			conf.Status.Remote.CIDR.External.String() != "",
-		nil
+func IsConfigurationStatusSet(confStatus networkingv1beta1.ConfigurationStatus) bool {
+	return confStatus.Remote != nil &&
+		confStatus.Remote.CIDR.Pod.String() != "" &&
+		confStatus.Remote.CIDR.External.String() != ""
 }

--- a/pkg/liqo-controller-manager/networking/utils/doc.go
+++ b/pkg/liqo-controller-manager/networking/utils/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package utils contains utility functions for the networking module.
+package utils

--- a/pkg/liqoctl/network/handler.go
+++ b/pkg/liqoctl/network/handler.go
@@ -103,12 +103,12 @@ func (o *Options) RunInit(ctx context.Context) error {
 
 	if o.Wait {
 		// Wait for cluster 1 to be ready.
-		if err := cluster1.waiter.ForConfiguration(ctx, cluster2.networkConfiguration); err != nil {
+		if err := cluster1.waiter.ForConfiguration(ctx, cluster2.localClusterID); err != nil {
 			return err
 		}
 
 		// Wait for cluster 2 to be ready.
-		if err := cluster2.waiter.ForConfiguration(ctx, cluster1.networkConfiguration); err != nil {
+		if err := cluster2.waiter.ForConfiguration(ctx, cluster1.localClusterID); err != nil {
 			return err
 		}
 	}
@@ -140,12 +140,12 @@ func (o *Options) RunReset(ctx context.Context) error {
 	}
 
 	// Delete Configuration on cluster 1
-	if err := cluster1.DeleteConfiguration(ctx, forge.DefaultConfigurationName(cluster2.localClusterID)); err != nil {
+	if err := cluster1.DeleteConfiguration(ctx, cluster2.localClusterID); err != nil {
 		return err
 	}
 
 	// Delete Configuration on cluster 2
-	return cluster2.DeleteConfiguration(ctx, forge.DefaultConfigurationName(cluster1.localClusterID))
+	return cluster2.DeleteConfiguration(ctx, cluster1.localClusterID)
 }
 
 // RunConnect connect two clusters using liqo networking.


### PR DESCRIPTION
# Description

This PR fixes a bug in Liqoctl where Configuration resources were retrieved by name instead of labels.

It also makes private the functions that forge default names on Kubeconfig, Nonce and SignedNonce resources.