### PR TITLE
[Feat] liqoctl gateway template check

### DIFF
--- a/cmd/liqoctl/cmd/network.go
+++ b/cmd/liqoctl/cmd/network.go
@@ -65,6 +65,7 @@ func newNetworkCommand(ctx context.Context, f *factory.Factory) *cobra.Command {
 
 	cmd.PersistentFlags().DurationVar(&options.Timeout, "timeout", 120*time.Second, "Timeout for completion")
 	cmd.PersistentFlags().BoolVar(&options.Wait, "wait", false, "Wait for completion")
+	cmd.PersistentFlags().BoolVar(&options.SkipValidation, "skip-validation", false, "Skip the validation")
 
 	options.LocalFactory.AddFlags(cmd.PersistentFlags(), cmd.RegisterFlagCompletionFunc)
 	options.RemoteFactory.AddFlags(cmd.PersistentFlags(), cmd.RegisterFlagCompletionFunc)
@@ -139,12 +140,7 @@ func newNetworkConnectCommand(ctx context.Context, options *network.Options) *co
 		Args:  cobra.NoArgs,
 
 		Run: func(_ *cobra.Command, _ []string) {
-			err := options.RunConnect(ctx)
-			if err != nil {
-				options.LocalFactory.Printer.CheckErr(
-					fmt.Errorf("`network connect` failed (error: %w). Issue `network disconnect` to cleanup the environment", err))
-			}
-			output.ExitOnErr(err)
+			output.ExitOnErr(options.RunConnect(ctx))
 		},
 	}
 
