### PR TITLE
fix: PodMonitor

### DIFF
--- a/cmd/crd-replicator/main.go
+++ b/cmd/crd-replicator/main.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	liqov1beta1 "github.com/liqotech/liqo/apis/core/v1beta1"
 	crdreplicator "github.com/liqotech/liqo/internal/crdReplicator"
@@ -47,6 +48,9 @@ func init() {
 }
 
 func main() {
+	// Manager flags
+	metricsAddr := pflag.String("metrics-address", ":8082", "The address the metric endpoint binds to")
+
 	clusterFlags := args.NewClusterIDFlags(true, nil)
 	resyncPeriod := pflag.Duration("resync-period", 10*time.Hour, "The resync period for the informers")
 	workers := pflag.Uint("workers", 1, "The number of workers managing the reflection of each remote cluster")
@@ -65,6 +69,9 @@ func main() {
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		MapperProvider: mapper.LiqoMapperProvider(scheme),
 		Scheme:         scheme,
+		Metrics: server.Options{
+			BindAddress: *metricsAddr,
+		},
 		LeaderElection: false,
 	})
 	if err != nil {

--- a/deployments/liqo/templates/liqo-virtualkubelet-podmonitor.yaml
+++ b/deployments/liqo/templates/liqo-virtualkubelet-podmonitor.yaml
@@ -16,8 +16,7 @@ spec:
     any: true
   selector:
     matchLabels: 
-      app.kubernetes.io/name: "virtual-kubelet"
-      app.kubernetes.io/component: "virtual-kubelet"
+      offloading.liqo.io/component: virtual-kubelet
   podMetricsEndpoints:
   - port: metrics
     {{- with .Values.virtualKubelet.metrics.podMonitor.interval }}


### PR DESCRIPTION
# Description

Fix `PodMonitor`.

* crd-replicator

    Commit 10ef3087 changed the default port for metrics from `8080` to `8082`, but crd-replicator was not changed because there is no command line option. However, only the `Deployment` port was changed to 8082, so `PodMonitor` no longer works properly.

    This commit reverts the `Deployment` port back to `8080`.

* VirtualKubelet

    Commit ddafea075 changed the label of VirtualKubelet but did not change the `PodMonitor` selector so it no longer works correctly.

    This commit makes `PodMonitor`'s selector follow commit ddafea075.
