### PR TITLE
feat(auth): add TLS compatibility mode for authentication keys

### DIFF
--- a/cmd/liqo-controller-manager/modules/authentication.go
+++ b/cmd/liqo-controller-manager/modules/authentication.go
@@ -47,6 +47,7 @@ type AuthOption struct {
 	APIServerAddressOverride string
 	CAOverrideB64            string
 	TrustedCA                bool
+	TLSCompatibilityMode     bool
 	SliceStatusOptions       *remoteresourceslicecontroller.SliceStatusOptions
 }
 
@@ -61,6 +62,7 @@ func NewAuthOption(identityProvider identitymanager.IdentityProvider, namespaceM
 		APIServerAddressOverride: opts.APIServerAddressOverride,
 		CAOverrideB64:            opts.CAOverride,
 		TrustedCA:                opts.TrustedCA,
+		TLSCompatibilityMode:     opts.TLSCompatibilityMode,
 		SliceStatusOptions: &remoteresourceslicecontroller.SliceStatusOptions{
 			EnableStorage:             opts.EnableStorage,
 			LocalRealStorageClassName: opts.RealStorageClassName,
@@ -85,7 +87,7 @@ func SetupAuthenticationModule(ctx context.Context, mgr manager.Manager, uncache
 		}
 	}
 
-	if err := enforceAuthenticationKeys(ctx, uncachedClient, opts.LiqoNamespace); err != nil {
+	if err := enforceAuthenticationKeys(ctx, uncachedClient, opts.LiqoNamespace, opts.TLSCompatibilityMode); err != nil {
 		klog.Errorf("Unable to enforce authentication keys: %v", err)
 		return err
 	}
@@ -178,8 +180,8 @@ func SetupAuthenticationModule(ctx context.Context, mgr manager.Manager, uncache
 	return nil
 }
 
-func enforceAuthenticationKeys(ctx context.Context, cl client.Client, liqoNamespace string) error {
-	if err := authentication.InitClusterKeys(ctx, cl, liqoNamespace); err != nil {
+func enforceAuthenticationKeys(ctx context.Context, cl client.Client, liqoNamespace string, tlsCompatibilityMode bool) error {
+	if err := authentication.InitClusterKeys(ctx, cl, liqoNamespace, tlsCompatibilityMode); err != nil {
 		return err
 	}
 

--- a/deployments/liqo/README.md
+++ b/deployments/liqo/README.md
@@ -11,6 +11,7 @@
 | authentication.awsConfig.secretAccessKey | string | `""` | SecretAccessKey for the Liqo user. |
 | authentication.awsConfig.useExistingSecret | bool | `false` | Use an existing secret to configure the AWS credentials. |
 | authentication.enabled | bool | `true` | Enable/Disable the authentication module. |
+| authentication.tlsCompatibilityMode | bool | `false` | Enable TLS compatibility mode for client certificates and keys. If set to true, Liqo will use widely supported algorithm (RSA) instead of Ed25519 (default) for generating private keys and CSRs. Enable this option to ensure compatibility with systems that do not yet support Ed25519 as signature algorithm. |
 | common.affinity | object | `{}` | Affinity for all liqo pods, excluding virtual kubelet. |
 | common.extraArgs | list | `[]` | Extra arguments for all liqo pods, excluding virtual kubelet. |
 | common.globalAnnotations | object | `{}` | Global annotations to be added to all resources created by Liqo controllers |

--- a/deployments/liqo/templates/liqo-controller-manager-deployment.yaml
+++ b/deployments/liqo/templates/liqo-controller-manager-deployment.yaml
@@ -52,6 +52,7 @@ spec:
           - --liqo-namespace=$(POD_NAMESPACE)
           - --networking-enabled={{ .Values.networking.enabled }}
           - --authentication-enabled={{ .Values.authentication.enabled }}
+          - --tls-compatibility-mode={{ .Values.authentication.tlsCompatibilityMode }}
           - --offloading-enabled={{ .Values.offloading.enabled }}
           - --default-limits-enforcement={{ .Values.controllerManager.config.defaultLimitsEnforcement }}
           {{- $d := dict "commandName" "--default-node-resources" "dictionary" .Values.offloading.defaultNodeResources -}}

--- a/deployments/liqo/values.yaml
+++ b/deployments/liqo/values.yaml
@@ -141,6 +141,12 @@ networking:
 authentication:
   # -- Enable/Disable the authentication module.
   enabled: true
+  # -- Enable TLS compatibility mode for client certificates and keys.
+  # If set to true, Liqo will use widely supported algorithm (RSA)
+  # instead of Ed25519 (default) for generating private keys and CSRs.
+  # Enable this option to ensure compatibility with systems that do not yet
+  # support Ed25519 as signature algorithm.
+  tlsCompatibilityMode: false
   # AWS-specific configuration for the local cluster and the Liqo user.
   # This user should be able (1) to create new IAM users, (2) to create new programmatic access
   # credentials, and (3) to describe EKS clusters.

--- a/docs/usage/liqoctl/liqoctl_generate.md
+++ b/docs/usage/liqoctl/liqoctl_generate.md
@@ -182,6 +182,10 @@ liqoctl generate peering-user [flags]
 
 >The cluster ID of the cluster from which peering will be performed
 
+`--tls-compatibility-mode` _string_:
+
+>TLS compatibility mode for peering-user keys: one of auto,true,false. If set to true keys are generated with a widely supported algorithm (RSA) to ensure compatibility with systems that do not yet support Ed25519 (default) as signature algorithm. When auto, liqoctl attempts to detect the system configuration. **(default "auto")**
+
 
 ### Global options
 

--- a/pkg/liqo-controller-manager/authentication/keys.go
+++ b/pkg/liqo-controller-manager/authentication/keys.go
@@ -16,8 +16,12 @@ package authentication
 
 import (
 	"context"
+	"crypto"
+	"crypto/ecdsa"
 	"crypto/ed25519"
 	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
@@ -55,26 +59,100 @@ func GenerateEd25519Keys() (privateKey, publicKey []byte, err error) {
 	return privateKeyPEM, publicKeyPEM, nil
 }
 
-// SignNonce signs a nonce using the provided private key.
-func SignNonce(priv ed25519.PrivateKey, nonce []byte) []byte {
-	return ed25519.Sign(priv, nonce)
+// GenerateRSAKeys returns a new pair of RSA private and public keys in PEM format.
+// Keys are generated using RSA 2048 bits and encoded in PEM format.
+func GenerateRSAKeys() (privateKey, publicKey []byte, err error) {
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to generate RSA private key: %w", err)
+	}
+
+	privateKeyBytes, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to marshal RSA private key: %w", err)
+	}
+	privateKeyPEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: privateKeyBytes})
+
+	publicKeyBytes, err := x509.MarshalPKIXPublicKey(&priv.PublicKey)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to marshal RSA public key: %w", err)
+	}
+	publicKeyPEM := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: publicKeyBytes})
+
+	return privateKeyPEM, publicKeyPEM, nil
 }
 
