### PR TITLE
fix: avoid creation of VirtualNode if ResourceSlice deleting

### DIFF
--- a/pkg/liqo-controller-manager/virtualnodecreator-controller/virtualnodecreator_controller.go
+++ b/pkg/liqo-controller-manager/virtualnodecreator-controller/virtualnodecreator_controller.go
@@ -75,6 +75,11 @@ func (r *VirtualNodeCreatorReconciler) Reconcile(ctx context.Context, req ctrl.R
 		return ctrl.Result{}, err
 	}
 
+	if resourceSlice.DeletionTimestamp != nil {
+		klog.V(6).Infof("ResourceSlice %q is being deleted", req.NamespacedName)
+		return ctrl.Result{}, nil
+	}
+
 	if resourceSlice.Annotations == nil ||
 		resourceSlice.Annotations[consts.CreateVirtualNodeAnnotation] == "" ||
 		strings.EqualFold(resourceSlice.Annotations[consts.CreateVirtualNodeAnnotation], "false") {


### PR DESCRIPTION
# Description

This PR fixes a bug where the virtualnode resource was created even when the owner resourceslice was deleting.
This fix helps deleting the offloading when using GitOps tools like ArgoCD.
