### PR TITLE
fix: peer command default network resources namespace

### DIFF
--- a/pkg/liqoctl/peer/handler.go
+++ b/pkg/liqoctl/peer/handler.go
@@ -76,6 +76,13 @@ func (o *Options) RunPeer(ctx context.Context) error {
 	ctx, cancel := context.WithTimeout(ctx, o.Timeout)
 	defer cancel()
 
+	// To ease the experience for most users, we disable the namespace and remote-namespace flags
+	// so that resources are created according to the default Liqo logic.
+	// Advanced users can use the individual commands (e.g., liqoctl init, liqoctl connect, etc..) to
+	// customize the namespaces according to their needs (e.g., networking resources in a specific namespace).
+	o.LocalFactory.Namespace = ""
+	o.RemoteFactory.Namespace = ""
+
 	// Ensure networking
 	if !o.NetworkingDisabled {
 		if err := ensureNetworking(ctx, o); err != nil {

--- a/pkg/liqoctl/unpeer/handler.go
+++ b/pkg/liqoctl/unpeer/handler.go
@@ -58,6 +58,13 @@ func (o *Options) RunUnpeer(ctx context.Context) error {
 	ctx, cancel := context.WithTimeout(ctx, o.Timeout)
 	defer cancel()
 
+	// To ease the experience for most users, we disable the namespace and remote-namespace flags
+	// so that resources are created according to the default Liqo logic.
+	// Advanced users can use the individual commands (e.g., liqoctl reset, liqoctl disconnect, etc..) to
+	// customize the namespaces according to their needs (e.g., networking resources in a specific namespace).
+	o.LocalFactory.Namespace = ""
+	o.RemoteFactory.Namespace = ""
+
 	// Get consumer clusterID
 	o.consumerClusterID, err = liqoutils.GetClusterIDWithControllerClient(ctx, o.LocalFactory.CRClient, o.LocalFactory.LiqoNamespace)
 	if err != nil {


### PR DESCRIPTION
# Description

This PR makes the peer command automatically default the namespaces used for network resources to the liqo tenant namespace, even if the user passes the `--kubeconfig` or `--remote-kubeconfig` args (or has the ns set in the kubeconfig).


