### PR TITLE
fix(liqoctl): rename `producer` occurences to `provider`

### DIFF
--- a/cmd/liqoctl/cmd/test.go
+++ b/cmd/liqoctl/cmd/test.go
@@ -89,7 +89,7 @@ func newTestNetworkCommand(ctx context.Context, topts *test.Options) *cobra.Comm
 	runtime.Must(cmd.RegisterFlagCompletionFunc(
 		string(flags.FlagNamesNodeportNodes), completion.Enumeration(flags.NodePortNodesValues),
 	))
-	runtime.Must(cmd.MarkFlagRequired(string(flags.FlagNamesProducersKubeconfigs)))
+	runtime.Must(cmd.MarkFlagRequired(string(flags.FlagNamesProvidersKubeconfigs)))
 
 	return cmd
 }

--- a/pkg/liqoctl/test/network/check/endpointslices.go
+++ b/pkg/liqoctl/test/network/check/endpointslices.go
@@ -27,7 +27,7 @@ import (
 	"github.com/liqotech/liqo/pkg/liqoctl/test/network/setup"
 )
 
-// Targets ia a map where the key is the name of the producer/consumer
+// Targets ia a map where the key is the name of the provider/consumer
 // and the values are the endpoints from their point of view.
 type Targets map[string][]string
 