-// VerifyNonce verifies the signature of a nonce using the public key of the cluster.
-func VerifyNonce(pubKey ed25519.PublicKey, nonce, signature []byte) bool {
-	return ed25519.Verify(pubKey, nonce, signature)
+// SignNonce signs a nonce using the provided private key. The private key can be
+// ed25519.PrivateKey, *rsa.PrivateKey, or *ecdsa.PrivateKey. For RSA/ECDSA the nonce
+// is hashed with SHA-256 before signing.
+func SignNonce(priv crypto.PrivateKey, nonce []byte) ([]byte, error) {
+	switch k := priv.(type) {
+	case ed25519.PrivateKey:
+		sig := ed25519.Sign(k, nonce)
+		return sig, nil
+	case *rsa.PrivateKey:
+		sum := sha256.Sum256(nonce)
+		sig, err := rsa.SignPKCS1v15(rand.Reader, k, crypto.SHA256, sum[:])
+		if err != nil {
+			return nil, fmt.Errorf("rsa sign failed: %w", err)
+		}
+		return sig, nil
+	case *ecdsa.PrivateKey:
+		sum := sha256.Sum256(nonce)
+		sig, err := ecdsa.SignASN1(rand.Reader, k, sum[:])
+		if err != nil {
+			return nil, fmt.Errorf("ecdsa sign failed: %w", err)
+		}
+		return sig, nil
+	default:
+		return nil, fmt.Errorf("unsupported private key type %T", priv)
+	}
+}
+
+// VerifyNonce verifies the signature of a nonce using the PKIX-encoded public key bytes of the cluster.
+// The public key can be Ed25519, RSA, or ECDSA.
+func VerifyNonce(pubKeyPKIX, nonce, signature []byte) (bool, error) {
+	pub, err := x509.ParsePKIXPublicKey(pubKeyPKIX)
+	if err != nil {
+		return false, fmt.Errorf("failed to parse public key: %w", err)
+	}
+
+	switch pk := pub.(type) {
+	case ed25519.PublicKey:
+		return ed25519.Verify(pk, nonce, signature), nil
+	case *rsa.PublicKey:
+		sum := sha256.Sum256(nonce)
+		if err := rsa.VerifyPKCS1v15(pk, crypto.SHA256, sum[:], signature); err != nil {
+			return false, nil
+		}
+		return true, nil
+	case *ecdsa.PublicKey:
+		sum := sha256.Sum256(nonce)
+		if ecdsa.VerifyASN1(pk, sum[:], signature) {
+			return true, nil
+		}
+		return false, nil
+	default:
+		return false, fmt.Errorf("unsupported public key type %T", pub)
+	}
 }
 
 // InitClusterKeys initializes the authentication keys for the cluster.
 // If the secret containing the keys does not exist, it generates a new pair of keys and stores them in a secret.
-func InitClusterKeys(ctx context.Context, cl client.Client, liqoNamespace string) error {
+// If tlsCompatibilityMode is true, RSA keys are generated instead of Ed25519.
+func InitClusterKeys(ctx context.Context, cl client.Client, liqoNamespace string, tlsCompatibilityMode bool) error {
 	// Get secret if it exists
 	var secret corev1.Secret
 	err := cl.Get(ctx, client.ObjectKey{Name: consts.AuthKeysSecretName, Namespace: liqoNamespace}, &secret)
 	switch {
 	case apierrors.IsNotFound(err):
 		// Forge a new pair of keys.
-		private, public, err := GenerateEd25519Keys()
+		var private, public []byte
+		if tlsCompatibilityMode {
+			private, public, err = GenerateRSAKeys()
+		} else {
+			private, public, err = GenerateEd25519Keys()
+		}
 		if err != nil {
 			return fmt.Errorf("error while generating cluster authentication keys: %w", err)
 		}
@@ -107,7 +185,8 @@ func InitClusterKeys(ctx context.Context, cl client.Client, liqoNamespace string
 }
 
 // GetClusterKeys retrieves the private and public keys of the cluster from the secret.
-func GetClusterKeys(ctx context.Context, cl client.Client, liqoNamespace string) (ed25519.PrivateKey, ed25519.PublicKey, error) {
+// It returns the private key as crypto.PrivateKey and the public key as PKIX-encoded bytes.
+func GetClusterKeys(ctx context.Context, cl client.Client, liqoNamespace string) (crypto.PrivateKey, []byte, error) {
 	var secret corev1.Secret
 	if err := cl.Get(ctx, client.ObjectKey{Name: consts.AuthKeysSecretName, Namespace: liqoNamespace}, &secret); err != nil {
 		return nil, nil, fmt.Errorf("unable to get secret with cluster authentication keys: %w", err)
@@ -134,16 +213,13 @@ func GetClusterKeys(ctx context.Context, cl client.Client, liqoNamespace string)
 		return nil, nil, fmt.Errorf("public key not found in secret %s/%s", liqoNamespace, consts.AuthKeysSecretName)
 	}
 
+	// The public key is stored in PEM format with PKIX-encoded bytes. Return the DER bytes for portability.
 	publicKeyPEM, _ := pem.Decode(publicKey)
 	if publicKeyPEM == nil {
 		return nil, nil, fmt.Errorf("failed to decode public key in PEM format")
 	}
-	pub, err := x509.ParsePKIXPublicKey(publicKeyPEM.Bytes)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to parse public key: %w", err)
-	}
 
-	return priv.(ed25519.PrivateKey), pub.(ed25519.PublicKey), nil
+	return priv, publicKeyPEM.Bytes, nil
 }
 
 // GetClusterKeysPEM retrieves the private and public keys of the cluster from the secret and encoded in PEM format.

--- a/pkg/liqo-controller-manager/authentication/noncesigner-controller/noncesigner_controller.go
+++ b/pkg/liqo-controller-manager/authentication/noncesigner-controller/noncesigner_controller.go
@@ -116,7 +116,11 @@ func (r *NonceSignerReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	}
 
 	// Sign the nonce using the private key.
-	signedNonce := authentication.SignNonce(privateKey, nonce)
+	signedNonce, err := authentication.SignNonce(privateKey, nonce)
+	if err != nil {
+		klog.Errorf("unable to sign nonce for secret %q: %v", req.NamespacedName, err)
+		return ctrl.Result{}, err
+	}
 
 	// Check if the secret is already signed and the signature is the same.
 	existingSignedNonce, found := secret.Data[consts.SignedNonceSecretField]

--- a/pkg/liqo-controller-manager/flags.go
+++ b/pkg/liqo-controller-manager/flags.go
@@ -83,6 +83,8 @@ func InitFlags(flagset *pflag.FlagSet, opts *Options) {
 		"Override the API server address where the Kuberentes APIServer is exposed")
 	flagset.StringVar(&opts.CAOverride, "ca-override", "", "Override the CA certificate used by Kubernetes to sign certificates (base64 encoded)")
 	flagset.BoolVar(&opts.TrustedCA, "trusted-ca", false, "Whether the Kubernetes APIServer certificate is issue by a trusted CA")
+	flagset.BoolVar(&opts.TLSCompatibilityMode, "tls-compatibility-mode", false,
+		"Enable TLS compatibility mode for client certificates and keys (use RSA instead of Ed25519)")
 	flagset.StringVar(&opts.AWSConfig.AwsAccessKeyID, "aws-access-key-id", "", "AWS IAM AccessKeyID for the Liqo User")
 	flagset.StringVar(&opts.AWSConfig.AwsSecretAccessKey, "aws-secret-access-key", "", "AWS IAM SecretAccessKey for the Liqo User")
 	flagset.StringVar(&opts.AWSConfig.AwsRegion, "aws-region", "", "AWS region where the local cluster is running")

--- a/pkg/liqo-controller-manager/options.go
+++ b/pkg/liqo-controller-manager/options.go
@@ -59,6 +59,7 @@ type Options struct {
 	APIServerAddressOverride string
 	CAOverride               string
 	TrustedCA                bool
+	TLSCompatibilityMode     bool
 	AWSConfig                *identitymanager.LocalAwsConfig
 	ClusterLabels            args.StringMap
 	IngressClasses           args.ClassNameList

--- a/pkg/liqoctl/rest/peering-user/types.go
+++ b/pkg/liqoctl/rest/peering-user/types.go
@@ -27,6 +27,9 @@ type Options struct {
 	namespaceManager tenantnamespace.Manager
 
 	clusterID args.ClusterIDFlags
+	// tlsCompatibilityMode controls key type selection for the generated user.
+	// Accepted values: "auto", "true", "false".
+	tlsCompatibilityMode string
 }
 
 var _ rest.API = &Options{}


### PR DESCRIPTION
# Description

This pr extends the Liqo compatibility to Kubernetes providers not supporting the Ed25519 signing algorithm.

Fix #2998 
