### PR TITLE
[Liqoctl] Specify other (non-standard) resources with liqoctl commands

### DIFF
--- a/cmd/liqoctl/cmd/peer.go
+++ b/cmd/liqoctl/cmd/peer.go
@@ -52,6 +52,7 @@ Examples:
   $ {{ .Executable }} peer --remote-kubeconfig <provider>
   $ {{ .Executable }} peer --remote-kubeconfig <provider> --gw-server-service-type NodePort
   $ {{ .Executable }} peer --remote-kubeconfig <provider> --cpu 2 --memory 4Gi --pods 10
+  $ {{ .Executable }} peer --remote-kubeconfig <provider> --cpu 2 --memory 4Gi --pods 10 --resource nvidia.com/gpu=2
   $ {{ .Executable }} peer --remote-kubeconfig <provider> --create-resource-slice false
   $ {{ .Executable }} peer --remote-kubeconfig <provider> --create-virtual-node false
 `
@@ -129,6 +130,8 @@ func newPeerCommand(ctx context.Context, f *factory.Factory) *cobra.Command {
 	cmd.Flags().StringVar(&options.CPU, "cpu", "", "The amount of CPU requested for the VirtualNode")
 	cmd.Flags().StringVar(&options.Memory, "memory", "", "The amount of memory requested for the VirtualNode")
 	cmd.Flags().StringVar(&options.Pods, "pods", "", "The amount of pods requested for the VirtualNode")
+	cmd.Flags().StringToStringVar(
+		&options.OtherResources, "resource", nil, "Other resources requested for the VirtualNode (e.g., '--resource=nvidia.com/gpu=2')")
 
 	return cmd
 }

--- a/docs/advanced/peering/offloading-in-depth.md
+++ b/docs/advanced/peering/offloading-in-depth.md
@@ -61,6 +61,7 @@ You can specify the resources you want to acquire by adding:
 * `--cpu` to specify the amount of CPU.
 * `--memory` to specify the amount of memory.
 * `--pods` to specify the number of pods.
+* `--resource` other resources can be specified with this flag, which can be even repeated multiple times. (e.g: `--resource=nvidia.com/gpu=2 --resource=my.custom/resource=2Gi`)
 
 To add other resources like `ephemeral-storage`, `gpu`, or any other custom resources, you can use the `-o yaml` flag for the `liqoctl create resourceslice` command and edit the `ResourceSlice` spec manifest before applying it.
 

--- a/docs/usage/liqoctl/liqoctl_create.md
+++ b/docs/usage/liqoctl/liqoctl_create.md
@@ -500,6 +500,8 @@ liqoctl create resourceslice [flags]
 ```bash
   $ liqoctl create resourceslice my-slice --remote-cluster-id remote-cluster-id \
   --cpu 4 --memory 8Gi --pods 30
+  $ liqoctl create resourceslice my-slice --remote-cluster-id remote-cluster-id \
+  --cpu 4 --memory 8Gi --pods 30 --resource nvidia.com/gpu=2
 ```
 
 
@@ -531,6 +533,10 @@ liqoctl create resourceslice [flags]
 `--remote-cluster-id` _clusterID_:
 
 >The cluster ID of the remote cluster
+
+`--resource` _stringToString_:
+
+>Other resources requested in the resource slice (e.g., 'resource=nvidia.com/gpu=2')
 
 
 ### Global options
@@ -655,6 +661,10 @@ liqoctl create virtualnode [flags]
 `--remote-cluster-id` _clusterID_:
 
 >The cluster ID of the remote cluster
+
+`--resource` _stringToString_:
+
+>Other resources available in the virtual node (e.g., 'resource=nvidia.com/gpu=2')
 
 `--resource-slice-name` _string_:
 

--- a/docs/usage/liqoctl/liqoctl_peer.md
+++ b/docs/usage/liqoctl/liqoctl_peer.md
@@ -37,6 +37,7 @@ liqoctl peer [flags]
   $ liqoctl peer --remote-kubeconfig <provider>
   $ liqoctl peer --remote-kubeconfig <provider> --gw-server-service-type NodePort
   $ liqoctl peer --remote-kubeconfig <provider> --cpu 2 --memory 4Gi --pods 10
+  $ liqoctl peer --remote-kubeconfig <provider> --cpu 2 --memory 4Gi --pods 10 --resource nvidia.com/gpu=2
   $ liqoctl peer --remote-kubeconfig <provider> --create-resource-slice false
   $ liqoctl peer --remote-kubeconfig <provider> --create-virtual-node false
 ```
@@ -145,6 +146,10 @@ liqoctl peer [flags]
 `--remote-user` _string_:
 
 >The name of the kubeconfig user to use (in the remote cluster)
