### PR TITLE
[liqoctl] generate peering-user

### DIFF
--- a/cmd/liqoctl/cmd/root.go
+++ b/cmd/liqoctl/cmd/root.go
@@ -39,6 +39,7 @@ import (
 	"github.com/liqotech/liqo/pkg/liqoctl/rest/identity"
 	"github.com/liqotech/liqo/pkg/liqoctl/rest/kubeconfig"
 	"github.com/liqotech/liqo/pkg/liqoctl/rest/nonce"
+	peeringuser "github.com/liqotech/liqo/pkg/liqoctl/rest/peering-user"
 	"github.com/liqotech/liqo/pkg/liqoctl/rest/publickey"
 	"github.com/liqotech/liqo/pkg/liqoctl/rest/resourceslice"
 	"github.com/liqotech/liqo/pkg/liqoctl/rest/tenant"
@@ -56,6 +57,7 @@ var liqoResources = []rest.APIProvider{
 	publickey.PublicKey,
 	tenant.Tenant,
 	nonce.Nonce,
+	peeringuser.PeeringUser,
 	identity.Identity,
 	resourceslice.ResourceSlice,
 	kubeconfig.Kubeconfig,

--- a/cmd/liqoctl/cmd/unpeer.go
+++ b/cmd/liqoctl/cmd/unpeer.go
@@ -38,7 +38,7 @@ offloaded workloads to be rescheduled. The Identity and Tenant are respectively
 removed from the consumer and provider clusters, and the networking between the
 two clusters is destroyed.
 
-The reverse peering, if any, is preserved, and the remote cluster can continue 
+The reverse peering, if any, is preserved, and the remote cluster can continue
 offloading workloads to its virtual node representing the local cluster.
 
 Examples:
@@ -66,7 +66,7 @@ func newUnpeerCommand(ctx context.Context, f *factory.Factory) *cobra.Command {
 
 	cmd.PersistentFlags().DurationVar(&options.Timeout, "timeout", 120*time.Second, "Timeout for unpeering completion")
 	cmd.PersistentFlags().BoolVar(&options.Wait, "wait", true, "Wait for resource to be deleted before returning")
-	cmd.PersistentFlags().BoolVar(&options.KeepNamespaces, "keep-namespaces", false, "Keep tenant namespaces after unpeering")
+	cmd.PersistentFlags().BoolVar(&options.DeleteNamespace, "delete-namespaces", false, "Delete the tenant namespace after unpeering")
 
 	options.LocalFactory.AddFlags(cmd.PersistentFlags(), cmd.RegisterFlagCompletionFunc)
 	options.RemoteFactory.AddFlags(cmd.PersistentFlags(), cmd.RegisterFlagCompletionFunc)

--- a/deployments/liqo/files/liqo-peering-user-ClusterRole.yaml
+++ b/deployments/liqo/files/liqo-peering-user-ClusterRole.yaml
@@ -1,0 +1,64 @@
+rules:
+- apiGroups:
+  - "networking.liqo.io"
+  resources:
+  - "configurations"
+  - "gatewayclients"
+  - "gatewayservers"
+  - "publickeies"
+  verbs:
+  - "create"
+  - "update"
+  - "get"
+  - "list"
+  - "delete"
+- apiGroups:
+  - "networking.liqo.io"
+  resources:
+  - "connections"
+  verbs:
+  - "get"
+  - "list"
+- apiGroups:
+  - "networking.liqo.io"
+  resources:
+  - "gatewayclients/status"
+  - "gatewayservers/status"
+  verbs:
+  - "get"
+- apiGroups:
+  - ""
+  resources:
+  - "secrets"
+  verbs:
+  - "create"
+  - "get"
+  - "list"
+  - "delete"
+- apiGroups:
+  - ""
+  resources:
+  - "services"
+  verbs:
+  - "get"
+- apiGroups:
+  - "apps"
+  resources:
+  - "deployments"
+  verbs:
+  - "get"
+- apiGroups:
+  - "ipam.liqo.io"
+  resources:
+  - "ips"
+  verbs:
+  - "create"
+  - "update"
+  - "get"
+  - "delete"
+- apiGroups:
+  - "authentication.liqo.io"
+  resources:
+  - "tenants/status"
+  verbs:
+  - "get"

--- a/deployments/liqo/files/liqo-peering-user-Role.yaml
+++ b/deployments/liqo/files/liqo-peering-user-Role.yaml
@@ -1,0 +1,17 @@
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - "networking.liqo.io"
+  resources:
+  - "wggatewayservertemplates"
+  - "wggatewayclienttemplates"
+  verbs:
+  - "get"
+  - "list"

--- a/deployments/liqo/templates/liqo-peer-rbac.yaml
+++ b/deployments/liqo/templates/liqo-peer-rbac.yaml
@@ -1,0 +1,17 @@
+{{- $peeringroles := (merge (dict "name" "peering-user" "module" "peering-user") .) -}}
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "liqo.prefixedName" $peeringroles}}
+  labels:
+  {{- include "liqo.labels" $peeringroles| nindent 4 }}
+{{ .Files.Get (include "liqo.cluster-role-filename" (dict "prefix" ( include "liqo.prefixedName" $peeringroles))) }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "liqo.prefixedName" $peeringroles}}
+  labels:
+  {{- include "liqo.labels" $peeringroles| nindent 4 }}
+{{ .Files.Get (include "liqo.role-filename" (dict "prefix" ( include "liqo.prefixedName" $peeringroles))) }}

--- a/pkg/consts/authentication.go
+++ b/pkg/consts/authentication.go
@@ -54,4 +54,7 @@ const (
 
 	// RenewAnnotation is the value of the annotation that enables the renewal of a resource.
 	RenewAnnotation = "liqo.io/renew"
+
+	// PeeringUserNameLabelKey labels all the resources created to grant peering permissions to the user doing a pering toward this cluster.
+	PeeringUserNameLabelKey = "liqo.io/peering-user-name"
 )

