### PR TITLE
[IPAM] Fix acquire preallocated IPs

### DIFF
--- a/pkg/ipam/initialize.go
+++ b/pkg/ipam/initialize.go
@@ -55,10 +55,9 @@ func (lipam *LiqoIPAM) initializeNetworks(ctx context.Context) error {
 		if _, err := lipam.networkAcquireSpecific(net); err != nil {
 			return err
 		}
-		for i := 0; i < int(netdetails.preallocated); i++ {
-			if _, err := lipam.ipAcquire(net); err != nil {
-				return errors.Join(err, lipam.networkRelease(net, 0))
-			}
+
+		if err := lipam.acquirePreallocatedIPs(net, netdetails.preallocated); err != nil {
+			return errors.Join(err, lipam.networkRelease(net, 0))
 		}
 	}
 

--- a/pkg/ipam/ipam.go
+++ b/pkg/ipam/ipam.go
@@ -164,11 +164,8 @@ func (lipam *LiqoIPAM) NetworkAcquire(_ context.Context, req *NetworkAcquireRequ
 		}
 	}
 
-	for i := 0; i < int(req.GetPreAllocated()); i++ {
-		_, err := lipam.ipAcquire(*remappedCidr)
-		if err != nil {
-			return &NetworkAcquireResponse{}, errors.Join(err, lipam.networkRelease(*remappedCidr, 0))
-		}
+	if err := lipam.acquirePreallocatedIPs(*remappedCidr, req.GetPreAllocated()); err != nil {
+		return &NetworkAcquireResponse{}, errors.Join(err, lipam.networkRelease(*remappedCidr, 0))
 	}
 
 	return &NetworkAcquireResponse{Cidr: remappedCidr.String()}, nil

--- a/pkg/ipam/sync.go
+++ b/pkg/ipam/sync.go
@@ -69,13 +69,13 @@ func syncNetworkAcquire(lipam *LiqoIPAM, clusterNetworks map[netip.Prefix]prefix
 			if _, err := lipam.networkAcquireSpecific(clusterNetwork); err != nil {
 				return fmt.Errorf("failed to acquire network %q: %w", clusterNetwork, err)
 			}
-			for i := 0; i < int(clusterNetworkDetails.preallocated); i++ {
-				if _, err := lipam.ipAcquire(clusterNetwork); err != nil {
-					return errors.Join(err, lipam.networkRelease(clusterNetwork, 0))
-				}
-			}
+		}
+
+		if err := lipam.acquirePreallocatedIPs(clusterNetwork, clusterNetworkDetails.preallocated); err != nil {
+			return errors.Join(err, lipam.networkRelease(clusterNetwork, 0))
 		}
 	}
+
 	return nil
 }
 

--- a/pkg/utils/ipam/ips.go
+++ b/pkg/utils/ipam/ips.go
@@ -18,6 +18,9 @@ import (
 	"encoding/binary"
 	"fmt"
 	"net"
+	"net/netip"
+
+	"iter"
 
 	ipamv1alpha1 "github.com/liqotech/liqo/apis/ipam/v1alpha1"
 	networkingv1beta1 "github.com/liqotech/liqo/apis/networking/v1beta1"
@@ -95,4 +98,17 @@ func NetFirstAndLastIP(networkCIDR string) (first, last net.IP, err error) {
 	}
 
 	return first, last, nil
+}
+
+// FirstNIPsFromPrefix returns an iterator with first num IPs from the given prefix.
+func FirstNIPsFromPrefix(prefix netip.Prefix, num uint32) iter.Seq[netip.Addr] {
+	return func(yield func(netip.Addr) bool) {
+		addr := prefix.Addr()
+		for i := 0; i < int(num); i++ {
+			if !yield(addr) {
+				return
+			}
+			addr = addr.Next()
+		}
+	}
 }


### PR DESCRIPTION
# Description

This PR fixes the acquiring of the preallocated IPs:
- iterate through the first N IPs of the cidr and acquire the specific IP
- check if network size is enough to acquire all N IPs
