### PR TITLE
fix: escape the shadowpod creator label

### DIFF
--- a/pkg/utils/getters/k8sGetters.go
+++ b/pkg/utils/getters/k8sGetters.go
@@ -41,6 +41,7 @@ import (
 	offloadingv1beta1 "github.com/liqotech/liqo/apis/offloading/v1beta1"
 	"github.com/liqotech/liqo/pkg/consts"
 	liqolabels "github.com/liqotech/liqo/pkg/utils/labels"
+	"github.com/liqotech/liqo/pkg/utils/resource"
 	vkforge "github.com/liqotech/liqo/pkg/vkMachinery/forge"
 )
 
@@ -463,7 +464,7 @@ func GetKubeconfigSecretFromIdentity(ctx context.Context, cl client.Client, iden
 // ListShadowPodsByCreator returns the list of ShadowPods created by the given user.
 func ListShadowPodsByCreator(ctx context.Context, cl client.Client, creator string) (*offloadingv1beta1.ShadowPodList, error) {
 	list := new(offloadingv1beta1.ShadowPodList)
-	if err := cl.List(ctx, list, client.MatchingLabels{consts.CreatorLabelKey: creator}); err != nil {
+	if err := cl.List(ctx, list, client.MatchingLabels{consts.CreatorLabelKey: resource.EscapeLabel(creator)}); err != nil {
 		return nil, err
 	}
 	return list, nil
@@ -479,7 +480,7 @@ func GetQuotaByUser(ctx context.Context, cl client.Client,
 	}
 
 	for i := range quotas.Items {
-		if quotas.Items[i].Spec.User == user {
+		if resource.EscapeLabel(quotas.Items[i].Spec.User) == user {
 			return &quotas.Items[i], nil
 		}
 	}

--- a/pkg/utils/resource/labels.go
+++ b/pkg/utils/resource/labels.go
@@ -16,13 +16,15 @@ package resource
 
 import (
 	"maps"
+	"regexp"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var (
 	// globalLabels stores the global labels that should be added to all resources.
-	globalLabels = make(map[string]string)
+	globalLabels     = make(map[string]string)
+	regexLabelEscape = regexp.MustCompile(`[^\w\-.]`)
 )
 
 // SetGlobalLabels sets the global labels that should be added to all resources.
@@ -46,4 +48,9 @@ func AddGlobalLabels(obj metav1.Object) {
 		obj.SetLabels(make(map[string]string))
 	}
 	maps.Copy(obj.GetLabels(), globalLabels)
+}
+
+// EscapeLabel escapes a label value so that it is compliant.
+func EscapeLabel(val string) string {
+	return regexLabelEscape.ReplaceAllString(val, "-")
 }

--- a/pkg/webhooks/shadowpod/webhook.go
+++ b/pkg/webhooks/shadowpod/webhook.go
@@ -33,6 +33,7 @@ import (
 	"github.com/liqotech/liqo/pkg/consts"
 	"github.com/liqotech/liqo/pkg/utils/getters"
 	pod "github.com/liqotech/liqo/pkg/utils/pod"
+	"github.com/liqotech/liqo/pkg/utils/resource"
 	"github.com/liqotech/liqo/pkg/virtualKubelet/forge"
 )
 
@@ -357,7 +358,7 @@ func (spm *Mutator) HandleDelete() admission.Response {
 }
 
 func extractCreatorInfo(userInfo *authenticationv1.UserInfo) (creatorName string, err error) {
-	creatorName = userInfo.Username
+	creatorName = resource.EscapeLabel(userInfo.Username)
 	if creatorName == "" {
 		return "", fmt.Errorf("missing creator name")
 	}


### PR DESCRIPTION
# Description

When a token of a service account is used as identity for a virtual node, the creation of a shadowpod fails due to the `liqo.io/creator-user` which contains a string like the following, when the token of a SA is used:
"system:serviceaccount:liqo-tenant-cl01:user01". This PR makes sure that the string is escaped before being written in the label field.
