### PR TITLE
chore: bump deprecated ubuntu 20.04 runner

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
 
   test:
     name: Launch Test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: configure
     steps:
 


### PR DESCRIPTION
# Description

This PR bumps a deprecated Ubuntu 20.04 runner.