### PR TITLE
[Offloading] Allow coexistence of podoffloadingpolicy and runtimeclass

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -90,8 +90,8 @@ func main() {
 		"Enforce offerer-side that offloaded pods do not exceed offered resources (based on container limits)")
 	refreshInterval := pflag.Duration("resource-validator-refresh-interval",
 		5*time.Minute, "The interval at which the resource validator cache is refreshed")
-	addVirtualNodeTolerationOnOffloadedPods := pflag.Bool("add-virtual-node-toleration-on-offloaded-pods", false,
-		"Automatically add the virtual node toleration on offloaded pods")
+	liqoRuntimeClassName := pflag.String("liqo-runtime-class", "liqo",
+		"Define the Liqo runtime class forcing the pods to be scheduled on virtual nodes")
 
 	flagsutils.InitKlogFlags(pflag.CommandLine)
 	restcfg.InitFlags(pflag.CommandLine)
@@ -192,7 +192,7 @@ func main() {
 	mgr.GetWebhookServer().Register("/validate/shadowpods", &webhook.Admission{Handler: spv})
 	mgr.GetWebhookServer().Register("/mutate/shadowpods", shadowpodswh.NewMutator(mgr.GetClient()))
 	mgr.GetWebhookServer().Register("/validate/namespace-offloading", nsoffwh.New())
-	mgr.GetWebhookServer().Register("/mutate/pod", podwh.New(mgr.GetClient(), *addVirtualNodeTolerationOnOffloadedPods))
+	mgr.GetWebhookServer().Register("/mutate/pod", podwh.New(mgr.GetClient(), *liqoRuntimeClassName))
 	mgr.GetWebhookServer().Register("/mutate/virtualnodes", virtualnodewh.New(
 		mgr.GetClient(), clusterID, *podcidr, *liqoNamespace, vkOptsDefaultTemplateRef))
 	mgr.GetWebhookServer().Register("/validate/resourceslices", resourceslicewh.NewValidator(mgr.GetClient()))

--- a/deployments/liqo/README.md
+++ b/deployments/liqo/README.md
@@ -138,7 +138,6 @@
 | offloading.reflection.skip.annotations | list | `["cloud.google.com/neg","cloud.google.com/neg-status","kubernetes.digitalocean.com/load-balancer-id","ingress.kubernetes.io/backends","ingress.kubernetes.io/forwarding-rule","ingress.kubernetes.io/target-proxy","ingress.kubernetes.io/url-map","metallb.universe.tf/address-pool","metallb.universe.tf/ip-allocated-from-pool","metallb.universe.tf/loadBalancerIPs","loadbalancer.openstack.org/load-balancer-id"]` | List of annotations that must not be reflected on remote clusters. |
 | offloading.reflection.skip.labels | list | `[]` | List of labels that must not be reflected on remote clusters. |
 | offloading.runtimeClass.annotations | object | `{}` | Annotations for the runtime class. |
-| offloading.runtimeClass.enabled | bool | `false` |  |
 | offloading.runtimeClass.handler | string | `"liqo"` | Handler for the runtime class. |
 | offloading.runtimeClass.labels | object | `{}` | Labels for the runtime class. |
 | offloading.runtimeClass.name | string | `"liqo"` | Name of the runtime class to use for offloading. |

--- a/deployments/liqo/templates/liqo-webhook-deployment.yaml
+++ b/deployments/liqo/templates/liqo-webhook-deployment.yaml
@@ -53,13 +53,11 @@ spec:
           - --cluster-id=$(CLUSTER_ID)
           - --liqo-namespace=$(POD_NAMESPACE)
           - --secret-name={{ include "liqo.prefixedName" $webhookConfig }}-certs
+          - --liqo-runtime-class={{ .Values.offloading.runtimeClass.name }}
           - --podcidr={{ .Values.ipam.podCIDR }}
           - --vk-options-default-template={{ .Release.Namespace }}/{{ printf "%s-default" $kubeletConfig.name }}
           {{- if .Values.controllerManager.config.enableResourceEnforcement }}
           - --enable-resource-enforcement
-          {{- end }}
-          {{- if not .Values.offloading.runtimeClass.enabled }}
-          - --add-virtual-node-toleration-on-offloaded-pods
           {{- end }}
           {{- if .Values.common.extraArgs }}
           {{- toYaml .Values.common.extraArgs | nindent 10 }}

--- a/deployments/liqo/templates/runtime-class.yaml
+++ b/deployments/liqo/templates/runtime-class.yaml
@@ -1,7 +1,5 @@
 {{- $runtimeConfig := (merge (dict "name" "runtimeclass" "module" "runtimeclass") .) -}}
 
-{{- if .Values.offloading.runtimeClass.enabled }}
-
 apiVersion: node.k8s.io/v1
 kind: RuntimeClass
 metadata:
@@ -25,5 +23,3 @@ scheduling:
   tolerations:
     {{- toYaml .Values.offloading.runtimeClass.tolerations.tolerations | nindent 4 }}
   {{- end }}
-
-{{- end }}

--- a/deployments/liqo/values.yaml
+++ b/deployments/liqo/values.yaml
@@ -179,7 +179,6 @@ offloading:
   # by setting the "disableNetworkCheck" field in the resource Spec.
   disableNetworkCheck: false
   runtimeClass:
-    enabled: false
     # -- Name of the runtime class to use for offloading.
     name: liqo
     # -- Annotations for the runtime class.

--- a/docs/examples/offloading-with-policies.md
+++ b/docs/examples/offloading-with-policies.md
@@ -1,7 +1,7 @@
 # Offloading with Policies
 
 This tutorial aims to guide you through a tour to learn how to use the core Liqo features.
-You will learn how to tune namespace offloading, and specify the target clusters through the [cluster selector](UsageOffloadingClusterSelector) concept.
+You will learn how to tune namespace offloading, and specify the target clusters through the [cluster selector](../usage/namespace-offloading.md#cluster-selector) concept.
 
 More specifically, you will configure a scenario composed of a *single entry point cluster* leveraged for the deployment of the applications (i.e., the *Venice* cluster, located in *north* Italy) and two *worker clusters* characterized by different geographical regions (i.e., the *Florence* and *Naples* clusters, respectively located in *center* and *south* Italy).
 Then, you will offload a given namespace (and the applications contained therein) to a subset of the worker clusters (i.e., only to the *Naples* cluster), while allowing pods to be also scheduled on the local cluster (i.e., the *Venice* one).

--- a/pkg/webhooks/pod/pod.go
+++ b/pkg/webhooks/pod/pod.go
@@ -39,16 +39,16 @@ type podwh struct {
 	client  client.Client
 	decoder admission.Decoder
 
-	addVirtualNodeToleration bool
+	runtimeClassName string
 }
 
 // New returns a new PodWebhook instance.
-func New(cl client.Client, addVirtualNodeToleration bool) *webhook.Admission {
+func New(cl client.Client, liqoRuntimeClassName string) *webhook.Admission {
 	return &webhook.Admission{Handler: &podwh{
 		client:  cl,
 		decoder: admission.NewDecoder(runtime.NewScheme()),
 
-		addVirtualNodeToleration: addVirtualNodeToleration,
+		runtimeClassName: liqoRuntimeClassName,
 	}}
 }
 
@@ -91,7 +91,7 @@ func (w *podwh) Handle(ctx context.Context, req admission.Request) admission.Res
 		return admission.Errored(http.StatusInternalServerError, errors.New("failed retrieving NamespaceOffloading"))
 	}
 
-	if err = mutatePod(nsoff, pod, w.addVirtualNodeToleration); err != nil {
+	if err = mutatePod(nsoff, pod, w.runtimeClassName); err != nil {
 		return admission.Errored(http.StatusInternalServerError, errors.New("failed constructing pod mutation"))
 	}
 

--- a/pkg/webhooks/pod/testutils/utils.go
+++ b/pkg/webhooks/pod/testutils/utils.go
@@ -183,49 +183,9 @@ func GetMergedNodeSelector(strategy offloadingv1beta1.PodOffloadingStrategyType)
 			{
 				MatchExpressions: []corev1.NodeSelectorRequirement{
 					{
-						Key:      "region",
-						Operator: corev1.NodeSelectorOpIn,
-						Values:   []string{"A,B"},
-					},
-					{
-						Key:      "provider",
-						Operator: corev1.NodeSelectorOpExists,
-					},
-					{
-						Key:      liqoconst.TypeLabel,
-						Operator: corev1.NodeSelectorOpIn,
-						Values:   []string{liqoconst.TypeNode},
-					},
-					{
 						Key:      "storage",
 						Operator: corev1.NodeSelectorOpExists,
 					},
-				},
-			},
-			{
-				MatchExpressions: []corev1.NodeSelectorRequirement{
-					{
-						Key:      "region",
-						Operator: corev1.NodeSelectorOpIn,
-						Values:   []string{"C,D"},
-					},
-					{
-						Key:      "NotProvider",
-						Operator: corev1.NodeSelectorOpExists,
-					},
-					{
-						Key:      liqoconst.TypeLabel,
-						Operator: corev1.NodeSelectorOpIn,
-						Values:   []string{liqoconst.TypeNode},
-					},
-					{
-						Key:      "storage",
-						Operator: corev1.NodeSelectorOpExists,
-					},
-				},
-			},
-			{
-				MatchExpressions: []corev1.NodeSelectorRequirement{
 					{
 						Key:      "region",
 						Operator: corev1.NodeSelectorOpIn,
@@ -240,15 +200,14 @@ func GetMergedNodeSelector(strategy offloadingv1beta1.PodOffloadingStrategyType)
 						Operator: corev1.NodeSelectorOpIn,
 						Values:   []string{liqoconst.TypeNode},
 					},
-					{
-						Key:      "provider",
-						Operator: corev1.NodeSelectorOpIn,
-						Values:   []string{"AWS"},
-					},
 				},
 			},
 			{
 				MatchExpressions: []corev1.NodeSelectorRequirement{
+					{
+						Key:      "storage",
+						Operator: corev1.NodeSelectorOpExists,
+					},
 					{
 						Key:      "region",
 						Operator: corev1.NodeSelectorOpIn,
@@ -263,10 +222,51 @@ func GetMergedNodeSelector(strategy offloadingv1beta1.PodOffloadingStrategyType)
 						Operator: corev1.NodeSelectorOpIn,
 						Values:   []string{liqoconst.TypeNode},
 					},
+				},
+			},
+			{
+				MatchExpressions: []corev1.NodeSelectorRequirement{
 					{
 						Key:      "provider",
 						Operator: corev1.NodeSelectorOpIn,
 						Values:   []string{"AWS"},
+					},
+					{
+						Key:      "region",
+						Operator: corev1.NodeSelectorOpIn,
+						Values:   []string{"A,B"},
+					},
+					{
+						Key:      "provider",
+						Operator: corev1.NodeSelectorOpExists,
+					},
+					{
+						Key:      liqoconst.TypeLabel,
+						Operator: corev1.NodeSelectorOpIn,
+						Values:   []string{liqoconst.TypeNode},
+					},
+				},
+			},
+			{
+				MatchExpressions: []corev1.NodeSelectorRequirement{
+					{
+						Key:      "provider",
+						Operator: corev1.NodeSelectorOpIn,
+						Values:   []string{"AWS"},
+					},
+					{
+						Key:      "region",
+						Operator: corev1.NodeSelectorOpIn,
+						Values:   []string{"C,D"},
+					},
+					{
+						Key:      "NotProvider",
+						Operator: corev1.NodeSelectorOpExists,
+					},
+					{
+						Key:      liqoconst.TypeLabel,
+						Operator: corev1.NodeSelectorOpIn,
+						Values:   []string{liqoconst.TypeNode},
 					},
 				},
 			},


### PR DESCRIPTION
# Description

This PR introduces some changes namespace offloading mechanism allowing the podoffloadingpolicy and runtimeclass.
The Liqo runtimeclass does not need to be manually enabled  anymore, and it can be used in conjunction with the pod offloading strategy and it can be used to force pods to be scheduled on virtual nodes (so on the provider clusters) independently from the pod offloading strategy. 

# How Has This Been Tested?

Unit test suite provided