### PR TITLE
[Telemetry] ResourceSliceNumber

### DIFF
--- a/pkg/telemetry/doc.go
+++ b/pkg/telemetry/doc.go
@@ -38,6 +38,7 @@
 //     -- Latency
 //     -- NodesNumber
 //     -- VirtualNodesNumber
+//     -- ResourceSliceNumber
 //   - Namespaces info
 //     -- UID
 //     -- MappingStrategy (EnforceSameName/DefaultName)


### PR DESCRIPTION
# Description

This PR adds info about telemetry exported data inside the documentation.
In particular it adds the ResourceSliceNumber inside the doc.go file.