### PR TITLE
Update common.sh

### DIFF
--- a/examples/common.sh
+++ b/examples/common.sh
@@ -116,7 +116,7 @@ function install_liqo() {
     shift 2
     labels="$*"
 
-    fail_on_error "liqoctl install kind --cluster-id $cluster_name \
+    fail_on_error "liqoctl install kind --cluster-name $cluster_name \
         --cluster-labels=$(join_by , "${labels[@]}") \
         --kubeconfig $kubeconfig" "Failed to install liqo on cluster \"$cluster_name\""
 
@@ -143,7 +143,7 @@ function install_liqo_k3d() {
 
     api_server_address=$(kubectl get nodes --kubeconfig "$kubeconfig" --selector=node-role.kubernetes.io/master -o jsonpath='{$.items[*].status.addresses[?(@.type=="InternalIP")].address}')
 
-    fail_on_error "liqoctl install k3s --cluster-id $cluster_name \
+    fail_on_error "liqoctl install k3s --cluster-name $cluster_name \
         --cluster-labels=$(join_by , "${labels[@]}") \
         --pod-cidr $pod_cidr \
         --service-cidr $service_cidr \


### PR DESCRIPTION
# Description

I had the following prompt while trying to spin up the quickstart clusters.

```sh
$ cd liqo/examples/global-ingress
$ ./setup.sh
SUCCESS	No cluster "edgedns" is running.
SUCCESS	No cluster "gslb-eu" is running.
SUCCESS	No cluster "gslb-us" is running.
SUCCESS	Cluster "edgedns" has been created.
SUCCESS	Cluster "gslb-eu" has been created.
SUCCESS	Cluster "gslb-us" has been created.
SUCCESS	Bind server has been deployed.
SUCCESS	K8gb has been installed on cluster.
SUCCESS	Ingress-nginx has been installed on cluster.
INFO	Installing liqo on cluster "gslb-eu"...
ERROR	Failed to install liqo on cluster "gslb-eu": Error: unknown flag: --cluster-id
```

Looks like `--cluster-id` is no longer a valid flag. Fixing it in the script

Fixes #(issue)

# How Has This Been Tested?

After the changes, the clusters are available to test.

```sh
$ ./setup.sh
SUCCESS	No cluster "edgedns" is running.
SUCCESS	No cluster "gslb-eu" is running.
SUCCESS	No cluster "gslb-us" is running.
SUCCESS	Cluster "edgedns" has been created.
SUCCESS	Cluster "gslb-eu" has been created.
SUCCESS	Cluster "gslb-us" has been created.
SUCCESS	Bind server has been deployed.
SUCCESS	K8gb has been installed on cluster.
SUCCESS	Ingress-nginx has been installed on cluster.
SUCCESS	Liqo has been installed on cluster "gslb-eu".
SUCCESS	K8gb has been installed on cluster.
SUCCESS	Ingress-nginx has been installed on cluster.
SUCCESS	Liqo has been installed on cluster "gslb-us".
```
