### PR TITLE
[Liqoctl] Force unpeer command

### DIFF
--- a/cmd/liqoctl/cmd/force.go
+++ b/cmd/liqoctl/cmd/force.go
@@ -1,0 +1,103 @@
+// Copyright 2019-2026 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cmd
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+
+	"github.com/liqotech/liqo/pkg/liqoctl/completion"
+	"github.com/liqotech/liqo/pkg/liqoctl/factory"
+	"github.com/liqotech/liqo/pkg/liqoctl/force/unpeer"
+	"github.com/liqotech/liqo/pkg/liqoctl/output"
+	"github.com/liqotech/liqo/pkg/liqoctl/utils"
+)
+
+const liqoctlForceLongHelp = `Force actions on Liqo components and resources.
+
+The force command allows you to override normal Liqo operations and execute
+actions that might otherwise be blocked or require manual intervention.
+This command provides mechanisms to forcefully manipulate Liqo resources
+when standard operations are not sufficient or when immediate action is required.
+
+Use with caution as force operations may bypass safety checks and could
+potentially impact cluster stability or data consistency.
+
+Examples:
+  $ {{ .Executable }} force
+`
+
+const liqoctUnpeerForceLongHelp = `Force unpeer from a remote cluster.
+
+This command forcefully terminates the peering relationship with a remote cluster,
+bypassing normal unpeer procedures and safety checks. It is designed to handle
+situations where the standard unpeer process fails or when the remote cluster
+is unreachable or unresponsive.
+
+The force unpeer operation will:
+- Mark the ForeignCluster as permanently unreachable
+- Clean up local resources associated with the peering
+- Remove tenant namespaces
+
+Use with caution as this operation cannot be undone and may leave resources
+in an inconsistent state if the remote cluster is still accessible.
+
+Examples:
+  $ {{ .Executable }} force unpeer <cluster-id>
+`
+
+func newForceUnpeerCommand(ctx context.Context, f *factory.Factory) *cobra.Command {
+	options := unpeer.NewOptions(f)
+
+	cmd := &cobra.Command{
+		Use:               "unpeer",
+		Short:             "Force unpeer a cluster",
+		Long:              liqoctUnpeerForceLongHelp,
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: completion.ClusterIDs(ctx, f, 1),
+
+		PreRun: func(_ *cobra.Command, _ []string) {
+			output.ExitOnErr(f.Printer.AskConfirm(
+				"force unpeer might leave the remote cluster in an inconsistent state and it",
+				f.SkipConfirm),
+			)
+		},
+
+		Run: func(_ *cobra.Command, args []string) {
+			options.ClusterID = args[0]
+			if options.ClusterID == "" {
+				options.Printer.ExitWithMessage("Cluster ID must be specified")
+			}
+			output.ExitOnErr(options.RunForceUnpeer(ctx))
+		},
+	}
+
+	return cmd
+}
+
+func newForceCommand(ctx context.Context, f *factory.Factory) *cobra.Command {
+	maincmd := &cobra.Command{
+		Use:   "force",
+		Short: "Force actions on Liqo",
+		Long:  liqoctlForceLongHelp,
+		Args:  cobra.NoArgs,
+	}
+
+	utils.AddCommand(maincmd, newForceUnpeerCommand(ctx, f))
+
+	return maincmd
+}

--- a/cmd/liqoctl/cmd/root.go
+++ b/cmd/liqoctl/cmd/root.go
@@ -139,6 +139,7 @@ func NewRootCommand(ctx context.Context) *cobra.Command {
 	utils.AddCommand(cmd, delete.NewDeleteCommand(ctx, liqoResources, f))
 	utils.AddCommand(cmd, newInfoCommand(ctx, f))
 	utils.AddCommand(cmd, newTestCommand(ctx, f))
+	utils.AddCommand(cmd, newForceCommand(ctx, f))
 
 	return cmd
 }

--- a/docs/usage/liqoctl/liqoctl_force.md
+++ b/docs/usage/liqoctl/liqoctl_force.md
@@ -1,0 +1,94 @@
+# liqoctl force
+
+Force actions on Liqo
+
+## Description
+
+### Synopsis
+
+Force actions on Liqo components and resources.
+
+The force command allows you to override normal Liqo operations and execute
+actions that might otherwise be blocked or require manual intervention.
+This command provides mechanisms to forcefully manipulate Liqo resources
+when standard operations are not sufficient or when immediate action is required.
+
+Use with caution as force operations may bypass safety checks and could
+potentially impact cluster stability or data consistency.
+
+
+
+## liqoctl force unpeer
+
+Force unpeer a cluster
+
+### Synopsis
+
+Force unpeer from a remote cluster.
+
+This command forcefully terminates the peering relationship with a remote cluster,
+bypassing normal unpeer procedures and safety checks. It is designed to handle
+situations where the standard unpeer process fails or when the remote cluster
+is unreachable or unresponsive.
+
+The force unpeer operation will:
+- Mark the ForeignCluster as permanently unreachable
+- Clean up local resources associated with the peering
+- Remove tenant namespaces
+
+Use with caution as this operation cannot be undone and may leave resources
+in an inconsistent state if the remote cluster is still accessible.
+
+
+
+```
+liqoctl force unpeer [flags]
+```
+
+### Examples
+
+
+```bash
+  $ liqoctl force unpeer <cluster-id>
+```
+
+
+
+
+
+### Options
+
+### Global options
+
+`--cluster` _string_:
+
+>The name of the kubeconfig cluster to use
+
+`--context` _string_:
+
+>The name of the kubeconfig context to use
+
+`--global-annotations` _stringToString_:
+
+>Global annotations to be added to all created resources (key=value)
+
+`--global-labels` _stringToString_:
+
+>Global labels to be added to all created resources (key=value)
+
+`--kubeconfig` _string_:
+
+>Path to the kubeconfig file to use for CLI requests
+
+`--skip-confirm`
+
+>Skip the confirmation prompt (suggested for automation)
+
+`--user` _string_:
+
+>The name of the kubeconfig user to use
+
+`-v`, `--verbose`
+
+>Enable verbose logs (default false)
+

