### PR TITLE
[liqoctl] include network init in connect

### DIFF
--- a/cmd/liqoctl/cmd/network.go
+++ b/cmd/liqoctl/cmd/network.go
@@ -31,10 +31,6 @@ import (
 
 const liqoctlNetworkLongHelp = `Manage liqo networking.`
 
-const liqoctlNetworkInitLongHelp = `Initialize the liqo networking between two clusters.
-
-It generates all network configurations required to connect the two clusters.`
-
 const liqoctlNetworkResetLongHelp = `Tear down all liqo networking between two clusters.
 
 It disconnects the two clusters and remove network configurations generated with the *network init* command.`
@@ -44,9 +40,10 @@ const liqoctlNetworConnectLongHelp = `Connect two clusters using liqo networking
 This command creates the Gateways to connect the two clusters.
 Run this command after inizialiting the network using the *network init* command.`
 
-const liqoctlNetworkDisconnectLongHelp = `Disconnect two clusters.
+const liqoctlNetworkDisconnectLongHelp = `Disconnect two clusters keeping the network configuration.
 
-It deletes the Gateways, but keeps the network configurations generated with the *network init* command.`
+It deletes the Gateways, but keeps the network configurations generated with the *network init* command.
+Useful when a user wants to disconnect the clusters keeping the same IP mapping.`
 
 func newNetworkCommand(ctx context.Context, f *factory.Factory) *cobra.Command {
 	options := network.NewOptions(f)
@@ -85,30 +82,9 @@ func newNetworkCommand(ctx context.Context, f *factory.Factory) *cobra.Command {
 	options.LocalFactory.Printer.CheckErr(cmd.RegisterFlagCompletionFunc("remote-liqo-namespace",
 		completion.Namespaces(ctx, options.RemoteFactory, completion.NoLimit)))
 
-	cmd.AddCommand(newNetworkInitCommand(ctx, options))
 	cmd.AddCommand(newNetworkResetCommand(ctx, options))
 	cmd.AddCommand(newNetworkConnectCommand(ctx, options))
 	cmd.AddCommand(newNetworkDisconnectCommand(ctx, options))
-
-	return cmd
-}
-
-func newNetworkInitCommand(ctx context.Context, options *network.Options) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "init",
-		Short: "Initialize the liqo networking between two clusters",
-		Long:  WithTemplate(liqoctlNetworkInitLongHelp),
-		Args:  cobra.NoArgs,
-
-		Run: func(_ *cobra.Command, _ []string) {
-			err := options.RunInit(ctx)
-			if err != nil {
-				options.LocalFactory.Printer.CheckErr(
-					fmt.Errorf("`network init` failed (error: %w). Issue `network reset` to cleanup the environment", err))
-			}
-			output.ExitOnErr(err)
-		},
-	}
 
 	return cmd
 }
@@ -191,7 +167,7 @@ func newNetworkConnectCommand(ctx context.Context, options *network.Options) *co
 func newNetworkDisconnectCommand(ctx context.Context, options *network.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "disconnect",
-		Short: "Disconnect two clusters",
+		Short: "Disconnect two clusters keeping the network configuration",
 		Long:  WithTemplate(liqoctlNetworkDisconnectLongHelp),
 		Args:  cobra.NoArgs,
 

--- a/docs/advanced/nat.md
+++ b/docs/advanced/nat.md
@@ -61,7 +61,7 @@ liqoctl peer \
 ```
 
 The command above sets up a complete peering between cluster 1 and cluster 2.
-**To configure only the network**, you can pass the same parameters to the `liqoctl network connect` command, once network have been initialized with `liqoctl init`:
+**To configure only the network**, you can pass the same parameters to the `liqoctl network connect` command:
 
 ```bash
 liqoctl network connect \

--- a/pkg/liqoctl/network/cluster.go
+++ b/pkg/liqoctl/network/cluster.go
@@ -350,12 +350,14 @@ func (c *Cluster) CheckNetworkInitialized(ctx context.Context, remoteClusterID l
 		s.Fail(fmt.Sprintf("An error occurred while checking network Configuration: %v", output.PrettyErr(err)))
 		return err
 	case apierrors.IsNotFound(err):
-		s.Fail(fmt.Sprintf("Network Configuration not found. Initialize the network first with `liqoctl network init`: %v", output.PrettyErr(err)))
+		s.Fail(fmt.Sprintf("Network Configuration not found. Retry to issue `liqoctl network connect`. If the issue persist, "+
+			"you can try to reset the network with `liqoctl network reset`: %v", output.PrettyErr(err)))
 		return err
 	}
 
 	if !networkingutils.IsConfigurationStatusSet(conf.Status) {
-		err := fmt.Errorf("network Configuration status is not set yet. Retry later or initialize the network again with `liqoctl network init`")
+		err := fmt.Errorf("network Configuration status is not set yet. Retry later. If the issue persist, " +
+			"you can try to reset the network with `liqoctl network reset`")
 		s.Fail(err)
 		return err
 	}

--- a/pkg/liqoctl/peer/handler.go
+++ b/pkg/liqoctl/peer/handler.go
@@ -78,7 +78,7 @@ func (o *Options) RunPeer(ctx context.Context) error {
 
 	// To ease the experience for most users, we disable the namespace and remote-namespace flags
 	// so that resources are created according to the default Liqo logic.
-	// Advanced users can use the individual commands (e.g., liqoctl init, liqoctl connect, etc..) to
+	// Advanced users can use the individual commands (e.g., liqoctl network connect, liqoctl network disconnect, etc..) to
 	// customize the namespaces according to their needs (e.g., networking resources in a specific namespace).
 	o.LocalFactory.Namespace = ""
 	o.RemoteFactory.Namespace = ""
@@ -133,10 +133,6 @@ func ensureNetworking(ctx context.Context, o *Options) error {
 
 		MTU:                o.MTU,
 		DisableSharingKeys: false,
-	}
-
-	if err := networkOptions.RunInit(ctx); err != nil {
-		return err
 	}
 
 	if err := networkOptions.RunConnect(ctx); err != nil {


### PR DESCRIPTION
# Description

This PR removes the `liqoctl network init` command, including its functionalities into `connect`. This simplifies usage and removes a command which is really unlikely used alone.

