### PR TITLE
refactor: use standard maps lib instead of experimental one

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,6 @@ require (
 	github.com/virtual-kubelet/virtual-kubelet v1.11.0
 	github.com/vishvananda/netlink v1.2.1-beta.2
 	go4.org/netipx v0.0.0-20220925034521-797b0c90d8ab
-	golang.org/x/exp v0.0.0-20240103183307-be819d1f06fc
 	golang.org/x/mod v0.21.0
 	golang.org/x/sync v0.8.0
 	golang.org/x/sys v0.25.0
@@ -240,6 +239,7 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.26.0 // indirect
 	golang.org/x/crypto v0.27.0 // indirect
+	golang.org/x/exp v0.0.0-20240103183307-be819d1f06fc // indirect
 	golang.org/x/net v0.29.0 // indirect
 	golang.org/x/oauth2 v0.23.0 // indirect
 	golang.org/x/term v0.24.0 // indirect

--- a/pkg/utils/getters/dataGetters.go
+++ b/pkg/utils/getters/dataGetters.go
@@ -17,9 +17,10 @@ package getters
 import (
 	"errors"
 	"fmt"
+	"maps"
+	"slices"
 	"strconv"
 
-	"golang.org/x/exp/maps"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
@@ -174,7 +175,7 @@ func RetrieveClusterIDsFromVirtualNodes(virtualNodes *offloadingv1beta1.VirtualN
 	for i := range virtualNodes.Items {
 		clusterIDs[string(virtualNodes.Items[i].Spec.ClusterID)] = nil
 	}
-	return maps.Keys(clusterIDs)
+	return slices.Collect(maps.Keys(clusterIDs))
 }
 
 // RetrieveClusterIDsFromObjectsLabels returns the remote cluster IDs in a list of objects avoiding duplicates.
@@ -191,5 +192,5 @@ func RetrieveClusterIDsFromObjectsLabels[T metav1.Object](objectList []T) []stri
 		}
 		clusterIDs[clusterID] = nil
 	}
-	return maps.Keys(clusterIDs)
+	return slices.Collect(maps.Keys(clusterIDs))
 }

--- a/pkg/utils/resources/resources.go
+++ b/pkg/utils/resources/resources.go
@@ -17,10 +17,10 @@ package resources
 import (
 	"context"
 	"fmt"
+	"maps"
 	"slices"
 	"sort"
 
-	"golang.org/x/exp/maps"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -66,7 +66,7 @@ func EphemeralStorage(r corev1.ResourceList) string {
 func Others(r corev1.ResourceList) map[string]string {
 	result := map[string]string{}
 
-	keys := maps.Keys(r)
+	keys := slices.Collect(maps.Keys(r))
 	sort.SliceStable(keys, func(i, j int) bool { return keys[i] < keys[j] })
 	for _, k := range keys {
 		if v, ok := (r)[k]; !slices.Contains(WellKnownResources, k.String()) && ok && v.Value() != 0 {


### PR DESCRIPTION
# Description

This PR replaces the experimental package `golang.org/x/exp/maps` with the new `maps` package from the standard Go library.