### PR TITLE
[Feat] Add nodePort and loadbalancerIPAddress as optional fields in WG gateway template

### DIFF
--- a/deployments/liqo/templates/liqo-wireguard-gateway-server-template.yaml
+++ b/deployments/liqo/templates/liqo-wireguard-gateway-server-template.yaml
@@ -32,10 +32,12 @@ spec:
           selector:
             {{- include "liqo.labelsTemplate" (merge (dict "isService" true) $templateConfig) | nindent 12 }}
           type: "{{"{{ .Spec.Endpoint.ServiceType }}"}}"
+          ?loadBalancerIP: "{{"{{ .Spec.Endpoint.LoadBalancerIP }}"}}"
           ports:
           - port: "{{"{{ .Spec.Endpoint.Port }}"}}"
             protocol: UDP
             targetPort: "{{"{{ .Spec.Endpoint.Port }}"}}"
+            ?nodePort: "{{"{{ .Spec.Endpoint.NodePort }}"}}"
           {{- if .Values.networking.gatewayTemplates.server.service.allocateLoadBalancerNodePorts }}
           allocateLoadBalancerNodePorts: {{ .Values.networking.gatewayTemplates.server.service.allocateLoadBalancerNodePorts }}
           {{- end }}
@@ -81,8 +83,8 @@ spec:
                 {{- if .Values.requirements.kernel.disabled }}
                 - --disable-kernel-version-check
                 {{- end }}
-                volumeMounts: 
-                - name: ipc 
+                volumeMounts:
+                - name: ipc
                   mountPath: /ipc
                 {{- if .Values.metrics.enabled }}
                 ports:
@@ -135,7 +137,7 @@ spec:
                   privileged: true
                   {{ end }}
                 volumeMounts:
-                - name: ipc 
+                - name: ipc
                   mountPath: /ipc
                 - name: wireguard-config
                   mountPath: /etc/wireguard/keys
@@ -156,8 +158,8 @@ spec:
                 - --metrics-address=:8084
                 {{- end }}
                 - --health-probe-bind-address=:8085
-                volumeMounts: 
-                - name: ipc 
+                volumeMounts:
+                - name: ipc
                   mountPath: /ipc
                 {{- if .Values.metrics.enabled }}
                 ports:
@@ -184,6 +186,6 @@ spec:
               - name: wireguard-config
                 secret:
                   secretName: "{{"{{ .SecretName }}"}}"
-              - name: ipc 
-                emptyDir: {} 
+              - name: ipc
+                emptyDir: {}
 {{- end }}

