### PR TITLE
Add global labels and annotations to liqo-created resources

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -40,16 +40,20 @@ import (
 	"github.com/liqotech/liqo/pkg/gateway/connection/conncheck"
 	"github.com/liqotech/liqo/pkg/liqo-controller-manager/networking/external-network/remapping"
 	"github.com/liqotech/liqo/pkg/route"
+	argsutils "github.com/liqotech/liqo/pkg/utils/args"
 	flagsutils "github.com/liqotech/liqo/pkg/utils/flags"
 	"github.com/liqotech/liqo/pkg/utils/kernel"
 	kernelversion "github.com/liqotech/liqo/pkg/utils/kernel/version"
 	"github.com/liqotech/liqo/pkg/utils/mapper"
+	"github.com/liqotech/liqo/pkg/utils/resource"
 	"github.com/liqotech/liqo/pkg/utils/restcfg"
 )
 
 var (
-	connoptions *connection.Options
-	scheme      = runtime.NewScheme()
+	connoptions       *connection.Options
+	scheme            = runtime.NewScheme()
+	globalLabels      argsutils.StringMap
+	globalAnnotations argsutils.StringMap
 )
 
 func init() {
@@ -83,6 +87,10 @@ func main() {
 
 	connection.InitFlags(cmd.Flags(), connoptions)
 
+	// Register the flags for setting global labels and annotations
+	cmd.Flags().Var(&globalLabels, "global-labels", "Global labels to be added to all created resources (key=value)")
+	cmd.Flags().Var(&globalAnnotations, "global-annotations", "Global annotations to be added to all created resources (key=value)")
+
 	if err := cmd.Execute(); err != nil {
 		klog.Error(err)
 		os.Exit(1)
@@ -111,6 +119,10 @@ func run(cmd *cobra.Command, _ []string) error {
 
 	// Set controller-runtime logger.
 	log.SetLogger(klog.NewKlogr())
+
+	// Initialize global labels from flag
+	resource.SetGlobalLabels(globalLabels.StringMap)
+	resource.SetGlobalAnnotations(globalAnnotations.StringMap)
 
 	// Get the rest config.
 	cfg := config.GetConfigOrDie()

--- a/cmd/liqo-controller-manager/main.go
+++ b/cmd/liqo-controller-manager/main.go
@@ -62,6 +62,7 @@ import (
 	"github.com/liqotech/liqo/pkg/utils/indexer"
 	ipamips "github.com/liqotech/liqo/pkg/utils/ipam/mapping"
 	"github.com/liqotech/liqo/pkg/utils/mapper"
+	"github.com/liqotech/liqo/pkg/utils/resource"
 	"github.com/liqotech/liqo/pkg/utils/restcfg"
 )
 
@@ -88,6 +89,8 @@ func main() {
 	var defaultNodeResources argsutils.ResourceMap
 	var gatewayServerResources argsutils.StringList
 	var gatewayClientResources argsutils.StringList
+	var globalLabels argsutils.StringMap
+	var globalAnnotations argsutils.StringMap
 	var apiServerAddressOverride string
 	var caOverride string
 	var trustedCA bool
@@ -149,6 +152,10 @@ func main() {
 	pflag.Var(&ingressClasses, "ingress-classes", "List of ingress classes offered by the cluster. Example: \"nginx;default,traefik\"")
 	pflag.Var(&loadBalancerClasses, "load-balancer-classes", "List of load balancer classes offered by the cluster. Example:\"metallb;default\"")
 	pflag.Var(&defaultNodeResources, "default-node-resources", "Default resources assigned to the Virtual Node Pod")
+	pflag.Var(&globalLabels, "global-labels",
+		"The set of labels that will be added to all resources created by Liqo controllers")
+	pflag.Var(&globalAnnotations, "global-annotations",
+		"The set of annotations that will be added to all resources created by Liqo controllers")
 
 	// OFFLOADING MODULE
 	// Storage Provisioner parameters
@@ -197,6 +204,10 @@ func main() {
 	factory := &dynamicutils.RunnableFactory{
 		DynamicSharedInformerFactory: dynamicinformer.NewFilteredDynamicSharedInformerFactory(dynClient, 0, corev1.NamespaceAll, nil),
 	}
+
+	// Initialize global labels from flag
+	resource.SetGlobalLabels(globalLabels.StringMap)
+	resource.SetGlobalAnnotations(globalAnnotations.StringMap)
 
 	// Create the main manager.
 	mgr, err := ctrl.NewManager(config, ctrl.Options{

--- a/cmd/liqoctl/cmd/root.go
+++ b/cmd/liqoctl/cmd/root.go
@@ -43,6 +43,7 @@ import (
 	"github.com/liqotech/liqo/pkg/liqoctl/rest/resourceslice"
 	"github.com/liqotech/liqo/pkg/liqoctl/rest/tenant"
 	"github.com/liqotech/liqo/pkg/liqoctl/rest/virtualnode"
+	"github.com/liqotech/liqo/pkg/utils/resource"
 )
 
 var liqoctl string
@@ -120,6 +121,10 @@ func NewRootCommand(ctx context.Context) *cobra.Command {
 	// Add the flags regarding Kubernetes access options.
 	f.AddFlags(cmd.PersistentFlags(), cmd.RegisterFlagCompletionFunc)
 	cmd.PersistentFlags().BoolVar(&f.SkipConfirm, "skip-confirm", false, "Skip the confirmation prompt (suggested for automation)")
+	cmd.PersistentFlags().StringToStringVar(&f.GlobalLabels, "global-labels", nil,
+		"Global labels to be added to all created resources (key=value)")
+	cmd.PersistentFlags().StringToStringVar(&f.GlobalAnnotations, "global-annotations", nil,
+		"Global annotations to be added to all created resources (key=value)")
 
 	cmd.AddCommand(newInstallCommand(ctx, f))
 	cmd.AddCommand(newUninstallCommand(ctx, f))
@@ -160,6 +165,8 @@ func WithTemplate(str string) string {
 func singleClusterPersistentPreRun(_ *cobra.Command, f *factory.Factory, opts ...factory.Options) {
 	// Populate the factory fields based on the configured parameters.
 	f.Printer.CheckErr(f.Initialize(opts...))
+	resource.SetGlobalLabels(f.GlobalLabels)
+	resource.SetGlobalAnnotations(f.GlobalAnnotations)
 }
 
 // twoClustersPersistentPreRun initializes both the local and the remote factory.

--- a/deployments/liqo/README.md
+++ b/deployments/liqo/README.md
@@ -13,6 +13,8 @@
 | authentication.enabled | bool | `true` | Enable/Disable the authentication module. |
 | common.affinity | object | `{}` | Affinity for all liqo pods, excluding virtual kubelet. |
 | common.extraArgs | list | `[]` | Extra arguments for all liqo pods, excluding virtual kubelet. |
+| common.globalAnnotations | object | `{}` | Global annotations to be added to all resources created by Liqo controllers |
+| common.globalLabels | object | `{"liqo.io/managed":"true"}` | Global labels to be added to all resources created by Liqo controllers |
 | common.nodeSelector | object | `{}` | NodeSelector for all liqo pods, excluding virtual kubelet. |
 | common.tolerations | list | `[]` | Tolerations for all liqo pods, excluding virtual kubelet. |
 | controllerManager.config.defaultLimitsEnforcement | string | `"None"` | It enforces offerer-side that offloaded pods do not exceed offered limits. This feature is suggested to be enabled when consumer-side enforcement is not sufficient. It has the same tradeoffs of resource quotas (i.e, it requires all offloaded pods to have resource limits set). Possible values are: None, Soft, Hard. None: no enforcement is applied. Soft: request <= limit. Hard: request == limit. |

--- a/deployments/liqo/templates/liqo-controller-manager-deployment.yaml
+++ b/deployments/liqo/templates/liqo-controller-manager-deployment.yaml
@@ -56,6 +56,14 @@ spec:
           - --default-limits-enforcement={{ .Values.controllerManager.config.defaultLimitsEnforcement }}
           {{- $d := dict "commandName" "--default-node-resources" "dictionary" .Values.offloading.defaultNodeResources -}}
           {{- include "liqo.concatenateMap" $d | nindent 10 }}
+          {{- if .Values.common.globalAnnotations }}
+          {{- $d := dict "commandName" "--global-annotations" "dictionary" .Values.common.globalAnnotations -}}
+          {{- include "liqo.concatenateMap" $d | nindent 10 }}
+          {{- end }}
+          {{- if .Values.common.globalLabels }}
+          {{- $d := dict "commandName" "--global-labels" "dictionary" .Values.common.globalLabels -}}
+          {{- include "liqo.concatenateMap" $d | nindent 10 }}
+          {{- end }}
           {{- if .Values.authentication.awsConfig.accessKeyId }}
           - --aws-access-key-id=$(ACCESS_KEY_ID)
           {{- end }}

--- a/deployments/liqo/templates/liqo-fabric-daemonset.yaml
+++ b/deployments/liqo/templates/liqo-fabric-daemonset.yaml
@@ -49,6 +49,14 @@ spec:
           - --disable-kernel-version-check
           {{- end }}
           - --enable-nft-monitor={{ .Values.networking.fabric.config.nftablesMonitor }}
+          {{- if .Values.common.globalAnnotations }}
+          {{- $d := dict "commandName" "--global-annotations" "dictionary" .Values.common.globalAnnotations -}}
+          {{- include "liqo.concatenateMap" $d | nindent 10 }}
+          {{- end }}
+          {{- if .Values.common.globalLabels }}
+          {{- $d := dict "commandName" "--global-labels" "dictionary" .Values.common.globalLabels -}}
+          {{- include "liqo.concatenateMap" $d | nindent 10 }}
+          {{- end }}
           {{- if .Values.common.extraArgs }}
           {{- toYaml .Values.common.extraArgs | nindent 10 }}
           {{- end }}

--- a/deployments/liqo/templates/liqo-wireguard-gateway-client-template.yaml
+++ b/deployments/liqo/templates/liqo-wireguard-gateway-client-template.yaml
@@ -51,6 +51,14 @@ spec:
                 - --mode=client
                 - --container-name=gateway
                 - --concurrent-containers-names=wireguard,geneve
+                {{- if .Values.common.globalAnnotations }}
+                {{- $d := dict "commandName" "--global-annotations" "dictionary" .Values.common.globalAnnotations -}}
+                {{- include "liqo.concatenateMap" $d | nindent 16 }}
+                {{- end }}
+                {{- if .Values.common.globalLabels }}
+                {{- $d := dict "commandName" "--global-labels" "dictionary" .Values.common.globalLabels -}}
+                {{- include "liqo.concatenateMap" $d | nindent 16 }}
+                {{- end }}
                 {{- if .Values.metrics.enabled }}
                 - --metrics-address=:8082
                 {{- end }}

--- a/deployments/liqo/templates/liqo-wireguard-gateway-server-template-eks.yaml
+++ b/deployments/liqo/templates/liqo-wireguard-gateway-server-template-eks.yaml
@@ -78,6 +78,14 @@ spec:
                 - --mode=server
                 - --container-name=gateway
                 - --concurrent-containers-names=wireguard,geneve
+                {{- if .Values.common.globalAnnotations }}
+                {{- $d := dict "commandName" "--global-annotations" "dictionary" .Values.common.globalAnnotations -}}
+                {{- include "liqo.concatenateMap" $d | nindent 16 }}
+                {{- end }}
+                {{- if .Values.common.globalLabels }}
+                {{- $d := dict "commandName" "--global-labels" "dictionary" .Values.common.globalLabels -}}
+                {{- include "liqo.concatenateMap" $d | nindent 16 }}
+                {{- end }}
                 {{- if .Values.metrics.enabled }}
                 - --metrics-address=:8082
                 {{- end }}

--- a/deployments/liqo/templates/liqo-wireguard-gateway-server-template.yaml
+++ b/deployments/liqo/templates/liqo-wireguard-gateway-server-template.yaml
@@ -71,6 +71,14 @@ spec:
                 - --mode=server
                 - --container-name=gateway
                 - --concurrent-containers-names=wireguard,geneve
+                {{- if .Values.common.globalAnnotations }}
+                {{- $d := dict "commandName" "--global-annotations" "dictionary" .Values.common.globalAnnotations -}}
+                {{- include "liqo.concatenateMap" $d | nindent 16 }}
+                {{- end }}
+                {{- if .Values.common.globalLabels }}
+                {{- $d := dict "commandName" "--global-labels" "dictionary" .Values.common.globalLabels -}}
+                {{- include "liqo.concatenateMap" $d | nindent 16 }}
+                {{- end }}
                 {{- if .Values.metrics.enabled }}
                 - --metrics-address=:8084
                 {{- end }}

--- a/deployments/liqo/values.yaml
+++ b/deployments/liqo/values.yaml
@@ -301,6 +301,11 @@ common:
   affinity: {}
   # -- Extra arguments for all liqo pods, excluding virtual kubelet.
   extraArgs: []
+  # -- Global labels to be added to all resources created by Liqo controllers
+  globalLabels:
+    liqo.io/managed: "true"
+  # -- Global annotations to be added to all resources created by Liqo controllers
+  globalAnnotations: {}
 
 controllerManager:
   # -- The number of controller-manager instances to run, which can be increased for active/passive high availability.

--- a/pkg/gateway/tunnel/wireguard/k8s.go
+++ b/pkg/gateway/tunnel/wireguard/k8s.go
@@ -24,12 +24,12 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	networkingv1beta1 "github.com/liqotech/liqo/apis/networking/v1beta1"
 	"github.com/liqotech/liqo/pkg/consts"
 	"github.com/liqotech/liqo/pkg/gateway"
 	"github.com/liqotech/liqo/pkg/gateway/forge"
+	"github.com/liqotech/liqo/pkg/utils/resource"
 )
 
 // CheckKeysSecret checks if the keys secret exists and if it contains the private and public keys.
@@ -62,7 +62,7 @@ func CreateKeysSecret(ctx context.Context, cl client.Client, opts *gateway.Optio
 		},
 	}
 
-	if _, err := controllerutil.CreateOrUpdate(ctx, cl, secret, func() error {
+	if _, err := resource.CreateOrUpdate(ctx, cl, secret, func() error {
 		secret.SetLabels(map[string]string{
 			string(consts.RemoteClusterID):      opts.RemoteClusterID,
 			string(consts.GatewayResourceLabel): string(consts.GatewayResourceLabelValue),
@@ -93,7 +93,7 @@ func EnsureConnection(ctx context.Context, cl client.Client, scheme *runtime.Sch
 
 	klog.Infof("Creating connection %q", conn.Name)
 
-	_, err := controllerutil.CreateOrUpdate(ctx, cl, conn, func() error {
+	_, err := resource.CreateOrUpdate(ctx, cl, conn, func() error {
 		if err := gateway.SetOwnerReferenceWithMode(opts.GwOptions, conn, scheme); err != nil {
 			return err
 		}

--- a/pkg/identityManager/certificateIdentityProvider.go
+++ b/pkg/identityManager/certificateIdentityProvider.go
@@ -31,7 +31,6 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	authv1beta1 "github.com/liqotech/liqo/apis/authentication/v1beta1"
 	"github.com/liqotech/liqo/pkg/consts"
@@ -39,6 +38,7 @@ import (
 	tenantnamespace "github.com/liqotech/liqo/pkg/tenantNamespace"
 	"github.com/liqotech/liqo/pkg/utils/apiserver"
 	certificateSigningRequest "github.com/liqotech/liqo/pkg/utils/csr"
+	"github.com/liqotech/liqo/pkg/utils/resource"
 )
 
 // random package initialization.
@@ -205,7 +205,7 @@ func (identityProvider *certificateIdentityProvider) storeRemoteCertificate(ctx 
 		},
 	}
 
-	_, err := controllerutil.CreateOrUpdate(ctx, identityProvider.cl, secret, func() error {
+	_, err := resource.CreateOrUpdate(ctx, identityProvider.cl, secret, func() error {
 		if secret.Labels == nil {
 			secret.Labels = map[string]string{}
 		}

--- a/pkg/identityManager/iamIdentityProvider.go
+++ b/pkg/identityManager/iamIdentityProvider.go
@@ -34,12 +34,12 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	authv1beta1 "github.com/liqotech/liqo/apis/authentication/v1beta1"
 	"github.com/liqotech/liqo/pkg/consts"
 	responsetypes "github.com/liqotech/liqo/pkg/identityManager/responseTypes"
 	"github.com/liqotech/liqo/pkg/liqo-controller-manager/authentication"
+	"github.com/liqotech/liqo/pkg/utils/resource"
 )
 
 const (
@@ -445,7 +445,7 @@ func (identityProvider *iamIdentityProvider) storeRemoteCertificate(ctx context.
 		},
 	}
 
-	_, err := controllerutil.CreateOrUpdate(ctx, identityProvider.cl, secret, func() error {
+	_, err := resource.CreateOrUpdate(ctx, identityProvider.cl, secret, func() error {
 		if secret.Labels == nil {
 			secret.Labels = map[string]string{}
 		}

--- a/pkg/liqo-controller-manager/authentication/identity-controller/identity_controller.go
+++ b/pkg/liqo-controller-manager/authentication/identity-controller/identity_controller.go
@@ -31,6 +31,7 @@ import (
 	"github.com/liqotech/liqo/pkg/consts"
 	"github.com/liqotech/liqo/pkg/liqo-controller-manager/authentication"
 	"github.com/liqotech/liqo/pkg/liqo-controller-manager/authentication/forge"
+	"github.com/liqotech/liqo/pkg/utils/resource"
 )
 
 // NewIdentityReconciler returns a new IdentityReconciler.
@@ -111,7 +112,7 @@ func (r *IdentityReconciler) ensureKubeconfigSecret(ctx context.Context, identit
 
 	// Create or update the secret containing the kubeconfig.
 	kubeconfigSecret := forge.KubeconfigSecret(identity)
-	op, err := controllerutil.CreateOrUpdate(ctx, r.Client, kubeconfigSecret, func() error {
+	op, err := resource.CreateOrUpdate(ctx, r.Client, kubeconfigSecret, func() error {
 		if err := forge.MutateKubeconfigSecret(kubeconfigSecret, identity, privateKey, namespace); err != nil {
 			return err
 		}

--- a/pkg/liqo-controller-manager/authentication/identitycreator-controller/identitycreator_controller.go
+++ b/pkg/liqo-controller-manager/authentication/identitycreator-controller/identitycreator_controller.go
@@ -35,6 +35,7 @@ import (
 	"github.com/liqotech/liqo/pkg/consts"
 	"github.com/liqotech/liqo/pkg/liqo-controller-manager/authentication"
 	"github.com/liqotech/liqo/pkg/liqo-controller-manager/authentication/forge"
+	"github.com/liqotech/liqo/pkg/utils/resource"
 )
 
 // NewIdentityCreatorReconciler returns a new IdentityCreatorReconciler.
@@ -107,7 +108,7 @@ func (r *IdentityCreatorReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 	// Create or update the Identity resource.
 	identity := forge.Identity(forge.ResourceSliceIdentityName(&resourceSlice), resourceSlice.Namespace)
-	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, identity, func() error {
+	if _, err := resource.CreateOrUpdate(ctx, r.Client, identity, func() error {
 		forge.MutateIdentity(identity, *resourceSlice.Spec.ProviderClusterID, authv1beta1.ResourceSliceIdentityType,
 			resourceSlice.Status.AuthParams, nil)
 		if identity.Labels == nil {

--- a/pkg/liqo-controller-manager/authentication/keys.go
+++ b/pkg/liqo-controller-manager/authentication/keys.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/liqotech/liqo/pkg/consts"
+	"github.com/liqotech/liqo/pkg/utils/resource"
 )
 
 // GenerateEd25519Keys returns a new pair of private and public keys in PEM format.
@@ -89,7 +90,9 @@ func InitClusterKeys(ctx context.Context, cl client.Client, liqoNamespace string
 				consts.PublicKeyField:  public,
 			},
 		}
-		if err := cl.Create(ctx, &secret); err != nil {
+		if _, err := resource.CreateOrUpdate(ctx, cl, &secret, func() error {
+			return nil
+		}); err != nil {
 			return fmt.Errorf("error while creating secret %s/%s: %w", liqoNamespace, consts.AuthKeysSecretName, err)
 		}
 		klog.Infof("Created Secret (%s/%s) containing cluster authentication keys", liqoNamespace, consts.AuthKeysSecretName)

--- a/pkg/liqo-controller-manager/ipmapping/configuration_controller.go
+++ b/pkg/liqo-controller-manager/ipmapping/configuration_controller.go
@@ -34,6 +34,7 @@ import (
 	"github.com/liqotech/liqo/pkg/consts"
 	"github.com/liqotech/liqo/pkg/ipam/utils"
 	configuration "github.com/liqotech/liqo/pkg/liqo-controller-manager/networking/external-network/configuration"
+	"github.com/liqotech/liqo/pkg/utils/resource"
 )
 
 // cluster-role
@@ -111,7 +112,7 @@ func (r *ConfigurationReconciler) createOrUpdateUnknownSourceIPResource(ctx cont
 			},
 		},
 	}
-	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, ip, func() error {
+	if _, err := resource.CreateOrUpdate(ctx, r.Client, ip, func() error {
 		ip.Spec = ipamv1alpha1.IPSpec{
 			IP: networkingv1beta1.IP(remoteUnknownSourceIP),
 		}

--- a/pkg/liqo-controller-manager/ipmapping/k8s.go
+++ b/pkg/liqo-controller-manager/ipmapping/k8s.go
@@ -27,6 +27,7 @@ import (
 
 	ipamv1alpha1 "github.com/liqotech/liqo/apis/ipam/v1alpha1"
 	networkingv1beta1 "github.com/liqotech/liqo/apis/networking/v1beta1"
+	"github.com/liqotech/liqo/pkg/utils/resource"
 )
 
 // CreateOrUpdateIP creates or updates an IP resource for the given pod.
@@ -37,7 +38,7 @@ func CreateOrUpdateIP(ctx context.Context, cl client.Client, scheme *runtime.Sch
 			Namespace: pod.Namespace,
 		},
 	}
-	if _, err := controllerutil.CreateOrUpdate(ctx, cl, ip, mutateIP(ip, pod, scheme)); err != nil {
+	if _, err := resource.CreateOrUpdate(ctx, cl, ip, mutateIP(ip, pod, scheme)); err != nil {
 		return fmt.Errorf("unable to create or update IP %q: %w", ip.Name, err)
 	}
 	return nil

--- a/pkg/liqo-controller-manager/networking/external-network/client-operator/client_controller.go
+++ b/pkg/liqo-controller-manager/networking/external-network/client-operator/client_controller.go
@@ -36,6 +36,7 @@ import (
 	"github.com/liqotech/liqo/pkg/consts"
 	enutils "github.com/liqotech/liqo/pkg/liqo-controller-manager/networking/external-network/utils"
 	dynamicutils "github.com/liqotech/liqo/pkg/utils/dynamic"
+	"github.com/liqotech/liqo/pkg/utils/resource"
 )
 
 // ClientReconciler manage GatewayClient lifecycle.
@@ -208,6 +209,8 @@ func (r *ClientReconciler) EnsureGatewayClient(ctx context.Context, gwClient *ne
 			objChildMetadata["labels"] = labels
 		}
 
+		resource.AddGlobalLabels(objChild)
+
 		var objectTemplateMetadataAnnotations interface{}
 		if objectTemplateMetadataAnnotations, ok = objectTemplateMetadata["annotations"]; ok {
 			annotations, err := enutils.RenderTemplate(objectTemplateMetadataAnnotations, td, true)
@@ -216,6 +219,8 @@ func (r *ClientReconciler) EnsureGatewayClient(ctx context.Context, gwClient *ne
 			}
 			objChildMetadata["annotations"] = annotations
 		}
+
+		resource.AddGlobalAnnotations(objChild)
 
 		objChild.SetOwnerReferences([]metav1.OwnerReference{
 			{

--- a/pkg/liqo-controller-manager/networking/external-network/configuration/label.go
+++ b/pkg/liqo-controller-manager/networking/external-network/configuration/label.go
@@ -19,11 +19,11 @@ import (
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/labels"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	networkingv1beta1 "github.com/liqotech/liqo/apis/networking/v1beta1"
 	"github.com/liqotech/liqo/pkg/consts"
+	"github.com/liqotech/liqo/pkg/utils/resource"
 )
 
 // LabelCIDRType is the label used to target a ipamv1alpha1.Network resource that manages a PodCIDR or an ExternalCIDR.
@@ -75,7 +75,7 @@ const (
 
 // SetConfigurationConfigured sets the Configured label of the given configuration to true.
 func SetConfigurationConfigured(ctx context.Context, cl client.Client, cfg *networkingv1beta1.Configuration) error {
-	_, err := ctrl.CreateOrUpdate(ctx, cl, cfg, func() error {
+	_, err := resource.CreateOrUpdate(ctx, cl, cfg, func() error {
 		if cfg.Labels == nil {
 			cfg.Labels = map[string]string{}
 		}

--- a/pkg/liqo-controller-manager/networking/external-network/configuration/network.go
+++ b/pkg/liqo-controller-manager/networking/external-network/configuration/network.go
@@ -27,6 +27,7 @@ import (
 	networkingv1beta1 "github.com/liqotech/liqo/apis/networking/v1beta1"
 	"github.com/liqotech/liqo/pkg/utils/events"
 	"github.com/liqotech/liqo/pkg/utils/getters"
+	"github.com/liqotech/liqo/pkg/utils/resource"
 )
 
 // ForgeNetworkMetadata creates the metadata of a ipamv1alpha1.Network resource.
@@ -92,7 +93,7 @@ func CreateOrGetNetwork(ctx context.Context, cl client.Client, scheme *runtime.S
 		return nil, err
 	}
 
-	if _, err := ctrlutil.CreateOrUpdate(ctx, cl, network, func() error {
+	if _, err := resource.CreateOrUpdate(ctx, cl, network, func() error {
 		return ForgeNetwork(network, cfg, cidrType, scheme)
 	}); err != nil {
 		return nil, err

--- a/pkg/liqo-controller-manager/networking/external-network/remapping/cidr.go
+++ b/pkg/liqo-controller-manager/networking/external-network/remapping/cidr.go
@@ -29,6 +29,7 @@ import (
 	"github.com/liqotech/liqo/apis/networking/v1beta1/firewall"
 	"github.com/liqotech/liqo/pkg/consts"
 	"github.com/liqotech/liqo/pkg/gateway/tunnel"
+	"github.com/liqotech/liqo/pkg/utils/resource"
 )
 
 // CIDRType is the type of the CIDR.
@@ -60,7 +61,7 @@ func CreateOrUpdateNatMappingCIDR(ctx context.Context, cl client.Client, opts *O
 
 	klog.Infof("Creating firewall configuration %q for %q", fwcfg.Name, cidrtype)
 
-	if _, err := controllerutil.CreateOrUpdate(
+	if _, err := resource.CreateOrUpdate(
 		ctx, cl, fwcfg,
 		mutateCIDRFirewallConfiguration(fwcfg, cfg, opts, scheme, cidrtype),
 	); err != nil {

--- a/pkg/liqo-controller-manager/networking/external-network/remapping/ip.go
+++ b/pkg/liqo-controller-manager/networking/external-network/remapping/ip.go
@@ -23,13 +23,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	ipamv1alpha1 "github.com/liqotech/liqo/apis/ipam/v1alpha1"
 	networkingv1beta1 "github.com/liqotech/liqo/apis/networking/v1beta1"
 	"github.com/liqotech/liqo/apis/networking/v1beta1/firewall"
 	"github.com/liqotech/liqo/pkg/consts"
 	ipamutils "github.com/liqotech/liqo/pkg/utils/ipam"
+	"github.com/liqotech/liqo/pkg/utils/resource"
 )
 
 func generateNatMappingIPGwName(ip *ipamv1alpha1.IP) string {
@@ -48,10 +48,7 @@ func CreateOrUpdateNatMappingIP(ctx context.Context, cl client.Client, ip *ipamv
 			Namespace: ip.Namespace,
 		},
 	}
-	_, err := controllerutil.CreateOrUpdate(
-		ctx, cl, fwcfg,
-		mutateFirewallConfiguration(fwcfg, ip),
-	)
+	_, err := resource.CreateOrUpdate(ctx, cl, fwcfg, mutateFirewallConfiguration(fwcfg, ip))
 
 	if ip.Spec.Masquerade != nil && *ip.Spec.Masquerade {
 		fwcfgMasq := &networkingv1beta1.FirewallConfiguration{
@@ -60,10 +57,7 @@ func CreateOrUpdateNatMappingIP(ctx context.Context, cl client.Client, ip *ipamv
 				Namespace: ip.Namespace,
 			},
 		}
-		_, err = controllerutil.CreateOrUpdate(
-			ctx, cl, fwcfgMasq,
-			mutateFirewallConfigurationMasquerade(fwcfgMasq, ip),
-		)
+		_, err = resource.CreateOrUpdate(ctx, cl, fwcfgMasq, mutateFirewallConfigurationMasquerade(fwcfgMasq, ip))
 	}
 
 	return err

--- a/pkg/liqo-controller-manager/networking/external-network/route/configuration_controller.go
+++ b/pkg/liqo-controller-manager/networking/external-network/route/configuration_controller.go
@@ -75,7 +75,7 @@ func (r *ConfigurationReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 	klog.V(4).Infof("Reconciling configuration %s", req.String())
 
-	return ctrl.Result{}, enforeRouteConfigurationPresence(ctx, r.Client, r.Scheme, conf)
+	return ctrl.Result{}, enforceRouteConfigurationPresence(ctx, r.Client, r.Scheme, conf)
 }
 
 // SetupWithManager register the ConfigurationReconciler to the manager.

--- a/pkg/liqo-controller-manager/networking/external-network/route/k8s.go
+++ b/pkg/liqo-controller-manager/networking/external-network/route/k8s.go
@@ -31,6 +31,7 @@ import (
 	"github.com/liqotech/liqo/pkg/gateway"
 	"github.com/liqotech/liqo/pkg/gateway/tunnel"
 	"github.com/liqotech/liqo/pkg/utils/getters"
+	"github.com/liqotech/liqo/pkg/utils/resource"
 )
 
 // GenerateRouteConfigurationName generates the name of the RouteConfiguration object.
@@ -51,7 +52,7 @@ func GetRemoteClusterID(cfg *networkingv1beta1.Configuration) (liqov1beta1.Clust
 }
 
 // enforceRouteConfigurationPresence creates or updates a RouteConfiguration object.
-func enforeRouteConfigurationPresence(ctx context.Context, cl client.Client, scheme *runtime.Scheme,
+func enforceRouteConfigurationPresence(ctx context.Context, cl client.Client, scheme *runtime.Scheme,
 	cfg *networkingv1beta1.Configuration) error {
 	remoteClusterID, err := GetRemoteClusterID(cfg)
 	if err != nil {
@@ -84,7 +85,7 @@ func enforeRouteConfigurationPresence(ctx context.Context, cl client.Client, sch
 		return err
 	}
 
-	_, err = controllerutil.CreateOrUpdate(ctx, cl, routecfg,
+	_, err = resource.CreateOrUpdate(ctx, cl, routecfg,
 		forgeMutateRouteConfiguration(cfg, routecfg, scheme, remoteClusterID, remoteInterfaceIP, internalNodes))
 	return err
 }

--- a/pkg/liqo-controller-manager/networking/external-network/server-operator/server_controller.go
+++ b/pkg/liqo-controller-manager/networking/external-network/server-operator/server_controller.go
@@ -36,6 +36,7 @@ import (
 	"github.com/liqotech/liqo/pkg/consts"
 	enutils "github.com/liqotech/liqo/pkg/liqo-controller-manager/networking/external-network/utils"
 	dynamicutils "github.com/liqotech/liqo/pkg/utils/dynamic"
+	"github.com/liqotech/liqo/pkg/utils/resource"
 )
 
 // ServerReconciler manage GatewayServer lifecycle.
@@ -208,6 +209,8 @@ func (r *ServerReconciler) EnsureGatewayServer(ctx context.Context, gwServer *ne
 			objChildMetadata["labels"] = labels
 		}
 
+		resource.AddGlobalLabels(objChild)
+
 		var objectTemplateMetadataAnnotations interface{}
 		if objectTemplateMetadataAnnotations, ok = objectTemplateMetadata["annotations"]; ok {
 			annotations, err := enutils.RenderTemplate(objectTemplateMetadataAnnotations, td, true)
@@ -216,6 +219,8 @@ func (r *ServerReconciler) EnsureGatewayServer(ctx context.Context, gwServer *ne
 			}
 			objChildMetadata["annotations"] = annotations
 		}
+
+		resource.AddGlobalAnnotations(objChild)
 
 		objChild.SetOwnerReferences([]metav1.OwnerReference{
 			{

--- a/pkg/liqo-controller-manager/networking/external-network/utils/metrics.go
+++ b/pkg/liqo-controller-manager/networking/external-network/utils/metrics.go
@@ -31,6 +31,7 @@ import (
 
 	networkingv1beta1 "github.com/liqotech/liqo/apis/networking/v1beta1"
 	mapsutil "github.com/liqotech/liqo/pkg/utils/maps"
+	"github.com/liqotech/liqo/pkg/utils/resource"
 )
 
 // EnsureMetrics ensures that the metrics service and service monitor are created or deleted.
@@ -119,7 +120,7 @@ func createMetricsService(ctx context.Context,
 			Namespace: owner.GetNamespace(),
 		},
 	}
-	_, err := controllerutil.CreateOrUpdate(ctx, cl, &svc, func() error {
+	_, err := resource.CreateOrUpdate(ctx, cl, &svc, func() error {
 		// Forge metadata
 		mapsutil.SmartMergeLabels(&svc, metrics.Service.Metadata.GetLabels())
 		mapsutil.SmartMergeAnnotations(&svc, metrics.Service.Metadata.GetAnnotations())
@@ -142,7 +143,7 @@ func createMetricsServiceMonitor(ctx context.Context,
 			Namespace: owner.GetNamespace(),
 		},
 	}
-	_, err := controllerutil.CreateOrUpdate(ctx, cl, &svcMonitor, func() error {
+	_, err := resource.CreateOrUpdate(ctx, cl, &svcMonitor, func() error {
 		// Forge metadata
 		mapsutil.SmartMergeLabels(&svcMonitor, metrics.ServiceMonitor.Metadata.GetLabels())
 		mapsutil.SmartMergeAnnotations(&svcMonitor, metrics.ServiceMonitor.Metadata.GetAnnotations())

--- a/pkg/liqo-controller-manager/networking/external-network/utils/rbac.go
+++ b/pkg/liqo-controller-manager/networking/external-network/utils/rbac.go
@@ -28,6 +28,7 @@ import (
 
 	networkingv1beta1 "github.com/liqotech/liqo/apis/networking/v1beta1"
 	"github.com/liqotech/liqo/pkg/consts"
+	"github.com/liqotech/liqo/pkg/utils/resource"
 )
 
 // DeleteClusterRoleBinding deletes the cluster role bindings owned by the given object.
@@ -69,7 +70,7 @@ func EnsureServiceAccountAndClusterRoleBinding(ctx context.Context, cl client.Cl
 			Namespace: namespace,
 		},
 	}
-	if _, err := controllerutil.CreateOrUpdate(ctx, cl, sa, func() error {
+	if _, err := resource.CreateOrUpdate(ctx, cl, sa, func() error {
 		return controllerutil.SetControllerReference(owner, sa, s)
 	}); err != nil {
 		klog.Errorf("error while creating service account %q: %v", saName, err)
@@ -82,7 +83,7 @@ func EnsureServiceAccountAndClusterRoleBinding(ctx context.Context, cl client.Cl
 			Name: fmt.Sprintf("%s-%s-%s", clusterRoleName, namespace, name),
 		},
 	}
-	if _, err := controllerutil.CreateOrUpdate(ctx, cl, crb, func() error {
+	if _, err := resource.CreateOrUpdate(ctx, cl, crb, func() error {
 		if crb.Labels == nil {
 			crb.Labels = make(map[string]string)
 		}

--- a/pkg/liqo-controller-manager/networking/external-network/wireguard/wggatewayclient_controller.go
+++ b/pkg/liqo-controller-manager/networking/external-network/wireguard/wggatewayclient_controller.go
@@ -42,6 +42,7 @@ import (
 	"github.com/liqotech/liqo/pkg/gateway/forge"
 	enutils "github.com/liqotech/liqo/pkg/liqo-controller-manager/networking/external-network/utils"
 	mapsutil "github.com/liqotech/liqo/pkg/utils/maps"
+	"github.com/liqotech/liqo/pkg/utils/resource"
 )
 
 // WgGatewayClientReconciler manage WgGatewayClient lifecycle.
@@ -224,7 +225,7 @@ func (r *WgGatewayClientReconciler) ensureDeployment(ctx context.Context, wgClie
 		Namespace: depNsName.Namespace,
 	}}
 
-	op, err := controllerutil.CreateOrUpdate(ctx, r.Client, &dep, func() error {
+	op, err := resource.CreateOrUpdate(ctx, r.Client, &dep, func() error {
 		return r.mutateFnWgClientDeployment(&dep, wgClient)
 	})
 	if err != nil {

--- a/pkg/liqo-controller-manager/networking/external-network/wireguard/wggatewayserver_controller.go
+++ b/pkg/liqo-controller-manager/networking/external-network/wireguard/wggatewayserver_controller.go
@@ -43,6 +43,7 @@ import (
 	enutils "github.com/liqotech/liqo/pkg/liqo-controller-manager/networking/external-network/utils"
 	"github.com/liqotech/liqo/pkg/utils"
 	mapsutil "github.com/liqotech/liqo/pkg/utils/maps"
+	"github.com/liqotech/liqo/pkg/utils/resource"
 )
 
 // WgGatewayServerReconciler manage WgGatewayServer lifecycle.
@@ -240,7 +241,7 @@ func (r *WgGatewayServerReconciler) ensureDeployment(ctx context.Context, wgServ
 		Namespace: depNsName.Namespace,
 	}}
 
-	op, err := controllerutil.CreateOrUpdate(ctx, r.Client, &dep, func() error {
+	op, err := resource.CreateOrUpdate(ctx, r.Client, &dep, func() error {
 		return r.mutateFnWgServerDeployment(&dep, wgServer)
 	})
 	if err != nil {
@@ -259,7 +260,7 @@ func (r *WgGatewayServerReconciler) ensureService(ctx context.Context, wgServer 
 		Namespace: svcNsName.Namespace,
 	}}
 
-	op, err := controllerutil.CreateOrUpdate(ctx, r.Client, &svc, func() error {
+	op, err := resource.CreateOrUpdate(ctx, r.Client, &svc, func() error {
 		return r.mutateFnWgServerService(&svc, wgServer)
 	})
 	if err != nil {

--- a/pkg/liqo-controller-manager/networking/internal-network/client-controller/client_controller.go
+++ b/pkg/liqo-controller-manager/networking/internal-network/client-controller/client_controller.go
@@ -33,6 +33,7 @@ import (
 	"github.com/liqotech/liqo/pkg/liqo-controller-manager/networking/internal-network/fabricipam"
 	"github.com/liqotech/liqo/pkg/utils"
 	"github.com/liqotech/liqo/pkg/utils/getters"
+	"github.com/liqotech/liqo/pkg/utils/resource"
 )
 
 // ClientReconciler manage GatewayClient lifecycle.
@@ -93,6 +94,7 @@ func (r *ClientReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res
 	return ctrl.Result{}, nil
 }
 
+// ensureInternalFabric ensures the InternalFabric is correctly configured.
 func (r *ClientReconciler) ensureInternalFabric(ctx context.Context, gwClient *networkingv1beta1.GatewayClient,
 	configuration *networkingv1beta1.Configuration, remoteClusterID liqov1beta1.ClusterID, ipam *fabricipam.IPAM) error {
 	if configuration.Status.Remote == nil {
@@ -108,7 +110,7 @@ func (r *ClientReconciler) ensureInternalFabric(ctx context.Context, gwClient *n
 			Namespace: gwClient.Namespace,
 		},
 	}
-	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, internalFabric, func() error {
+	if _, err := resource.CreateOrUpdate(ctx, r.Client, internalFabric, func() error {
 		var err error
 		if internalFabric.Labels == nil {
 			internalFabric.Labels = make(map[string]string)

--- a/pkg/liqo-controller-manager/networking/internal-network/configuration-controller/firewall.go
+++ b/pkg/liqo-controller-manager/networking/internal-network/configuration-controller/firewall.go
@@ -28,6 +28,7 @@ import (
 	firewallapi "github.com/liqotech/liqo/apis/networking/v1beta1/firewall"
 	"github.com/liqotech/liqo/pkg/fabric"
 	"github.com/liqotech/liqo/pkg/ipam/utils"
+	"github.com/liqotech/liqo/pkg/utils/resource"
 )
 
 func (r *ConfigurationReconciler) ensureFirewallConfiguration(ctx context.Context,
@@ -38,7 +39,7 @@ func (r *ConfigurationReconciler) ensureFirewallConfiguration(ctx context.Contex
 			Namespace: cfg.GetNamespace(),
 		},
 	}
-	_, err := controllerutil.CreateOrUpdate(ctx, r.Client, firewall, forgeMutateFirewallConfiguration(firewall, cfg, r.Scheme, opts))
+	_, err := resource.CreateOrUpdate(ctx, r.Client, firewall, forgeMutateFirewallConfiguration(firewall, cfg, r.Scheme, opts))
 	if err != nil {
 		return err
 	}

--- a/pkg/liqo-controller-manager/networking/internal-network/gw-masq-bypass/k8s.go
+++ b/pkg/liqo-controller-manager/networking/internal-network/gw-masq-bypass/k8s.go
@@ -30,6 +30,7 @@ import (
 	networkingv1beta1 "github.com/liqotech/liqo/apis/networking/v1beta1"
 	"github.com/liqotech/liqo/apis/networking/v1beta1/firewall"
 	"github.com/liqotech/liqo/pkg/fabric"
+	"github.com/liqotech/liqo/pkg/utils/resource"
 )
 
 // generateGatewayMasqueradeBypassFirewallConfigurationName generates the name of the firewall configuration for the given node.
@@ -56,7 +57,7 @@ func enforceFirewallPodPresence(ctx context.Context, cl client.Client, scheme *r
 		ObjectMeta: metav1.ObjectMeta{Name: generateFirewallConfigurationName(pod.Spec.NodeName), Namespace: opts.Namespace},
 	}
 
-	op, err := controllerutil.CreateOrUpdate(ctx, cl, fwcfg, forgeFirewallPodUpdateFunction(internalnode, fwcfg, pod, scheme, opts.GenevePort))
+	op, err := resource.CreateOrUpdate(ctx, cl, fwcfg, forgeFirewallPodUpdateFunction(internalnode, fwcfg, pod, scheme, opts.GenevePort))
 
 	return op, err
 }
@@ -76,7 +77,7 @@ func enforceFirewallPodAbsence(ctx context.Context, cl client.Client, opts *Opti
 		return fmt.Errorf("unable to get firewall configuration %s: %w", fwcfg.GetName(), err)
 	}
 
-	if _, err := controllerutil.CreateOrUpdate(ctx, cl, &fwcfg, forgeFirewallPodDeleteFunction(pod, &fwcfg)); err != nil {
+	if _, err := resource.CreateOrUpdate(ctx, cl, &fwcfg, forgeFirewallPodDeleteFunction(pod, &fwcfg)); err != nil {
 		return fmt.Errorf("unable to update firewall configuration %s: %w", fwcfg.GetName(), err)
 	}
 

--- a/pkg/liqo-controller-manager/networking/internal-network/internalfabric-controller/genevetunnel.go
+++ b/pkg/liqo-controller-manager/networking/internal-network/internalfabric-controller/genevetunnel.go
@@ -28,6 +28,7 @@ import (
 	networkingv1beta1 "github.com/liqotech/liqo/apis/networking/v1beta1"
 	"github.com/liqotech/liqo/pkg/consts"
 	"github.com/liqotech/liqo/pkg/liqo-controller-manager/networking/internal-network/id"
+	"github.com/liqotech/liqo/pkg/utils/resource"
 )
 
 func geneveTunnelName(internalFabric *networkingv1beta1.InternalFabric, internalNode *networkingv1beta1.InternalNode) string {
@@ -101,7 +102,7 @@ func ensureGeneveTunnels(ctx context.Context, cl client.Client, s *runtime.Schem
 			},
 		}
 
-		if _, err := controllerutil.CreateOrUpdate(ctx, cl, tunnel, func() error {
+		if _, err := resource.CreateOrUpdate(ctx, cl, tunnel, func() error {
 			if err := mutateGeneveTunnel(ctx, cl, tunnel, internalFabric, node); err != nil {
 				klog.Errorf("Unable to mutate GeneveTunnel %q: %s", client.ObjectKeyFromObject(tunnel).String(), err)
 				return err

--- a/pkg/liqo-controller-manager/networking/internal-network/internalfabric-controller/route.go
+++ b/pkg/liqo-controller-manager/networking/internal-network/internalfabric-controller/route.go
@@ -28,6 +28,7 @@ import (
 
 	networkingv1beta1 "github.com/liqotech/liqo/apis/networking/v1beta1"
 	"github.com/liqotech/liqo/pkg/fabric"
+	"github.com/liqotech/liqo/pkg/utils/resource"
 )
 
 func (r *InternalFabricReconciler) ensureRouteConfiguration(ctx context.Context, internalFabric *networkingv1beta1.InternalFabric) error {
@@ -41,7 +42,7 @@ func (r *InternalFabricReconciler) ensureRouteConfiguration(ctx context.Context,
 			Namespace: internalFabric.Namespace,
 		},
 	}
-	_, err := controllerutil.CreateOrUpdate(ctx, r.Client, route, func() error {
+	_, err := resource.CreateOrUpdate(ctx, r.Client, route, func() error {
 		// Forge metadata
 		if route.Labels == nil {
 			route.Labels = make(labels.Set)

--- a/pkg/liqo-controller-manager/networking/internal-network/node-controller/node_controller.go
+++ b/pkg/liqo-controller-manager/networking/internal-network/node-controller/node_controller.go
@@ -34,6 +34,7 @@ import (
 	internalnetwork "github.com/liqotech/liqo/pkg/liqo-controller-manager/networking/internal-network"
 	"github.com/liqotech/liqo/pkg/liqo-controller-manager/networking/internal-network/fabricipam"
 	"github.com/liqotech/liqo/pkg/utils/getters"
+	"github.com/liqotech/liqo/pkg/utils/resource"
 )
 
 // NodeReconciler creates and manages InternalNodes.
@@ -91,7 +92,7 @@ func (r *NodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res c
 			Name: node.Name,
 		},
 	}
-	if _, err = controllerutil.CreateOrUpdate(ctx, r.Client, internalNode, func() error {
+	if _, err = resource.CreateOrUpdate(ctx, r.Client, internalNode, func() error {
 		if internalNode.Spec.Interface.Gateway.Name, err = internalnetwork.FindFreeInterfaceName(ctx, r.Client, internalNode); err != nil {
 			return err
 		}

--- a/pkg/liqo-controller-manager/networking/internal-network/route/internalnode_k8s.go
+++ b/pkg/liqo-controller-manager/networking/internal-network/route/internalnode_k8s.go
@@ -31,6 +31,7 @@ import (
 	"github.com/liqotech/liqo/apis/networking/v1beta1/firewall"
 	"github.com/liqotech/liqo/pkg/gateway"
 	"github.com/liqotech/liqo/pkg/gateway/tunnel"
+	"github.com/liqotech/liqo/pkg/utils/resource"
 )
 
 const (
@@ -52,7 +53,7 @@ func enforceRouteWithConntrackPresence(ctx context.Context, cl client.Client,
 		ObjectMeta: metav1.ObjectMeta{Name: configurationNameSvc, Namespace: opts.Namespace},
 	}
 
-	if _, err := controllerutil.CreateOrUpdate(ctx, cl, fwcfg,
+	if _, err := resource.CreateOrUpdate(ctx, cl, fwcfg,
 		forgeFirewallConfigurationMutateFunction(internalnode, fwcfg, mark, nodePortSrcIP)); err != nil {
 		return fmt.Errorf("an error occurred while creating or updating the firewall configuration: %w", err)
 	}
@@ -61,7 +62,7 @@ func enforceRouteWithConntrackPresence(ctx context.Context, cl client.Client,
 		ObjectMeta: metav1.ObjectMeta{Name: generateInternalNodeSvcRouteConfigurationName(internalnode.Name), Namespace: opts.Namespace},
 	}
 
-	if _, err := controllerutil.CreateOrUpdate(ctx, cl, routecfg,
+	if _, err := resource.CreateOrUpdate(ctx, cl, routecfg,
 		forgeRouteConfigurationMutateFunction(internalnode, routecfg, scheme, mark, nodePortSrcIP)); err != nil {
 		return fmt.Errorf("an error occurred while creating or updating the route configuration: %w", err)
 	}
@@ -75,7 +76,7 @@ func enforceRouteWithConntrackAbsence(ctx context.Context, cl client.Client,
 		ObjectMeta: metav1.ObjectMeta{Name: configurationNameSvc, Namespace: opts.Namespace},
 	}
 
-	if _, err := controllerutil.CreateOrUpdate(ctx, cl, fwcfg,
+	if _, err := resource.CreateOrUpdate(ctx, cl, fwcfg,
 		cleanFirewallConfigurationMutateFunction(internalnode, fwcfg)); err != nil {
 		return fmt.Errorf("an error occurred while cleaning the firewall configuration: %w", err)
 	}
@@ -269,7 +270,7 @@ func enforceRouteConfigurationExtCIDR(ctx context.Context, cl client.Client,
 		ObjectMeta: metav1.ObjectMeta{Name: generateInternalNodeExtCIDRRouteConfigurationName(internalnode.Name), Namespace: opts.Namespace},
 	}
 
-	if _, err := controllerutil.CreateOrUpdate(ctx, cl, routecfg,
+	if _, err := resource.CreateOrUpdate(ctx, cl, routecfg,
 		forgeRouteConfigurationExtCIDRMutateFunction(internalnode, routecfg, configurations, ips, scheme)); err != nil {
 		return fmt.Errorf("an error occurred while creating or updating the route configuration: %w", err)
 	}

--- a/pkg/liqo-controller-manager/networking/internal-network/route/pod_k8s.go
+++ b/pkg/liqo-controller-manager/networking/internal-network/route/pod_k8s.go
@@ -29,6 +29,7 @@ import (
 	networkingv1beta1 "github.com/liqotech/liqo/apis/networking/v1beta1"
 	"github.com/liqotech/liqo/pkg/gateway"
 	"github.com/liqotech/liqo/pkg/gateway/tunnel"
+	"github.com/liqotech/liqo/pkg/utils/resource"
 )
 
 // generatePodRouteConfigurationName generates the name of the route configuration for the given node.
@@ -55,7 +56,7 @@ func enforceRoutePodPresence(ctx context.Context, cl client.Client, scheme *runt
 		ObjectMeta: metav1.ObjectMeta{Name: generatePodRouteConfigurationName(pod.Spec.NodeName), Namespace: opts.Namespace},
 	}
 
-	op, err := controllerutil.CreateOrUpdate(ctx, cl, routecfg, forgeRoutePodUpdateFunction(internalnode, routecfg, pod, scheme))
+	op, err := resource.CreateOrUpdate(ctx, cl, routecfg, forgeRoutePodUpdateFunction(internalnode, routecfg, pod, scheme))
 
 	return op, err
 }
@@ -73,7 +74,7 @@ func enforceRoutePodAbsence(ctx context.Context, cl client.Client, opts *Options
 		return err
 	}
 
-	if _, err := controllerutil.CreateOrUpdate(ctx, cl, &routecfg, forgeRoutePodDeleteFunction(pod, &routecfg)); err != nil {
+	if _, err := resource.CreateOrUpdate(ctx, cl, &routecfg, forgeRoutePodDeleteFunction(pod, &routecfg)); err != nil {
 		return err
 	}
 
@@ -179,11 +180,11 @@ func addPodToRoute(pod *corev1.Pod, internalnode *networkingv1beta1.InternalNode
 	})
 }
 
-func addNodeToRoute(internlnode *networkingv1beta1.InternalNode, rule *networkingv1beta1.Rule) {
+func addNodeToRoute(internalnode *networkingv1beta1.InternalNode, rule *networkingv1beta1.Rule) {
 	rule.Routes = []networkingv1beta1.Route{
 		{
-			Dst:   ptr.To(networkingv1beta1.CIDR(fmt.Sprintf("%s/32", internlnode.Spec.Interface.Node.IP))),
-			Dev:   &internlnode.Spec.Interface.Gateway.Name,
+			Dst:   ptr.To(networkingv1beta1.CIDR(fmt.Sprintf("%s/32", internalnode.Spec.Interface.Node.IP))),
+			Dev:   &internalnode.Spec.Interface.Gateway.Name,
 			Scope: ptr.To(networkingv1beta1.LinkScope),
 		},
 	}

--- a/pkg/liqo-controller-manager/networking/internal-network/server-controller/server_controller.go
+++ b/pkg/liqo-controller-manager/networking/internal-network/server-controller/server_controller.go
@@ -33,6 +33,7 @@ import (
 	"github.com/liqotech/liqo/pkg/liqo-controller-manager/networking/internal-network/fabricipam"
 	"github.com/liqotech/liqo/pkg/utils"
 	"github.com/liqotech/liqo/pkg/utils/getters"
+	"github.com/liqotech/liqo/pkg/utils/resource"
 )
 
 // ServerReconciler manage GatewayServer lifecycle.
@@ -93,6 +94,7 @@ func (r *ServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res
 	return ctrl.Result{}, nil
 }
 
+// ensureInternalFabric ensures the InternalFabric is correctly configured.
 func (r *ServerReconciler) ensureInternalFabric(ctx context.Context, gwServer *networkingv1beta1.GatewayServer,
 	configuration *networkingv1beta1.Configuration, remoteClusterID liqov1beta1.ClusterID, ipam *fabricipam.IPAM) error {
 	if configuration.Status.Remote == nil {
@@ -108,7 +110,7 @@ func (r *ServerReconciler) ensureInternalFabric(ctx context.Context, gwServer *n
 			Namespace: gwServer.Namespace,
 		},
 	}
-	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, internalFabric, func() error {
+	if _, err := resource.CreateOrUpdate(ctx, r.Client, internalFabric, func() error {
 		var err error
 		if internalFabric.Labels == nil {
 			internalFabric.Labels = make(map[string]string)

--- a/pkg/liqo-controller-manager/networking/ip-controller/exposition.go
+++ b/pkg/liqo-controller-manager/networking/ip-controller/exposition.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	ipamv1alpha1 "github.com/liqotech/liqo/apis/ipam/v1alpha1"
+	"github.com/liqotech/liqo/pkg/utils/resource"
 )
 
 // handleAssociatedService creates, updates or deletes the service associated to the IP.
@@ -99,7 +100,7 @@ func (r *IPReconciler) handleAssociatedService(ctx context.Context, ip *ipamv1al
 // enforceResource ensures that the given resource exists.
 // It either creates or update the resource.
 func enforceResource(ctx context.Context, r client.Client, obj client.Object, mutateFn controllerutil.MutateFn, resourceKind string) error {
-	op, err := controllerutil.CreateOrUpdate(ctx, r, obj, mutateFn)
+	op, err := resource.CreateOrUpdate(ctx, r, obj, mutateFn)
 	if err != nil {
 		klog.Errorf("error while creating/updating %s %q (operation: %s): %v", resourceKind, obj.GetName(), op, err)
 		return err

--- a/pkg/liqo-controller-manager/offloading/namespacemap-controller/enforcement.go
+++ b/pkg/liqo-controller-manager/offloading/namespacemap-controller/enforcement.go
@@ -28,12 +28,12 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	offloadingv1beta1 "github.com/liqotech/liqo/apis/offloading/v1beta1"
 	"github.com/liqotech/liqo/pkg/consts"
 	"github.com/liqotech/liqo/pkg/utils"
 	liqoerrors "github.com/liqotech/liqo/pkg/utils/errors"
+	"github.com/liqotech/liqo/pkg/utils/resource"
 )
 
 // createNamespace creates a new namespace associated with a NamespaceMap. It returns whether a possible error
@@ -83,7 +83,7 @@ func (r *NamespaceMapReconciler) createNamespace(ctx context.Context, name, orig
 	// The rolebinding is named after the tenant namespace name, since that is guaranteed to be unique.
 	// This will simplify the support for remote namespaces associated with multiple origins.
 	binding := rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Namespace: name, Name: nm.GetNamespace()}}
-	result, err := controllerutil.CreateOrUpdate(ctx, r.Client, &binding, func() error {
+	result, err := resource.CreateOrUpdate(ctx, r.Client, &binding, func() error {
 		binding.Annotations = labels.Merge(binding.GetAnnotations(), map[string]string{
 			consts.RemoteNamespaceManagedByAnnotationKey: nmID,
 		})

--- a/pkg/liqo-controller-manager/offloading/shadowendpointslice-controller/shadowendpointslice_controller.go
+++ b/pkg/liqo-controller-manager/offloading/shadowendpointslice-controller/shadowendpointslice_controller.go
@@ -42,6 +42,7 @@ import (
 	"github.com/liqotech/liqo/pkg/utils"
 	clientutils "github.com/liqotech/liqo/pkg/utils/clients"
 	foreigncluster "github.com/liqotech/liqo/pkg/utils/foreigncluster"
+	"github.com/liqotech/liqo/pkg/utils/resource"
 	"github.com/liqotech/liqo/pkg/virtualKubelet/forge"
 )
 
@@ -142,6 +143,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	case errors.IsNotFound(err):
 		// Create the endpointslice
 		utilruntime.Must(ctrl.SetControllerReference(&shadowEps, &newEps, r.Scheme))
+
+		resource.AddGlobalLabels(&newEps)
+		resource.AddGlobalAnnotations(&newEps)
 
 		if err := r.Create(ctx, &newEps, client.FieldOwner(ctrlFieldManager)); err != nil {
 			klog.Errorf("unable to create endpointslice for shadowendpointslice %q: %v", klog.KObj(&shadowEps), err)

--- a/pkg/liqo-controller-manager/offloading/storageprovisioner/localprovisioner.go
+++ b/pkg/liqo-controller-manager/offloading/storageprovisioner/localprovisioner.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/liqotech/liqo/pkg/consts"
 	"github.com/liqotech/liqo/pkg/utils"
+	"github.com/liqotech/liqo/pkg/utils/resource"
 )
 
 func (p *liqoLocalStorageProvisioner) provisionLocalPVC(ctx context.Context,
@@ -39,7 +40,7 @@ func (p *liqoLocalStorageProvisioner) provisionLocalPVC(ctx context.Context,
 		},
 	}
 
-	if operation, err := controllerutil.CreateOrUpdate(ctx, p.client, &realPvc, func() error {
+	if operation, err := resource.CreateOrUpdate(ctx, p.client, &realPvc, func() error {
 		return p.mutateLocalRealPVC(virtualPvc, &realPvc, options.SelectedNode)
 	}); err != nil {
 		return nil, controller.ProvisioningInBackground, err

--- a/pkg/liqo-controller-manager/offloading/virtualnode-controller/virtualkubelet.go
+++ b/pkg/liqo-controller-manager/offloading/virtualnode-controller/virtualkubelet.go
@@ -32,6 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	offloadingv1beta1 "github.com/liqotech/liqo/apis/offloading/v1beta1"
+	"github.com/liqotech/liqo/pkg/utils/resource"
 	"github.com/liqotech/liqo/pkg/vkMachinery"
 	vkforge "github.com/liqotech/liqo/pkg/vkMachinery/forge"
 	vkutils "github.com/liqotech/liqo/pkg/vkMachinery/utils"
@@ -72,7 +73,7 @@ func (r *VirtualNodeReconciler) ensureVirtualKubeletDeploymentPresence(
 	// create the base resources
 	vkServiceAccount := vkforge.VirtualKubeletServiceAccount(namespace, name)
 	var op controllerutil.OperationResult
-	op, err = controllerutil.CreateOrUpdate(ctx, r.Client, vkServiceAccount, func() error {
+	op, err = resource.CreateOrUpdate(ctx, r.Client, vkServiceAccount, func() error {
 		return nil
 	})
 	if err != nil {
@@ -82,7 +83,7 @@ func (r *VirtualNodeReconciler) ensureVirtualKubeletDeploymentPresence(
 		remoteClusterID, vkServiceAccount.Namespace, vkServiceAccount.Name, op)
 
 	vkClusterRoleBinding := vkforge.VirtualKubeletClusterRoleBinding(namespace, name, remoteClusterID)
-	op, err = controllerutil.CreateOrUpdate(ctx, r.Client, vkClusterRoleBinding, func() error {
+	op, err = resource.CreateOrUpdate(ctx, r.Client, vkClusterRoleBinding, func() error {
 		return nil
 	})
 	if err != nil {
@@ -99,7 +100,7 @@ func (r *VirtualNodeReconciler) ensureVirtualKubeletDeploymentPresence(
 			Namespace: virtualNode.Spec.Template.GetNamespace(),
 		},
 	}
-	op, err = controllerutil.CreateOrUpdate(ctx, r.Client, &vkDeployment, func() error {
+	op, err = resource.CreateOrUpdate(ctx, r.Client, &vkDeployment, func() error {
 		vkDeployment.Annotations = labels.Merge(vkDeployment.Annotations, virtualNode.Spec.Template.ObjectMeta.GetAnnotations())
 		vkDeployment.Labels = labels.Merge(vkDeployment.Labels, virtualNode.Spec.Template.ObjectMeta.GetLabels())
 

--- a/pkg/liqo-controller-manager/quotacreator-controller/quotacreator_controller.go
+++ b/pkg/liqo-controller-manager/quotacreator-controller/quotacreator_controller.go
@@ -35,6 +35,7 @@ import (
 	"github.com/liqotech/liqo/internal/crdReplicator/reflection"
 	"github.com/liqotech/liqo/pkg/consts"
 	"github.com/liqotech/liqo/pkg/liqo-controller-manager/authentication"
+	"github.com/liqotech/liqo/pkg/utils/resource"
 )
 
 // QuotaCreatorReconciler manage Quota lifecycle.
@@ -90,7 +91,7 @@ func (r *QuotaCreatorReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			Namespace: resourceSlice.Namespace,
 		},
 	}
-	_, err := controllerutil.CreateOrUpdate(ctx, r.Client, &quota, func() error {
+	_, err := resource.CreateOrUpdate(ctx, r.Client, &quota, func() error {
 		quota.Spec.User = userName
 		quota.Spec.LimitsEnforcement = r.DefaultLimitsEnforcement
 		quota.Spec.Resources = resourceSlice.Status.Resources.DeepCopy()

--- a/pkg/liqo-controller-manager/virtualnodecreator-controller/virtualnodecreator_controller.go
+++ b/pkg/liqo-controller-manager/virtualnodecreator-controller/virtualnodecreator_controller.go
@@ -26,7 +26,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	authv1beta1 "github.com/liqotech/liqo/apis/authentication/v1beta1"
@@ -37,6 +36,7 @@ import (
 	"github.com/liqotech/liqo/pkg/liqo-controller-manager/authentication"
 	"github.com/liqotech/liqo/pkg/liqo-controller-manager/offloading/forge"
 	"github.com/liqotech/liqo/pkg/utils/getters"
+	"github.com/liqotech/liqo/pkg/utils/resource"
 )
 
 // VirtualNodeCreatorReconciler create virtualnodes from resourceslice resources.
@@ -119,7 +119,7 @@ func (r *VirtualNodeCreatorReconciler) Reconcile(ctx context.Context, req ctrl.R
 
 	// CreateOrUpdate the VirtualNode.
 	virtualNode := forge.VirtualNode(resourceSlice.Name, resourceSlice.Namespace)
-	if _, err := ctrl.CreateOrUpdate(ctx, r.Client, virtualNode, func() error {
+	if _, err := resource.CreateOrUpdate(ctx, r.Client, virtualNode, func() error {
 		// Forge the VirtualNodeOptions from the ResourceSlice.
 		vnOpts := forge.VirtualNodeOptionsFromResourceSlice(&resourceSlice, kubeconfigSecret.Name,
 			virtualNode.Spec.VkOptionsTemplateRef)
@@ -132,7 +132,7 @@ func (r *VirtualNodeCreatorReconciler) Reconcile(ctx context.Context, req ctrl.R
 			virtualNode.Labels = map[string]string{}
 		}
 		virtualNode.Labels[consts.ResourceSliceNameLabelKey] = resourceSlice.Name
-		return controllerutil.SetControllerReference(&resourceSlice, virtualNode, r.Scheme)
+		return ctrl.SetControllerReference(&resourceSlice, virtualNode, r.Scheme)
 	}); err != nil {
 		klog.Errorf("Unable to create or update the VirtualNode for resourceslice %q: %s", req.NamespacedName, err)
 		return ctrl.Result{}, err

--- a/pkg/liqoctl/authenticate/cluster.go
+++ b/pkg/liqoctl/authenticate/cluster.go
@@ -20,7 +20,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	authv1beta1 "github.com/liqotech/liqo/apis/authentication/v1beta1"
 	liqov1beta1 "github.com/liqotech/liqo/apis/core/v1beta1"
@@ -33,6 +32,7 @@ import (
 	liqoutils "github.com/liqotech/liqo/pkg/utils"
 	"github.com/liqotech/liqo/pkg/utils/getters"
 	ipamips "github.com/liqotech/liqo/pkg/utils/ipam/mapping"
+	"github.com/liqotech/liqo/pkg/utils/resource"
 )
 
 // Cluster contains the information about a cluster.
@@ -166,7 +166,7 @@ func (c *Cluster) GenerateTenant(ctx context.Context, signedNonce []byte, proxyU
 // EnsureTenant apply the tenant resource on the provider cluster and wait for the status to be updated.
 func (c *Cluster) EnsureTenant(ctx context.Context, tenant *authv1beta1.Tenant) error {
 	s := c.local.Printer.StartSpinner("Applying tenant on provider cluster")
-	if _, err := controllerutil.CreateOrUpdate(ctx, c.local.CRClient, tenant, func() error {
+	if _, err := resource.CreateOrUpdate(ctx, c.local.CRClient, tenant, func() error {
 		return nil
 	}); err != nil {
 		s.Fail(fmt.Sprintf("Unable to apply tenant on provider cluster: %v", output.PrettyErr(err)))
@@ -199,7 +199,7 @@ func (c *Cluster) GenerateIdentity(ctx context.Context, remoteTenantNamespace st
 // EnsureIdentity apply the identity resource on the consumer cluster and wait for the status to be updated.
 func (c *Cluster) EnsureIdentity(ctx context.Context, identity *authv1beta1.Identity) error {
 	s := c.local.Printer.StartSpinner("Applying identity on consumer cluster")
-	if _, err := controllerutil.CreateOrUpdate(ctx, c.local.CRClient, identity, func() error {
+	if _, err := resource.CreateOrUpdate(ctx, c.local.CRClient, identity, func() error {
 		return nil
 	}); err != nil {
 		s.Fail(fmt.Sprintf("Unable to apply identity on consumer cluster: %v", output.PrettyErr(err)))

--- a/pkg/liqoctl/factory/factory.go
+++ b/pkg/liqoctl/factory/factory.go
@@ -69,6 +69,12 @@ type Factory struct {
 	// Namespace is the namespace that the user has requested with the "--namespace" / "-n" flag.
 	Namespace string
 
+	// GlobalLabels is a map of labels that will be added to all resources created by liqoctl
+	GlobalLabels map[string]string
+
+	// GlobalAnnotations is a map of annotations that will be added to all resources created by liqoctl
+	GlobalAnnotations map[string]string
+
 	// LiqoNamespace is the namespace (where Liqo is installed) that the user has requested with the "--liqo-namespace" / "-l" flag,
 	// if registered.
 	LiqoNamespace string

--- a/pkg/liqoctl/move/restic.go
+++ b/pkg/liqoctl/move/restic.go
@@ -26,7 +26,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	"github.com/liqotech/liqo/pkg/utils/resource"
 )
 
 func (o *Options) ensureResticRepository(ctx context.Context, targetPvc *corev1.PersistentVolumeClaim) error {
@@ -36,7 +37,7 @@ func (o *Options) ensureResticRepository(ctx context.Context, targetPvc *corev1.
 			Namespace: liqoStorageNamespace,
 		},
 	}
-	_, err := controllerutil.CreateOrUpdate(ctx, o.CRClient, &svc, func() error {
+	_, err := resource.CreateOrUpdate(ctx, o.CRClient, &svc, func() error {
 		svc.Spec = corev1.ServiceSpec{
 			Selector: map[string]string{
 				"app": resticRegistry,
@@ -61,7 +62,7 @@ func (o *Options) ensureResticRepository(ctx context.Context, targetPvc *corev1.
 			Namespace: liqoStorageNamespace,
 		},
 	}
-	_, err = controllerutil.CreateOrUpdate(ctx, o.CRClient, &statefulSet, func() error {
+	_, err = resource.CreateOrUpdate(ctx, o.CRClient, &statefulSet, func() error {
 		statefulSet.Spec = appsv1.StatefulSetSpec{
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{

--- a/pkg/liqoctl/network/cluster.go
+++ b/pkg/liqoctl/network/cluster.go
@@ -40,6 +40,7 @@ import (
 	liqoutils "github.com/liqotech/liqo/pkg/utils"
 	"github.com/liqotech/liqo/pkg/utils/getters"
 	"github.com/liqotech/liqo/pkg/utils/maps"
+	"github.com/liqotech/liqo/pkg/utils/resource"
 )
 
 // Cluster contains the information about a cluster.
@@ -176,7 +177,7 @@ func (c *Cluster) SetupConfiguration(ctx context.Context, conf *networkingv1beta
 	s := c.local.Printer.StartSpinner("Setting up network configuration")
 	conf.Namespace = c.local.Namespace
 	confCopy := conf.DeepCopy()
-	_, err := controllerutil.CreateOrUpdate(ctx, c.local.CRClient, conf, func() error {
+	_, err := resource.CreateOrUpdate(ctx, c.local.CRClient, conf, func() error {
 		if conf.Labels == nil {
 			conf.Labels = make(map[string]string)
 		}
@@ -411,7 +412,7 @@ func (c *Cluster) EnsureGatewayServer(ctx context.Context, opts *forge.GwServerO
 		}
 	}
 
-	_, err = controllerutil.CreateOrUpdate(ctx, c.local.CRClient, gwServer, func() error {
+	_, err = resource.CreateOrUpdate(ctx, c.local.CRClient, gwServer, func() error {
 		return forge.MutateGatewayServer(gwServer, opts)
 	})
 	if err != nil {
@@ -441,7 +442,7 @@ func (c *Cluster) EnsureGatewayClient(ctx context.Context, opts *forge.GwClientO
 		s.Fail(fmt.Sprintf("An error occurred while forging gateway client: %v", output.PrettyErr(err)))
 		return nil, err
 	}
-	_, err = controllerutil.CreateOrUpdate(ctx, c.local.CRClient, gwClient, func() error {
+	_, err = resource.CreateOrUpdate(ctx, c.local.CRClient, gwClient, func() error {
 		return forge.MutateGatewayClient(gwClient, opts)
 	})
 	if err != nil {
@@ -473,7 +474,7 @@ func (c *Cluster) EnsurePublicKey(ctx context.Context, remoteClusterID liqov1bet
 		s.Fail(fmt.Sprintf("An error occurred while forging public key: %v", output.PrettyErr(err)))
 		return err
 	}
-	_, err = controllerutil.CreateOrUpdate(ctx, c.local.CRClient, pubKey, func() error {
+	_, err = resource.CreateOrUpdate(ctx, c.local.CRClient, pubKey, func() error {
 		if err := forge.MutatePublicKey(pubKey, remoteClusterID, key); err != nil {
 			return err
 		}

--- a/pkg/liqoctl/offload/handler.go
+++ b/pkg/liqoctl/offload/handler.go
@@ -23,13 +23,13 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/printers"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	offloadingv1beta1 "github.com/liqotech/liqo/apis/offloading/v1beta1"
 	"github.com/liqotech/liqo/pkg/consts"
 	"github.com/liqotech/liqo/pkg/liqoctl/factory"
 	"github.com/liqotech/liqo/pkg/liqoctl/output"
 	"github.com/liqotech/liqo/pkg/liqoctl/wait"
+	"github.com/liqotech/liqo/pkg/utils/resource"
 )
 
 // Options encapsulates the arguments of the offload namespace command.
@@ -84,7 +84,7 @@ func (o *Options) Run(ctx context.Context) error {
 		Name: consts.DefaultNamespaceOffloadingName, Namespace: o.Namespace}}
 
 	var oldStrategy offloadingv1beta1.PodOffloadingStrategyType
-	_, err := controllerutil.CreateOrUpdate(ctx, o.CRClient, nsoff, func() error {
+	_, err := resource.CreateOrUpdate(ctx, o.CRClient, nsoff, func() error {
 		oldStrategy = nsoff.Spec.PodOffloadingStrategy
 		nsoff.Spec.PodOffloadingStrategy = o.PodOffloadingStrategy
 		nsoff.Spec.NamespaceMappingStrategy = o.NamespaceMappingStrategy

--- a/pkg/liqoctl/rest/configuration/create.go
+++ b/pkg/liqoctl/rest/configuration/create.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/cli-runtime/pkg/printers"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	networkingv1beta1 "github.com/liqotech/liqo/apis/networking/v1beta1"
 	"github.com/liqotech/liqo/pkg/liqo-controller-manager/networking/forge"
@@ -33,6 +32,7 @@ import (
 	"github.com/liqotech/liqo/pkg/liqoctl/output"
 	"github.com/liqotech/liqo/pkg/liqoctl/rest"
 	"github.com/liqotech/liqo/pkg/utils/args"
+	"github.com/liqotech/liqo/pkg/utils/resource"
 )
 
 const liqoctlCreateConfigurationLongHelp = `Create a Configuration.
@@ -98,7 +98,7 @@ func (o *Options) handleCreate(ctx context.Context) error {
 	}
 
 	s := opts.Printer.StartSpinner("Creating configuration")
-	_, err := controllerutil.CreateOrUpdate(ctx, opts.CRClient, conf, func() error {
+	_, err := resource.CreateOrUpdate(ctx, opts.CRClient, conf, func() error {
 		forge.MutateConfiguration(conf, o.RemoteClusterID.GetClusterID(), o.PodCIDR.String(), o.ExternalCIDR.String())
 		return nil
 	})

--- a/pkg/liqoctl/rest/gatewayclient/create.go
+++ b/pkg/liqoctl/rest/gatewayclient/create.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/cli-runtime/pkg/printers"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	networkingv1beta1 "github.com/liqotech/liqo/apis/networking/v1beta1"
 	forge "github.com/liqotech/liqo/pkg/liqo-controller-manager/networking/forge"
@@ -33,6 +32,7 @@ import (
 	"github.com/liqotech/liqo/pkg/liqoctl/output"
 	"github.com/liqotech/liqo/pkg/liqoctl/rest"
 	"github.com/liqotech/liqo/pkg/utils/args"
+	"github.com/liqotech/liqo/pkg/utils/resource"
 )
 
 const liqoctlCreateGatewayClientLongHelp = `Create a Gateway Client.
@@ -108,7 +108,7 @@ func (o *Options) handleCreate(ctx context.Context) error {
 
 	s := opts.Printer.StartSpinner("Creating gatewayclient")
 
-	_, err = controllerutil.CreateOrUpdate(ctx, opts.CRClient, gwClient, func() error {
+	_, err = resource.CreateOrUpdate(ctx, opts.CRClient, gwClient, func() error {
 		return forge.MutateGatewayClient(gwClient, o.getForgeOptions())
 	})
 	if err != nil {

--- a/pkg/liqoctl/rest/gatewayserver/create.go
+++ b/pkg/liqoctl/rest/gatewayserver/create.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/cli-runtime/pkg/printers"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	networkingv1beta1 "github.com/liqotech/liqo/apis/networking/v1beta1"
 	"github.com/liqotech/liqo/pkg/liqo-controller-manager/networking/forge"
@@ -33,6 +32,7 @@ import (
 	"github.com/liqotech/liqo/pkg/liqoctl/output"
 	"github.com/liqotech/liqo/pkg/liqoctl/rest"
 	"github.com/liqotech/liqo/pkg/utils/args"
+	"github.com/liqotech/liqo/pkg/utils/resource"
 )
 
 const liqoctlCreateGatewayServerLongHelp = `Create a Gateway Server.
@@ -111,7 +111,7 @@ func (o *Options) handleCreate(ctx context.Context) error {
 
 	s := opts.Printer.StartSpinner("Creating gatewayserver")
 
-	_, err = controllerutil.CreateOrUpdate(ctx, opts.CRClient, gwServer, func() error {
+	_, err = resource.CreateOrUpdate(ctx, opts.CRClient, gwServer, func() error {
 		return forge.MutateGatewayServer(gwServer, o.getForgeOptions())
 	})
 	if err != nil {

--- a/pkg/liqoctl/rest/publickey/create.go
+++ b/pkg/liqoctl/rest/publickey/create.go
@@ -22,7 +22,6 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/cli-runtime/pkg/printers"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	networkingv1beta1 "github.com/liqotech/liqo/apis/networking/v1beta1"
 	"github.com/liqotech/liqo/pkg/liqo-controller-manager/networking/forge"
@@ -30,6 +29,7 @@ import (
 	"github.com/liqotech/liqo/pkg/liqoctl/output"
 	"github.com/liqotech/liqo/pkg/liqoctl/rest"
 	"github.com/liqotech/liqo/pkg/utils/args"
+	"github.com/liqotech/liqo/pkg/utils/resource"
 )
 
 const liqoctlCreatePublicKeyLongHelp = `Create a PublicKey.
@@ -95,7 +95,7 @@ func (o *Options) handleCreate(ctx context.Context) error {
 
 	s := opts.Printer.StartSpinner("Creating publickey")
 
-	_, err = controllerutil.CreateOrUpdate(ctx, opts.CRClient, pubKey, func() error {
+	_, err = resource.CreateOrUpdate(ctx, opts.CRClient, pubKey, func() error {
 		return forge.MutatePublicKey(pubKey, o.RemoteClusterID.GetClusterID(), o.PublicKey)
 	})
 	if err != nil {

--- a/pkg/liqoctl/rest/resourceslice/create.go
+++ b/pkg/liqoctl/rest/resourceslice/create.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/cli-runtime/pkg/printers"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	authv1beta1 "github.com/liqotech/liqo/apis/authentication/v1beta1"
 	"github.com/liqotech/liqo/pkg/liqo-controller-manager/authentication"
@@ -36,6 +35,7 @@ import (
 	"github.com/liqotech/liqo/pkg/liqoctl/wait"
 	tenantnamespace "github.com/liqotech/liqo/pkg/tenantNamespace"
 	"github.com/liqotech/liqo/pkg/utils/args"
+	"github.com/liqotech/liqo/pkg/utils/resource"
 )
 
 const liqoctlCreateResourceSliceLongHelp = `Create a ResourceSlice.
@@ -109,7 +109,7 @@ func (o *Options) HandleCreate(ctx context.Context) error {
 	}
 
 	resourceSlice := forge.ResourceSlice(opts.Name, namespace)
-	_, err = controllerutil.CreateOrUpdate(ctx, opts.CRClient, resourceSlice, func() error {
+	_, err = resource.CreateOrUpdate(ctx, opts.CRClient, resourceSlice, func() error {
 		return forge.MutateResourceSlice(resourceSlice, o.RemoteClusterID.GetClusterID(), &forge.ResourceSliceOptions{
 			Class: authv1beta1.ResourceSliceClass(o.Class),
 			Resources: map[corev1.ResourceName]string{

--- a/pkg/liqoctl/rest/virtualnode/create.go
+++ b/pkg/liqoctl/rest/virtualnode/create.go
@@ -22,11 +22,10 @@ import (
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/resource"
+	k8sresource "k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/cli-runtime/pkg/printers"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	authv1beta1 "github.com/liqotech/liqo/apis/authentication/v1beta1"
 	liqov1beta1 "github.com/liqotech/liqo/apis/core/v1beta1"
@@ -38,6 +37,7 @@ import (
 	tenantnamespace "github.com/liqotech/liqo/pkg/tenantNamespace"
 	"github.com/liqotech/liqo/pkg/utils/args"
 	"github.com/liqotech/liqo/pkg/utils/getters"
+	"github.com/liqotech/liqo/pkg/utils/resource"
 )
 
 const liqoctlCreateVirtualNodeLongHelp = `Create a VirtualNode.
@@ -164,7 +164,7 @@ func (o *Options) handleCreate(ctx context.Context) error {
 	s := opts.Printer.StartSpinner("Creating virtual node")
 
 	virtualNode := forge.VirtualNode(opts.Name, tenantNamespace)
-	if _, err := controllerutil.CreateOrUpdate(ctx, opts.CRClient, virtualNode, func() error {
+	if _, err := resource.CreateOrUpdate(ctx, opts.CRClient, virtualNode, func() error {
 		return forge.MutateVirtualNode(ctx, opts.CRClient,
 			virtualNode, o.remoteClusterID.GetClusterID(), vnOpts, &o.createNode, &o.disableNetworkCheck)
 	}); err != nil {
@@ -211,15 +211,15 @@ func (o *Options) forgeVirtualNodeOptionsFromResourceSlice(ctx context.Context,
 }
 
 func (o *Options) forgeVirtualNodeOptions(vkOptionsTemplateRef *corev1.ObjectReference) (*forge.VirtualNodeOptions, error) {
-	cpuQnt, err := resource.ParseQuantity(o.cpu)
+	cpuQnt, err := k8sresource.ParseQuantity(o.cpu)
 	if err != nil {
 		return nil, fmt.Errorf("unable to parse cpu quantity: %w", err)
 	}
-	memoryQnt, err := resource.ParseQuantity(o.memory)
+	memoryQnt, err := k8sresource.ParseQuantity(o.memory)
 	if err != nil {
 		return nil, fmt.Errorf("unable to parse memory quantity: %w", err)
 	}
-	podsQnt, err := resource.ParseQuantity(o.pods)
+	podsQnt, err := k8sresource.ParseQuantity(o.pods)
 	if err != nil {
 		return nil, fmt.Errorf("unable to parse pod quantity: %w", err)
 	}

--- a/pkg/tenantNamespace/bindings.go
+++ b/pkg/tenantNamespace/bindings.go
@@ -27,6 +27,7 @@ import (
 
 	liqov1beta1 "github.com/liqotech/liqo/apis/core/v1beta1"
 	"github.com/liqotech/liqo/pkg/consts"
+	"github.com/liqotech/liqo/pkg/utils/resource"
 )
 
 // add the bindings for the remote clusterid for the given ClusterRoles
@@ -102,6 +103,9 @@ func (nm *tenantNamespaceManager) bindClusterRole(ctx context.Context, cluster l
 		}
 	}
 
+	resource.AddGlobalLabels(rb)
+	resource.AddGlobalAnnotations(rb)
+
 	rb, err := nm.client.RbacV1().RoleBindings(namespace.Name).Create(ctx, rb, metav1.CreateOptions{})
 	if apierrors.IsAlreadyExists(err) {
 		return nm.client.RbacV1().RoleBindings(namespace.Name).Get(ctx, name, metav1.GetOptions{})
@@ -169,6 +173,9 @@ func (nm *tenantNamespaceManager) bindClusterRoleClusterWide(ctx context.Context
 			return nil, err
 		}
 	}
+
+	resource.AddGlobalLabels(crb)
+	resource.AddGlobalAnnotations(crb)
 
 	crb, err := nm.client.RbacV1().ClusterRoleBindings().Create(ctx, crb, metav1.CreateOptions{})
 	if apierrors.IsAlreadyExists(err) {

--- a/pkg/utils/ipam/mapping/ips.go
+++ b/pkg/utils/ipam/mapping/ips.go
@@ -22,13 +22,13 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	liqov1beta1 "github.com/liqotech/liqo/apis/core/v1beta1"
 	ipamv1alpha1 "github.com/liqotech/liqo/apis/ipam/v1alpha1"
 	networkingv1beta1 "github.com/liqotech/liqo/apis/networking/v1beta1"
 	"github.com/liqotech/liqo/pkg/consts"
 	"github.com/liqotech/liqo/pkg/utils/getters"
+	"github.com/liqotech/liqo/pkg/utils/resource"
 )
 
 // EnforceAPIServerIPRemapping creates or updates the IP resource for the API server IP remapping.
@@ -47,7 +47,7 @@ func EnforceAPIServerIPRemapping(ctx context.Context, cl client.Client, liqoName
 			Namespace: liqoNamespace,
 		},
 	}
-	if _, err := controllerutil.CreateOrUpdate(ctx, cl, ip, func() error {
+	if _, err := resource.CreateOrUpdate(ctx, cl, ip, func() error {
 		if ip.Labels == nil {
 			ip.Labels = map[string]string{}
 		}
@@ -93,7 +93,7 @@ func EnforceAPIServerProxyIPRemapping(ctx context.Context, cl client.Client, liq
 			Namespace: liqoNamespace,
 		},
 	}
-	if _, err := controllerutil.CreateOrUpdate(ctx, cl, ip, func() error {
+	if _, err := resource.CreateOrUpdate(ctx, cl, ip, func() error {
 		if ip.Labels == nil {
 			ip.Labels = map[string]string{}
 		}

--- a/pkg/utils/ipam/networks.go
+++ b/pkg/utils/ipam/networks.go
@@ -22,12 +22,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	ipamv1alpha1 "github.com/liqotech/liqo/apis/ipam/v1alpha1"
 	networkingv1beta1 "github.com/liqotech/liqo/apis/networking/v1beta1"
 	"github.com/liqotech/liqo/pkg/consts"
 	liqogetters "github.com/liqotech/liqo/pkg/utils/getters"
+	"github.com/liqotech/liqo/pkg/utils/resource"
 )
 
 // GetPodCIDR retrieves the podCIDR of the local cluster.
@@ -151,7 +151,7 @@ func CreateNetwork(ctx context.Context, cl client.Client, name, namespace, cidr 
 		},
 	}
 
-	if _, err := controllerutil.CreateOrUpdate(ctx, cl, network, func() error {
+	if _, err := resource.CreateOrUpdate(ctx, cl, network, func() error {
 		if network.Labels == nil {
 			network.Labels = map[string]string{}
 		}

--- a/pkg/utils/resource/annotations.go
+++ b/pkg/utils/resource/annotations.go
@@ -1,0 +1,49 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resource
+
+import (
+	"maps"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var (
+	// globalAnnotations stores the global annotations that should be added to all resources.
+	globalAnnotations = make(map[string]string)
+)
+
+// SetGlobalAnnotations sets the global annotations that should be added to all resources.
+func SetGlobalAnnotations(annotations map[string]string) {
+	if annotations == nil {
+		globalAnnotations = make(map[string]string)
+		return
+	}
+	globalAnnotations = annotations
+}
+
+// GetGlobalAnnotations returns a copy of the current global annotations.
+func GetGlobalAnnotations() map[string]string {
+	return maps.Clone(globalAnnotations)
+}
+
+// AddGlobalAnnotations adds the global annotations to the given object's annotations.
+// If the object's annotations is nil, it will be initialized.
+func AddGlobalAnnotations(obj metav1.Object) {
+	if obj.GetAnnotations() == nil {
+		obj.SetAnnotations(make(map[string]string))
+	}
+	maps.Copy(obj.GetAnnotations(), globalAnnotations)
+}

--- a/pkg/utils/resource/doc.go
+++ b/pkg/utils/resource/doc.go
@@ -1,0 +1,17 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package resource contains shared utility methods for
+// resource management.
+package resource

--- a/pkg/utils/resource/labels.go
+++ b/pkg/utils/resource/labels.go
@@ -1,0 +1,49 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resource
+
+import (
+	"maps"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var (
+	// globalLabels stores the global labels that should be added to all resources.
+	globalLabels = make(map[string]string)
+)
+
+// SetGlobalLabels sets the global labels that should be added to all resources.
+func SetGlobalLabels(labels map[string]string) {
+	if labels == nil {
+		globalLabels = make(map[string]string)
+		return
+	}
+	globalLabels = labels
+}
+
+// GetGlobalLabels returns a copy of the current global labels.
+func GetGlobalLabels() map[string]string {
+	return maps.Clone(globalLabels)
+}
+
+// AddGlobalLabels adds the global labels to the given object's labels.
+// If the object's labels is nil, it will be initialized.
+func AddGlobalLabels(obj metav1.Object) {
+	if obj.GetLabels() == nil {
+		obj.SetLabels(make(map[string]string))
+	}
+	maps.Copy(obj.GetLabels(), globalLabels)
+}

--- a/pkg/utils/resource/wrappers.go
+++ b/pkg/utils/resource/wrappers.go
@@ -1,0 +1,59 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resource
+
+import (
+	"context"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+// CreateOrUpdate is a wrapper around controllerutil.CreateOrUpdate that automatically adds global labels and annotations.
+// It takes the same parameters as controllerutil.CreateOrUpdate plus an optional list of additional labels to merge.
+func CreateOrUpdate(ctx context.Context, c client.Client, obj client.Object,
+	mutateFn func() error) (controllerutil.OperationResult, error) {
+	// Create a wrapper mutation function that adds labels before calling the original
+	wrappedMutateFn := func() error {
+		// First call the original mutation function
+		if err := mutateFn(); err != nil {
+			return err
+		}
+
+		// Then add global labels and any additional labels
+		if obj.GetLabels() == nil {
+			obj.SetLabels(make(map[string]string))
+		}
+		labels := obj.GetLabels()
+		for k, v := range GetGlobalLabels() {
+			labels[k] = v
+		}
+		obj.SetLabels(labels)
+
+		// Add global annotations
+		if obj.GetAnnotations() == nil {
+			obj.SetAnnotations(make(map[string]string))
+		}
+		annotations := obj.GetAnnotations()
+		for k, v := range GetGlobalAnnotations() {
+			annotations[k] = v
+		}
+		obj.SetAnnotations(annotations)
+
+		return nil
+	}
+
+	return controllerutil.CreateOrUpdate(ctx, c, obj, wrappedMutateFn)
+}

--- a/test/e2e/testutils/util/configmap.go
+++ b/test/e2e/testutils/util/configmap.go
@@ -20,7 +20,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	"github.com/liqotech/liqo/pkg/utils/resource"
 )
 
 // ConfigMapOption is a function that modifies a ConfigMap.
@@ -38,7 +39,7 @@ func EnforceConfigMap(ctx context.Context, cl client.Client, namespace, name str
 		},
 	}
 
-	return Second(controllerutil.CreateOrUpdate(ctx, cl, cm, func() error {
+	return Second(resource.CreateOrUpdate(ctx, cl, cm, func() error {
 		if cm.Data == nil {
 			cm.Data = make(map[string]string)
 		}

--- a/test/e2e/testutils/util/deployment.go
+++ b/test/e2e/testutils/util/deployment.go
@@ -24,9 +24,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/liqotech/liqo/pkg/consts"
+	"github.com/liqotech/liqo/pkg/utils/resource"
 )
 
 var (
@@ -104,7 +104,7 @@ func EnforceDeployment(ctx context.Context, cl client.Client, namespace, name st
 		},
 	}
 
-	return Second(controllerutil.CreateOrUpdate(ctx, cl, deploy, func() error {
+	return Second(resource.CreateOrUpdate(ctx, cl, deploy, func() error {
 		deploy.Spec.Replicas = ptr.To(int32(1))
 		deploy.Spec.Selector = &metav1.LabelSelector{
 			MatchLabels: map[string]string{"app": name},

--- a/test/e2e/testutils/util/event.go
+++ b/test/e2e/testutils/util/event.go
@@ -20,7 +20,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	"github.com/liqotech/liqo/pkg/utils/resource"
 )
 
 // EventOption is a function that modifies a Event.
@@ -39,7 +40,7 @@ func EnforceEvent(ctx context.Context, cl client.Client, namespace, name string,
 		InvolvedObject: *involvedObject,
 	}
 
-	return Second(controllerutil.CreateOrUpdate(ctx, cl, ev, func() error {
+	return Second(resource.CreateOrUpdate(ctx, cl, ev, func() error {
 		for _, opt := range options {
 			opt(ev)
 		}

--- a/test/e2e/testutils/util/ingress.go
+++ b/test/e2e/testutils/util/ingress.go
@@ -20,7 +20,8 @@ import (
 	netv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	"github.com/liqotech/liqo/pkg/utils/resource"
 )
 
 // IngressOption is a function that modifies a Ingress.
@@ -35,7 +36,7 @@ func EnforceIngress(ctx context.Context, cl client.Client, namespace, name strin
 		},
 	}
 
-	return Second(controllerutil.CreateOrUpdate(ctx, cl, ing, func() error {
+	return Second(resource.CreateOrUpdate(ctx, cl, ing, func() error {
 		ing.Spec.DefaultBackend = &netv1.IngressBackend{
 			Service: &netv1.IngressServiceBackend{
 				Name: "default-backend",

--- a/test/e2e/testutils/util/pod.go
+++ b/test/e2e/testutils/util/pod.go
@@ -18,18 +18,18 @@ import (
 	"context"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
+	k8sresource "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	liqov1beta1 "github.com/liqotech/liqo/apis/core/v1beta1"
 	"github.com/liqotech/liqo/pkg/consts"
 	fcutils "github.com/liqotech/liqo/pkg/utils/foreigncluster"
 	podutils "github.com/liqotech/liqo/pkg/utils/pod"
+	"github.com/liqotech/liqo/pkg/utils/resource"
 )
 
 // PodType -> defines the type of a pod (local/remote).
@@ -107,8 +107,8 @@ func NumTenantNamespaces(numPeeredConsumers, numPeeredProviders int, role liqov1
 // ResourceRequirements returns the default resource requirements for a pod during tests.
 func ResourceRequirements() corev1.ResourceRequirements {
 	return corev1.ResourceRequirements{Limits: corev1.ResourceList{
-		corev1.ResourceCPU:    *resource.NewScaledQuantity(250, resource.Milli),
-		corev1.ResourceMemory: *resource.NewScaledQuantity(100, resource.Mega),
+		corev1.ResourceCPU:    *k8sresource.NewScaledQuantity(250, k8sresource.Milli),
+		corev1.ResourceMemory: *k8sresource.NewScaledQuantity(100, k8sresource.Mega),
 	}}
 }
 
@@ -158,7 +158,7 @@ func EnforcePod(ctx context.Context, cl client.Client, namespace, name string, o
 		},
 	}
 
-	return Second(controllerutil.CreateOrUpdate(ctx, cl, pod, func() error {
+	return Second(resource.CreateOrUpdate(ctx, cl, pod, func() error {
 		pod.Spec = corev1.PodSpec{
 			Containers: []corev1.Container{
 				{

--- a/test/e2e/testutils/util/secret.go
+++ b/test/e2e/testutils/util/secret.go
@@ -20,7 +20,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	"github.com/liqotech/liqo/pkg/utils/resource"
 )
 
 // SecretOption is a function that modifies a Secret.
@@ -39,7 +40,7 @@ func EnforceSecret(ctx context.Context, cl client.Client, namespace, name string
 		Type: corev1.SecretTypeOpaque,
 	}
 
-	return Second(controllerutil.CreateOrUpdate(ctx, cl, sec, func() error {
+	return Second(resource.CreateOrUpdate(ctx, cl, sec, func() error {
 		if sec.Data == nil {
 			sec.Data = make(map[string][]byte)
 		}

--- a/test/e2e/testutils/util/service.go
+++ b/test/e2e/testutils/util/service.go
@@ -21,7 +21,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	"github.com/liqotech/liqo/pkg/utils/resource"
 )
 
 // ServiceOption is a function that modifies a Service.
@@ -36,7 +37,7 @@ func EnforceService(ctx context.Context, cl client.Client, namespace, name strin
 		},
 	}
 
-	return Second(controllerutil.CreateOrUpdate(ctx, cl, svc, func() error {
+	return Second(resource.CreateOrUpdate(ctx, cl, svc, func() error {
 		svc.Spec.Ports = []corev1.ServicePort{
 			{
 				Name:       "http",


### PR DESCRIPTION
# Description

This pr adds global labels and annotations to all liqo-created resources.

It can be useful to add the resources created by liqo controllers to an argocd application
