### PR TITLE
[Liqoctl] network test exit error code

### DIFF
--- a/pkg/liqoctl/test/network/check/check.go
+++ b/pkg/liqoctl/test/network/check/check.go
@@ -118,6 +118,9 @@ func RunChecks(ctx context.Context, cl *client.Client, cfg client.Configs, opts 
 	logger.Info("All checks completed")
 	PrintCheckResults(successCountTot, errorCountTot, logger)
 
+	if errorCountTot > 0 {
+		return fmt.Errorf("some checks failed")
+	}
 	return nil
 }
 


### PR DESCRIPTION
# Description

This PR allows the liqoctl test network command to return  an exit code different from 0 in case the command fails without the --fail-fast flag
