### PR TITLE
[E2E] use `liqoctl info` instead of status in diagnostic

### DIFF
--- a/test/e2e/pipeline/diagnostic/diagnose.sh
+++ b/test/e2e/pipeline/diagnostic/diagnose.sh
@@ -45,8 +45,8 @@ do
    ${KUBECTL} get no -o wide --show-labels
    echo "Liqo local status"
    echo "|------------------------------------------------------------|"
-   ${LIQOCTL} status --verbose
+   ${LIQOCTL} info --verbose
    echo "Liqo peerings statuses"
    echo "|------------------------------------------------------------|"
-   ${LIQOCTL} status peer --verbose
+   ${LIQOCTL} info peer --verbose
 done;


### PR DESCRIPTION
# Description

The E2E diagnostic was still using the `liqoctl status` command, which does not existing anymore with 1.0.
This PR replaces these calls with `liqoctl info`.
