### PR TITLE
chore: Bump alpine from 3.21.0 to 3.21.2

### DIFF
--- a/build/cert-creator/Dockerfile
+++ b/build/cert-creator/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.21.0
+FROM alpine:3.21.2
 
 RUN apk update && \
   apk add --no-cache openssl && \

--- a/build/common/Dockerfile
+++ b/build/common/Dockerfile
@@ -12,7 +12,7 @@ COPY . ./
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=$(go env GOARCH) go build -ldflags="-s -w" ./cmd/$COMPONENT
 
 
-FROM alpine:3.21.0
+FROM alpine:3.21.2
 
 RUN apk update && \
     apk add --no-cache ca-certificates && \

--- a/build/fabric/Dockerfile
+++ b/build/fabric/Dockerfile
@@ -9,7 +9,7 @@ COPY . ./
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=$(go env GOARCH) go build -ldflags="-s -w" ./cmd/fabric
 
 
-FROM alpine:3.21.0
+FROM alpine:3.21.2
 
 RUN apk update && \
     apk add iproute2 nftables bash tcpdump conntrack-tools curl iputils && \

--- a/build/gateway/Dockerfile
+++ b/build/gateway/Dockerfile
@@ -9,7 +9,7 @@ COPY . ./
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=$(go env GOARCH) go build -ldflags="-s -w" ./cmd/gateway
 
 
-FROM alpine:3.21.0
+FROM alpine:3.21.2
 
 RUN apk update && \
     apk add iproute2 nftables bash tcpdump conntrack-tools curl iputils && \

--- a/build/gateway/geneve/Dockerfile
+++ b/build/gateway/geneve/Dockerfile
@@ -9,7 +9,7 @@ COPY . ./
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=$(go env GOARCH) go build -ldflags="-s -w" ./cmd/gateway/geneve
 
 
-FROM alpine:3.21.0
+FROM alpine:3.21.2
 
 RUN apk update && \
     apk add iproute2 nftables bash tcpdump conntrack-tools curl iputils && \

--- a/build/gateway/wireguard/Dockerfile
+++ b/build/gateway/wireguard/Dockerfile
@@ -17,7 +17,7 @@ COPY . ./
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=$(go env GOARCH) go build -ldflags="-s -w" ./cmd/gateway/wireguard
 
 
-FROM alpine:3.21.0
+FROM alpine:3.21.2
 
 RUN apk update && \
     apk add iproute2 nftables bash wireguard-tools tcpdump conntrack-tools curl iputils && \


### PR DESCRIPTION
# Description

This PR upgrades alpine versions from 3.21.0 to 3.21.2 in all Dockerfile
