### PR TITLE
docs: Add missing labels in resource slice for declarative peering

### DIFF
--- a/docs/advanced/peering/peering-via-cr.md
+++ b/docs/advanced/peering/peering-via-cr.md
@@ -399,6 +399,7 @@ metadata:
   labels:
     liqo.io/remote-cluster-id: <PROVIDER_CLUSTER_ID>
     liqo.io/remoteID: <PROVIDER_CLUSTER_ID>
+    liqo.io/replication: "true"
   name: test
   namespace: <CONSUMER_TENANT_NAMESPACE>
 spec:


### PR DESCRIPTION
# Description

The resource slice was missing required labels, which caused issues when trying to create resource slices in a declarative way.
