### PR TITLE
[Liqoctl] control-planes in liqoctl network np-nodes flag

### DIFF
--- a/pkg/liqoctl/test/network/check/service.go
+++ b/pkg/liqoctl/test/network/check/service.go
@@ -112,6 +112,9 @@ func RunCheckExternalToNodePortServiceWithClient(ctx context.Context, cl ctrlcli
 			if opts.NodePortNodes == flags.NodePortNodesWorkers && setup.IsNodeControlPlane(nodes.Items[i].Spec.Taints) {
 				continue
 			}
+			if opts.NodePortNodes == flags.NodePortNodesControlPlanes && !setup.IsNodeControlPlane(nodes.Items[i].Spec.Taints) {
+				continue
+			}
 			nodeip := GetNodeAddress(&nodes.Items[i])
 			ok, err := httpclient.Curl(ctx, fmt.Sprintf("http://%s:%d", nodeip, nodeport), !opts.Topts.Verbose, opts.Topts.LocalFactory.Printer.Logger)
 			successCount, errorCount, err = utils.ManageResults(opts.Topts.FailFast, err, ok, successCount, errorCount)
@@ -261,7 +264,10 @@ func RunsCheckPodToNodePortServiceWithClient(ctx context.Context, cl ctrlclient.
 			if nodes.Items[i].GetLabels()[consts.TypeLabel] == consts.TypeNode {
 				continue
 			}
-			if opts.NodePortNodes == "workers" && setup.IsNodeControlPlane(nodes.Items[i].Spec.Taints) {
+			if opts.NodePortNodes == flags.NodePortNodesWorkers && setup.IsNodeControlPlane(nodes.Items[i].Spec.Taints) {
+				continue
+			}
+			if opts.NodePortNodes == flags.NodePortNodesControlPlanes && !setup.IsNodeControlPlane(nodes.Items[i].Spec.Taints) {
 				continue
 			}
 			nodeip := GetNodeAddress(&nodes.Items[i])

--- a/pkg/liqoctl/test/network/flags/flags.go
+++ b/pkg/liqoctl/test/network/flags/flags.go
@@ -48,7 +48,7 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&o.RemoveNamespace, string(FlagNamesRemoveNamespace), false, "Remove namespace after the test")
 	fs.BoolVar(&o.Info, string(FlagNamesInfo), false, "Print information about the network configurations of the clusters")
 	fs.BoolVar(&o.NodePortExt, string(FlagNamesNodeportExternal), false, "Enable curl from external to nodeport service")
-	fs.Var(&o.NodePortNodes, string(FlagNamesNodeportNodes), "Select nodes type for NodePort tests. Possible values: all, workers")
+	fs.Var(&o.NodePortNodes, string(FlagNamesNodeportNodes), "Select nodes type for NodePort tests. Possible values: all, workers, control-planes")
 	fs.BoolVar(&o.LoadBalancer, string(FlagNamesLoadbalancer), false, "Enable curl from external to loadbalancer service")
 	fs.BoolVar(&o.Basic, string(FlagNamesBasic), false, "Run only pod-to-pod checks")
 	fs.BoolVar(&o.PodToNodePort, string(FlagNamesPodNodeport), false, "Enable curl from pod to nodeport service")

--- a/pkg/liqoctl/test/network/flags/options.go
+++ b/pkg/liqoctl/test/network/flags/options.go
@@ -29,12 +29,15 @@ const (
 	NodePortNodesAll NodePortNodes = "all"
 	// NodePortNodesWorkers represents the value to target worker nodes.
 	NodePortNodesWorkers NodePortNodes = "workers"
+	// NodePortNodesControlPlanes represents the value to target control plane nodes.
+	NodePortNodesControlPlanes NodePortNodes = "control-planes"
 )
 
 // NodePortNodesValues contains the possible values for NodePortNodes.
 var NodePortNodesValues = []string{
 	string(NodePortNodesAll),
 	string(NodePortNodesWorkers),
+	string(NodePortNodesControlPlanes),
 }
 
 // String returns the string representation of the NodePortNodes.
@@ -44,7 +47,7 @@ func (npn *NodePortNodes) String() string {
 
 // Set sets the NodePortNodes value.
 func (npn *NodePortNodes) Set(s string) error {
-	if s != "" && s != string(NodePortNodesAll) && s != string(NodePortNodesWorkers) {
+	if s != "" && s != string(NodePortNodesAll) && s != string(NodePortNodesWorkers) && s != string(NodePortNodesControlPlanes) {
 		return fmt.Errorf("valid values are %s", strings.Join(NodePortNodesValues, ","))
 	}
 	if s == "" {


### PR DESCRIPTION
# Description

This pr adds the value `control-planes` inside the `np-nodes` flag in `liqoctl test network`
