### PR TITLE
[CI] Assign label based on `Conventional Commits`

### DIFF
--- a/.github/workflows/labels.yaml
+++ b/.github/workflows/labels.yaml
@@ -1,0 +1,49 @@
+name: Conventional Commit Labels
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  assign-labels:
+    runs-on: ubuntu-latest
+    name: Assign labels in pull request
+    if: github.event.pull_request.merged == false
+    steps:
+      - name: Execute assign labels
+        id: action-assign-labels
+        uses: mauroalderete/action-assign-labels@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          conventional-commits: |
+            conventional-commits:
+              - type: 'fix'
+                nouns: ['fix']
+                labels: ['fix']
+              - type: 'feat'
+                nouns: ['feat']
+                labels: ['feat']
+              - type: 'build'
+                nouns: ['build']
+                labels: ['build']
+              - type: 'chore'
+                nouns: ['chore']
+                labels: ['chore']
+              - type: 'ci'
+                nouns: ['ci']
+                labels: ['ci']
+              - type: 'docs'
+                nouns: ['docs']
+                labels: ['docs']
+              - type: 'style'
+                nouns: ['style']
+                labels: ['style']
+              - type: 'refactor'
+                nouns: ['refactor']
+                labels: ['refactor']
+              - type: 'perf'
+                nouns: ['perf']
+                labels: ['perf']
+              - type: 'test'
+                nouns: ['test']
+                labels: ['test']
+          


### PR DESCRIPTION
# Description

This PR adds an action to assign labels automatically based on conventional commits
