### PR TITLE
fix: wggateway controllers pod watch

### DIFF
--- a/deployments/liqo/templates/_helpers.tpl
+++ b/deployments/liqo/templates/_helpers.tpl
@@ -97,6 +97,8 @@ helm.sh/chart: {{ quote (include "liqo.chart" .) }}
 app.kubernetes.io/version: {{ quote (include "liqo.version" .) }}
 app.kubernetes.io/managed-by: {{ quote .Release.Service }}
 networking.liqo.io/component: "gateway"
+networking.liqo.io/gateway-name: "{{"{{ .Name }}"}}"
+networking.liqo.io/gateway-namespace: "{{"{{ .Namespace }}"}}"
 {{- if .isService }}
 networking.liqo.io/active: "true"
 {{- end }}

--- a/pkg/liqo-controller-manager/networking/external-network/wireguard/utils.go
+++ b/pkg/liqo-controller-manager/networking/external-network/wireguard/utils.go
@@ -97,6 +97,34 @@ func clusterRoleBindingEnquerer(_ context.Context, obj client.Object) []ctrl.Req
 	}
 }
 
+func podEnquerer(_ context.Context, obj client.Object) []ctrl.Request {
+	pod, ok := obj.(*corev1.Pod)
+	if !ok {
+		return nil
+	}
+
+	if pod.Labels == nil {
+		return nil
+	}
+	gwName, ok := pod.Labels[consts.GatewayNameLabel]
+	if !ok {
+		return nil
+	}
+	gwNs, ok := pod.Labels[consts.GatewayNamespaceLabel]
+	if !ok {
+		return nil
+	}
+
+	return []ctrl.Request{
+		{
+			NamespacedName: types.NamespacedName{
+				Namespace: gwNs,
+				Name:      gwName,
+			},
+		},
+	}
+}
+
 // ensureKeysSecret ensure the presence of the private and public keys for the Wireguard interface and save them inside a Secret resource and Options.
 func ensureKeysSecret(ctx context.Context, cl client.Client, wgObj metav1.Object, mode gateway.Mode) error {
 	var controllerRef metav1.OwnerReference

--- a/pkg/liqo-controller-manager/networking/external-network/wireguard/wggatewayclient_controller.go
+++ b/pkg/liqo-controller-manager/networking/external-network/wireguard/wggatewayclient_controller.go
@@ -208,6 +208,7 @@ func (r *WgGatewayClientReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&networkingv1beta1.WgGatewayClient{}).
 		Owns(&appsv1.Deployment{}).
 		Owns(&corev1.ServiceAccount{}).
+		Watches(&corev1.Pod{}, handler.EnqueueRequestsFromMapFunc(podEnquerer)).
 		Watches(&rbacv1.ClusterRoleBinding{},
 			handler.EnqueueRequestsFromMapFunc(clusterRoleBindingEnquerer)).
 		Watches(&corev1.Secret{},

--- a/pkg/liqo-controller-manager/networking/external-network/wireguard/wggatewayserver_controller.go
+++ b/pkg/liqo-controller-manager/networking/external-network/wireguard/wggatewayserver_controller.go
@@ -224,6 +224,7 @@ func (r *WgGatewayServerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&appsv1.Deployment{}).
 		Owns(&corev1.Service{}).
 		Owns(&corev1.ServiceAccount{}).
+		Watches(&corev1.Pod{}, handler.EnqueueRequestsFromMapFunc(podEnquerer)).
 		Watches(&rbacv1.ClusterRoleBinding{},
 			handler.EnqueueRequestsFromMapFunc(clusterRoleBindingEnquerer)).
 		Watches(&corev1.Secret{},

--- a/test/e2e/cruise/network/network_test.go
+++ b/test/e2e/cruise/network/network_test.go
@@ -44,7 +44,7 @@ import (
 
 const (
 	// clustersRequired is the number of clusters required in this E2E test.
-	clustersRequired = 3
+	clustersRequired = 2
 	// testName is the name of this E2E test.
 	testName = "NETWORK"
 	// StressMax is the maximum number of stress iterations.


### PR DESCRIPTION
# Description

This PR fixes a bug about wireguard gateway server and client controllers. With the new leader election mechanism introduced to support HA on gateways these controllers need to be triggered when gateway pod labels change.