### PR TITLE
[liqoctl] improve liqoctl version error message

### DIFF
--- a/pkg/liqoctl/version/handler.go
+++ b/pkg/liqoctl/version/handler.go
@@ -41,13 +41,20 @@ func (o *Options) Run(ctx context.Context) error {
 		return nil
 	}
 
-	version, err := liqogetters.GetLiqoVersion(ctx, o.CRClient, o.LiqoNamespace)
+	serverVersion, err := liqogetters.GetLiqoVersion(ctx, o.CRClient, o.LiqoNamespace)
 	if err != nil {
-		o.Printer.Error.Printfln("Failed to retrieve Liqo version: %v", output.PrettyErr(err))
+		fmt.Println("Server version: Unknown")
+		o.Printer.Warning.Printfln("Failed to retrieve Liqo server version: %v", output.PrettyErr(err))
+		o.Printer.Warning.Println(
+			"Is Liqo installed in your cluster? Is the cluster reachable? Do you have the permissions to access the target cluster?")
 		return err
 	}
 
-	fmt.Printf("Server version: %s\n", version)
+	fmt.Printf("Server version: %s\n", serverVersion)
+
+	if serverVersion != LiqoctlVersion {
+		o.Printer.Warning.Println("The version of liqoctl does not match the Liqo server version. This might cause unexpected behaviors.")
+	}
 
 	return nil
 }


### PR DESCRIPTION
# Description

This patch improves the returned error message when it is not possible to retrieve the version of the Liqo server, by changing the error type from ERROR to WARNING, as an error is expected when there is no remote cluster with Liqo installed. Moreover, it clarifies that the error is related to the version of the Liqo instance running in the cluster and provides a set reasons why an error is produced.

Before
![image](https://github.com/user-attachments/assets/71fc5eca-345a-4f55-a245-b48df2524b77)

After
![image](https://github.com/user-attachments/assets/a2492db9-6e6f-4e5b-aaaa-25350873eb85)