+
+`--resource` _stringToString_:
+
+>Other resources requested for the VirtualNode (e.g., '--resource=nvidia.com/gpu=2')
 
 `--resource-slice-class` _string_:
 

--- a/docs/usage/peer.md
+++ b/docs/usage/peer.md
@@ -36,8 +36,8 @@ To perform a peering without having access to both clusters, you need to manuall
 The peering command enables all 3 liqo modules and performs the following steps:
 
 1. **enables networking**.
-Exchanges network configurations and creates the two **gateways** (one acting as _server_ and located in the provider cluster, another acting as _client_ in the consumer cluster) to let the two clusters communicate over a secure tunnel.  
-The location of the client/server gateway can be customized when creating the peering using the `--gw-server-service-location` flag in `liqoctl`.  
+Exchanges network configurations and creates the two **gateways** (one acting as _server_ and located in the provider cluster, another acting as _client_ in the consumer cluster) to let the two clusters communicate over a secure tunnel.
+The location of the client/server gateway can be customized when creating the peering using the `--gw-server-service-location` flag in `liqoctl`.
 2. **enables authentication**.
 Authenticates the consumer with the provider.
 In this step, the consumer obtains an `Identity` (*kubeconfig*) to replicate resources to the provider cluster.
@@ -235,6 +235,18 @@ liqoctl peer \
   --remote-kubeconfig=$PROVIDER_KUBECONFIG_PATH \
   --cpu=2 \
   --memory=2Gi
+```
+
+Other non-standard resources can be defined via the `--resource` flag:
+
+```bash
+liqoctl peer \
+  --kubeconfig=$CONSUMER_KUBECONFIG_PATH \
+  --remote-kubeconfig=$PROVIDER_KUBECONFIG_PATH \
+  --cpu=2 \
+  --memory=2Gi \
+  --resource=nvidia.com/gpu=2 \
+  --resource=custom=2Gi
 ```
 
 ```{warning}

--- a/pkg/liqoctl/peer/handler.go
+++ b/pkg/liqoctl/peer/handler.go
@@ -61,6 +61,7 @@ type Options struct {
 	CPU               string
 	Memory            string
 	Pods              string
+	OtherResources    map[string]string
 }
 
 // NewOptions returns a new Options struct.
@@ -195,9 +196,10 @@ func ensureOffloading(ctx context.Context, o *Options) error {
 		Class:                      o.ResourceSliceClass,
 		DisableVirtualNodeCreation: !o.CreateVirtualNode,
 
-		CPU:    o.CPU,
-		Memory: o.Memory,
-		Pods:   o.Pods,
+		CPU:            o.CPU,
+		Memory:         o.Memory,
+		Pods:           o.Pods,
+		OtherResources: o.OtherResources,
 	}
 
 	if err := rsOptions.HandleCreate(ctx); err != nil {

--- a/pkg/liqoctl/rest/resourceslice/types.go
+++ b/pkg/liqoctl/rest/resourceslice/types.go
@@ -29,9 +29,10 @@ type Options struct {
 	Class                      string
 	DisableVirtualNodeCreation bool
 
-	CPU    string
-	Memory string
-	Pods   string
+	CPU            string
+	Memory         string
+	Pods           string
+	OtherResources map[string]string
 }
 
 var _ rest.API = &Options{}

--- a/pkg/liqoctl/rest/virtualnode/types.go
+++ b/pkg/liqoctl/rest/virtualnode/types.go
@@ -33,9 +33,10 @@ type Options struct {
 	resourceSliceName    string
 	vkOptionsTemplate    string
 
-	cpu    string
-	memory string
-	pods   string
+	cpu            string
+	memory         string
+	pods           string
+	otherResources map[string]string
 
 	storageClasses      []string
 	ingressClasses      []string


### PR DESCRIPTION
# Description

This PR introduces the `--resource` flag to the `peer` `create virtualnode` and `create resourceslice` commands, to allow the user to
directly specify custom resources without the needs to manually edit the manifests.

E.g.

```
liqoctl peer --remote-kubeconfig $MY_KUBECONFIG \
  --cpu 10 \
  --memory 20Gi \
  --resource nvidia.com/gpu 2
```

or

```
liqoctl create resourceslice my-slice --remote-cluster-id remote-cluster-id \
  --cpu 4 \
  --memory 8Gi \
  --pods 30 \
  --resource nvidia.com/gpu=2`
``` 

The `resource` flag can be repeated as many times as the number of non-standard resources to ask the provider cluster for:

```
liqoctl peer ... --resource nvidia.com/gpu=2 --resource custom.my/resource=2Gi
```