@@ -156,15 +152,15 @@ func newNetworkConnectCommand(ctx context.Context, options *network.Options) *co
 	cmd.Flags().StringVar(&options.ServerTemplateNamespace, "server-template-namespace", "",
 		"Namespace of the Gateway Server template")
 	cmd.Flags().Var(options.ServerServiceType, "server-service-type",
-		fmt.Sprintf("Service type of the Gateway Server. Default: %s."+
+		fmt.Sprintf("Service type of the Gateway Server service. Default: %s."+
 			" Note: use ClusterIP only if you know what you are doing and you have a proper network configuration",
 			forge.DefaultGwServerServiceType))
-	cmd.Flags().Int32Var(&options.ServerPort, "server-port", forge.DefaultGwServerPort,
-		fmt.Sprintf("Port of the Gateway Server. Default: %d", forge.DefaultGwServerPort))
-	cmd.Flags().Int32Var(&options.ServerNodePort, "node-port", 0,
-		"Force the NodePort of the Gateway Server. Leave empty to let Kubernetes allocate a random NodePort")
-	cmd.Flags().StringVar(&options.ServerLoadBalancerIP, "load-balancer-ip", "",
-		"Force LoadBalancer IP of the Gateway Server. Leave empty to use the one provided by the LoadBalancer provider")
+	cmd.Flags().Int32Var(&options.ServerServicePort, "server-service-port", forge.DefaultGwServerPort,
+		fmt.Sprintf("Port of the Gateway Server service. Default: %d", forge.DefaultGwServerPort))
+	cmd.Flags().Int32Var(&options.ServerServiceNodePort, "server-service-nodeport", 0,
+		"Force the NodePort of the Gateway Server service. Leave empty to let Kubernetes allocate a random NodePort")
+	cmd.Flags().StringVar(&options.ServerServiceLoadBalancerIP, "server-service-loadbalancerip", "",
+		"Force LoadBalancer IP of the Gateway Server service. Leave empty to use the one provided by the LoadBalancer provider")
 
 	// Client flags
 	cmd.Flags().StringVar(&options.ClientGatewayType, "client-type", forge.DefaultGwClientType,

--- a/cmd/liqoctl/cmd/peer.go
+++ b/cmd/liqoctl/cmd/peer.go
@@ -75,6 +75,7 @@ func newPeerCommand(ctx context.Context, f *factory.Factory) *cobra.Command {
 	}
 
 	cmd.PersistentFlags().DurationVar(&options.Timeout, "timeout", 10*time.Minute, "Timeout for peering completion")
+	cmd.PersistentFlags().BoolVar(&options.SkipValidation, "skip-validation", false, "Skip the validation")
 
 	options.LocalFactory.AddFlags(cmd.PersistentFlags(), cmd.RegisterFlagCompletionFunc)
 	options.RemoteFactory.AddFlags(cmd.PersistentFlags(), cmd.RegisterFlagCompletionFunc)
@@ -90,11 +91,15 @@ func newPeerCommand(ctx context.Context, f *factory.Factory) *cobra.Command {
 	// Networking flags
 	cmd.Flags().BoolVar(&options.NetworkingDisabled, "networking-disabled", false, "Disable networking between the two clusters")
 	cmd.Flags().Var(options.ServerServiceType, "server-service-type",
-		fmt.Sprintf("Service type of the Gateway Server. Default: %s."+
+		fmt.Sprintf("Service type of the Gateway Server service. Default: %s."+
 			" Note: use ClusterIP only if you know what you are doing and you have a proper network configuration",
 			nwforge.DefaultGwServerServiceType))
-	cmd.Flags().Int32Var(&options.ServerPort, "server-port", nwforge.DefaultGwServerPort,
-		fmt.Sprintf("Port of the Gateway Server. Default: %d", nwforge.DefaultGwServerPort))
+	cmd.Flags().Int32Var(&options.ServerServicePort, "server-service-port", nwforge.DefaultGwServerPort,
+		fmt.Sprintf("Port of the Gateway Server service. Default: %d", nwforge.DefaultGwServerPort))
+	cmd.Flags().Int32Var(&options.ServerServiceNodePort, "server-service-nodeport", 0,
+		"Force the NodePort of the Gateway Server service. Leave empty to let Kubernetes allocate a random NodePort")
+	cmd.Flags().StringVar(&options.ServerServiceLoadBalancerIP, "server-service-loadbalancerip", "",
+		"IP of the LoadBalancer for the Gateway Server service")
 	cmd.Flags().IntVar(&options.MTU, "mtu", nwforge.DefaultMTU,
 		fmt.Sprintf("MTU of the Gateway server and client. Default: %d", nwforge.DefaultMTU))
 

--- a/pkg/liqoctl/output/output.go
+++ b/pkg/liqoctl/output/output.go
@@ -264,6 +264,11 @@ func NewRemotePrinter(scoped, verbose bool) *Printer {
 	return newPrinter(remoteClusterName, remoteClusterColor, scoped, verbose)
 }
 
+// NewGlobalPrinter returns a new printer referring to the global scope.
+func NewGlobalPrinter(scoped, verbose bool) *Printer {
+	return newPrinter("global", pterm.FgDefault, scoped, verbose)
+}
+
 func newPrinter(scope string, color pterm.Color, scoped, verbose bool) *Printer {
 	generic := &pterm.PrefixPrinter{MessageStyle: pterm.NewStyle(pterm.FgDefault)}
 

--- a/pkg/utils/maps/maps.go
+++ b/pkg/utils/maps/maps.go
@@ -197,3 +197,24 @@ func SerializeMap(m map[string]string) string {
 func DeSerializeCache(s string) []string {
 	return strings.Split(s, ",")
 }
+
+// GetNestedField returns the nested field of a map.
+// Example: GetNestedField(map[string]any{"a": map[string]any{"b": "c"}}, "a.b") returns "c".
+func GetNestedField(m map[string]any, path string) (any, error) {
+	fields := strings.Split(path, ".")
+	current := m
+	for i, field := range fields {
+		next, ok := current[field]
+		if !ok {
+			return nil, fmt.Errorf("unable to get %s", strings.Join(fields[:i+1], "."))
+		}
+		if i == len(fields)-1 {
+			return next, nil
+		}
+		current, ok = next.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("unable to get %s", strings.Join(fields[:i+1], "."))
+		}
+	}
+	return current, nil
+}


### PR DESCRIPTION
# Description

This PR adds some checks in liqoctl (at peering time) about the gateway template used.
This checks are:
- template existence
- in case `--server-service-nodeport` flag has been specified, it checks if the template selected support static nodeports
- in case `--server-service-loadbalancerip` flag has been specified, it checks if the template selected support static load balancer ips
