### PR TITLE
Adopt `Conventional Commits` specification

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug report
 about: Report a bug encountered while using Liqo
-labels: kind/bug
+labels: fix
 
 ---
 

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,25 +1,43 @@
 changelog:
   exclude:
     labels:
-    - kind/no-changelog
+    - no-changelog
     authors:
     - dependabot
   categories:
-    - title: ":boom: Breaking Change"
-      labels:
-      - kind/breaking
     - title: ":rocket: New Features"
       labels:
-      - kind/feature
+      - feat
     - title: ":bug: Bug Fixes"
       labels:
-      - kind/bug
+      - fix
     - title: ":broom: Code Refactoring"
       labels:
-      - kind/cleanup
+      - refactor
     - title: ":memo: Documentation"
       labels:
-      - kind/docs
+      - docs
+    - title: ":lipstick: Code Style"
+      labels:
+      - style
+    - title: ":racehorse: Performance Improvement"
+      labels:
+      - perf
+    - title: ":white_check_mark: Tests"
+      labels:
+      - test
+    - title: ":truck: Dependencies Management"
+      labels:
+      - chore
+    - title: ":package: Builds Management"
+      labels:
+      - build
+    - title: ":construction_worker: CI/CD"
+      labels:
+      - ci
+    - title: ":rewind: Reverts Previous Changes"
+      labels:
+      - revert
     - title: Other Changes
       labels:
       - "*"

--- a/.github/workflows/greeting.yml
+++ b/.github/workflows/greeting.yml
@@ -29,8 +29,15 @@ jobs:
             * `/hold`, `/unhold`    Add/remove the hold label to prevent merging with /merge
 
             Make sure this PR appears in the **${{ github.event.repository.name }} changelog**, adding one of the following **labels**:
-            * `kind/breaking`:      :boom: Breaking Change
-            * `kind/feature`:       :rocket: New Feature
-            * `kind/bug`:           :bug: Bug Fix
-            * `kind/cleanup`:       :broom: Code Refactoring
-            * `kind/docs`:          :memo: Documentation
+            * `feat`:          :rocket: New Feature
+            * `fix`:           :bug: Bug Fix
+            * `refactor`:      :broom: Code Refactoring
+            * `docs`:          :memo: Documentation
+            * `style`:         :lipstick: Code Style
+            * `perf`:          :racehorse: Performance Improvement
+            * `test`:          :white_check_mark: Tests
+            * `chore`:         :truck: Dependencies Management
+            * `build`:         :package: Builds Management
+            * `ci`:            :construction_worker: CI/CD
+            * `revert`:        :rewind: Reverts Previous Changes
+

--- a/docs/contributing/contributing.md
+++ b/docs/contributing/contributing.md
@@ -8,16 +8,42 @@ This page lists a set of contributing guidelines, including suggestions about th
 
 The Liqo repository structure follows the [Standard Go Project Layout](https://github.com/golang-standards/project-layout).
 
+## Commits convention
+
+The project adopts the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification to classify commits, according to the nature of the change.
+In summary, commit messages should follow the following structure:
+
+```text
+<type>[optional scope]: <description>`  
+
+[optional body]
+
+[optional footer(s)]
+```
+
+where `<type>` is one of:
+
+* `feat`: 🚀 New Features
+* `fix`: 🐛 Bug Fixes
+* `refactor`: 🧹 Code Refactoring
+* `docs`: 📝 Documentation
+* `style`: 💄Code Style
+* `perf`: 🐎 Performance Improvement
+* `test`: ✅ Tests
+* `chore`: 🚚 Dependencies Management
+* `build`: 📦 Builds Management
+* `ci`: 👷 CI/CD
+* `revert`: ⏪ Reverts Previous Changes
+
+## PRs convention
+
+PRs are automatically assigned the label according to the `<type>` specified in the commit message(s) (see [commits convention section](#commits-convention)).
+The PR's name can contain an optional scope as prefix (e.g., `[<scope>]: ...`) indicating which component(s) is being involved in the PR.
+
 ## Release notes generation
 
 Liqo leverages the automatic release notes generation capabilities featured by GitHub.
-Specifically, PRs characterized by the following labels get included in the respective category:
-
-* *kind/breaking*: 💥 Breaking Change
-* *kind/feature*: 🚀 New Features
-* *kind/bug*: 🐛 Bug Fixes
-* *kind/cleanup*: 🧹 Code Refactoring
-* *kind/docs*: 📝 Documentation
+Specifically, PRs characterized by the labels described in the [PRs convention section](#prs-convention) get included in the respective category.
 
 ## Local development
 


### PR DESCRIPTION
# Description

This PR adds new labels to better classify PRs and commits, adopting [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) specification.

In particular:
- commits should follow Conventional Commits. In particular, they should contain a `<type>` as prefix:
	* `feat`: 🚀 New Features
	* `fix`: 🐛 Bug Fixes
	* `refactor`: 🧹 Code Refactoring
	* `docs`: 📝 Documentation
	* `style`: 💄Code Style
	* `perf`: 🐎 Performance Improvement
	* `test`: ✅ Tests
	* `chore`: 🚚 Dependencies Management
	* `build`: 📦 Builds Management
	* `ci`: 👷 CI/CD
	* `revert`: ⏪ Reverts Previous Changes
- a label corresponding to the commit type should be added to PRs
- the automatic release notes generator will group PRs based on their commit type.

Note: the convention is adopted for releases > v1.0.0-rc.3
