### PR TITLE
fix: retrieve publickey resources by labels

### DIFF
--- a/pkg/liqo-controller-manager/networking/forge/publickey.go
+++ b/pkg/liqo-controller-manager/networking/forge/publickey.go
@@ -20,6 +20,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	liqov1beta1 "github.com/liqotech/liqo/apis/core/v1beta1"
@@ -29,20 +30,20 @@ import (
 	liqoutils "github.com/liqotech/liqo/pkg/utils"
 )
 
-// DefaultPublicKeyName returns the default name of a PublicKey.
-func DefaultPublicKeyName(remoteClusterID liqov1beta1.ClusterID) string {
+// defaultPublicKeyName returns the default name of a PublicKey.
+func defaultPublicKeyName(remoteClusterID liqov1beta1.ClusterID) string {
 	return string(remoteClusterID)
 }
 
 // PublicKey forges a PublicKey.
-func PublicKey(name, namespace string, remoteClusterID liqov1beta1.ClusterID, key []byte) (*networkingv1beta1.PublicKey, error) {
+func PublicKey(namespace string, name *string, remoteClusterID liqov1beta1.ClusterID, key []byte) (*networkingv1beta1.PublicKey, error) {
 	pubKey := &networkingv1beta1.PublicKey{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       networkingv1beta1.PublicKeyKind,
 			APIVersion: networkingv1beta1.GroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
+			Name:      ptr.Deref(name, defaultPublicKeyName(remoteClusterID)),
 			Namespace: namespace,
 			Labels: map[string]string{
 				consts.RemoteClusterID:      string(remoteClusterID),
@@ -88,7 +89,7 @@ func PublicKeyForRemoteCluster(ctx context.Context, cl client.Client,
 			APIVersion: networkingv1beta1.GroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: DefaultPublicKeyName(clusterID),
+			Name: defaultPublicKeyName(clusterID),
 			Labels: map[string]string{
 				consts.RemoteClusterID:      string(clusterID),
 				consts.GatewayResourceLabel: consts.GatewayResourceLabelValue,

--- a/pkg/liqoctl/rest/publickey/create.go
+++ b/pkg/liqoctl/rest/publickey/create.go
@@ -82,7 +82,7 @@ func (o *Options) Create(ctx context.Context, options *rest.CreateOptions) *cobr
 func (o *Options) handleCreate(ctx context.Context) error {
 	opts := o.createOptions
 
-	pubKey, err := forge.PublicKey(opts.Name, opts.Namespace, o.RemoteClusterID.GetClusterID(), o.PublicKey)
+	pubKey, err := forge.PublicKey(opts.Namespace, &opts.Name, o.RemoteClusterID.GetClusterID(), o.PublicKey)
 	if err != nil {
 		opts.Printer.CheckErr(err)
 		return err

--- a/pkg/utils/getters/k8sGetters.go
+++ b/pkg/utils/getters/k8sGetters.go
@@ -842,6 +842,26 @@ func GetGatewayClientByClusterID(ctx context.Context, cl client.Client,
 	}
 }
 
+// GetPublicKeyByClusterID returns the PublicKey resource with the given clusterID.
+func GetPublicKeyByClusterID(ctx context.Context, cl client.Client,
+	remoteClusterID liqov1beta1.ClusterID) (*networkingv1beta1.PublicKey, error) {
+	publicKeys, err := ListPublicKeysByLabel(ctx, cl, corev1.NamespaceAll, labels.SelectorFromSet(map[string]string{
+		consts.RemoteClusterID: string(remoteClusterID),
+	}))
+	if err != nil {
+		return nil, err
+	}
+
+	switch len(publicKeys.Items) {
+	case 0:
+		return nil, kerrors.NewNotFound(networkingv1beta1.PublicKeyGroupResource, networkingv1beta1.PublicKeyResource)
+	case 1:
+		return &publicKeys.Items[0], nil
+	default:
+		return nil, fmt.Errorf("multiple PublicKeys found for ForeignCluster %s", remoteClusterID)
+	}
+}
+
 // ListPhysicalNodes returns the list of physical nodes. (i.e. nodes not created by Liqo).
 func ListPhysicalNodes(ctx context.Context, cl client.Client) (*corev1.NodeList, error) {
 	req, err := labels.NewRequirement(consts.TypeLabel, selection.DoesNotExist, nil)


### PR DESCRIPTION
# Description

This PR fixes a bug in Liqoctl where PublicKey resources were retrieved by name instead of labels.
