### PR TITLE
Fix minor doc inconsistencies around mariadb invokation

### DIFF
--- a/docs/examples/stateful-applications.md
+++ b/docs/examples/stateful-applications.md
@@ -109,7 +109,7 @@ kubectl run db-mariadb-galera-client --rm --tty -i \
     --restart='Never' --namespace default \
     --image docker.io/bitnami/mariadb-galera:11.4.5-debian-12-r6 \
     --command \
-    -- mysql -h db-mariadb-galera.liqo-demo -uuser -ppassword my_database
+      -- mariadb -h db-mariadb-galera.liqo-demo -uuser -p'password' my_database
 ```
 
 And then create an example table and insert some data:
@@ -159,9 +159,9 @@ And querying again for your data:
 ```bash
 kubectl run db-mariadb-galera-client --rm --tty -i \
     --restart='Never' --namespace default \
-    --image docker.io/bitnami/mariadb-galera:10.6.7-debian-10-r56 \
+    --image docker.io/bitnami/mariadb-galera:11.4.5-debian-12-r6 \
     --command \
-      -- mysql -h db-mariadb-galera.liqo-demo -uuser -ppassword my_database \
+      -- mariadb -h db-mariadb-galera.liqo-demo -uuser -p'password' my_database \
       --execute "SELECT * FROM People;"
 ```
 

--- a/docs/features/peering.md
+++ b/docs/features/peering.md
@@ -38,9 +38,9 @@ The approach is schematized at a high level in the figure below.
 
 ```{warning}
 The standard *liqoctl* peer command requires the machine running it to have simultaneous access to both cluster API servers, through their *kubeconfigs*.
-If this is not possible, refer to the advanced guide to learn how to perform the [peering manually](/advanced/manual-peering) without having contemporary access to both clusters.
+If this is not possible, refer to the advanced guide to learn how to perform the [peering manually](/advanced/manual-peering) without having simultaneous access to both clusters.
 ```
 
 ```{admonition} Note
-The user can adopt different peering approaches depending if it has contemporary access to both clusters or not, as described in the [dedicated page](/advanced/peering-strategies.md). 
+The user can adopt different peering approaches depending if it has simultaneous access to both clusters or not, as described in the [dedicated page](/advanced/peering-strategies.md). 
 ```


### PR DESCRIPTION
# Description

The second SQL mariadb command had the old image version. Both invokations used 'mysql' which is deprecated.

Fixes # NONE

# How Has This Been Tested?

Both commands were checked in editor preview for formatting, and successfully executed from a terminal.