--- a/pkg/liqo-controller-manager/networking/external-network/utils/template_test.go
+++ b/pkg/liqo-controller-manager/networking/external-network/utils/template_test.go
@@ -1,0 +1,216 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package utils_test
+
+import (
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/liqotech/liqo/pkg/liqo-controller-manager/networking/external-network/utils"
+)
+
+type sampleDataStructure struct {
+	Number         int
+	Value          string
+	OptionalString *string
+	OptionalNumber *int
+}
+
+type nestedSampleDataStructure struct {
+	Number         int
+	Value          string
+	OptionalString *string
+	OptionalNumber *int
+	Nested         sampleDataStructure
+}
+
+type testDataStructure struct {
+	Name      string
+	Namespace string
+	Spec      nestedSampleDataStructure
+}
+
+type templateTestCase struct {
+	template    any
+	expectedRes any
+	data        testDataStructure
+}
+
+var optionalNumber = 10
+var optionalString = "Mr. Jack!"
+var nestedOptionalString = "optionalVal"
+
+var _ = DescribeTable("Templating tests", func(testCase templateTestCase) {
+	res, err := utils.RenderTemplate(testCase.template, testCase.data, false)
+
+	Expect(err).NotTo(HaveOccurred())
+	Expect(testCase.expectedRes).To(Equal(res), "Unexpected result returned")
+},
+	Entry("Simple case", templateTestCase{
+		template: map[string]any{
+			"Name":      "{{ .Name }}",
+			"Namespace": "{{ .Namespace }}",
+		},
+		expectedRes: map[string]any{
+			"Name":      "hello",
+			"Namespace": "world!",
+		},
+		data: testDataStructure{
+			Name:      "hello",
+			Namespace: "world!",
+		},
+	}),
+	Entry("Labels and annotations should force string", templateTestCase{
+		template: map[string]any{
+			"labels": map[string]any{
+				"hello": "{{ .Namespace }}",
+				"test":  4,
+			},
+			"annotations": map[string]any{
+				"hello": "{{ .Name }}",
+				"test":  5,
+			},
+		},
+		expectedRes: map[string]any{
+			"labels": map[string]any{
+				"hello": "world!",
+				"test":  "4",
+			},
+			"annotations": map[string]any{
+				"hello": "hello",
+				"test":  "5",
+			},
+		},
+		data: testDataStructure{
+			Name:      "hello",
+			Namespace: "world!",
+		},
+	}),
+	Entry("Nested variables", templateTestCase{
+		template: map[string]any{
+			"Name": "{{ .Name }}",
+			"Nested": map[string]any{
+				"NestedVal": map[string]any{
+					"Value":  "{{ .Spec.Nested.Value }}",
+					"Number": "{{ .Spec.Nested.Number }}",
+				},
+				"ListVal": []any{
+					map[string]any{
+						"Another": "{{ .Spec.Value }}",
+					},
+					map[string]any{
+						"Number": "{{ .Spec.Number }}",
+					},
+				},
+			},
+		},
+		expectedRes: map[string]any{
+			"Name": "hello",
+			"Nested": map[string]any{
+				"NestedVal": map[string]any{
+					"Value":  "world!",
+					"Number": 1924,
+				},
+				"ListVal": []any{
+					map[string]any{
+						"Another": "value",
+					},
+					map[string]any{
+						"Number": 10,
+					},
+				},
+			},
+		},
+		data: testDataStructure{
+			Name: "hello",
+			Spec: nestedSampleDataStructure{
+				Value:  "value",
+				Number: 10,
+				Nested: sampleDataStructure{
+					Value:  "world!",
+					Number: 1924,
+				},
+			},
+		},
+	}),
+	Entry("Optional fields", templateTestCase{
+		template: map[string]any{
+			"Name":         "{{ .Name }}",
+			"?NotOptional": "This should be kept as is",
+			"Nested": map[string]any{
+				"NestedVal": map[string]any{
+					"Value":           "{{ .Spec.Nested.Value }}",
+					"?Optional":       "Some text plus variable {{ .Spec.Nested.OptionalString }}",
+					"?OptionalNumber": "{{ .Spec.Nested.OptionalNumber }}",
+				},
+				"ListVal": []any{
+					map[string]any{
+						"Another": "{{ .Spec.Value }}",
+						"?Hey":    "{{ .Spec.OptionalString }}",
+					},
+					map[string]any{
+						"number":                        "{{ .Spec.Number }}",
+						"?anotherNumber":                "{{ .Spec.OptionalNumber }}",
+						"?optionalDifferentThanPointer": "{{ .Spec.Value }}",
+					},
+				},
+			},
+		},
+		expectedRes: map[string]any{
+			"Name":         "hello",
+			"?NotOptional": "This should be kept as is",
+			"Nested": map[string]any{
+				"NestedVal": map[string]any{
+					"Value":          "world!",
+					"Optional":       fmt.Sprintf("Some text plus variable %s", nestedOptionalString),
+					"OptionalNumber": optionalNumber,
+				},
+				"ListVal": []any{
+					map[string]any{
+						"Another": "value",
+						"Hey":     optionalString,
+					},
+					map[string]any{
+						"number":                       42,
+						"optionalDifferentThanPointer": "value",
+					},
+				},
+			},
+		},
+		data: testDataStructure{
+			Name: "hello",
+			Spec: nestedSampleDataStructure{
+				Value:          "value",
+				Number:         42,
+				OptionalString: &optionalString,
+				Nested: sampleDataStructure{
+					Value:          "world!",
+					Number:         1924,
+					OptionalNumber: &optionalNumber,
+					OptionalString: &nestedOptionalString,
+				},
+			},
+		},
+	}),
+)
+
+func TestLocal(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "External network utils test suite")
+}


### PR DESCRIPTION
# Description

This PR introduces two features:

- Templates can now have optional fields, which are identified by a ? (question mark) at the beginning of their name: : when a field in a template starts with  the question mark and the value contains a variable, that field is rendered in the templateonly if that variable has a value.
- `nodePort` and `loadbalancerIPAddress` are now present by default in the WG gateway server template, allowing the user to specify them without the need to manually add them in the template.

# How Has This Been Tested?

Test suite has been provided