@@ -67,7 +67,7 @@ func ForgePodTargetForProvider(ctx context.Context, cl *client.Client, name stri
 		if len(eps.Items) != 2 {
 			return fmt.Errorf("%q expected 2 endpoint slice, got %d", name, len(eps.Items))
 		}
-		return fmt.Errorf("error waiting for producer %q endpoint slice: %w", name, err)
+		return fmt.Errorf("error waiting for provider %q endpoint slice: %w", name, err)
 	}
 
 	if len(eps.Items[0].Endpoints)+len(eps.Items[1].Endpoints) != int(totalReplicas) {

--- a/pkg/liqoctl/test/network/check/external.go
+++ b/pkg/liqoctl/test/network/check/external.go
@@ -43,7 +43,7 @@ func RunChecksPodToExternal(ctx context.Context, cl *client.Client,
 		successCountTot += successCount
 		errorCountTot += errorCount
 		if err != nil {
-			return successCountTot, errorCountTot, fmt.Errorf("producer %q failed to run checks: %w", k, err)
+			return successCountTot, errorCountTot, fmt.Errorf("provider %q failed to run checks: %w", k, err)
 		}
 	}
 

--- a/pkg/liqoctl/test/network/check/ip.go
+++ b/pkg/liqoctl/test/network/check/ip.go
@@ -57,7 +57,7 @@ func RunChecksPodToExternalRemappedIP(ctx context.Context, cl *client.Client,
 		successCountTot += successCount
 		errorCountTot += errorCount
 		if err != nil {
-			return successCountTot, errorCountTot, fmt.Errorf("producer %q failed to run checks: %w", k, err)
+			return successCountTot, errorCountTot, fmt.Errorf("provider %q failed to run checks: %w", k, err)
 		}
 	}
 
@@ -81,7 +81,7 @@ func ForgeIPTargets(ctx context.Context, cl *client.Client) (Targets, error) {
 	for k := range cl.Providers {
 		targets[k], err = forgeIPTarget(ctx, cl.Providers[k], localIPRemapped, k)
 		if err != nil {
-			return nil, fmt.Errorf("failed to forge producer %q IP target: %w", k, err)
+			return nil, fmt.Errorf("failed to forge provider %q IP target: %w", k, err)
 		}
 	}
 

--- a/pkg/liqoctl/test/network/check/node.go
+++ b/pkg/liqoctl/test/network/check/node.go
@@ -44,7 +44,7 @@ func RunChecksNodeToPod(ctx context.Context, cl *client.Client, cfg client.Confi
 		successCount, errorCount, err := RunCheckToTargets(ctx, cl.Providers[k],
 			cfg[k], opts, k, targets[k], true, ExecCurl)
 		if err != nil {
-			return 0, 0, fmt.Errorf("producer %q failed to run checks: %w", k, err)
+			return 0, 0, fmt.Errorf("provider %q failed to run checks: %w", k, err)
 		}
 		successCountTot += successCount
 		errorCountTot += errorCount

--- a/pkg/liqoctl/test/network/check/pod.go
+++ b/pkg/liqoctl/test/network/check/pod.go
@@ -46,7 +46,7 @@ func RunChecksPodToPod(ctx context.Context, cl *client.Client, cfg client.Config
 		successCountTot += successCount
 		errorCountTot += errorCount
 		if err != nil {
-			return successCountTot, errorCountTot, fmt.Errorf("producer %q failed to run checks: %w", k, err)
+			return successCountTot, errorCountTot, fmt.Errorf("provider %q failed to run checks: %w", k, err)
 		}
 	}
 

--- a/pkg/liqoctl/test/network/check/service.go
+++ b/pkg/liqoctl/test/network/check/service.go
@@ -70,7 +70,7 @@ func RunCheckPodToClusterIPService(ctx context.Context, cl *client.Client, cfg c
 	}
 
 	for k := range cl.Providers {
-		// The test is repeated twice for each producer and consumer pods.
+		// The test is repeated twice for each provider and consumer pods.
 		// This is to ensure that all pods have been contacted from each other pods through the service.
 		for i := 0; i < int(totreplicas*2); i++ {
 			successCount, errorCount, err := RunCheckToTargets(ctx, cl.Providers[k], cfg[k],
@@ -78,7 +78,7 @@ func RunCheckPodToClusterIPService(ctx context.Context, cl *client.Client, cfg c
 			successCountTot += successCount
 			errorCountTot += errorCount
 			if err != nil {
-				return successCountTot, errorCountTot, fmt.Errorf("producer %q failed to run checks: %w", k, err)
+				return successCountTot, errorCountTot, fmt.Errorf("provider %q failed to run checks: %w", k, err)
 			}
 		}
 	}
@@ -142,7 +142,7 @@ func RunsCheckExternalToNodePortService(ctx context.Context, cl *client.Client, 
 		successCountTot += successCount
 		errorCountTot += errorCount
 		if err != nil {
-			return successCount, errorCount, fmt.Errorf("producer %q failed to run checks: %w", k, err)
+			return successCount, errorCount, fmt.Errorf("provider %q failed to run checks: %w", k, err)
 		}
 	}
 
@@ -211,7 +211,7 @@ func RunsCheckExternalToLoadBalancerService(ctx context.Context, cl *client.Clie
 		successCountTot += successCount
 		errorCountTot += errorCount
 		if err != nil {
-			return successCount, errorCount, fmt.Errorf("producer %q failed to run checks: %w", k, err)
+			return successCount, errorCount, fmt.Errorf("provider %q failed to run checks: %w", k, err)
 		}
 	}
 
@@ -233,7 +233,7 @@ func RunsCheckPodToNodePortService(ctx context.Context, cl *client.Client, cfg c
 		successCountTot += successCount
 		errorCountTot += errorCount
 		if err != nil {
-			return successCount, errorCount, fmt.Errorf("producer %q failed to run checks: %w", k, err)
+			return successCount, errorCount, fmt.Errorf("provider %q failed to run checks: %w", k, err)
 		}
 	}
 

--- a/pkg/liqoctl/test/network/client/k8s.go
+++ b/pkg/liqoctl/test/network/client/k8s.go
@@ -31,9 +31,9 @@ type Client struct {
 	Consumer        client.Client
 	ConsumerName    string
 	ConsumerDynamic *dynamic.DynamicClient
-	// Providers key is the name of the producer kubeconfig file.
+	// Providers key is the name of the provider kubeconfig file.
 	Providers map[string]client.Client
-	// ProvidersDynamic key is the name of the producer kubeconfig file.
+	// ProvidersDynamic key is the name of the provider kubeconfig file.
 	ProvidersDynamic map[string]*dynamic.DynamicClient
 }
 

--- a/pkg/liqoctl/test/network/flags/flags.go
+++ b/pkg/liqoctl/test/network/flags/flags.go
@@ -22,8 +22,8 @@ import (
 type FlagNames string
 
 const (
-	// FlagNamesProducersKubeconfigs is the flag name for the kubeconfigs of the remote clusters.
-	FlagNamesProducersKubeconfigs FlagNames = "remote-kubeconfigs"
+	// FlagNamesProvidersKubeconfigs is the flag name for the kubeconfigs of the remote clusters.
+	FlagNamesProvidersKubeconfigs FlagNames = "remote-kubeconfigs"
 	// FlagNamesInfo is the flag name for the information output.
 	FlagNamesInfo FlagNames = "info"
 	// FlagNamesRemoveNamespace is the flag name for the namespace removal.
@@ -44,7 +44,8 @@ const (
 
 // AddFlags adds the flags used by the network tests to the given flag set.
 func (o *Options) AddFlags(fs *pflag.FlagSet) {
-	fs.StringSliceVarP(&o.RemoteKubeconfigs, string(FlagNamesProducersKubeconfigs), "p", []string{}, "A list of kubeconfigs for remote provider clusters")
+	fs.StringSliceVarP(&o.RemoteKubeconfigs, string(FlagNamesProvidersKubeconfigs), "p", []string{},
+		"A list of kubeconfigs for remote provider clusters")
 	fs.BoolVar(&o.RemoveNamespace, string(FlagNamesRemoveNamespace), false, "Remove namespace after the test")
 	fs.BoolVar(&o.Info, string(FlagNamesInfo), false, "Print information about the network configurations of the clusters")
 	fs.BoolVar(&o.NodePortExt, string(FlagNamesNodeportExternal), false, "Enable curl from external to nodeport service")

--- a/pkg/liqoctl/test/network/setup/deployment.go
+++ b/pkg/liqoctl/test/network/setup/deployment.go
@@ -45,11 +45,11 @@ func CreateAllDeployments(ctx context.Context, cl *client.Client) (totreplicas i
 	for k := range cl.Providers {
 		replicas, err := getReplicas(ctx, cl.Providers[k])
 		if err != nil {
-			return 0, fmt.Errorf("producer %q error getting replicas: %w", k, err)
+			return 0, fmt.Errorf("provider %q error getting replicas: %w", k, err)
 		}
 		totreplicas += replicas
 		if err := CreateDeployment(ctx, cl.Consumer, replicas, k, false); err != nil {
-			return 0, fmt.Errorf("producer %q error creating deployment: %w", k, err)
+			return 0, fmt.Errorf("provider %q error creating deployment: %w", k, err)
 		}
 		if err := CreateDeployment(ctx, cl.Consumer, replicas, k, true); err != nil {
 			return 0, fmt.Errorf("consumer error creating deployment: %w", err)
@@ -64,10 +64,10 @@ func CreateAllDeployments(ctx context.Context, cl *client.Client) (totreplicas i
 	}
 	for k := range cl.Providers {
 		if err := WaitDeploymentReady(ctx, cl.Consumer, k, false); err != nil {
-			return 0, fmt.Errorf("producer %q error waiting for deployments to be ready: %w", k, err)
+			return 0, fmt.Errorf("provider %q error waiting for deployments to be ready: %w", k, err)
 		}
 		if err := WaitDeploymentReady(ctx, cl.Consumer, k, true); err != nil {
-			return 0, fmt.Errorf("producer %q error waiting for deployments to be ready: %w", k, err)
+			return 0, fmt.Errorf("provider %q error waiting for deployments to be ready: %w", k, err)
 		}
 	}
 	return totreplicas, nil

--- a/pkg/liqoctl/test/network/setup/kyverno.go
+++ b/pkg/liqoctl/test/network/setup/kyverno.go
@@ -50,12 +50,12 @@ func CreatePolicy(ctx context.Context, cl *client.Client) error {
 		policy := ForgeKyvernoPodAntiaffinityPolicy(k, false)
 		if _, err := cl.ProvidersDynamic[k].Resource(KyvernoPolicyGroupVersionResource).
 			Namespace(NamespaceName).Create(ctx, policy, metav1.CreateOptions{}); err != nil && !apierrors.IsAlreadyExists(err) {
-			return fmt.Errorf("producer %q failed to create policy: %w", k, err)
+			return fmt.Errorf("provider %q failed to create policy: %w", k, err)
 		}
 		policy = ForgeKyvernoPodAntiaffinityPolicy(k, true)
 		if _, err := cl.ProvidersDynamic[k].Resource(KyvernoPolicyGroupVersionResource).
 			Namespace(NamespaceName).Create(ctx, policy, metav1.CreateOptions{}); err != nil && !apierrors.IsAlreadyExists(err) {
-			return fmt.Errorf("producer %q failed to create policy: %w", k, err)
+			return fmt.Errorf("provider %q failed to create policy: %w", k, err)
 		}
 	}
 	return nil


### PR DESCRIPTION
# Description

This PR renames all occurrences of `producer` to `provider` to be more coherent with the terminology adopted.