### PR TITLE
[IPAM] NetworkIsAvailable refuse nodes with children

### DIFF
--- a/pkg/ipam/core/ipam.go
+++ b/pkg/ipam/core/ipam.go
@@ -102,6 +102,9 @@ func (ipam *Ipam) NetworkIsAvailable(prefix netip.Prefix) bool {
 	if node == nil {
 		return true
 	}
+	if node.left != nil || node.right != nil {
+		return false
+	}
 	return !node.acquired
 }
 


### PR DESCRIPTION
# Description

This PR fixes a bug in NetworkIsAvailable function. Now when a node has children returns false
