### PR TITLE
fix(setup.sh): Added a sleep to ensure correct creation of both clusters

### DIFF
--- a/examples/quick-start/setup.sh
+++ b/examples/quick-start/setup.sh
@@ -19,4 +19,5 @@ check_requirements
 delete_clusters "$CLUSTER_NAME_1" "$CLUSTER_NAME_2"
 
 create_cluster "$CLUSTER_NAME_1" "$KUBECONFIG_1" "$LIQO_CLUSTER_CONFIG_YAML"
+sleep 15 
 create_cluster "$CLUSTER_NAME_2" "$KUBECONFIG_2" "$LIQO_CLUSTER_CONFIG_YAML"


### PR DESCRIPTION
# Description
Added a sleep between clusters creation in setup.sh, since otherwise the second one would fail due to a timeout.
