### PR TITLE
Metrics: changed port from 8080 to 8082

### DIFF
--- a/cmd/liqo-controller-manager/main.go
+++ b/cmd/liqo-controller-manager/main.go
@@ -100,7 +100,7 @@ func main() {
 
 	// Manager flags
 	webhookPort := pflag.Uint("webhook-port", 9443, "The port the webhook server binds to")
-	metricsAddr := pflag.String("metrics-address", ":8080", "The address the metric endpoint binds to")
+	metricsAddr := pflag.String("metrics-address", ":8082", "The address the metric endpoint binds to")
 	probeAddr := pflag.String("health-probe-address", ":8081", "The address the health probe endpoint binds to")
 	leaderElection := pflag.Bool("enable-leader-election", false, "Enable leader election for controller manager")
 

--- a/cmd/virtual-kubelet/root/flag.go
+++ b/cmd/virtual-kubelet/root/flag.go
@@ -72,7 +72,7 @@ func InstallFlags(flags *pflag.FlagSet, o *Opts) {
 	flags.StringVar(&o.RemoteRealLoadBalancerClassName, "remote-real-load-balancer-class-name", "",
 		"Name of the real load balancer class to use for the actual load balancer")
 	flags.BoolVar(&o.EnableMetrics, "metrics-enabled", false, "Enable the metrics server")
-	flags.StringVar(&o.MetricsAddress, "metrics-address", ":8080", "The address to listen to for metrics requests")
+	flags.StringVar(&o.MetricsAddress, "metrics-address", ":8082", "The address to listen to for metrics requests")
 	flags.StringVar(&o.HomeAPIServerHost, "home-api-server-host", "",
 		"Home cluster API server HOST, this parameter is optional and required only to override the default values")
 	flags.StringVar(&o.HomeAPIServerPort, "home-api-server-port", "",

--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -75,7 +75,7 @@ func init() {
 func main() {
 	// Manager flags
 	webhookPort := pflag.Uint("webhook-port", 9443, "The port the webhook server binds to")
-	metricsAddr := pflag.String("metrics-address", ":8080", "The address the metric endpoint binds to")
+	metricsAddr := pflag.String("metrics-address", ":8082", "The address the metric endpoint binds to")
 	probeAddr := pflag.String("health-probe-address", ":8081", "The address the health probe endpoint binds to")
 	leaderElection := pflag.Bool("enable-leader-election", false, "Enable leader election for the webhook pod")
 	secretName := pflag.String("secret-name", "", "The name of the secret containing the webhook certificates")

--- a/deployments/liqo/templates/liqo-controller-manager-deployment.yaml
+++ b/deployments/liqo/templates/liqo-controller-manager-deployment.yaml
@@ -164,7 +164,7 @@ spec:
           containerPort: 8081
           protocol: TCP
         - name: metrics
-          containerPort: 8080
+          containerPort: 8082
           protocol: TCP
         readinessProbe:
           httpGet:

--- a/deployments/liqo/templates/liqo-controller-manager-service.yaml
+++ b/deployments/liqo/templates/liqo-controller-manager-service.yaml
@@ -36,6 +36,6 @@ spec:
     {{- include "liqo.selectorLabels" $ctrlManagerConfig | nindent 4 }}
   ports:
   - name: metrics
-    port: 8080
+    port: 8082
     targetPort: metrics
 {{- end }}

--- a/deployments/liqo/templates/liqo-crd-replicator-deployment.yaml
+++ b/deployments/liqo/templates/liqo-crd-replicator-deployment.yaml
@@ -50,7 +50,7 @@ spec:
           resources: {{- toYaml .Values.crdReplicator.pod.resources | nindent 12 }}
           ports:
           - name: metrics
-            containerPort: 8080
+            containerPort: 8082
             protocol: TCP
       {{- if ((.Values.common).nodeSelector) }}
       nodeSelector:

--- a/deployments/liqo/templates/liqo-webhook-deployment.yaml
+++ b/deployments/liqo/templates/liqo-webhook-deployment.yaml
@@ -92,7 +92,7 @@ spec:
           containerPort: 8081
           protocol: TCP
         - name: metrics
-          containerPort: 8080
+          containerPort: 8082
           protocol: TCP
         readinessProbe:
           httpGet:

--- a/deployments/liqo/templates/liqo-webhook-service.yaml
+++ b/deployments/liqo/templates/liqo-webhook-service.yaml
@@ -42,6 +42,6 @@ spec:
     {{- end }}
   ports:
   - name: metrics
-    port: 8080
+    port: 8082
     targetPort: metrics
 {{- end }}

--- a/deployments/liqo/templates/liqo-wireguard-gateway-client-template.yaml
+++ b/deployments/liqo/templates/liqo-wireguard-gateway-client-template.yaml
@@ -52,9 +52,9 @@ spec:
                 - --container-name=gateway
                 - --concurrent-containers-names=wireguard,geneve
                 {{- if .Values.metrics.enabled }}
-                - --metrics-address=:8080
+                - --metrics-address=:8082
                 {{- end }}
-                - --health-probe-bind-address=:8081
+                - --health-probe-bind-address=:8083
                 - --ping-enabled=true
                 - --ping-loss-threshold={{ .Values.networking.gatewayTemplates.ping.lossThreshold }}
                 - --ping-interval={{ .Values.networking.gatewayTemplates.ping.interval }}
@@ -68,7 +68,7 @@ spec:
                   mountPath: /ipc
                 {{- if .Values.metrics.enabled }}
                 ports:
-                - containerPort: 8080
+                - containerPort: 8082
                   name: gw-metrics
                 {{- end }}
                 env:
@@ -100,13 +100,13 @@ spec:
                 - --endpoint-address={{"{{ index .Spec.Endpoint.Addresses 0 }}"}}
                 - --endpoint-port={{"{{ .Spec.Endpoint.Port }}"}}
                 {{- if .Values.metrics.enabled }}
-                - --metrics-address=:8082
+                - --metrics-address=:8084
                 {{- end }}
-                - --health-probe-bind-address=:8083
+                - --health-probe-bind-address=:8085
                 - --implementation={{ .Values.networking.gatewayTemplates.wireguard.implementation }}
                 {{- if .Values.metrics.enabled }}
                 ports:
-                - containerPort: 8082
+                - containerPort: 8084
                   name: wg-metrics
                 {{- end }}
                 securityContext:
@@ -136,15 +136,15 @@ spec:
                 - --container-name=geneve
                 - --geneve-port={{ .Values.networking.genevePort }}
                 {{- if .Values.metrics.enabled }}
-                - --metrics-address=:8084
+                - --metrics-address=:8086
                 {{- end }}
-                - --health-probe-bind-address=:8085
+                - --health-probe-bind-address=:8087
                 volumeMounts: 
                 - name: ipc 
                   mountPath: /ipc
                 {{- if .Values.metrics.enabled }}
                 ports:
-                - containerPort: 8084
+                - containerPort: 8086
                   name: gv-metrics
                 {{- end }} 
                 env:

--- a/deployments/liqo/templates/liqo-wireguard-gateway-server-template-eks.yaml
+++ b/deployments/liqo/templates/liqo-wireguard-gateway-server-template-eks.yaml
@@ -79,9 +79,9 @@ spec:
                 - --container-name=gateway
                 - --concurrent-containers-names=wireguard,geneve
                 {{- if .Values.metrics.enabled }}
-                - --metrics-address=:8080
+                - --metrics-address=:8082
                 {{- end }}
-                - --health-probe-bind-address=:8081
+                - --health-probe-bind-address=:8083
                 - --ping-enabled=true
                 - --ping-loss-threshold={{ .Values.networking.gatewayTemplates.ping.lossThreshold }}
                 - --ping-interval={{ .Values.networking.gatewayTemplates.ping.interval }}
@@ -95,7 +95,7 @@ spec:
                   mountPath: /ipc
                 {{- if .Values.metrics.enabled }}
                 ports:
-                - containerPort: 8080
+                - containerPort: 8082
                   name: gw-metrics
                 {{- end }}
                 env:
@@ -126,13 +126,13 @@ spec:
                 - --mtu={{"{{ .Spec.MTU }}"}}
                 - --listen-port={{"{{ .Spec.Endpoint.Port }}"}}
                 {{- if .Values.metrics.enabled }}
-                - --metrics-address=:8082
+                - --metrics-address=:8084
                 {{- end }}
-                - --health-probe-bind-address=:8083
+                - --health-probe-bind-address=:8085
                 - --implementation={{ .Values.networking.gatewayTemplates.wireguard.implementation }}
                 {{- if .Values.metrics.enabled }}
                 ports:
-                - containerPort: 8082
+                - containerPort: 8084
                   name: wg-metrics
                 {{- end }}
                 securityContext:
@@ -162,15 +162,15 @@ spec:
                 - --container-name=geneve
                 - --geneve-port={{ .Values.networking.genevePort }}
                 {{- if .Values.metrics.enabled }}
-                - --metrics-address=:8084
+                - --metrics-address=:8086
                 {{- end }}
-                - --health-probe-bind-address=:8085
+                - --health-probe-bind-address=:8086
                 volumeMounts: 
                 - name: ipc 
                   mountPath: /ipc
                 {{- if .Values.metrics.enabled }}
                 ports:
-                - containerPort: 8084
+                - containerPort: 8086
                   name: gv-metrics
                 {{- end }}
                 env:

--- a/deployments/liqo/templates/liqo-wireguard-gateway-server-template.yaml
+++ b/deployments/liqo/templates/liqo-wireguard-gateway-server-template.yaml
@@ -72,9 +72,9 @@ spec:
                 - --container-name=gateway
                 - --concurrent-containers-names=wireguard,geneve
                 {{- if .Values.metrics.enabled }}
-                - --metrics-address=:8080
+                - --metrics-address=:8084
                 {{- end }}
-                - --health-probe-bind-address=:8081
+                - --health-probe-bind-address=:8085
                 - --ping-enabled=true
                 - --ping-loss-threshold={{ .Values.networking.gatewayTemplates.ping.lossThreshold }}
                 - --ping-interval={{ .Values.networking.gatewayTemplates.ping.interval }}
@@ -88,7 +88,7 @@ spec:
                   mountPath: /ipc
                 {{- if .Values.metrics.enabled }}
                 ports:
-                - containerPort: 8080
+                - containerPort: 8084
                   name: gw-metrics
                 {{- end }}
                 env:
@@ -155,15 +155,15 @@ spec:
                 - --container-name=geneve
                 - --geneve-port={{ .Values.networking.genevePort }}
                 {{- if .Values.metrics.enabled }}
-                - --metrics-address=:8084
+                - --metrics-address=:8086
                 {{- end }}
-                - --health-probe-bind-address=:8085
+                - --health-probe-bind-address=:8087
                 volumeMounts:
                 - name: ipc
                   mountPath: /ipc
                 {{- if .Values.metrics.enabled }}
                 ports:
-                - containerPort: 8084
+                - containerPort: 8086
                   name: gv-metrics
                 {{- end }}
                 env:

--- a/examples/networking/wireguard-client-default.yaml
+++ b/examples/networking/wireguard-client-default.yaml
@@ -41,7 +41,7 @@ spec:
                 - --remote-cluster-id={{ .ClusterID }}
                 - --gateway-uid={{ .GatewayUID }}
                 - --mode=client
-                - --metrics-address=:8080
+                - --metrics-address=:8082
                 - --health-probe-bind-address=:8081
                 - --ping-enabled=true
                 - --ping-loss-threshold=5

--- a/examples/networking/wireguard-client-high-availability.yaml
+++ b/examples/networking/wireguard-client-high-availability.yaml
@@ -49,7 +49,7 @@ spec:
                 - --remote-cluster-id={{ .ClusterID }}
                 - --gateway-uid={{ .GatewayUID }}
                 - --mode=client
-                - --metrics-address=:8080
+                - --metrics-address=:8082
                 - --health-probe-bind-address=:8081
                 - --ping-enabled=true
                 - --ping-loss-threshold=5

--- a/examples/networking/wireguard-client-pingdisabled.yaml
+++ b/examples/networking/wireguard-client-pingdisabled.yaml
@@ -41,7 +41,7 @@ spec:
                 - --remote-cluster-id={{ .ClusterID }}
                 - --gateway-uid={{ .GatewayUID }}
                 - --mode=client
-                - --metrics-address=:8080
+                - --metrics-address=:8082
                 - --health-probe-bind-address=:8081
                 - --ping-enabled=false
                 image: ghcr.io/liqotech/gateway:<VERSION>

--- a/examples/networking/wireguard-client-selector.yaml
+++ b/examples/networking/wireguard-client-selector.yaml
@@ -50,7 +50,7 @@ spec:
                 - --remote-cluster-id={{ .ClusterID }}
                 - --gateway-uid={{ .GatewayUID }}
                 - --mode=client
-                - --metrics-address=:8080
+                - --metrics-address=:8082
                 - --health-probe-bind-address=:8081
                 - --ping-enabled=true
                 - --ping-loss-threshold=5

--- a/examples/networking/wireguard-server-default.yaml
+++ b/examples/networking/wireguard-server-default.yaml
@@ -41,7 +41,7 @@ spec:
                 - --remote-cluster-id={{ .ClusterID }}
                 - --gateway-uid={{ .GatewayUID }}
                 - --mode=server
-                - --metrics-address=:8080
+                - --metrics-address=:8082
                 - --health-probe-bind-address=:8081
                 - --ping-enabled=true
                 - --ping-loss-threshold=5

--- a/examples/networking/wireguard-server-high-availability.yaml
+++ b/examples/networking/wireguard-server-high-availability.yaml
@@ -49,7 +49,7 @@ spec:
                 - --remote-cluster-id={{ .ClusterID }}
                 - --gateway-uid={{ .GatewayUID }}
                 - --mode=server
-                - --metrics-address=:8080
+                - --metrics-address=:8082
                 - --health-probe-bind-address=:8081
                 - --ping-enabled=true
                 - --ping-loss-threshold=5

--- a/examples/networking/wireguard-server-overridetargetport.yaml
+++ b/examples/networking/wireguard-server-overridetargetport.yaml
@@ -41,7 +41,7 @@ spec:
                 - --remote-cluster-id={{ .ClusterID }}
                 - --gateway-uid={{ .GatewayUID }}
                 - --mode=server
-                - --metrics-address=:8080
+                - --metrics-address=:8082
                 - --health-probe-bind-address=:8081
                 - --ping-enabled=true
                 - --ping-loss-threshold=5

--- a/examples/networking/wireguard-server-pingdisabled.yaml
+++ b/examples/networking/wireguard-server-pingdisabled.yaml
@@ -41,7 +41,7 @@ spec:
                 - --remote-cluster-id={{ .ClusterID }}
                 - --gateway-uid={{ .GatewayUID }}
                 - --mode=server
-                - --metrics-address=:8080
+                - --metrics-address=:8082
                 - --health-probe-bind-address=:8081
                 - --ping-enabled=false
                 image: ghcr.io/liqotech/gateway:<VERSION>

--- a/examples/networking/wireguard-server-selector.yaml
+++ b/examples/networking/wireguard-server-selector.yaml
@@ -50,7 +50,7 @@ spec:
                 - --remote-cluster-id={{ .ClusterID }}
                 - --gateway-uid={{ .GatewayUID }}
                 - --mode=server
-                - --metrics-address=:8080
+                - --metrics-address=:8082
                 - --health-probe-bind-address=:8081
                 - --ping-enabled=true
                 - --ping-loss-threshold=5

--- a/pkg/fabric/flags.go
+++ b/pkg/fabric/flags.go
@@ -62,7 +62,7 @@ func InitFlags(flagset *pflag.FlagSet, opts *Options) {
 	flagset.StringVar(&opts.NodeName, FlagNameNodeName.String(), "", "Name of the node where the pod is scheduled")
 	flagset.StringVar(&opts.PodName, "podname", "", "Name of the pod")
 
-	flagset.StringVar(&opts.MetricsAddress, FlagNameMetricsAddress.String(), ":8080", "Address for the metrics endpoint")
+	flagset.StringVar(&opts.MetricsAddress, FlagNameMetricsAddress.String(), ":8082", "Address for the metrics endpoint")
 	flagset.StringVar(&opts.ProbeAddr, FlagNameProbeAddr.String(), ":8081", "Address for the health probe endpoint")
 
 	flagset.BoolVar(&opts.DisableARP, FlagNameDisableARP.String(), false, "Disable ARP")

--- a/pkg/vkMachinery/const.go
+++ b/pkg/vkMachinery/const.go
@@ -43,4 +43,4 @@ var ClusterRoleBindingLabels = map[string]string{
 }
 
 // MetricsAddress is the default address used to expose metrics.
-const MetricsAddress = ":8080"
+const MetricsAddress = ":8082"


### PR DESCRIPTION
# Description

This PR changes the ports used for metrics from 8080 to 8082. This is useful to avoid using port 8080 with host network pods, as port 8080 should be used by another service on the host.