--- a/pkg/liqo-controller-manager/authentication/tenant-controller/tenant_controller.go
+++ b/pkg/liqo-controller-manager/authentication/tenant-controller/tenant_controller.go
@@ -138,7 +138,7 @@ func (r *TenantReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res
 	if authv1beta1.GetAuthzPolicyValue(tenant.Spec.AuthzPolicy) != authv1beta1.TolerateNoHandshake {
 		// get the nonce for the tenant
 
-		nonceSecret, err := getters.GetNonceSecretByClusterID(ctx, r.Client, clusterID)
+		nonceSecret, err := getters.GetNonceSecretByClusterID(ctx, r.Client, clusterID, corev1.NamespaceAll)
 		if err != nil {
 			klog.Errorf("Unable to get the nonce for the Tenant %q: %s", req.Name, err)
 			r.EventRecorder.Event(tenant, corev1.EventTypeWarning, "NonceNotFound", err.Error())

--- a/pkg/liqo-controller-manager/authentication/utils/nonce.go
+++ b/pkg/liqo-controller-manager/authentication/utils/nonce.go
@@ -47,7 +47,7 @@ func EnsureNonceSecret(ctx context.Context, cl client.Client,
 // already a nonce secret in the tenant namespace.
 func EnsureSignedNonceSecret(ctx context.Context, cl client.Client,
 	remoteClusterID liqov1beta1.ClusterID, tenantNamespace string, nonce *string) error {
-	nonceSecret, err := getters.GetSignedNonceSecretByClusterID(ctx, cl, remoteClusterID)
+	nonceSecret, err := getters.GetSignedNonceSecretByClusterID(ctx, cl, remoteClusterID, tenantNamespace)
 	switch {
 	case errors.IsNotFound(err):
 		// Secret not found. Create it given the provided nonce.
@@ -80,8 +80,8 @@ func EnsureSignedNonceSecret(ctx context.Context, cl client.Client,
 }
 
 // RetrieveNonce retrieves the nonce from the secret in the tenant namespace.
-func RetrieveNonce(ctx context.Context, cl client.Client, remoteClusterID liqov1beta1.ClusterID) ([]byte, error) {
-	nonce, err := getters.GetNonceSecretByClusterID(ctx, cl, remoteClusterID)
+func RetrieveNonce(ctx context.Context, cl client.Client, remoteClusterID liqov1beta1.ClusterID, tenantNamespace string) ([]byte, error) {
+	nonce, err := getters.GetNonceSecretByClusterID(ctx, cl, remoteClusterID, tenantNamespace)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get nonce secret: %w", err)
 	}
@@ -90,8 +90,9 @@ func RetrieveNonce(ctx context.Context, cl client.Client, remoteClusterID liqov1
 }
 
 // RetrieveSignedNonce retrieves the signed nonce from the secret in the tenant namespace.
-func RetrieveSignedNonce(ctx context.Context, cl client.Client, remoteClusterID liqov1beta1.ClusterID) ([]byte, error) {
-	secret, err := getters.GetSignedNonceSecretByClusterID(ctx, cl, remoteClusterID)
+// If tenantNamespace is empty this function searches in all the namespaces in the cluster.
+func RetrieveSignedNonce(ctx context.Context, cl client.Client, remoteClusterID liqov1beta1.ClusterID, tenantNamespace string) ([]byte, error) {
+	secret, err := getters.GetSignedNonceSecretByClusterID(ctx, cl, remoteClusterID, tenantNamespace)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get signed nonce secret: %w", err)
 	}

--- a/pkg/liqo-controller-manager/offloading/virtualnode-controller/virtualkubelet.go
+++ b/pkg/liqo-controller-manager/offloading/virtualnode-controller/virtualkubelet.go
@@ -171,12 +171,14 @@ func (r *VirtualNodeReconciler) ensureVirtualKubeletDeploymentAbsence(
 		return err
 	}
 
+	crbName := k8strings.ShortenString(fmt.Sprintf("%s%s", vkMachinery.CRBPrefix, virtualNode.Name), 253)
 	err = r.Client.Delete(ctx, &rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{
-		Name: k8strings.ShortenString(fmt.Sprintf("%s%s", vkMachinery.CRBPrefix, virtualNode.Name), 253),
+		Name: crbName,
 	}})
 	if client.IgnoreNotFound(err) != nil {
 		return err
 	}
+	klog.Info(fmt.Sprintf("[%v] Deleted virtual-kubelet CRB %s", virtualNode.Spec.ClusterID, crbName))
 
 	err = r.Client.Delete(ctx, &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{
 		Name: virtualNode.Name, Namespace: virtualNode.Namespace,

--- a/pkg/liqoctl/authenticate/cluster.go
+++ b/pkg/liqoctl/authenticate/cluster.go
@@ -104,13 +104,13 @@ func (c *Cluster) EnsureNonce(ctx context.Context) ([]byte, error) {
 	s.Success("Nonce secret ensured")
 
 	// Wait for secret to be filled with the nonce.
-	if err := c.waiter.ForNonce(ctx, c.RemoteClusterID, false); err != nil {
+	if err := c.waiter.ForNonce(ctx, c.RemoteClusterID, c.TenantNamespace, false); err != nil {
 		return nil, err
 	}
 
 	// Retrieve nonce from secret.
 	s = c.local.Printer.StartSpinner("Retrieving nonce")
-	nonceValue, err := authutils.RetrieveNonce(ctx, c.local.CRClient, c.RemoteClusterID)
+	nonceValue, err := authutils.RetrieveNonce(ctx, c.local.CRClient, c.RemoteClusterID, c.TenantNamespace)
 	if err != nil {
 		s.Fail(fmt.Sprintf("Unable to retrieve nonce: %v", output.PrettyErr(err)))
 		return nil, err
@@ -135,13 +135,13 @@ func (c *Cluster) EnsureSignedNonce(ctx context.Context, nonce []byte) ([]byte, 
 	s.Success("Signed nonce secret ensured")
 
 	// Wait for secret to be filled with the signed nonce.
-	if err := c.waiter.ForSignedNonce(ctx, c.RemoteClusterID, false); err != nil {
+	if err := c.waiter.ForSignedNonce(ctx, c.RemoteClusterID, c.TenantNamespace, false); err != nil {
 		return nil, err
 	}
 
 	// Retrieve signed nonce from secret.
 	s = c.local.Printer.StartSpinner("Retrieving signed nonce")
-	signedNonceValue, err := authutils.RetrieveSignedNonce(ctx, c.local.CRClient, c.RemoteClusterID)
+	signedNonceValue, err := authutils.RetrieveSignedNonce(ctx, c.local.CRClient, c.RemoteClusterID, c.TenantNamespace)
 	if err != nil {
 		s.Fail(fmt.Sprintf("Unable to retrieve signed nonce: %v", output.PrettyErr(err)))
 		return nil, err

--- a/pkg/liqoctl/output/output.go
+++ b/pkg/liqoctl/output/output.go
@@ -270,7 +270,10 @@ func NewGlobalPrinter(scoped, verbose bool) *Printer {
 }
 
 func newPrinter(scope string, color pterm.Color, scoped, verbose bool) *Printer {
-	generic := &pterm.PrefixPrinter{MessageStyle: pterm.NewStyle(pterm.FgDefault)}
+	generic := &pterm.PrefixPrinter{
+		MessageStyle: pterm.NewStyle(pterm.FgDefault),
+		Writer:       os.Stderr,
+	}
 
 	if scoped {
 		generic = generic.WithScope(pterm.Scope{Text: scope, Style: pterm.NewStyle(pterm.FgGray)})
@@ -311,6 +314,7 @@ func newPrinter(scope string, color pterm.Color, scoped, verbose bool) *Printer 
 		ShowTimer:           true,
 		TimerRoundingFactor: time.Second,
 		TimerStyle:          &pterm.ThemeDefault.TimerStyle,
+		Writer:              os.Stderr,
 	}
 
 	printer.BulletList = &pterm.BulletListPrinter{}

--- a/pkg/liqoctl/peer/handler.go
+++ b/pkg/liqoctl/peer/handler.go
@@ -86,21 +86,21 @@ func (o *Options) RunPeer(ctx context.Context) error {
 	// Ensure networking
 	if !o.NetworkingDisabled {
 		if err := ensureNetworking(ctx, o); err != nil {
-			o.LocalFactory.PrinterGlobal.Error.Println("unable to ensure networking")
+			o.LocalFactory.PrinterGlobal.Error.Printfln("Unable to ensure networking: %v", err)
 			return err
 		}
 	}
 
 	// Ensure authentication
 	if err := ensureAuthentication(ctx, o); err != nil {
-		o.LocalFactory.PrinterGlobal.Error.Println("unable to ensure authentication")
+		o.LocalFactory.PrinterGlobal.Error.Printfln("Unable to ensure authentication: %v", err)
 		return err
 	}
 
 	// Ensure offloading
 	if o.CreateResourceSlice {
 		if err := ensureOffloading(ctx, o); err != nil {
-			o.LocalFactory.PrinterGlobal.Error.Println("unable to ensure offloading")
+			o.LocalFactory.PrinterGlobal.Error.Printfln("Unable to ensure offloading: %v", err)
 			return err
 		}
 	}

--- a/pkg/liqoctl/rest/nonce/create.go
+++ b/pkg/liqoctl/rest/nonce/create.go
@@ -96,22 +96,23 @@ func (o *Options) handleCreate(ctx context.Context) error {
 		return err
 	}
 
+	tenantNsName := tenantNs.GetName()
 	// Ensure the presence of the nonce secret.
 	s := opts.Printer.StartSpinner("Creating nonce")
-	if err := authutils.EnsureNonceSecret(ctx, opts.CRClient, o.clusterID.GetClusterID(), tenantNs.GetName()); err != nil {
+	if err := authutils.EnsureNonceSecret(ctx, opts.CRClient, o.clusterID.GetClusterID(), tenantNsName); err != nil {
 		s.Fail(fmt.Sprintf("Unable to create nonce secret: %v", output.PrettyErr(err)))
 		return err
 	}
 	s.Success("Nonce created")
 
 	// Wait for secret to be filled with the nonce.
-	if err := waiter.ForNonce(ctx, o.clusterID.GetClusterID(), false); err != nil {
+	if err := waiter.ForNonce(ctx, o.clusterID.GetClusterID(), tenantNsName, false); err != nil {
 		return err
 	}
 
 	// Retrieve nonce from secret.
 	s = opts.Printer.StartSpinner("Retrieving nonce")
-	nonceValue, err := authutils.RetrieveNonce(ctx, opts.CRClient, o.clusterID.GetClusterID())
+	nonceValue, err := authutils.RetrieveNonce(ctx, opts.CRClient, o.clusterID.GetClusterID(), tenantNsName)
 	if err != nil {
 		s.Fail(fmt.Sprintf("Unable to retrieve nonce: %v", output.PrettyErr(err)))
 		return err

--- a/pkg/liqoctl/rest/peering-user/create.go
+++ b/pkg/liqoctl/rest/peering-user/create.go
@@ -1,0 +1,28 @@
+// Copyright 2019-2025 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package peeringuser
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+
+	"github.com/liqotech/liqo/pkg/liqoctl/rest"
+)
+
+// Create implements the create command.
+func (o *Options) Create(_ context.Context, _ *rest.CreateOptions) *cobra.Command {
+	panic("not implemented")
+}

--- a/pkg/liqoctl/rest/peering-user/delete.go
+++ b/pkg/liqoctl/rest/peering-user/delete.go
@@ -1,0 +1,74 @@
+// Copyright 2019-2025 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package peeringuser
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/util/runtime"
+
+	liqov1beta1 "github.com/liqotech/liqo/apis/core/v1beta1"
+	"github.com/liqotech/liqo/pkg/liqoctl/output"
+	"github.com/liqotech/liqo/pkg/liqoctl/rest"
+	"github.com/liqotech/liqo/pkg/liqoctl/rest/peering-user/userfactory"
+)
+
+const liqoctlDeletePeeringUserHelp = `elete an existing user with the permissions to peer with this cluster.
+
+Delete a peering user, so that it will no longer be able to peer with this cluster from the cluster with the given Cluster ID.
+The previous credentials will be invalidated, and cannot be used anymore, even if the user is recreated.
+
+Examples:
+  $ {{ .Executable }} delete peering-user --consumer-cluster-id=<cluster-id>`
+
+// Delete deletes a user.
+func (o *Options) Delete(ctx context.Context, options *rest.DeleteOptions) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "peering-user",
+		Short: "Delete an existing user with the permissions to peer with this cluster",
+		Long:  liqoctlDeletePeeringUserHelp,
+		Args:  cobra.NoArgs,
+
+		PreRun: func(_ *cobra.Command, _ []string) {
+			o.deleteOptions = options
+		},
+
+		Run: func(_ *cobra.Command, _ []string) {
+			output.ExitOnErr(o.handleDelete(ctx))
+		},
+	}
+
+	cmd.Flags().Var(&o.clusterID, "consumer-cluster-id", "The cluster ID of the cluster from which peering has been performed")
+
+	runtime.Must(cmd.MarkFlagRequired("consumer-cluster-id"))
+
+	return cmd
+}
+
+func (o *Options) handleDelete(ctx context.Context) error {
+	opts := o.deleteOptions
+	clusterID := liqov1beta1.ClusterID(*o.clusterID.ClusterID)
+
+	if err := userfactory.RemovePermissions(ctx, opts.CRClient, clusterID); err != nil {
+		wErr := fmt.Errorf("unable to delete peering user: %w", err)
+		opts.Printer.Error.Println(wErr)
+		return wErr
+	}
+
+	opts.Printer.Success.Printfln("Peering user for cluster with ID %q deleted successfully", clusterID)
+	return nil
+}

--- a/pkg/liqoctl/rest/peering-user/doc.go
+++ b/pkg/liqoctl/rest/peering-user/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2019-2025 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package peeringuser contains the rest API commands to allow liqoctl to create an authentication token to authenticate to this cluster.
+package peeringuser

--- a/pkg/liqoctl/rest/peering-user/generate.go
+++ b/pkg/liqoctl/rest/peering-user/generate.go
@@ -1,0 +1,90 @@
+// Copyright 2019-2025 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package peeringuser
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/util/runtime"
+
+	liqov1beta1 "github.com/liqotech/liqo/apis/core/v1beta1"
+	"github.com/liqotech/liqo/pkg/liqoctl/output"
+	"github.com/liqotech/liqo/pkg/liqoctl/rest"
+	"github.com/liqotech/liqo/pkg/liqoctl/rest/peering-user/userfactory"
+	tenantnamespace "github.com/liqotech/liqo/pkg/tenantNamespace"
+)
+
+const liqoctlGeneratePeeringUserHelp = `Generate a new user with the permissions to peer with this cluster.
+
+This command generates a user with the minimum permissions to peer with this cluster, from the cluster with
+the given cluster ID, and returns a kubeconfig to be used to create or destroy the peering.
+
+Examples:
+  $ {{ .Executable }} generate peering-user --consumer-cluster-id=<cluster-id>`
+
+// Generate generates a Nonce.
+func (o *Options) Generate(ctx context.Context, options *rest.GenerateOptions) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "peering-user",
+		Short: "Generate a new user with the permissions to peer with this cluster",
+		Long:  liqoctlGeneratePeeringUserHelp,
+		Args:  cobra.NoArgs,
+
+		PreRun: func(_ *cobra.Command, _ []string) {
+			o.generateOptions = options
+
+			o.namespaceManager = tenantnamespace.NewManager(options.KubeClient, options.CRClient.Scheme())
+		},
+
+		Run: func(_ *cobra.Command, _ []string) {
+			output.ExitOnErr(o.handleGenerate(ctx))
+		},
+	}
+
+	cmd.Flags().Var(&o.clusterID, "consumer-cluster-id", "The cluster ID of the cluster from which peering will be performed")
+
+	runtime.Must(cmd.MarkFlagRequired("consumer-cluster-id"))
+
+	return cmd
+}
+
+func (o *Options) handleGenerate(ctx context.Context) error {
+	opts := o.generateOptions
+
+	clusterID := liqov1beta1.ClusterID(*o.clusterID.ClusterID)
+	opts.Printer.Warning.Println("Note that this functionality is currently not supported in EKS clusters")
+	opts.Printer.Warning.Println("Please take note of this kubeconfig as it is not stored.")
+	opts.Printer.Warning.Printfln("Note that it can only be used to peer with this cluster from a cluster with ID %s", clusterID)
+
+	tenantNs, err := o.namespaceManager.CreateNamespace(ctx, clusterID)
+	if err != nil {
+		wErr := fmt.Errorf("unable to create the tenant namespace: %w", err)
+		opts.Printer.Error.Println(wErr)
+		return wErr
+	}
+
+	spinner := opts.Printer.StartSpinner("Generating a user for peering with this cluster")
+	kubeconfig, err := userfactory.GeneratePeerUser(ctx, clusterID, tenantNs.Name, opts.Factory)
+	if err != nil {
+		spinner.Fail(err)
+		return err
+	}
+	spinner.Success("User generated successfully")
+
+	fmt.Println(kubeconfig)
+	return nil
+}

--- a/pkg/liqoctl/rest/peering-user/get.go
+++ b/pkg/liqoctl/rest/peering-user/get.go
@@ -1,0 +1,28 @@
+// Copyright 2019-2025 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package peeringuser
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+
+	"github.com/liqotech/liqo/pkg/liqoctl/rest"
+)
+
+// Get implements the get command.
+func (o *Options) Get(_ context.Context, _ *rest.GetOptions) *cobra.Command {
+	panic("not implemented")
+}

--- a/pkg/liqoctl/rest/peering-user/types.go
+++ b/pkg/liqoctl/rest/peering-user/types.go
@@ -1,0 +1,45 @@
+// Copyright 2019-2025 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package peeringuser
+
+import (
+	"github.com/liqotech/liqo/pkg/liqoctl/rest"
+	tenantnamespace "github.com/liqotech/liqo/pkg/tenantNamespace"
+	"github.com/liqotech/liqo/pkg/utils/args"
+)
+
+// Options encapsulates the arguments of the token command.
+type Options struct {
+	generateOptions  *rest.GenerateOptions
+	deleteOptions    *rest.DeleteOptions
+	namespaceManager tenantnamespace.Manager
+
+	clusterID args.ClusterIDFlags
+}
+
+var _ rest.API = &Options{}
+
+// PeeringUser returns the rest API for the token command.
+func PeeringUser() rest.API {
+	return &Options{}
+}
+
+// APIOptions returns the APIOptions for the nonce API.
+func (o *Options) APIOptions() *rest.APIOptions {
+	return &rest.APIOptions{
+		EnableGenerate: true,
+		EnableDelete:   true,
+	}
+}

--- a/pkg/liqoctl/rest/peering-user/update.go
+++ b/pkg/liqoctl/rest/peering-user/update.go
@@ -1,0 +1,28 @@
+// Copyright 2019-2025 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package peeringuser
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+
+	"github.com/liqotech/liqo/pkg/liqoctl/rest"
+)
+
+// Update implements the update command.
+func (o *Options) Update(_ context.Context, _ *rest.UpdateOptions) *cobra.Command {
+	panic("not implemented")
+}

--- a/pkg/liqoctl/rest/peering-user/userfactory/cert.go
+++ b/pkg/liqoctl/rest/peering-user/userfactory/cert.go
@@ -1,0 +1,200 @@
+// Copyright 2019-2025 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package userfactory
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"time"
+
+	certv1 "k8s.io/api/certificates/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	liqov1beta1 "github.com/liqotech/liqo/apis/core/v1beta1"
+	"github.com/liqotech/liqo/pkg/consts"
+	"github.com/liqotech/liqo/pkg/liqo-controller-manager/authentication"
+	"github.com/liqotech/liqo/pkg/liqoctl/factory"
+	liqoctlutils "github.com/liqotech/liqo/pkg/liqoctl/utils"
+	"github.com/liqotech/liqo/pkg/utils/apiserver"
+	certificateSigningRequest "github.com/liqotech/liqo/pkg/utils/csr"
+	"github.com/liqotech/liqo/pkg/utils/getters"
+	kubeconfigutils "github.com/liqotech/liqo/pkg/utils/kubeconfig"
+)
+
+// GeneratePeerUser generates a new user to peer with the local cluster and returns its kubeconfig.
+func GeneratePeerUser(ctx context.Context, clusterID liqov1beta1.ClusterID, tenantNsName string, opts *factory.Factory) (string, error) {
+	if exists, err := IsExistingPeerUser(ctx, opts.CRClient, clusterID); err != nil {
+		return "", fmt.Errorf("unable to check if the user already exists: %w", err)
+	} else if exists {
+		return "", fmt.Errorf("a user to peer from cluster with ID %q already exists. Please delete it first before creting a new one."+
+			"You can delete the previous secret via 'liqoctl delete peering-user --consumer-cluster-id %s'", clusterID, clusterID)
+	}
+
+	// Get the certification authority
+	ca, err := apiserver.RetrieveAPIServerCA(opts.RESTConfig, nil, false)
+	if err != nil {
+		return "", fmt.Errorf("unable to get the API server CA: %w", err)
+	}
+
+	// Forge a new pair of keys.
+	_, private, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return "", fmt.Errorf("error while generating token credentials: %w", err)
+	}
+
+	// Generate a CSR with the newly created keys.
+	csr, userCN, err := authentication.GenerateCSRForPeerUser(private, clusterID)
+	if err != nil {
+		return "", fmt.Errorf("error while generating the csr for the token credentials: %w", err)
+	}
+
+	// Sign the csr to generate the certificate
+	cert, err := generateSignedCert(ctx, opts.CRClient, opts.KubeClient, csr, clusterID)
+	if err != nil {
+		return "", fmt.Errorf("unable to generate certificate for the user: %w", err)
+	}
+
+	if err := EnsureRoles(ctx, opts.CRClient, clusterID, userCN, tenantNsName); err != nil {
+		return "", fmt.Errorf("unable to ensure roles: %w", err)
+	}
+
+	// Convert the private key in PEM format
+	privateKeyBytes, err := x509.MarshalPKCS8PrivateKey(private)
+	if err != nil {
+		return "", fmt.Errorf("unable to parse private key: %w", err)
+	}
+	privatePEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: privateKeyBytes})
+
+	// Get K8S API Server address
+	apiAddr, err := getAPIServerAddress(ctx, opts.CRClient, opts.LiqoNamespace)
+	if err != nil {
+		return "", fmt.Errorf("unable to get the API Server addr: %w", err)
+	}
+
+	userName := fmt.Sprintf("%s-user", clusterID)
+	kubeconfig, err := kubeconfigutils.GenerateKubeconfig(userName, string(clusterID), apiAddr, ca, cert, privatePEM, nil, &tenantNsName)
+	if err != nil {
+		return "", fmt.Errorf("unable to generate kubeconfig: %w", err)
+	}
+
+	return string(kubeconfig), nil
+}
+
+// GetUserNameFromClusterID returns the username of the peering user for the given clusterID.
+func GetUserNameFromClusterID(clusterID liqov1beta1.ClusterID) string {
+	return fmt.Sprintf("liqo-peer-user-%s", clusterID)
+}
+
+func getAPIServerAddress(ctx context.Context, c client.Client, liqoNamespaceName string) (string, error) {
+	// Get the controller manager deployment
+	ctrlDeployment, err := getters.GetControllerManagerDeployment(ctx, c, liqoNamespaceName)
+	if err != nil {
+		return "", err
+	}
+
+	// Get the controller manager container
+	ctrlContainer, err := liqoctlutils.GetCtrlManagerContainer(ctrlDeployment)
+	if err != nil {
+		return "", err
+	}
+
+	// Get the URL of the K8s API
+	apiServerAddressOverride, _ := liqoctlutils.ExtractValuesFromArgumentList("--api-server-address-override", ctrlContainer.Args)
+	apiAddr, err := apiserver.GetURL(ctx, c, apiServerAddressOverride)
+	if err != nil {
+		return "", err
+	}
+
+	return apiAddr, nil
+}
+
+// generateSignedCert generates a new signed certificate to create a peering with the local cluster.
+func generateSignedCert(
+	ctx context.Context,
+	c client.Client,
+	clientset kubernetes.Interface,
+	csr []byte,
+	clusterID liqov1beta1.ClusterID,
+) ([]byte, error) {
+	userName := GetUserNameFromClusterID(clusterID)
+	cert := &certv1.CertificateSigningRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: userName,
+			Labels: map[string]string{
+				consts.PeeringUserNameLabelKey: userName,
+			},
+		},
+		Spec: certv1.CertificateSigningRequestSpec{
+			Groups: []string{
+				"system:authenticated",
+			},
+			SignerName: certv1.KubeAPIServerClientSignerName,
+			Request:    csr,
+			Usages: []certv1.KeyUsage{
+				certv1.UsageDigitalSignature,
+				certv1.UsageKeyEncipherment,
+				certv1.UsageClientAuth,
+			},
+		},
+	}
+
+	cert, err := clientset.CertificatesV1().CertificateSigningRequests().Create(ctx, cert, metav1.CreateOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	// approve the CertificateSigningRequest
+	if err = certificateSigningRequest.Approve(clientset, cert, "IdentityManagerApproval",
+		"This CSR was approved by liqoctl generate token"); err != nil {
+		return nil, err
+	}
+
+	// retrieve the certificate issued by the Kubernetes issuer in the CSR (with a 30 seconds timeout)
+	ctxC, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	return getSignedCSRBlocker(ctxC, c, cert.Name)
+}
+
+// getSignedCSRBlocker waits until the csr with the given name has been signed and it returned the certificate.
+func getSignedCSRBlocker(ctx context.Context, c client.Client, csrName string) ([]byte, error) {
+	var certificate []byte
+	err := wait.PollUntilContextCancel(ctx, 1*time.Second, true, func(ctx context.Context) (done bool, err error) {
+		var csr certv1.CertificateSigningRequest
+		if err := c.Get(ctx, client.ObjectKey{Name: csrName}, &csr); err != nil {
+			return false, err
+		}
+		if len(csr.Status.Certificate) > 0 {
+			certificate = csr.Status.Certificate
+			return true, nil
+		}
+
+		return false, nil
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("failed waiting for CSR to be signed: %w", err)
+	}
+
+	return certificate, nil
+}

--- a/pkg/liqoctl/rest/peering-user/userfactory/doc.go
+++ b/pkg/liqoctl/rest/peering-user/userfactory/doc.go
@@ -1,0 +1,17 @@
+// Copyright 2019-2025 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+// Package userfactory contains the logic to create a new user for the peering.
+package userfactory

--- a/pkg/liqoctl/rest/peering-user/userfactory/roles.go
+++ b/pkg/liqoctl/rest/peering-user/userfactory/roles.go
@@ -1,0 +1,311 @@
+// Copyright 2019-2025 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package userfactory
+
+import (
+	"context"
+	"fmt"
+
+	certv1 "k8s.io/api/certificates/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	authv1beta1 "github.com/liqotech/liqo/apis/authentication/v1beta1"
+	liqov1beta1 "github.com/liqotech/liqo/apis/core/v1beta1"
+	ipamv1alpha1 "github.com/liqotech/liqo/apis/ipam/v1alpha1"
+	networkingv1beta1 "github.com/liqotech/liqo/apis/networking/v1beta1"
+	"github.com/liqotech/liqo/pkg/consts"
+)
+
+var peeringUserLabel = client.ListOptions{
+	LabelSelector: labels.SelectorFromSet(labels.Set{
+		"app.kubernetes.io/component": "peering-user",
+	}),
+}
+
+var minimumClusterPermissions = []rbacv1.PolicyRule{
+	{
+		APIGroups: []string{""},
+		Resources: []string{"namespaces"},
+		Verbs:     []string{"get", "list", "create"},
+	},
+	{
+		APIGroups: []string{ipamv1alpha1.NetworkGroupResource.Group},
+		Resources: []string{ipamv1alpha1.NetworkResource},
+		Verbs:     []string{"get", "list"},
+	},
+	{
+		APIGroups: []string{networkingv1beta1.ConfigurationGroupResource.Group},
+		Resources: []string{networkingv1beta1.ConfigurationResource},
+		Verbs:     []string{"get", "list"},
+	},
+	{
+		APIGroups: []string{networkingv1beta1.GatewayClientGroupResource.Group},
+		Resources: []string{networkingv1beta1.GatewayClientResource},
+		Verbs:     []string{"get", "list"},
+	},
+	{
+		APIGroups: []string{networkingv1beta1.GatewayServerGroupResource.Group},
+		Resources: []string{networkingv1beta1.GatewayServerResource},
+		Verbs:     []string{"get", "list"},
+	},
+	{
+		APIGroups: []string{networkingv1beta1.PublicKeyGroupResource.Group},
+		Resources: []string{networkingv1beta1.PublicKeyResource},
+		Verbs:     []string{"get", "list"},
+	},
+	{
+		APIGroups: []string{liqov1beta1.ForeignClusterGroupResource.Group},
+		Resources: []string{liqov1beta1.ForeignClusterResource},
+		Verbs:     []string{"get", "list"},
+	},
+	{
+		APIGroups: []string{authv1beta1.TenantGroupResource.Group},
+		Resources: []string{authv1beta1.TenantResource},
+		Verbs:     []string{"create", "list"},
+	},
+}
+
+// EnsureRoles ensures that the required roles are created and bound to the user.
+func EnsureRoles(ctx context.Context, c client.Client, clusterID liqov1beta1.ClusterID, userCN, tenantNsName string) error {
+	if err := ensureLiqoNsReaderRole(ctx, c, userCN, clusterID); err != nil {
+		return err
+	}
+
+	if err := ensureTenantNsWriterRole(ctx, c, userCN, clusterID, tenantNsName); err != nil {
+		return err
+	}
+
+	if err := ensureClusterMinPermissions(ctx, c, userCN, clusterID); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// IsExistingPeerUser checks whether the user has already been created.
+func IsExistingPeerUser(ctx context.Context, c client.Client, clusterID liqov1beta1.ClusterID) (bool, error) {
+	userName := GetUserNameFromClusterID(clusterID)
+
+	clusterRoleList := &rbacv1.ClusterRoleList{}
+	if err := c.List(ctx, clusterRoleList, &client.ListOptions{
+		LabelSelector: getUserLabelSelector(userName),
+	}); err != nil {
+		return false, fmt.Errorf("unable to check whether the user has already been created: %w", err)
+	}
+
+	return len(clusterRoleList.Items) > 0, nil
+}
+
+// RemovePermissions removes the permissions related to the user.
+func RemovePermissions(ctx context.Context, c client.Client, clusterID liqov1beta1.ClusterID) error {
+	userName := GetUserNameFromClusterID(clusterID)
+
+	userLabelSelector := getUserLabelSelector(userName)
+
+	// Delete the ClusterRole related to the user
+	if err := c.DeleteAllOf(ctx, &rbacv1.ClusterRole{}, client.MatchingLabelsSelector{Selector: userLabelSelector}); err != nil {
+		return fmt.Errorf("unable to delete ClusterRoles: %w", err)
+	}
+
+	// Delete the ClusterRoleBindings related to the user
+	if err := c.DeleteAllOf(ctx, &rbacv1.ClusterRoleBinding{}, client.MatchingLabelsSelector{Selector: userLabelSelector}); err != nil {
+		return fmt.Errorf("unable to delete ClusterRoleBindings: %w", err)
+	}
+
+	// Cannot delete RoleBinding with DeleteAllOf, list it and delete one by one
+	roleBindingList := &rbacv1.RoleBindingList{}
+
+	if err := c.List(ctx, roleBindingList, &client.ListOptions{
+		LabelSelector: userLabelSelector,
+	}); err != nil {
+		return fmt.Errorf("unable to get RoleBindings: %w", err)
+	}
+
+	for i := range roleBindingList.Items {
+		err := c.Delete(ctx, &roleBindingList.Items[i])
+		if client.IgnoreNotFound(err) != nil {
+			return fmt.Errorf("unable to delete RoleBinding %q: %w", roleBindingList.Items[i].Name, err)
+		}
+	}
+
+	// Delete the CertificateSigningRequest with the certificate of the user
+	if err := c.DeleteAllOf(
+		ctx,
+		&certv1.CertificateSigningRequest{},
+		client.MatchingLabelsSelector{Selector: userLabelSelector},
+	); err != nil {
+		return fmt.Errorf("unable to delete ClusterRoleBindings: %w", err)
+	}
+
+	return nil
+}
+
+func getUserLabelSelector(userName string) labels.Selector {
+	return labels.SelectorFromSet(labels.Set{
+		consts.PeeringUserNameLabelKey: userName,
+	})
+}
+
+// ensureLiqoNsReaderRole ensures that the peering-user Role is bound to the user in the Liqo namespace.
+func ensureLiqoNsReaderRole(ctx context.Context, c client.Client, userCN string, clusterID liqov1beta1.ClusterID) error {
+	var peeringUserRoleList rbacv1.RoleList
+	if err := c.List(ctx, &peeringUserRoleList, &peeringUserLabel); err != nil {
+		return fmt.Errorf("unable to get peering-user Role from liqo namespace: %w", err)
+	}
+
+	if nRoles := len(peeringUserRoleList.Items); nRoles == 0 {
+		return fmt.Errorf("no peering-user Role found in the Liqo namespace")
+	} else if nRoles > 1 {
+		return fmt.Errorf("multiple peering-user Roles found in the Liqo namespace")
+	}
+
+	peeringUserRole := peeringUserRoleList.Items[0]
+	userName := GetUserNameFromClusterID(clusterID)
+
+	// Bind the roles to operate on the liqo namespace
+	roleBinding := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-liqo-ns-reader", userName),
+			Namespace: peeringUserRole.Namespace,
+			Labels: map[string]string{
+				consts.PeeringUserNameLabelKey: userName,
+			},
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:     "User",
+				Name:     userCN,
+				APIGroup: "rbac.authorization.k8s.io",
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "Role",
+			Name:     peeringUserRole.Name,
+		},
+	}
+
+	if err := c.Create(ctx, roleBinding); err != nil {
+		return fmt.Errorf("unable to create role binding in the %q namespace: %w", peeringUserRole.Namespace, err)
+	}
+
+	return nil
+}
+
+func ensureTenantNsWriterRole(ctx context.Context, c client.Client, userCN string, clusterID liqov1beta1.ClusterID, tenantNsName string) error {
+	var peeringClusterRoles rbacv1.ClusterRoleList
+	if err := c.List(ctx, &peeringClusterRoles, &peeringUserLabel); err != nil {
+		return fmt.Errorf("unable to get peering-user role from liqo namespace: %w", err)
+	}
+
+	if nRoles := len(peeringClusterRoles.Items); nRoles == 0 {
+		return fmt.Errorf("no peering-user ClusterRole found")
+	} else if nRoles > 1 {
+		return fmt.Errorf("multiple peering-user ClusterRoles found ")
+	}
+
+	// bind the ClusterRole to the userName user
+	userName := GetUserNameFromClusterID(clusterID)
+	peeringUserClusterRole := peeringClusterRoles.Items[0]
+	clusterRoleBinding := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-tenant-ns-writer", userName),
+			Namespace: tenantNsName,
+			Labels: map[string]string{
+				consts.PeeringUserNameLabelKey: userName,
+			},
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:     "User",
+				Name:     userCN,
+				APIGroup: "rbac.authorization.k8s.io",
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "ClusterRole",
+			Name:     peeringUserClusterRole.Name,
+		},
+	}
+
+	if err := c.Create(ctx, clusterRoleBinding); err != nil {
+		return fmt.Errorf("unable to create cluster role binding: %w", err)
+	}
+
+	return nil
+}
+
+func ensureClusterMinPermissions(ctx context.Context, c client.Client, userCN string, clusterID liqov1beta1.ClusterID) error {
+	userName := GetUserNameFromClusterID(clusterID)
+
+	// Append to the minimum permissions the permissions to operate on the user Tenant resource
+	permissions := append(
+		[]rbacv1.PolicyRule{
+			{
+				APIGroups:     []string{authv1beta1.TenantGroupResource.Group},
+				Resources:     []string{authv1beta1.TenantResource},
+				ResourceNames: []string{string(clusterID)},
+				Verbs:         []string{"update", "get", "delete"},
+			},
+		},
+		minimumClusterPermissions...,
+	)
+
+	clusterRole := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fmt.Sprintf("%s-cluster-min-perm", userName),
+			Labels: map[string]string{
+				consts.PeeringUserNameLabelKey: userName,
+			},
+		},
+		Rules: permissions,
+	}
+
+	if err := c.Create(ctx, clusterRole); err != nil {
+		return fmt.Errorf("unable to create ClusterRole for minimum permissions on the cluster: %w", err)
+	}
+
+	clusterRoleBinding := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fmt.Sprintf("%s-cluster-min-perm", userName),
+			Labels: map[string]string{
+				consts.PeeringUserNameLabelKey: userName,
+			},
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:     "User",
+				Name:     userCN,
+				APIGroup: "rbac.authorization.k8s.io",
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "ClusterRole",
+			Name:     clusterRole.Name,
+		},
+	}
+
+	if err := c.Create(ctx, clusterRoleBinding); err != nil {
+		return fmt.Errorf("unable to create ClusterRoleBinding for minimum permissions on the cluster: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/liqoctl/unpeer/handler.go
+++ b/pkg/liqoctl/unpeer/handler.go
@@ -35,9 +35,9 @@ type Options struct {
 	RemoteFactory *factory.Factory
 	waiter        *wait.Waiter
 
-	Timeout        time.Duration
-	Wait           bool
-	KeepNamespaces bool
+	Timeout         time.Duration
+	Wait            bool
+	DeleteNamespace bool
 
 	consumerClusterID liqov1beta1.ClusterID
 	providerClusterID liqov1beta1.ClusterID
@@ -85,8 +85,8 @@ func (o *Options) RunUnpeer(ctx context.Context) error {
 		o.LocalFactory.Printer.CheckErr(fmt.Errorf("an error occurred while checking bidirectional peering: %v", output.PrettyErr(err)))
 		return err
 	}
-	if bidirectional && !o.KeepNamespaces {
-		err = fmt.Errorf("cannot unpeer bidirectional peering without keeping namespaces, please set the --keep-namespaces flag")
+	if bidirectional && o.DeleteNamespace {
+		err = fmt.Errorf("cannot delete the tenant namespace when a bidirectional is enabled, please remove the --delete-namespaces flag")
 		o.LocalFactory.Printer.CheckErr(err)
 		return err
 	}
@@ -111,7 +111,7 @@ func (o *Options) RunUnpeer(ctx context.Context) error {
 		}
 	}
 
-	if !o.KeepNamespaces {
+	if o.DeleteNamespace {
 		consumer := unauthenticate.NewCluster(o.LocalFactory)
 		provider := unauthenticate.NewCluster(o.RemoteFactory)
 

--- a/pkg/liqoctl/utils/utils.go
+++ b/pkg/liqoctl/utils/utils.go
@@ -21,10 +21,25 @@ import (
 	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/liqotech/liqo/pkg/consts"
 	liqolabels "github.com/liqotech/liqo/pkg/utils/labels"
 )
+
+// GetCtrlManagerContainer retrieves the container of the controller manager from the deployment.
+func GetCtrlManagerContainer(ctrlDeployment *appsv1.Deployment) (*corev1.Container, error) {
+	// Get the container of the controller manager
+	containers := ctrlDeployment.Spec.Template.Spec.Containers
+	for i := range containers {
+		if containers[i].Name == consts.ControllerManagerAppName {
+			return &containers[i], nil
+		}
+	}
+
+	return nil, fmt.Errorf("invalid controller manager deployment: no container with name %q found", consts.ControllerManagerAppName)
+}
 
 // RetrieveLiqoControllerManagerDeploymentArgs retrieves the list of arguments associated with the liqo controller manager deployment.
 func RetrieveLiqoControllerManagerDeploymentArgs(ctx context.Context, cl client.Client, namespace string) ([]string, error) {

--- a/pkg/liqoctl/wait/wait.go
+++ b/pkg/liqoctl/wait/wait.go
@@ -333,7 +333,8 @@ func (w *Waiter) ForConnectionEstablished(ctx context.Context, conn *networkingv
 }
 
 // ForNonce waits until the secret containing the nonce has been created or the timeout expires.
-func (w *Waiter) ForNonce(ctx context.Context, remoteClusterID liqov1beta1.ClusterID, silent bool) error {
+// If tenantNamespace is empty this function searches in all the namespaces in the cluster.
+func (w *Waiter) ForNonce(ctx context.Context, remoteClusterID liqov1beta1.ClusterID, tenantNamespace string, silent bool) error {
 	var s *pterm.SpinnerPrinter
 
 	if !silent {
@@ -341,7 +342,7 @@ func (w *Waiter) ForNonce(ctx context.Context, remoteClusterID liqov1beta1.Clust
 	}
 
 	err := wait.PollUntilContextCancel(ctx, 1*time.Second, true, func(ctx context.Context) (done bool, err error) {
-		secret, err := getters.GetNonceSecretByClusterID(ctx, w.CRClient, remoteClusterID)
+		secret, err := getters.GetNonceSecretByClusterID(ctx, w.CRClient, remoteClusterID, tenantNamespace)
 		if err != nil {
 			return false, client.IgnoreNotFound(err)
 		}
@@ -366,7 +367,8 @@ func (w *Waiter) ForNonce(ctx context.Context, remoteClusterID liqov1beta1.Clust
 }
 
 // ForSignedNonce waits until the signed nonce secret has been signed and returns the signature.
-func (w *Waiter) ForSignedNonce(ctx context.Context, remoteClusterID liqov1beta1.ClusterID, silent bool) error {
+// If tenantNamespace is empty this function searches in all the namespaces in the cluster.
+func (w *Waiter) ForSignedNonce(ctx context.Context, remoteClusterID liqov1beta1.ClusterID, tenantNamespace string, silent bool) error {
 	var s *pterm.SpinnerPrinter
 
 	if !silent {
@@ -374,7 +376,7 @@ func (w *Waiter) ForSignedNonce(ctx context.Context, remoteClusterID liqov1beta1
 	}
 
 	err := wait.PollUntilContextCancel(ctx, 1*time.Second, true, func(ctx context.Context) (done bool, err error) {
-		secret, err := getters.GetSignedNonceSecretByClusterID(ctx, w.CRClient, remoteClusterID)
+		secret, err := getters.GetSignedNonceSecretByClusterID(ctx, w.CRClient, remoteClusterID, tenantNamespace)
 		if err != nil {
 			return false, client.IgnoreNotFound(err)
 		}

--- a/pkg/utils/getters/k8sGetters.go
+++ b/pkg/utils/getters/k8sGetters.go
@@ -215,9 +215,13 @@ func ListNodesByClusterID(ctx context.Context, cl client.Client, clusterID liqov
 }
 
 // GetNonceSecretByClusterID returns the secret containing the nonce to be signed by the consumer cluster.
-func GetNonceSecretByClusterID(ctx context.Context, cl client.Client, remoteClusterID liqov1beta1.ClusterID) (*corev1.Secret, error) {
+// If tenantNamespace is empty this function searches in all the namespaces in the cluster.
+func GetNonceSecretByClusterID(ctx context.Context, cl client.Client, remoteClusterID liqov1beta1.ClusterID,
+	tenantNamespace string) (*corev1.Secret, error) {
 	var secrets corev1.SecretList
+
 	if err := cl.List(ctx, &secrets, &client.ListOptions{
+		Namespace: tenantNamespace,
 		LabelSelector: labels.SelectorFromSet(map[string]string{
 			consts.RemoteClusterID:     string(remoteClusterID),
 			consts.NonceSecretLabelKey: "true",
@@ -237,11 +241,17 @@ func GetNonceSecretByClusterID(ctx context.Context, cl client.Client, remoteClus
 }
 
 // GetSignedNonceSecretByClusterID returns the secret containing the nonce signed by the consumer cluster.
-func GetSignedNonceSecretByClusterID(ctx context.Context, cl client.Client, remoteClusterID liqov1beta1.ClusterID) (*corev1.Secret, error) {
+// If tenantNamespace is empty this function searches in all the namespaces in the cluster.
+func GetSignedNonceSecretByClusterID(
+	ctx context.Context, cl client.Client, remoteClusterID liqov1beta1.ClusterID, tenantNamespace string) (*corev1.Secret, error) {
 	var secrets corev1.SecretList
-	if err := cl.List(ctx, &secrets, client.MatchingLabels{
-		consts.RemoteClusterID:           string(remoteClusterID),
-		consts.SignedNonceSecretLabelKey: "true",
+
+	if err := cl.List(ctx, &secrets, &client.ListOptions{
+		Namespace: tenantNamespace,
+		LabelSelector: labels.SelectorFromSet(map[string]string{
+			consts.RemoteClusterID:           string(remoteClusterID),
+			consts.SignedNonceSecretLabelKey: "true",
+		}),
 	}); err != nil {
 		return nil, err
 	}

--- a/pkg/utils/kubeconfig/kubeconfig.go
+++ b/pkg/utils/kubeconfig/kubeconfig.go
@@ -1,0 +1,55 @@
+// Copyright 2019-2025 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubeconfig
+
+import (
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	"k8s.io/utils/ptr"
+)
+
+// GenerateKubeconfig generates a kubeconfig file with the provided user, cluster, server, and certificate data.
+func GenerateKubeconfig(user, cluster, server string, ca, clientCertificate, clientKey []byte, proxyURL, namespace *string) ([]byte, error) {
+	clusters := make(map[string]*clientcmdapi.Cluster)
+	clusters[cluster] = &clientcmdapi.Cluster{
+		Server:                   server,
+		CertificateAuthorityData: ca,
+		ProxyURL:                 ptr.Deref(proxyURL, ""),
+	}
+
+	contexts := make(map[string]*clientcmdapi.Context)
+	contexts["default-context"] = &clientcmdapi.Context{
+		Cluster:   cluster,
+		Namespace: ptr.Deref(namespace, ""),
+		AuthInfo:  user,
+	}
+
+	authinfos := make(map[string]*clientcmdapi.AuthInfo)
+	authinfos[user] = &clientcmdapi.AuthInfo{
+		ClientKeyData:         clientKey,
+		ClientCertificateData: clientCertificate,
+	}
+
+	clientConfig := clientcmdapi.Config{
+		Kind:           "Config",
+		APIVersion:     "v1",
+		Clusters:       clusters,
+		Contexts:       contexts,
+		CurrentContext: "default-context",
+		AuthInfos:      authinfos,
+	}
+
+	return clientcmd.Write(clientConfig)
+}

--- a/test/e2e/pipeline/installer/liqo/unpeer.sh
+++ b/test/e2e/pipeline/installer/liqo/unpeer.sh
@@ -39,14 +39,21 @@ error() {
 }
 trap 'error "${BASH_SOURCE}" "${LINENO}"' ERR
 
-CONSUMER_KUBECONFIG="${TMPDIR}/kubeconfigs/liqo_kubeconf_1"
+SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+# shellcheck disable=SC1091
+# shellcheck source=../../utils.sh
+source "${SCRIPT_DIR}/../../utils.sh"
 
+CONSUMER_KUBECONFIG="${TMPDIR}/kubeconfigs/liqo_kubeconf_1"
+CLUSTER_ID=$(forge_clustername 1)
 for i in $(seq 2 "${CLUSTER_NUMBER}");
 do
   export KUBECONFIG="${CONSUMER_KUBECONFIG}"
-  export PROVIDER_KUBECONFIG="${TMPDIR}/kubeconfigs/liqo_kubeconf_${i}"
+  export PROVIDER_KUBECONFIG_ADMIN="${TMPDIR}/kubeconfigs/liqo_kubeconf_${i}"
+  export PROVIDER_KUBECONFIG="${TMPDIR}/kubeconfigs/generated/liqo_kubeconf_${i}"
 
   "${LIQOCTL}" unpeer --kubeconfig "${KUBECONFIG}" --remote-kubeconfig "${PROVIDER_KUBECONFIG}" --skip-confirm
+  "${LIQOCTL}" delete peering-user --kubeconfig "${PROVIDER_KUBECONFIG_ADMIN}" --consumer-cluster-id "${CLUSTER_ID}"
 done;
 
 # check that the peering is correctly removed


### PR DESCRIPTION
# Description

This PR introduces a set of commands allowing to generate a user with the minimum permissions to create a peering from the cluster with the specified cluster ID.

To create an user with the minimum permissions to peer with the current cluster from a cluster with ID $CLUSTER_ID:

```
liqoctl generate peering-user --consumer-cluster-id $CLUSTER_ID
```

to remove all the permissions to the user:

```
liqoctl delete peering-user --consumer-cluster-id $CLUSTER_ID
```
