### PR TITLE
fix: network status in ForeignCluster resource

### DIFF
--- a/apis/core/v1beta1/foreigncluster_types.go
+++ b/apis/core/v1beta1/foreigncluster_types.go
@@ -96,8 +96,11 @@ const (
 	APIServerStatusCondition ConditionType = "APIServerStatus"
 
 	// NETWORKING
+	// NetworkConfigurationStatusCondition tells whether the network configuration of the peer cluster is present.
+	NetworkConfigurationStatusCondition ConditionType = "NetworkConfigurationStatus"
 	// NetworkConnectionStatusCondition shows the network connection status.
 	NetworkConnectionStatusCondition ConditionType = "NetworkConnectionStatus"
+	NetworkGatewayPresenceCondition  ConditionType = "NetworkGatewayPresence"
 	// NetworkGatewayServerStatusCondition shows the network gateway server status.
 	NetworkGatewayServerStatusCondition ConditionType = "NetworkGatewayServerStatus"
 	// NetworkGatewayClientStatusCondition shows the network gateway client status.
@@ -139,7 +142,7 @@ const (
 // Condition contains details about state of a.
 type Condition struct {
 	// Type of the condition.
-	// +kubebuilder:validation:Enum="APIServerStatus";"NetworkConnectionStatus";"NetworkGatewayServerStatus";"NetworkGatewayClientStatus";"AuthIdentityControlPlaneStatus";"AuthTenantStatus";"OffloadingVirtualNodeStatus";"OffloadingNodeStatus"
+	// +kubebuilder:validation:Enum="APIServerStatus";"NetworkConnectionStatus";"NetworkGatewayServerStatus";"NetworkGatewayClientStatus";"NetworkGatewayPresence";"NetworkConfigurationStatus";"AuthIdentityControlPlaneStatus";"AuthTenantStatus";"OffloadingVirtualNodeStatus";"OffloadingNodeStatus"
 	//
 	//nolint:lll // ignore long lines given by Kubebuilder marker annotations
 	Type ConditionType `json:"type"`

--- a/deployments/liqo/charts/liqo-crds/crds/core.liqo.io_foreignclusters.yaml
+++ b/deployments/liqo/charts/liqo-crds/crds/core.liqo.io_foreignclusters.yaml
@@ -107,6 +107,8 @@ spec:
                       - NetworkConnectionStatus
                       - NetworkGatewayServerStatus
                       - NetworkGatewayClientStatus
+                      - NetworkGatewayPresence
+                      - NetworkConfigurationStatus
                       - AuthIdentityControlPlaneStatus
                       - AuthTenantStatus
                       - OffloadingVirtualNodeStatus
@@ -170,6 +172,8 @@ spec:
                               - NetworkConnectionStatus
                               - NetworkGatewayServerStatus
                               - NetworkGatewayClientStatus
+                              - NetworkGatewayPresence
+                              - NetworkConfigurationStatus
                               - AuthIdentityControlPlaneStatus
                               - AuthTenantStatus
                               - OffloadingVirtualNodeStatus
@@ -231,6 +235,8 @@ spec:
                               - NetworkConnectionStatus
                               - NetworkGatewayServerStatus
                               - NetworkGatewayClientStatus
+                              - NetworkGatewayPresence
+                              - NetworkConfigurationStatus
                               - AuthIdentityControlPlaneStatus
                               - AuthTenantStatus
                               - OffloadingVirtualNodeStatus
@@ -292,6 +298,8 @@ spec:
                               - NetworkConnectionStatus
                               - NetworkGatewayServerStatus
                               - NetworkGatewayClientStatus
+                              - NetworkGatewayPresence
+                              - NetworkConfigurationStatus
                               - AuthIdentityControlPlaneStatus
                               - AuthTenantStatus
                               - OffloadingVirtualNodeStatus

--- a/pkg/liqo-controller-manager/core/foreigncluster-controller/conditions.go
+++ b/pkg/liqo-controller-manager/core/foreigncluster-controller/conditions.go
@@ -24,6 +24,9 @@ const (
 	connectionErrorReason  = "ConnectionError"
 	connectionErrorMessage = "The network connection with the foreign cluster is in error"
 
+	connectionMissingReason  = "ConnectionMissing"
+	connectionMissingMessage = "There is no network connection with the foreign cluster"
+
 	gatewaysReadyReason  = "GatewaysReady"
 	gatewaysReadyMessage = "All gateway replicas are ready"
 
@@ -32,6 +35,18 @@ const (
 
 	gatewaysNotReadyReason  = "GatewaysNotReady"
 	gatewaysNotReadyMessage = "All gateway replicas are not ready"
+
+	gatewayMissingReason  = "GatewayMissing"
+	gatewayMissingMessage = "The gateway resource connecting to the foreign cluster is missing"
+
+	gatewayPresentReason  = "GatewayPresence"
+	gatewayPresentMessage = "There is a gateway connecting to the foreign cluster"
+
+	networkConfigurationPresenceReason  = "NetworkConfigurationPresence"
+	networkConfigurationPresenceMessage = "The network configuration of the peer cluster is present"
+
+	networkConfigurationMissingReason  = "NetworkConfigurationMissing"
+	networkConfigurationMissingMessage = "The network configuration for the connection with the foreign cluster is missing"
 
 	tenantReadyReason  = "TenantReady"
 	tenantReadyMessage = "The tenant has been successfully configured"

--- a/pkg/liqo-controller-manager/core/foreigncluster-controller/foreigncluster_controller.go
+++ b/pkg/liqo-controller-manager/core/foreigncluster-controller/foreigncluster_controller.go
@@ -170,6 +170,7 @@ func (r *ForeignClusterReconciler) SetupWithManager(mgr ctrl.Manager, workers in
 
 	return ctrl.NewControllerManagedBy(mgr).Named(consts.CtrlForeignCluster).
 		For(&liqov1beta1.ForeignCluster{}, builder.WithPredicates(foreignClusterPredicate)).
+		Watches(&networkingv1beta1.Configuration{}, handler.EnqueueRequestsFromMapFunc(r.foreignclusterEnqueuer)).
 		Watches(&networkingv1beta1.Connection{}, handler.EnqueueRequestsFromMapFunc(r.foreignclusterEnqueuer)).
 		Watches(&networkingv1beta1.GatewayServer{}, handler.EnqueueRequestsFromMapFunc(r.foreignclusterEnqueuer)).
 		Watches(&networkingv1beta1.GatewayClient{}, handler.EnqueueRequestsFromMapFunc(r.foreignclusterEnqueuer)).


### PR DESCRIPTION
# Description

This patch fixes the network status in the ForeignCluster resource. Previously, when the connection or the configuration were missing no conditions were shown, so who looked at the ForeignCluster status could think that everything is correctly configured.
Moreover, this patch makes the status check more robust, collecting all the errors first and only once we are sure that the module is enabled (there is at least a network resource present), it writes the errors in the status.