### PR TITLE
[IPAM] Wait for gRPC server to be Ready

### DIFF
--- a/cmd/liqo-controller-manager/main.go
+++ b/cmd/liqo-controller-manager/main.go
@@ -58,6 +58,7 @@ import (
 	dynamicutils "github.com/liqotech/liqo/pkg/utils/dynamic"
 	liqoerrors "github.com/liqotech/liqo/pkg/utils/errors"
 	flagsutils "github.com/liqotech/liqo/pkg/utils/flags"
+	grpcutils "github.com/liqotech/liqo/pkg/utils/grpc"
 	"github.com/liqotech/liqo/pkg/utils/indexer"
 	ipamips "github.com/liqotech/liqo/pkg/utils/ipam/mapping"
 	"github.com/liqotech/liqo/pkg/utils/mapper"
@@ -256,7 +257,15 @@ func main() {
 				klog.Errorf("failed to establish a connection to the IPAM %q", *ipamServer)
 				os.Exit(1)
 			}
+
+			if err := grpcutils.WaitForConnectionReady(ctx, conn, 10*time.Second); err != nil {
+				klog.Errorf("failed to establish a connection to the IPAM server %q", *ipamServer)
+				os.Exit(1)
+			}
+			klog.Infof("connected to the IPAM server (status: %s)", conn.GetState())
+
 			defer conn.Close()
+
 			ipamClient = ipam.NewIPAMClient(conn)
 		}
 

--- a/pkg/utils/grpc/connection.go
+++ b/pkg/utils/grpc/connection.go
@@ -1,0 +1,47 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package grpc
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/connectivity"
+)
+
+// WaitForConnectionReady tries to connect with a gRPC server until it is Ready.
+// It stops waiting if the context expires or the connection is not Ready after the timeout.
+func WaitForConnectionReady(ctx context.Context, conn *grpc.ClientConn, timeout time.Duration) error {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	for {
+		state := conn.GetState()
+		switch state {
+		case connectivity.Idle:
+			conn.Connect()
+		case connectivity.Ready:
+			return nil
+		default:
+		}
+
+		changed := conn.WaitForStateChange(ctx, state)
+		if !changed {
+			return fmt.Errorf("timeout connection to the gRPC server")
+		}
+	}
+}

--- a/pkg/utils/grpc/doc.go
+++ b/pkg/utils/grpc/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2019-2024 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package grpc provides a set of utilities to manage grpc connections.
+package grpc


### PR DESCRIPTION
# Description

This PR modifies the liqo-controller-manager to wait for the connection to the IPAM server to be `Ready` before setting up the modules and starting controllers.
