### PR TITLE
[Networking] internalfabric getter name refactoring

### DIFF
--- a/pkg/liqo-controller-manager/networking/utils/internalfabric.go
+++ b/pkg/liqo-controller-manager/networking/utils/internalfabric.go
@@ -50,5 +50,5 @@ func ForgeInternalFabricName(ctx context.Context, cl client.Client, meta *metav1
 	case err != nil:
 		return "", fmt.Errorf("unable to get the internal fabric %q: %w", meta.Name, err)
 	}
-	return internalFabric.Name, nil
+	return meta.Name, nil
 }


### PR DESCRIPTION
This PR refactors the logic used by **getInternalFabric** to get the internalfabric name. We have a function called ForgeInternalFabricName which is already used in other code places.