### PR TITLE
[Deploy] Fixes for smooth ArgoCD uninstall

### DIFF
--- a/cmd/liqo-controller-manager/main.go
+++ b/cmd/liqo-controller-manager/main.go
@@ -274,7 +274,7 @@ func main() {
 			ipamClient = ipam.NewIpamClient(connection)
 		}
 
-		if err := modules.SetupNetworkingModule(ctx, mgr, &modules.NetworkingOption{
+		opts := &modules.NetworkingOption{
 			DynClient: dynClient,
 			Factory:   factory,
 
@@ -291,7 +291,9 @@ func main() {
 			GwmasqbypassEnabled:            *gwmasqbypassEnabled,
 
 			GenevePort: *genevePort,
-		}); err != nil {
+		}
+
+		if err := modules.SetupNetworkingModule(ctx, mgr, uncachedClient, opts); err != nil {
 			klog.Fatalf("Unable to setup the networking module: %v", err)
 		}
 	}

--- a/deployments/liqo/templates/pre-delete-rbac.yaml
+++ b/deployments/liqo/templates/pre-delete-rbac.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
   {{- include "liqo.labels" $predelete| nindent 4 }}
   annotations:
-  {{- include "liqo.preDeleteAnnotations" $predelete| nindent 4 }}
+    {{- include "liqo.preDeleteAnnotations" $predelete| nindent 4 }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/pkg/consts/labels.go
+++ b/pkg/consts/labels.go
@@ -38,6 +38,15 @@ const (
 	// APIServerProxyAppName label value that denotes the name of the liqo-api-server-proxy deployment.
 	APIServerProxyAppName = "proxy"
 
+	// OffloadingComponentKey is the label assigned to the Liqo components related to offloading.
+	OffloadingComponentKey = "offloading.liqo.io/component"
+
+	// VirtualKubeletComponentValue is the value to use with the OffloadingComponentKey to label the Virtual Kubelet component.
+	VirtualKubeletComponentValue = "virtual-kubelet"
+
+	// NetworkingComponentKey is the label assigned to the Liqo components related to networking.
+	NetworkingComponentKey = "networking.liqo.io/component"
+
 	// IpamStorageResourceLabelKey is the constant representing
 	// the key of the label assigned to all IpamStorage resources.
 	IpamStorageResourceLabelKey = "ipam.liqo.io/ipamstorage"

--- a/pkg/gateway/label.go
+++ b/pkg/gateway/label.go
@@ -15,6 +15,7 @@
 package gateway
 
 import (
+	"github.com/liqotech/liqo/pkg/consts"
 	"github.com/liqotech/liqo/pkg/firewall"
 	"github.com/liqotech/liqo/pkg/gateway/concurrent"
 	"github.com/liqotech/liqo/pkg/route"
@@ -22,7 +23,7 @@ import (
 
 const (
 	// GatewayComponentKey is the key used to label the gateway pod.
-	GatewayComponentKey = "networking.liqo.io/component"
+	GatewayComponentKey = consts.NetworkingComponentKey
 
 	// GatewayComponentGateway is the key used to label the gateway pod.
 	GatewayComponentGateway = "gateway"

--- a/pkg/liqo-controller-manager/networking/internal-network/route/internalnode_controller.go
+++ b/pkg/liqo-controller-manager/networking/internal-network/route/internalnode_controller.go
@@ -164,10 +164,13 @@ func (r *InternalNodeReconciler) genericEnqueuerfunc(ctx context.Context, _ clie
 		klog.Error(err)
 		return nil
 	}
+
 	var requests []reconcile.Request
 	for i := range internalNodes.Items {
+		iNode := &internalNodes.Items[i]
+
 		requests = append(requests, reconcile.Request{
-			NamespacedName: client.ObjectKeyFromObject(&internalNodes.Items[i]),
+			NamespacedName: client.ObjectKeyFromObject(iNode),
 		})
 	}
 	return requests

--- a/pkg/vkMachinery/const.go
+++ b/pkg/vkMachinery/const.go
@@ -30,11 +30,7 @@ const CRBPrefix = "liqo-node-"
 
 // KubeletBaseLabels are the static labels that are set on every VirtualKubelet.
 var KubeletBaseLabels = map[string]string{
-	consts.K8sAppNameKey:      "virtual-kubelet",
-	consts.K8sAppInstanceKey:  "virtual-kubelet",
-	consts.K8sAppManagedByKey: consts.LiqoAppLabelValue,
-	consts.K8sAppComponentKey: "virtual-kubelet",
-	consts.K8sAppPartOfKey:    "liqo",
+	consts.OffloadingComponentKey: consts.VirtualKubeletComponentValue,
 }
 
 // ClusterRoleBindingLabels are the static labels that are set on every ClusterRoleBinding managed by Liqo.


### PR DESCRIPTION
# Description

Cleanly uninstall Liqo with ArgoCD was not possible due to the fact that sometimes the deleting process was stuck due to resources having finalizers that were removed after the removal of the controller-manager (in charge of removing those finalizers) and some other residual resources polluted the cluster even after Liqo removal.

This PR introduces some fixes allowing to smoothly uninstall ArgoCD provided the following conditions are verified:

- There are no pending peerings of offloaded namespace
- The following configuration is defined at installation time:
```
common:
          globalLabels:
            app.kubernetes.io/instance: <ARGOCD_APP_NAME>
          globalAnnotations:
            argocd.argoproj.io/ignore-resource-updates: "true"
            argocd.argoproj.io/sync-options: Delete=true
            argocd.argoproj.io/sync-wave: 10
            argocd.argoproj.io/compare-options: IgnoreExtraneous
 
```
Where:
  - `app.kubernetes.io/instance` in `globalLabels` tells Liqo to add that labels to all the resources created by the controllers, in this case this allows ArgoCD to track all the resources created afterwards by controllers. While:
  - ` argocd.argoproj.io/sync-options: Delete=true`: tells ArgoCD to remove the resources tracked with this annotation during deletion
  - `argocd.argoproj.io/sync-wave`: anticipate the deletion of the resources annotated with that label, so that controllers can remove the finalizers and perform the necessary cleanup
