### PR TITLE
[liqoctl] set gateway server Service location in `peer` command

### DIFF
--- a/cmd/liqoctl/cmd/peer.go
+++ b/cmd/liqoctl/cmd/peer.go
@@ -22,6 +22,7 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/util/runtime"
 
+	liqov1beta1 "github.com/liqotech/liqo/apis/core/v1beta1"
 	nwforge "github.com/liqotech/liqo/pkg/liqo-controller-manager/networking/forge"
 	"github.com/liqotech/liqo/pkg/liqoctl/completion"
 	"github.com/liqotech/liqo/pkg/liqoctl/factory"
@@ -90,8 +91,11 @@ func newPeerCommand(ctx context.Context, f *factory.Factory) *cobra.Command {
 
 	// Networking flags
 	cmd.Flags().BoolVar(&options.NetworkingDisabled, "networking-disabled", false, "Disable networking between the two clusters")
+	cmd.Flags().Var(options.ServerServiceLocation, "server-service-location",
+		fmt.Sprintf("Location of the service to expose the Gateway Server (%q or %q). Default: %q",
+			liqov1beta1.ConsumerRole, liqov1beta1.ProviderRole, nwforge.DefaultGwServerLocation))
 	cmd.Flags().Var(options.ServerServiceType, "server-service-type",
-		fmt.Sprintf("Service type of the Gateway Server service. Default: %s."+
+		fmt.Sprintf("Service type of the Gateway Server service. Default: %q."+
 			" Note: use ClusterIP only if you know what you are doing and you have a proper network configuration",
 			nwforge.DefaultGwServerServiceType))
 	cmd.Flags().Int32Var(&options.ServerServicePort, "server-service-port", nwforge.DefaultGwServerPort,
@@ -111,6 +115,7 @@ func newPeerCommand(ctx context.Context, f *factory.Factory) *cobra.Command {
 	cmd.Flags().IntVar(&options.MTU, "mtu", nwforge.DefaultMTU,
 		fmt.Sprintf("MTU of the Gateway server and client. Default: %d", nwforge.DefaultMTU))
 
+	runtime.Must(cmd.RegisterFlagCompletionFunc("server-service-location", completion.Enumeration(options.ServerServiceLocation.Allowed)))
 	runtime.Must(cmd.RegisterFlagCompletionFunc("server-service-type", completion.Enumeration(options.ServerServiceType.Allowed)))
 
 	// Authentication flags

--- a/docs/advanced/manual-peering.md
+++ b/docs/advanced/manual-peering.md
@@ -3,7 +3,6 @@
 In the [peer two clusters](../usage/peer.md) section of this documentation, we used the `liqoctl peer`, which automatically configure each single module of Liqo to create a peering between two clusters. However, in some cases where:
 
 - you want to configure Liqo peerings via a [declarative approach](./peering/peering-via-cr.md) via CRs.
-- it is required to configure the WireGuard gateway server on the cluster consumer (e.g. the nodes of the cluster provider are [behind a NAT or a physical load balancer](./nat.md))
 - The consumer needs to create multiple requests for resources (ResourceSlice) or you want to customize the way resources are distributed on virtual nodes
 
 you might need to configure each single module separatly, or to interact with a specific module to obtain the desired result.

--- a/docs/advanced/nat.md
+++ b/docs/advanced/nat.md
@@ -9,12 +9,15 @@ This page describes how to configure Liqo in the above scenarios.
 
 ![The provider is behind a NAT](../_static/images/advanced/nat/provider-nat.svg)
 
-The `liqoctl peer` command configures the gateway server on the provider cluster.
+The `liqoctl peer` command by default configures the gateway server on the provider cluster.
 However, there may be cases where the provider cluster's nodes are not directly reachable, such as when they are behind a NAT, while the consumer cluster is directly accessible.
 For instance, in the image above, cluster 2 is behind a NAT and is therefore not directly reachable.
 
 This problem can be solved by swapping the roles of the gateways, hence configuring the client on the cluster provider and the server on the consumer.
-To do so, you need to use [manual peering](./manual-peering.md), setting the inter-cluster network up separately.
+To do so, you have two options:
+
+- run the `liqoctl peer` command with the `--server-service-location=Consumer` flag
+- perform a [manual peering](./manual-peering.md), setting the inter-cluster network up separately
 
 ![The gateway server has been on the consumer side](../_static/images/advanced/nat/consumer-nat.svg)
 

--- a/docs/usage/peer.md
+++ b/docs/usage/peer.md
@@ -36,7 +36,8 @@ To perform a peering without having access to both clusters, you need to manuall
 The peering command enables all 3 liqo modules and performs the following steps:
 
 1. **enables networking**.
-Exchanges network configurations and creates the two **gateways** (server in the provider, client in the consumer) to let the two clusters communicate over a secure tunnel.
+Exchanges network configurations and creates the two **gateways** (one acting as _server_ and located in the provider cluster, another acting as _client_ in the consumer cluster) to let the two clusters communicate over a secure tunnel.  
+The location of the client/server gateway can be customized when creating the peering using the `--server-service-location` flag in `liqoctl`.  
 2. **enables authentication**.
 Authenticates the consumer with the provider.
 In this step, the consumer obtains an `Identity` (*kubeconfig*) to replicate resources to the provider cluster.

--- a/pkg/liqo-controller-manager/networking/forge/gatewayserver.go
+++ b/pkg/liqo-controller-manager/networking/forge/gatewayserver.go
@@ -30,6 +30,7 @@ import (
 const (
 	DefaultGwServerType         = "networking.liqo.io/v1beta1/wggatewayservertemplates"
 	DefaultGwServerTemplateName = "wireguard-server"
+	DefaultGwServerLocation     = liqov1beta1.ProviderRole
 	DefaultGwServerServiceType  = corev1.ServiceTypeLoadBalancer
 	DefaultGwServerPort         = 51840
 	DefaultKeysDir              = "/etc/wireguard/keys"


### PR DESCRIPTION
# Description

This PR introduces the support to specify the gateway client and server location in a peering.
The `--server-service-location` flag in `liqoctl peer` allows to place the gateway server service in the provider (default) or consumer.
This can be useful if you cannot expose Services (or don't have LB UDP support) in the provider cluster or if the provider is behind a NAT (without going through the manual peering procedure or setting up the networking module individually).
