### PR TITLE
fix: examples

### DIFF
--- a/examples/stateful-applications/manifests/cluster1.yaml
+++ b/examples/stateful-applications/manifests/cluster1.yaml
@@ -1,7 +1,7 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 networking:
-  serviceSubnet: "10.90.0.0/12"
+  serviceSubnet: "10.80.0.0/12"
   podSubnet: "10.200.0.0/16"
 nodes:
   - role: control-plane

--- a/examples/stateful-applications/manifests/cluster2.yaml
+++ b/examples/stateful-applications/manifests/cluster2.yaml
@@ -1,7 +1,7 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 networking:
-  serviceSubnet: "10.70.0.0/12"
+  serviceSubnet: "10.64.0.0/12"
   podSubnet: "10.210.0.0/16"
 nodes:
   - role: control-plane


### PR DESCRIPTION
# Description

`serviceSubnet` "10.70.0.0/12" and "10.90.0.0/12" are invalid.
