### PR TITLE
[Network] fix SNAT remaping CIDR

### DIFF
--- a/pkg/liqo-controller-manager/networking/external-network/remapping/cidr.go
+++ b/pkg/liqo-controller-manager/networking/external-network/remapping/cidr.go
@@ -179,13 +179,13 @@ func forgeCIDRFirewallConfigurationDNATRules(cfg *networkingv1beta1.Configuratio
 
 func forgeCIDRFirewallConfigurationSNATRules(cfg *networkingv1beta1.Configuration,
 	opts *Options, cidrtype CIDRType) []firewall.NatRule {
-	var localCIDR, remoteRemapCIDR string
+	var remoteCIDR, remoteRemapCIDR string
 	switch cidrtype {
 	case PodCIDR:
-		localCIDR = cidrutils.GetPrimary(cfg.Spec.Local.CIDR.Pod).String()
+		remoteCIDR = cidrutils.GetPrimary(cfg.Spec.Remote.CIDR.Pod).String()
 		remoteRemapCIDR = cidrutils.GetPrimary(cfg.Status.Remote.CIDR.Pod).String()
 	case ExternalCIDR:
-		localCIDR = cidrutils.GetPrimary(cfg.Spec.Local.CIDR.External).String()
+		remoteCIDR = cidrutils.GetPrimary(cfg.Spec.Remote.CIDR.External).String()
 		remoteRemapCIDR = cidrutils.GetPrimary(cfg.Status.Remote.CIDR.External).String()
 	}
 
@@ -204,7 +204,7 @@ func forgeCIDRFirewallConfigurationSNATRules(cfg *networkingv1beta1.Configuratio
 				{
 					Op: firewall.MatchOperationEq,
 					IP: &firewall.MatchIP{
-						Value:    localCIDR,
+						Value:    remoteCIDR,
 						Position: firewall.MatchPositionSrc,
 					},
 				},


### PR DESCRIPTION
This PR fixes a huge bug we had in CIDR remapping. The SNAT rules for the pod-cidr and ext-cidr inside the gateway were populated with the wrong CIDRs.

Why wasn’t the bug spotted after a year and a half? Because when we perform remapping tests, we typically set the same pod CIDR and external CIDR on every cluster. In this particular case, the bug doesn’t occur because, in a similar scenario, the local pod CIDR and the remote CIDR (not the remapped one) are equal.

Should we consider changing the CIDR used in E2E tests to enhance entropy?