--- a/pkg/liqoctl/force/doc.go
+++ b/pkg/liqoctl/force/doc.go
@@ -1,0 +1,17 @@
+// Copyright 2019-2026 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+// Package force contains the logic to force operations.
+package force

--- a/pkg/liqoctl/force/unpeer/doc.go
+++ b/pkg/liqoctl/force/unpeer/doc.go
@@ -1,0 +1,17 @@
+// Copyright 2019-2026 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+// Package unpeer contains the logic to force the unpeering of a cluster from another one, without the need to have access to the remote cluster.
+package unpeer

--- a/pkg/liqoctl/force/unpeer/handler.go
+++ b/pkg/liqoctl/force/unpeer/handler.go
@@ -1,0 +1,95 @@
+// Copyright 2019-2026 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package unpeer
+
+import (
+	"context"
+	"fmt"
+
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	liqov1beta1 "github.com/liqotech/liqo/apis/core/v1beta1"
+	"github.com/liqotech/liqo/pkg/consts"
+	"github.com/liqotech/liqo/pkg/liqoctl/factory"
+	"github.com/liqotech/liqo/pkg/liqoctl/unauthenticate"
+	"github.com/liqotech/liqo/pkg/liqoctl/wait"
+	fcutils "github.com/liqotech/liqo/pkg/utils/foreigncluster"
+	mapsutil "github.com/liqotech/liqo/pkg/utils/maps"
+)
+
+// Options encapsulates the arguments of the force unpeer command.
+type Options struct {
+	*factory.Factory
+	waiter *wait.Waiter
+
+	ClusterID string
+}
+
+// NewOptions returns a new Options instance.
+func NewOptions(localFactory *factory.Factory) *Options {
+	return &Options{
+		Factory: localFactory,
+		waiter:  wait.NewWaiterFromFactory(localFactory),
+	}
+}
+
+// RunForceUnpeer execute the `force unpeer` command.
+func (o *Options) RunForceUnpeer(ctx context.Context) error {
+	s := o.Printer.StartSpinner("Retrieving remote cluster info...")
+
+	fc, err := fcutils.GetForeignClusterByID(ctx, o.CRClient, liqov1beta1.ClusterID(o.ClusterID))
+	if k8sErrors.IsNotFound(err) {
+		s.Fail("Remote cluster with ID %s not found", o.ClusterID)
+		return fmt.Errorf("remote cluster with ID %s not found", o.ClusterID)
+	} else if err != nil {
+		s.Fail("Failed to get info about remote cluster")
+		return fmt.Errorf("failed to get ForeignCluster by ID: %w", err)
+	}
+
+	s.Success("Info about the remote cluster retrieved successfully")
+	s = o.Printer.StartSpinner("Declaring foreign cluster as permanently unreachable...")
+
+	patch := client.MergeFrom(fc.DeepCopy())
+	if fc.Annotations == nil {
+		fc.Annotations = map[string]string{}
+	}
+
+	fc.SetAnnotations(
+		mapsutil.Merge(fc.Annotations, map[string]string{
+			consts.ForeignClusterPermanentlyUnreachableAnnotationKey: "true",
+		}),
+	)
+
+	err = o.CRClient.Patch(ctx, fc, patch)
+	if err != nil {
+		s.Fail("Failed to declare ForeignCluster as permanently unreachable")
+		return fmt.Errorf("failed to patch ForeignCluster with force-unpeer annotation: %w", err)
+	}
+	s.Success("Foreign cluster declared as permanently unreachable successfully")
+
+	consumer := unauthenticate.NewCluster(o.Factory)
+
+	// Delete tenant namespace on consumer cluster
+	if err := consumer.DeleteTenantNamespace(ctx, liqov1beta1.ClusterID(o.ClusterID), true); err != nil {
+		s.Fail("Failed to delete tenant namespace on consumer cluster")
+		return fmt.Errorf("failed to delete tenant namespace on consumer cluster: %w", err)
+	}
+
+	o.Printer.Success.Println("Force unpeer executed successfully")
+
+	return nil
+}


### PR DESCRIPTION
# Description
I created the ‘force unpeer --cluster-id <cluster id>’ command, which allows you to force the unpeer command if one of the two clusters is no longer reachable. What this command actually does is set an annotation to the foreigncluster and delete the namespace-tenant of the one invoking the force. These additions will be taken over by the backend, which will perform the actual force unpeer.

Fixes #3051 
