### PR TITLE
feat(offload): Add the liqoctl offload namespaces command.

### DIFF
--- a/cmd/liqoctl/cmd/offload.go
+++ b/cmd/liqoctl/cmd/offload.go
@@ -64,6 +64,20 @@ or (output the NamespaceOffloading resource as a yaml manifest, without applying
   $ {{ .Executable }} offload namespace foo --output yaml
 `
 
+const liqoctlOffloadNamespacesLongHelp = `Offload all namespaces with optional label filtering.
+
+This command offloads all namespaces in the cluster to remote clusters, optionally filtered by a label selector.
+It applies the same offloading configuration to each matching namespace, similar to 'liqoctl offload namespace <name>'.
+
+Examples:
+  $ {{ .Executable }} offload namespaces
+or
+  $ {{ .Executable }} offload namespaces --selector 'key=value'
+or
+  $ {{ .Executable }} offload namespaces --selector 'key=value,env!=prod' \
+      --pod-offloading-strategy Remote --namespace-mapping-strategy EnforceSameName
+`
+
 func newOffloadCommand(ctx context.Context, f *factory.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "offload",
@@ -73,6 +87,7 @@ func newOffloadCommand(ctx context.Context, f *factory.Factory) *cobra.Command {
 	}
 
 	utils.AddCommand(cmd, newOffloadNamespaceCommand(ctx, f))
+	utils.AddCommand(cmd, newOffloadNamespacesCommand(ctx, f))
 	return cmd
 }
 
@@ -137,6 +152,76 @@ func newOffloadNamespaceCommand(ctx context.Context, f *factory.Factory) *cobra.
 	f.Printer.CheckErr(cmd.RegisterFlagCompletionFunc("pod-offloading-strategy", completion.Enumeration(podOffloadingStrategy.Allowed)))
 	f.Printer.CheckErr(cmd.RegisterFlagCompletionFunc("namespace-mapping-strategy", completion.Enumeration(namespaceMappingStrategy.Allowed)))
 	f.Printer.CheckErr(cmd.RegisterFlagCompletionFunc("selector", completion.LabelsSelector(ctx, f, completion.NoLimit)))
+	f.Printer.CheckErr(cmd.RegisterFlagCompletionFunc("output", completion.Enumeration(outputFormat.Allowed)))
+
+	return cmd
+}
+
+func newOffloadNamespacesCommand(ctx context.Context, f *factory.Factory) *cobra.Command {
+	var selectors []string
+	var labelSelector string
+
+	podOffloadingStrategy := args.NewEnum([]string{
+		string(offloadingv1beta1.LocalAndRemotePodOffloadingStrategyType),
+		string(offloadingv1beta1.RemotePodOffloadingStrategyType),
+		string(offloadingv1beta1.LocalPodOffloadingStrategyType)},
+		string(offloadingv1beta1.LocalAndRemotePodOffloadingStrategyType))
+
+	namespaceMappingStrategy := args.NewEnum([]string{
+		string(offloadingv1beta1.EnforceSameNameMappingStrategyType),
+		string(offloadingv1beta1.DefaultNameMappingStrategyType),
+		string(offloadingv1beta1.SelectedNameMappingStrategyType)},
+		string(offloadingv1beta1.DefaultNameMappingStrategyType))
+
+	var remoteNamespaceName = ""
+
+	outputFormat := args.NewEnum([]string{"json", "yaml"}, "")
+
+	options := offload.Options{Factory: f}
+
+	cmd := &cobra.Command{
+		Use:     "namespaces",
+		Aliases: []string{"ns"},
+		Short:   "Offload all namespaces with optional label filtering",
+		Long:    liqoctlOffloadNamespacesLongHelp,
+
+		Args: cobra.NoArgs,
+
+		PreRun: func(_ *cobra.Command, _ []string) {
+			options.PodOffloadingStrategy = offloadingv1beta1.PodOffloadingStrategyType(podOffloadingStrategy.Value)
+			options.NamespaceMappingStrategy = offloadingv1beta1.NamespaceMappingStrategyType(namespaceMappingStrategy.Value)
+			options.RemoteNamespaceName = remoteNamespaceName
+			options.OutputFormat = outputFormat.Value
+			options.LabelSelector = labelSelector
+			options.Printer.CheckErr(options.ParseClusterSelectors(selectors))
+		},
+
+		Run: func(_ *cobra.Command, _ []string) {
+			output.ExitOnErr(options.OffloadNamespaces(ctx))
+		},
+	}
+
+	cmd.Flags().Var(podOffloadingStrategy, "pod-offloading-strategy",
+		"The constraints regarding pods scheduling in this namespace, among Local, Remote and LocalAndRemote")
+	cmd.Flags().Var(namespaceMappingStrategy, "namespace-mapping-strategy",
+		"The naming strategy adopted for the creation of remote namespaces, among DefaultName, EnforceSameName and SelectedName")
+	cmd.Flags().DurationVar(&options.Timeout, "timeout", 20*time.Second, "The timeout for the offloading process")
+	cmd.Flags().StringVar(&remoteNamespaceName, "remote-namespace-name", "",
+		"The name of the remote namespace, required when using the SelectedName NamespaceMappingStrategy. "+
+			"Otherwise, it is ignored")
+
+	cmd.Flags().StringArrayVarP(&selectors, "selector", "l", []string{},
+		"The selector to filter the target clusters. Can be specified multiple times, defining alternative requirements (i.e., in logical OR)")
+	cmd.Flags().StringVar(&labelSelector, "label-selector", "",
+		"Selector (label query) to filter namespaces, supports '=', '==', and '!=' (e.g., -l key1=value1,key2=value2).")
+
+	cmd.Flags().VarP(outputFormat, "output", "o",
+		"Output the resulting NamespaceOffloading resource, instead of applying it. Supported formats: json, yaml")
+
+	f.Printer.CheckErr(cmd.RegisterFlagCompletionFunc("pod-offloading-strategy", completion.Enumeration(podOffloadingStrategy.Allowed)))
+	f.Printer.CheckErr(cmd.RegisterFlagCompletionFunc("namespace-mapping-strategy", completion.Enumeration(namespaceMappingStrategy.Allowed)))
+	f.Printer.CheckErr(cmd.RegisterFlagCompletionFunc("selector", completion.LabelsSelector(ctx, f, completion.NoLimit)))
+	f.Printer.CheckErr(cmd.RegisterFlagCompletionFunc("label-selector", completion.NamespacesSelector(ctx, f, completion.NoLimit)))
 	f.Printer.CheckErr(cmd.RegisterFlagCompletionFunc("output", completion.Enumeration(outputFormat.Allowed)))
 
 	return cmd

--- a/pkg/liqoctl/offload/handler.go
+++ b/pkg/liqoctl/offload/handler.go
@@ -22,7 +22,9 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/cli-runtime/pkg/printers"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	offloadingv1beta1 "github.com/liqotech/liqo/apis/offloading/v1beta1"
 	"github.com/liqotech/liqo/pkg/consts"
@@ -37,6 +39,7 @@ type Options struct {
 	*factory.Factory
 
 	Namespace                string
+	LabelSelector            string
 	PodOffloadingStrategy    offloadingv1beta1.PodOffloadingStrategyType
 	NamespaceMappingStrategy offloadingv1beta1.NamespaceMappingStrategyType
 	RemoteNamespaceName      string
@@ -111,6 +114,52 @@ func (o *Options) Run(ctx context.Context) error {
 	waiter := wait.NewWaiterFromFactory(o.Factory)
 	if err := waiter.ForOffloading(ctx, o.Namespace); err != nil {
 		return err
+	}
+
+	return nil
+}
+
+// OffloadNamespaces offloads all namespaces matching the label selector.
+func (o *Options) OffloadNamespaces(ctx context.Context) error {
+	// Parse the label selector
+	selector, err := labels.Parse(o.LabelSelector)
+	if err != nil && o.LabelSelector != "" {
+		return fmt.Errorf("invalid label selector: %w", err)
+	}
+
+	// List namespaces
+	var nsList corev1.NamespaceList
+	if err := o.CRClient.List(ctx, &nsList, &client.ListOptions{LabelSelector: selector}); err != nil {
+		return fmt.Errorf("cannot list namespace objects: %w", err)
+	}
+
+	if len(nsList.Items) == 0 {
+		o.Printer.Info.Println("No namespaces found matching the selector")
+		return nil
+	}
+
+	// Offload each namespace
+	var errors []error
+	for _, ns := range nsList.Items {
+		// Create a new options instance for each namespace to avoid state pollution
+		nsOptions := &Options{
+			Factory:                  o.Factory,
+			Namespace:                ns.Name,
+			PodOffloadingStrategy:    o.PodOffloadingStrategy,
+			NamespaceMappingStrategy: o.NamespaceMappingStrategy,
+			RemoteNamespaceName:      o.RemoteNamespaceName,
+			ClusterSelector:          o.ClusterSelector,
+			OutputFormat:             o.OutputFormat,
+			Timeout:                  o.Timeout,
+		}
+
+		if err := nsOptions.Run(ctx); err != nil {
+			errors = append(errors, err)
+		}
+	}
+
+	if len(errors) > 0 {
+		return fmt.Errorf("encountered %d errors during offloading", len(errors))
 	}
 
 	return nil


### PR DESCRIPTION
Multiple namespaces can be offloaded.

# Description

Added the liqoctl offload namespaces command. Matching namespaces can be found using `--label-selector`.

Fixes #(issue)

#3057

# How Has This Been Tested?
Yes, I hava tested it locally.

~~~
 $ liqoctl offload namespaces --label-selector='app=namespaces'
 INFO  Offloading of namespace "need01" correctly enabled
 INFO  Offloading completed successfully
 INFO  Offloading of namespace "need03" correctly enabled
 INFO  Offloading completed successfully
~~~

