### PR TITLE
[Firewall] moved FwCfg util functions out of apis types folder

### DIFF
--- a/apis/networking/v1beta1/firewall/common_types.go
+++ b/apis/networking/v1beta1/firewall/common_types.go
@@ -14,14 +14,6 @@
 
 package firewall
 
-import (
-	"fmt"
-	"net"
-	"strconv"
-
-	"github.com/liqotech/liqo/pkg/utils/network/port"
-)
-
 // IPValueType is the type of the match value.
 type IPValueType string
 
@@ -45,41 +37,3 @@ const (
 	// PortValueTypeVoid is a void match value.
 	PortValueTypeVoid PortValueType = "void"
 )
-
-// GetIPValueType parses the match value and returns the type of the value.
-func GetIPValueType(value *string) (IPValueType, error) {
-	if value == nil {
-		return IPValueTypeVoid, nil
-	}
-
-	// Check if the value is a pool subnet.
-	if _, _, err := net.ParseCIDR(*value); err == nil {
-		return IPValueTypeSubnet, nil
-	}
-
-	// Check if the value is an IP.
-	if net.ParseIP(*value) != nil {
-		return IPValueTypeIP, nil
-	}
-
-	return IPValueTypeVoid, fmt.Errorf("invalid match value %s", *value)
-}
-
-// GetPortValueType parses the match value and returns the type of the value.
-func GetPortValueType(value *string) (PortValueType, error) {
-	if value == nil {
-		return PortValueTypeVoid, nil
-	}
-
-	// Check if the value is a port range.
-	if _, _, err := port.ParsePortRange(*value); err == nil {
-		return PortValueTypeRange, nil
-	}
-
-	// Check if the value is a port.
-	if _, err := strconv.Atoi(*value); err != nil {
-		return PortValueTypePort, nil
-	}
-
-	return PortValueTypeVoid, fmt.Errorf("invalid match value %s", *value)
-}

--- a/docs/advanced/peering/peering-via-cr.md
+++ b/docs/advanced/peering/peering-via-cr.md
@@ -260,7 +260,7 @@ This section shows how to configure the authentication between the clusters, all
 When authentication is manually configured, **the user is in charge of providing the credentials with the permission required** by the consumer cluster to operate.
 
 If your are not familiar with how authentication works in Kubernetes you can check [this documentation page](https://kubernetes.io/docs/reference/access-authn-authz/authentication/).
-You can also check [here to know how to issue a certificate for a user](https://kubernetes.io/docs/reference/access-authn-authz/certificate-signing-requests/#normal-user).
+You can also check [here to know how to issue a certificate for a user](https://kubernetes.io/docs/tasks/tls/certificate-issue-client-csr/).
 
 ```{warning}
 Note that with EKS authentication via client certificate [is not directly supported](https://aws.amazon.com/blogs/containers/managing-access-to-amazon-elastic-kubernetes-service-clusters-with-x-509-certificates/).

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -63,6 +63,7 @@ linkcheck_ignore = [
     'https://medium.com/', # often rate-limited
     'https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api#service-types',
     'https://ieeexplore.ieee.org',
+    'https://dl.acm.org', # often 403
 ]
 
 

--- a/pkg/firewall/utils/common.go
+++ b/pkg/firewall/utils/common.go
@@ -1,0 +1,62 @@
+// Copyright 2019-2025 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+
+	firewallv1beta1 "github.com/liqotech/liqo/apis/networking/v1beta1/firewall"
+	"github.com/liqotech/liqo/pkg/utils/network/port"
+)
+
+// GetIPValueType parses the match value and returns the type of the value.
+func GetIPValueType(value *string) (firewallv1beta1.IPValueType, error) {
+	if value == nil {
+		return firewallv1beta1.IPValueTypeVoid, nil
+	}
+
+	// Check if the value is a pool subnet.
+	if _, _, err := net.ParseCIDR(*value); err == nil {
+		return firewallv1beta1.IPValueTypeSubnet, nil
+	}
+
+	// Check if the value is an IP.
+	if net.ParseIP(*value) != nil {
+		return firewallv1beta1.IPValueTypeIP, nil
+	}
+
+	return firewallv1beta1.IPValueTypeVoid, fmt.Errorf("invalid match value %s", *value)
+}
+
+// GetPortValueType parses the match value and returns the type of the value.
+func GetPortValueType(value *string) (firewallv1beta1.PortValueType, error) {
+	if value == nil {
+		return firewallv1beta1.PortValueTypeVoid, nil
+	}
+
+	// Check if the value is a port range.
+	if _, _, err := port.ParsePortRange(*value); err == nil {
+		return firewallv1beta1.PortValueTypeRange, nil
+	}
+
+	// Check if the value is a port.
+	if _, err := strconv.Atoi(*value); err == nil {
+		return firewallv1beta1.PortValueTypePort, nil
+	}
+
+	return firewallv1beta1.PortValueTypeVoid, fmt.Errorf("invalid match value %s", *value)
+}

--- a/pkg/firewall/utils/match.go
+++ b/pkg/firewall/utils/match.go
@@ -62,7 +62,7 @@ func applyMatch(m *firewallv1beta1.Match, rule *nftables.Rule) error {
 }
 
 func applyMatchIP(m *firewallv1beta1.Match, rule *nftables.Rule, op expr.CmpOp) error {
-	matchIPValueType, err := firewallv1beta1.GetIPValueType(&m.IP.Value)
+	matchIPValueType, err := GetIPValueType(&m.IP.Value)
 	if err != nil {
 		return err
 	}
@@ -233,7 +233,7 @@ func applyMatchDev(m *firewallv1beta1.Match, rule *nftables.Rule, op expr.CmpOp)
 }
 
 func applyMatchPort(m *firewallv1beta1.Match, rule *nftables.Rule, op expr.CmpOp) error {
-	matchPortValueType, err := firewallv1beta1.GetPortValueType(&m.IP.Value)
+	matchPortValueType, err := GetPortValueType(&m.IP.Value)
 	if err != nil {
 		return err
 	}

--- a/pkg/firewall/utils/natrule.go
+++ b/pkg/firewall/utils/natrule.go
@@ -112,7 +112,7 @@ func forgeNatRule(nr *firewallv1beta1.NatRule, chain *nftables.Chain) (*nftables
 }
 
 func applyNatRule(nr *firewallv1beta1.NatRule, rule *nftables.Rule) error {
-	ipType, err := firewallv1beta1.GetIPValueType(nr.To)
+	ipType, err := GetIPValueType(nr.To)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
# Description

This PR moves some utilities functions that were left on the api types definition to a utils package under `./pkg/...`.
