### PR TITLE
Fix rendering of WgGateway templates when metrics disabled

### DIFF
--- a/deployments/liqo/templates/liqo-wireguard-gateway-client-template.yaml
+++ b/deployments/liqo/templates/liqo-wireguard-gateway-client-template.yaml
@@ -74,8 +74,8 @@ spec:
                 volumeMounts: 
                 - name: ipc 
                   mountPath: /ipc
-                {{- if .Values.metrics.enabled }}
                 ports:
+                {{- if .Values.metrics.enabled }}
                 - containerPort: 8082
                   name: gw-metrics
                 {{- end }}
@@ -120,8 +120,8 @@ spec:
                 {{- end }}
                 - --health-probe-bind-address=:8085
                 - --implementation={{ .Values.networking.gatewayTemplates.wireguard.implementation }}
-                {{- if .Values.metrics.enabled }}
                 ports:
+                {{- if .Values.metrics.enabled }}
                 - containerPort: 8084
                   name: wg-metrics
                 {{- end }}
@@ -166,8 +166,8 @@ spec:
                 volumeMounts: 
                 - name: ipc 
                   mountPath: /ipc
-                {{- if .Values.metrics.enabled }}
                 ports:
+                {{- if .Values.metrics.enabled }}
                 - containerPort: 8086
                   name: gv-metrics
                 {{- end }} 

--- a/deployments/liqo/templates/liqo-wireguard-gateway-server-template-eks.yaml
+++ b/deployments/liqo/templates/liqo-wireguard-gateway-server-template-eks.yaml
@@ -101,12 +101,11 @@ spec:
                 volumeMounts: 
                 - name: ipc 
                   mountPath: /ipc
-                {{- if .Values.metrics.enabled }}
                 ports:
+                {{- if .Values.metrics.enabled }}
                 - containerPort: 8082
                   name: gw-metrics
                 {{- end }}
-                ports:
                 - containerPort: 8083
                   name: healthz
                 # ATTENTION: uncomment the readinessProbe section if you are aware of the consequences.
@@ -147,12 +146,11 @@ spec:
                 {{- end }}
                 - --health-probe-bind-address=:8085
                 - --implementation={{ .Values.networking.gatewayTemplates.wireguard.implementation }}
-                {{- if .Values.metrics.enabled }}
                 ports:
+                {{- if .Values.metrics.enabled }}
                 - containerPort: 8084
                   name: wg-metrics
                 {{- end }}
-                ports:
                 - containerPort: 8085
                   name: healthz
                 # ATTENTION: uncomment the readinessProbe section if you are aware of the consequences.
@@ -194,12 +192,11 @@ spec:
                 volumeMounts: 
                 - name: ipc 
                   mountPath: /ipc
-                {{- if .Values.metrics.enabled }}
                 ports:
+                {{- if .Values.metrics.enabled }}
                 - containerPort: 8086
                   name: gv-metrics
                 {{- end }}
-                ports:
                 - containerPort: 8087
                   name: healthz
                 # ATTENTION: uncomment the readinessProbe section if you are aware of the consequences.

--- a/deployments/liqo/templates/liqo-wireguard-gateway-server-template.yaml
+++ b/deployments/liqo/templates/liqo-wireguard-gateway-server-template.yaml
@@ -94,8 +94,8 @@ spec:
                 volumeMounts:
                 - name: ipc
                   mountPath: /ipc
-                {{- if .Values.metrics.enabled }}
                 ports:
+                {{- if .Values.metrics.enabled }}
                 - containerPort: 8082
                   name: gw-metrics
                 {{- end }}
@@ -139,8 +139,8 @@ spec:
                 {{- end }}
                 - --health-probe-bind-address=:8085
                 - --implementation={{ .Values.networking.gatewayTemplates.wireguard.implementation }}
-                {{- if .Values.metrics.enabled }}
                 ports:
+                {{- if .Values.metrics.enabled }}
                 - containerPort: 8084
                   name: wg-metrics
                 {{- end }}
@@ -185,8 +185,8 @@ spec:
                 volumeMounts:
                 - name: ipc
                   mountPath: /ipc
-                {{- if .Values.metrics.enabled }}
                 ports:
+                {{- if .Values.metrics.enabled }}
                 - containerPort: 8086
                   name: gv-metrics
                 {{- end }}


### PR DESCRIPTION
# Description

This PR fixes a bug where the wggateway templates were not rendered correctly when defining ports.
This happens only if metrics are not enabled.
