### PR TITLE
[Network] avoid panic when setting gateway secretRef

### DIFF
--- a/docs/advanced/peering/peering-via-cr.md
+++ b/docs/advanced/peering/peering-via-cr.md
@@ -121,6 +121,7 @@ kind: Secret
 metadata:
   labels:
     liqo.io/remote-cluster-id: <REMOTE_CLUSTER_ID>
+    networking.liqo.io/gateway-resource: "true"
   name: gw-keys
   namespace: <TENANT_NAMESPACE>
 type: Opaque
@@ -146,7 +147,7 @@ spec:
   publicKey: <REMOTE_WIREGUARD_PUBLIC_KEY>
 ```
 
-In order to make things work, make sure that the PublicKey resource has the labels:
+In order to make things work, make sure that both the Secret and PublicKey resources have the labels:
 
 ```yaml
 liqo.io/remote-cluster-id: <HERE_THE_CLUSTER_ID_OF_PEER_CLUSTER>

--- a/pkg/liqo-controller-manager/networking/external-network/wireguard/wggatewayclient_controller.go
+++ b/pkg/liqo-controller-manager/networking/external-network/wireguard/wggatewayclient_controller.go
@@ -171,8 +171,8 @@ func (r *WgGatewayClientReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		}
 		r.eventRecorder.Event(wgClient, corev1.EventTypeNormal, "KeysSecretEnforced", "Enforced keys secret")
 	} else {
-		// Check that the secret exists and is correctly labeled
-		if err = checkExistingKeysSecret(ctx, r.Client, wgClient.Spec.SecretRef.Name, wgClient.Namespace); err != nil {
+		// Check that the secret exists and ensure is correctly labeled
+		if err = checkExistingKeysSecret(ctx, r.Client, wgClient.Spec.SecretRef.Name, wgClient.Namespace, wgClient.GetObjectMeta()); err != nil {
 			r.eventRecorder.Event(wgClient, corev1.EventTypeWarning, "KeysSecretCheckFailed", fmt.Sprintf("Failed to check keys secret: %s", err))
 			return ctrl.Result{}, err
 		}

--- a/pkg/liqo-controller-manager/networking/external-network/wireguard/wggatewayserver_controller.go
+++ b/pkg/liqo-controller-manager/networking/external-network/wireguard/wggatewayserver_controller.go
@@ -164,13 +164,6 @@ func (r *WgGatewayServerReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return ctrl.Result{}, err
 	}
 
-	if err := r.handleSecretRefStatus(ctx, wgServer); err != nil {
-		klog.Errorf("Error while handling secret ref status: %v", err)
-		r.eventRecorder.Event(wgServer, corev1.EventTypeWarning, "SecretRefStatusFailed",
-			fmt.Sprintf("Failed to handle secret ref status: %s", err))
-		return ctrl.Result{}, err
-	}
-
 	if err := r.handleInternalEndpointStatus(ctx, wgServer, svcNsName, deploy); err != nil {
 		klog.Errorf("Error while handling internal endpoint status: %v", err)
 		r.eventRecorder.Event(wgServer, corev1.EventTypeWarning, "InternalEndpointStatusFailed",
@@ -178,6 +171,7 @@ func (r *WgGatewayServerReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return ctrl.Result{}, err
 	}
 
+	// If a secret has not been provided in the gateway specification, the controller is in charge of generating a secret with the Wireguard keys.
 	if wgServer.Spec.SecretRef.Name == "" {
 		// Ensure WireGuard keys secret (create or update)
 		if err = ensureKeysSecret(ctx, r.Client, wgServer, gateway.ModeServer); err != nil {
@@ -187,11 +181,18 @@ func (r *WgGatewayServerReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		r.eventRecorder.Event(wgServer, corev1.EventTypeNormal, "KeysSecretEnforced", "Enforced keys secret")
 	} else {
 		// Check that the secret exists and is correctly labeled
-		if err = checkExistingKeysSecret(ctx, r.Client, wgServer.Status.SecretRef.Name, wgServer.Namespace); err != nil {
+		if err = checkExistingKeysSecret(ctx, r.Client, wgServer.Spec.SecretRef.Name, wgServer.Namespace); err != nil {
 			r.eventRecorder.Event(wgServer, corev1.EventTypeWarning, "KeysSecretCheckFailed", fmt.Sprintf("Failed to check keys secret: %s", err))
 			return ctrl.Result{}, err
 		}
 		r.eventRecorder.Event(wgServer, corev1.EventTypeNormal, "KeysSecretChecked", "Checked keys secret")
+	}
+
+	if err := r.handleSecretRefStatus(ctx, wgServer); err != nil {
+		klog.Errorf("Error while handling secret ref status: %v", err)
+		r.eventRecorder.Event(wgServer, corev1.EventTypeWarning, "SecretRefStatusFailed",
+			fmt.Sprintf("Failed to handle secret ref status: %s", err))
+		return ctrl.Result{}, err
 	}
 
 	// Ensure deployment (create or update)

--- a/pkg/liqo-controller-manager/networking/external-network/wireguard/wggatewayserver_controller.go
+++ b/pkg/liqo-controller-manager/networking/external-network/wireguard/wggatewayserver_controller.go
@@ -180,8 +180,8 @@ func (r *WgGatewayServerReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		}
 		r.eventRecorder.Event(wgServer, corev1.EventTypeNormal, "KeysSecretEnforced", "Enforced keys secret")
 	} else {
-		// Check that the secret exists and is correctly labeled
-		if err = checkExistingKeysSecret(ctx, r.Client, wgServer.Spec.SecretRef.Name, wgServer.Namespace); err != nil {
+		// Check that the secret exists and ensure is correctly labeled
+		if err = checkExistingKeysSecret(ctx, r.Client, wgServer.Spec.SecretRef.Name, wgServer.Namespace, wgServer.GetObjectMeta()); err != nil {
 			r.eventRecorder.Event(wgServer, corev1.EventTypeWarning, "KeysSecretCheckFailed", fmt.Sprintf("Failed to check keys secret: %s", err))
 			return ctrl.Result{}, err
 		}


### PR DESCRIPTION
# Description

This PR fixes a bug causing the WireGuard gateway server controller to panic if a secretRef is specified on the GatewayServer resource.

The controller now checks the secretRef in the spec rather than the status, which is updated only after ensuring that the referenced secret exists and is correctly labeled.
The docs for the declarative peering have also been updated to add a missing label on the WireGuard secret manifest.