### PR TITLE
[Linting] ignore broken link

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -64,7 +64,8 @@ linkcheck_ignore = [
     'https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api#service-types',
     'https://ieeexplore.ieee.org',
     'https://dl.acm.org', # often 403
-    'https://scholar.google.com'
+    'https://scholar.google.com',
+    'https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/'
 ]
 
 


### PR DESCRIPTION
# Description

This PR adds 'https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/' to the linter ignore list.
