### PR TITLE
[Core] feat: mark foreigncluster as permanently unreachable

### DIFF
--- a/cmd/crd-replicator/main.go
+++ b/cmd/crd-replicator/main.go
@@ -45,6 +45,8 @@ var scheme = runtime.NewScheme()
 func init() {
 	_ = clientgoscheme.AddToScheme(scheme)
 	// +kubebuilder:scaffold:scheme
+
+	_ = liqov1beta1.AddToScheme(scheme)
 }
 
 func main() {
@@ -88,6 +90,7 @@ func main() {
 	reflectionManager := reflection.NewManager(dynClient, clusterID, *workers, *resyncPeriod)
 	reflectionManager.Start(ctx, resources.GetResourcesToReplicate())
 
+	reflectors := make(map[liqov1beta1.ClusterID]*reflection.Reflector)
 	d := &crdreplicator.Controller{
 		Scheme:    mgr.GetScheme(),
 		Client:    mgr.GetClient(),
@@ -95,7 +98,7 @@ func main() {
 
 		RegisteredResources: resources.GetResourcesToReplicate(),
 		ReflectionManager:   reflectionManager,
-		Reflectors:          make(map[liqov1beta1.ClusterID]*reflection.Reflector),
+		Reflectors:          reflectors,
 
 		IdentityReader: identitymanager.NewCertificateIdentityReader(ctx,
 			mgr.GetClient(), k8sClient, mgr.GetConfig(),
@@ -103,6 +106,16 @@ func main() {
 	}
 	if err = d.SetupWithManager(mgr); err != nil {
 		klog.Error(err, "unable to setup the crdReplicator controller")
+		os.Exit(1)
+	}
+
+	// Set up ForeignClusterStateController
+	fcStateController := &crdreplicator.ForeignClusterStateController{
+		Client:     mgr.GetClient(),
+		Reflectors: reflectors,
+	}
+	if err = fcStateController.SetupWithManager(mgr); err != nil {
+		klog.Error(err, "unable to setup the ForeignClusterState controller")
 		os.Exit(1)
 	}
 

--- a/deployments/liqo/files/liqo-crd-replicator-ClusterRole.yaml
+++ b/deployments/liqo/files/liqo-crd-replicator-ClusterRole.yaml
@@ -17,3 +17,11 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - core.liqo.io
+  resources:
+  - foreignclusters
+  verbs:
+  - get
+  - list
+  - watch

--- a/internal/crdReplicator/foreignclusterstate_controller.go
+++ b/internal/crdReplicator/foreignclusterstate_controller.go
@@ -1,0 +1,79 @@
+// Copyright 2019-2026 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package crdreplicator
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/klog/v2"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	liqov1beta1 "github.com/liqotech/liqo/apis/core/v1beta1"
+	"github.com/liqotech/liqo/internal/crdReplicator/reflection"
+	"github.com/liqotech/liqo/pkg/consts"
+	"github.com/liqotech/liqo/pkg/utils/foreigncluster"
+)
+
+// ForeignClusterStateController reconciles on the state of the foreign clusters to manager the reflection.
+type ForeignClusterStateController struct {
+	client.Client
+
+	// Reflectors is a map containing the reflectors towards each remote cluster.
+	Reflectors map[liqov1beta1.ClusterID]*reflection.Reflector
+}
+
+// cluster-role
+// +kubebuilder:rbac:groups=core.liqo.io,resources=foreignclusters,verbs=get;list;watch
+
+// Reconcile reconciles the state of the foreign clusters to manage the reflection.
+func (c *ForeignClusterStateController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	// Fetch the ForeignCluster object
+	foreignCluster := &liqov1beta1.ForeignCluster{}
+	if err := c.Get(ctx, req.NamespacedName, foreignCluster); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	// If the foreign cluster seems to be disabled, skip reconciliation.
+	if foreignCluster.Status.Role == liqov1beta1.UnknownRole {
+		klog.Infof("ForeignCluster %q has unknown role, skipping reconciliation", foreignCluster.Name)
+		return ctrl.Result{}, nil
+	}
+
+	// Get the reflector for the remote cluster
+	reflector, exists := c.Reflectors[foreignCluster.Spec.ClusterID]
+	if !exists {
+		klog.Warningf("No reflector found for ForeignCluster %q, will retry later", foreignCluster.Name)
+		return ctrl.Result{}, fmt.Errorf("no reflector found for ForeignCluster %q", foreignCluster.Name)
+	}
+
+	if dead, message := foreigncluster.IsDead(foreignCluster); dead {
+		reflector.RemoteReachable.Store(false)
+		klog.Warningf("Remote cluster %q is dead: %s", foreignCluster.Name, message)
+	} else {
+		reflector.RemoteReachable.Store(true)
+		klog.Infof("Remote cluster %q is alive", foreignCluster.Name)
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// SetupWithManager registers a new controller for identity Secrets.
+func (c *ForeignClusterStateController) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).Named(consts.CtrlForeignClusterStateCRDReplicator).
+		For(&liqov1beta1.ForeignCluster{}).
+		Complete(c)
+}

--- a/internal/crdReplicator/reflection/handler.go
+++ b/internal/crdReplicator/reflection/handler.go
@@ -96,6 +96,7 @@ func (r *Reflector) handle(ctx context.Context, key item) error {
 	// Check if the local resource has been marked for deletion
 	if !localUnstr.GetDeletionTimestamp().IsZero() {
 		klog.Infof("[%v] Deleting remote %v with name %v, since the local one is being deleted", r.remoteClusterID, key.gvr, key.name)
+
 		vanished, err := r.deleteRemoteObject(ctx, resource, key)
 		if err != nil {
 			return err
@@ -117,6 +118,11 @@ func (r *Reflector) handle(ctx context.Context, key item) error {
 		return err
 	}
 	tracer.Step("Ensured the local finalizer presence")
+
+	if !resource.informer.HasSynced() {
+		klog.Warningf("[%v] The informer for %v is not synced, skipping remote reconciliation for %v", r.remoteClusterID, key.gvr, key.name)
+		return fmt.Errorf("the informer for %v is not synced, skipping remote reconciliation for %v", key.gvr, key.name)
+	}
 
 	// Retrieve the resource from the remote cluster
 	remote, err := resource.remote.Get(key.name)
@@ -258,6 +264,11 @@ func (r *Reflector) updateObjectStatusInner(ctx context.Context, cl dynamic.Inte
 
 // deleteRemoteObject deletes a given object from the remote cluster.
 func (r *Reflector) deleteRemoteObject(ctx context.Context, resource *reflectedResource, key item) (vanished bool, err error) {
+	if !r.RemoteReachable.Load() {
+		klog.Warningf("[%v] Remote cluster is marked as dead, skipping deletion of %v with name %v", r.remoteClusterID, key.gvr, key.name)
+		return true, nil
+	}
+
 	if _, err := resource.remote.Get(key.name); err != nil {
 		if kerrors.IsForbidden(err) {
 			klog.Infof("[%v] Cannot retrieve remote %v with name %v (permission removed by provider)", r.remoteClusterID, key.gvr, key.name)

--- a/internal/crdReplicator/reflection/handler_test.go
+++ b/internal/crdReplicator/reflection/handler_test.go
@@ -29,14 +29,22 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/dynamic/dynamicinformer"
 	"k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/informers"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/tools/cache"
 
 	liqov1beta1 "github.com/liqotech/liqo/apis/core/v1beta1"
 	ipamv1alpha1 "github.com/liqotech/liqo/apis/ipam/v1alpha1"
 	offloadingv1beta1 "github.com/liqotech/liqo/apis/offloading/v1beta1"
 	"github.com/liqotech/liqo/pkg/consts"
 )
+
+func getDummyInformer(ctx context.Context, client dynamic.Interface, namespace string, gvr schema.GroupVersionResource) informers.GenericInformer {
+	factory := dynamicinformer.NewFilteredDynamicSharedInformerFactory(client, 0, namespace, func(lo *metav1.ListOptions) {})
+	informer := factory.ForResource(gvr)
+	factory.Start(ctx.Done())
+	factory.WaitForCacheSync(ctx.Done())
+	return informer
+}
 
 var _ = Describe("Handler tests", func() {
 
@@ -64,13 +72,6 @@ var _ = Describe("Handler tests", func() {
 	)
 
 	Item := func(name string) item { return item{gvr: gvr, name: name} }
-	Lister := func(ctx context.Context, client dynamic.Interface, namespace string, gvr schema.GroupVersionResource) cache.GenericNamespaceLister {
-		factory := dynamicinformer.NewFilteredDynamicSharedInformerFactory(client, 0, namespace, func(lo *metav1.ListOptions) {})
-		informer := factory.ForResource(gvr)
-		factory.Start(ctx.Done())
-		factory.WaitForCacheSync(ctx.Done())
-		return informer.Lister().ByNamespace(namespace)
-	}
 
 	BeforeEach(func() {
 		ctx, cancel = context.WithCancel(context.Background())
@@ -99,6 +100,8 @@ var _ = Describe("Handler tests", func() {
 		local = fake.NewSimpleDynamicClient(scheme, localBefore.DeepCopy())
 		remote = fake.NewSimpleDynamicClient(scheme, remoteBefore.DeepCopy())
 
+		localInformer := getDummyInformer(ctx, local, localNamespace, gvr)
+		remoteInformer := getDummyInformer(ctx, remote, remoteNamespace, gvr)
 		reflector = Reflector{
 			manager: &Manager{
 				client: local,
@@ -114,11 +117,13 @@ var _ = Describe("Handler tests", func() {
 				gvr: {
 					gvr:       gvr,
 					ownership: ownership,
-					local:     Lister(ctx, local, localNamespace, gvr),
-					remote:    Lister(ctx, remote, remoteNamespace, gvr),
+					informer:  remoteInformer.Informer(),
+					local:     localInformer.Lister().ByNamespace(localNamespace),
+					remote:    remoteInformer.Lister().ByNamespace(remoteNamespace),
 				},
 			},
 		}
+		reflector.RemoteReachable.Store(true)
 
 		err = reflector.handle(ctx, key)
 	})

--- a/internal/crdReplicator/reflection/reflector_test.go
+++ b/internal/crdReplicator/reflection/reflector_test.go
@@ -73,6 +73,7 @@ var _ = Describe("Reflector tests", func() {
 		manager = NewManager(local, localClusterID, workers, 0)
 		manager.Start(ctx, []resources.Resource{res})
 		reflector = manager.NewForRemote(remote, remoteClusterID, localNamespace, remoteNamespace, "")
+		reflector.RemoteReachable.Store(true)
 	})
 
 	AfterEach(func() { cancel() })

--- a/pkg/consts/annotations.go
+++ b/pkg/consts/annotations.go
@@ -49,4 +49,8 @@ const (
 	// WebhookServiceNameAnnotationKey is the constant representing
 	// the key of the annotation containing the Webhook service name.
 	WebhookServiceNameAnnotationKey = "liqo.io/webhook-service-name"
+
+	// ForeignClusterPermanentlyUnreachableAnnotationKey is the annotation used to signal that the foreign cluster is not reachable and it will
+	// never come up.
+	ForeignClusterPermanentlyUnreachableAnnotationKey = "liqo.io/foreign-cluster-permanently-unreachable"
 )

--- a/pkg/consts/controllers.go
+++ b/pkg/consts/controllers.go
@@ -24,9 +24,10 @@ package consts
 // with the prefix "Ctrl".
 const (
 	// Core.
-	CtrlForeignCluster      = "foreigncluster"
-	CtrlSecretCRDReplicator = "secret_crdreplicator" //nolint:gosec // not a credential
-	CtrlSecretWebhook       = "secret_webhook"
+	CtrlForeignCluster                   = "foreigncluster"
+	CtrlSecretCRDReplicator              = "secret_crdreplicator" //nolint:gosec // not a credential
+	CtrlForeignClusterStateCRDReplicator = "foreignclusterstate_crdreplicator"
+	CtrlSecretWebhook                    = "secret_webhook"
 
 	// Networking.
 	CtrlConfigurationExternal  = "configuration_external"

--- a/pkg/utils/foreigncluster/conditions.go
+++ b/pkg/utils/foreigncluster/conditions.go
@@ -20,7 +20,39 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	liqov1beta1 "github.com/liqotech/liqo/apis/core/v1beta1"
+	"github.com/liqotech/liqo/pkg/consts"
 )
+
+// IsDead checks whether the foreign cluster is dead, meaning that it is not reachable and it will never come up.
+func IsDead(foreignCluster *liqov1beta1.ForeignCluster) (isDead bool, message string) {
+	if foreignCluster == nil {
+		return true, "ForeignCluster is nil"
+	}
+
+	// Return dead only if the foreign cluster is marked as permanently unreachable.
+	if foreignCluster.Annotations == nil || foreignCluster.Annotations[consts.ForeignClusterPermanentlyUnreachableAnnotationKey] != "true" {
+		return false, ""
+	}
+
+	// In all the other cases we consider the connection dead, as there is an annotation marking the cluster unreachable
+	// unless the API server is still responding.
+
+	if foreignCluster.Status.Conditions != nil {
+		// Check the API server reachability condition.
+		for _, condition := range foreignCluster.Status.Conditions {
+			if condition.Type == liqov1beta1.APIServerStatusCondition {
+				switch condition.Status {
+				case liqov1beta1.ConditionStatusEstablished:
+					return false, ""
+				default:
+					return true, condition.Message
+				}
+			}
+		}
+	}
+
+	return true, "The foreign cluster has been marked as permanently unreachable"
+}
 
 // EnsureGenericCondition ensures the presence of a generic condition in the foreign cluster status.
 func EnsureGenericCondition(foreignCluster *liqov1beta1.ForeignCluster,


### PR DESCRIPTION
# Description

This PR fixes a known issue with Liqo: when a provider cluster becomes unreachable, it is not easy to disable a peering connection with that cluster, as the CRDreplicator and the ControllerManager attempt to remove resources from a cluster that will never come back up. A mechanism based on the
`liqo.io/foreign-cluster-permanently-unreachable: true` has been added: when a ForeignCluster is marked with that annotations, and the API server of the remote cluster is considered unreachable, then replicated resources are removed from the local cluster, ignoring the remote ones.

