### PR TITLE
Use liqo.selectorTemplate for label definitions

### DIFF
--- a/deployments/liqo/templates/_helpers.tpl
+++ b/deployments/liqo/templates/_helpers.tpl
@@ -92,9 +92,16 @@ labels:
 Common Labels for Gateway Templates
 */}}
 {{- define "liqo.labelsTemplate" -}}
-{{ include "liqo.selectorLabelsTemplate" . }}
+{{ include "liqo.selectorTemplate" . }}
 helm.sh/chart: {{ quote (include "liqo.chart" .) }}
 app.kubernetes.io/version: {{ quote (include "liqo.version" .) }}
+{{- end }}
+
+{{/*
+Common Label Selector for Gateway Template
+*/}}
+{{- define "liqo.selectorTemplate" -}}
+{{ include "liqo.selectorLabelsTemplate" . }}
 app.kubernetes.io/managed-by: {{ quote .Release.Service }}
 networking.liqo.io/component: "gateway"
 networking.liqo.io/gateway-name: "{{"{{ .Name }}"}}"

--- a/deployments/liqo/templates/liqo-wireguard-gateway-client-template.yaml
+++ b/deployments/liqo/templates/liqo-wireguard-gateway-client-template.yaml
@@ -30,7 +30,7 @@ spec:
             type: Recreate
           selector:
             matchLabels:
-              {{- include "liqo.labelsTemplate" $templateConfig | nindent 14 }}
+              {{- include "liqo.selectorTemplate" $templateConfig | nindent 14 }}
           template:
             metadata:
               {{- include "liqo.metadataTemplate" $templateConfig | nindent 14 }}

--- a/deployments/liqo/templates/liqo-wireguard-gateway-server-template-eks.yaml
+++ b/deployments/liqo/templates/liqo-wireguard-gateway-server-template-eks.yaml
@@ -39,7 +39,7 @@ spec:
           {{- end }}
         spec:
           selector:
-            {{- include "liqo.labelsTemplate" (merge (dict "isService" true) $templateConfig) | nindent 12 }}
+            {{- include "liqo.selectorTemplate" (merge (dict "isService" true) $templateConfig) | nindent 12 }}
           type: "{{"{{ .Spec.Endpoint.ServiceType }}"}}"
           ports:
           - port: "{{"{{ .Spec.Endpoint.Port }}"}}"
@@ -57,7 +57,7 @@ spec:
             type: Recreate
           selector:
             matchLabels:
-              {{- include "liqo.labelsTemplate" $templateConfig | nindent 14 }}
+              {{- include "liqo.selectorTemplate" $templateConfig | nindent 14 }}
           template:
             metadata:
               {{- include "liqo.metadataTemplate" $templateConfig | nindent 14 }}

--- a/deployments/liqo/templates/liqo-wireguard-gateway-server-template.yaml
+++ b/deployments/liqo/templates/liqo-wireguard-gateway-server-template.yaml
@@ -30,7 +30,7 @@ spec:
           {{- end }}
         spec:
           selector:
-            {{- include "liqo.labelsTemplate" (merge (dict "isService" true) $templateConfig) | nindent 12 }}
+            {{- include "liqo.selectorTemplate" (merge (dict "isService" true) $templateConfig) | nindent 12 }}
           type: "{{"{{ .Spec.Endpoint.ServiceType }}"}}"
           ?loadBalancerIP: "{{"{{ .Spec.Endpoint.LoadBalancerIP }}"}}"
           ports:
@@ -50,7 +50,7 @@ spec:
             type: Recreate
           selector:
             matchLabels:
-              {{- include "liqo.labelsTemplate" $templateConfig | nindent 14 }}
+              {{- include "liqo.selectorTemplate" $templateConfig | nindent 14 }}
           template:
             metadata:
               {{- include "liqo.metadataTemplate" $templateConfig | nindent 14 }}


### PR DESCRIPTION
# Description

This pr fixes the gateway label selectors making it possible to update a running gateway
