### PR TITLE
feat(firewall): add connection tracking state matching support

### DIFF
--- a/apis/networking/v1beta1/firewall/match_types.go
+++ b/apis/networking/v1beta1/firewall/match_types.go
@@ -54,6 +54,23 @@ const (
 	L4ProtoUDP L4Proto = "udp"
 )
 
+// CtStateValue is the connection tracking state of the packet.
+// +kubebuilder:validation:Enum=new;established;related;untracked;invalid
+type CtStateValue string
+
+const (
+	// CtStateNew is the connection tracking state of the packet.
+	CtStateNew CtStateValue = "new"
+	// CtStateEstablished is the connection tracking state of the packet.
+	CtStateEstablished CtStateValue = "established"
+	// CtStateRelated is the connection tracking state of the packet.
+	CtStateRelated CtStateValue = "related"
+	// CtStateUntracked is the connection tracking state of the packet.
+	CtStateUntracked CtStateValue = "untracked"
+	// CtStateInvalid is the connection tracking state of the packet.
+	CtStateInvalid CtStateValue = "invalid"
+)
+
 // MatchIP is an IP to be matched.
 // +kubebuilder:object:generate=true
 type MatchIP struct {
@@ -92,6 +109,14 @@ type MatchProto struct {
 	Value L4Proto `json:"value"`
 }
 
+// MatchCtState is a connection tracking state to be matched.
+// +kubebuilder:object:generate=true
+type MatchCtState struct {
+	// Value is the connection tracking state to be matched.
+	// +kubebuilder:validation:MinItems=1
+	Value []CtStateValue `json:"value"`
+}
+
 // Match is a match to be applied to a rule.
 // +kubebuilder:object:generate=true
 type Match struct {
@@ -106,4 +131,6 @@ type Match struct {
 	Proto *MatchProto `json:"proto,omitempty"`
 	// Dev contains the options to match a device.
 	Dev *MatchDev `json:"dev,omitempty"`
+	// CtState contains the options to match a connection tracking state.
+	CtState *MatchCtState `json:"ctstate,omitempty"`
 }

--- a/deployments/liqo/charts/liqo-crds/crds/networking.liqo.io_firewallconfigurations.yaml
+++ b/deployments/liqo/charts/liqo-crds/crds/networking.liqo.io_firewallconfigurations.yaml
@@ -121,6 +121,28 @@ spec:
                                       description: Match is a match to be applied
                                         to a rule.
                                       properties:
+                                        ctstate:
+                                          description: CtState contains the options
+                                            to match a connection tracking state.
+                                          properties:
+                                            value:
+                                              description: Value is the connection
+                                                tracking state to be matched.
+                                              items:
+                                                description: CtStateValue is the connection
+                                                  tracking state of the packet.
+                                                enum:
+                                                - new
+                                                - established
+                                                - related
+                                                - untracked
+                                                - invalid
+                                                type: string
+                                              minItems: 1
+                                              type: array
+                                          required:
+                                          - value
+                                          type: object
                                         dev:
                                           description: Dev contains the options to
                                             match a device.
@@ -231,6 +253,28 @@ spec:
                                       description: Match is a match to be applied
                                         to a rule.
                                       properties:
+                                        ctstate:
+                                          description: CtState contains the options
+                                            to match a connection tracking state.
+                                          properties:
+                                            value:
+                                              description: Value is the connection
+                                                tracking state to be matched.
+                                              items:
+                                                description: CtStateValue is the connection
+                                                  tracking state of the packet.
+                                                enum:
+                                                - new
+                                                - established
+                                                - related
+                                                - untracked
+                                                - invalid
+                                                type: string
+                                              minItems: 1
+                                              type: array
+                                          required:
+                                          - value
+                                          type: object
                                         dev:
                                           description: Dev contains the options to
                                             match a device.

--- a/pkg/firewall/utils/match.go
+++ b/pkg/firewall/utils/match.go
@@ -58,6 +58,12 @@ func applyMatch(m *firewallv1beta1.Match, rule *nftables.Rule) error {
 			return err
 		}
 	}
+	if m.CtState != nil {
+		err = applyMatchCtState(m, rule, op)
+		if err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -340,4 +346,59 @@ func ifname(n string) []byte {
 	b := make([]byte, 16)
 	copy(b, n+"\x00")
 	return b
+}
+
+func applyMatchCtState(m *firewallv1beta1.Match, rule *nftables.Rule, op expr.CmpOp) error {
+	var stateBits uint32
+
+	cmpOp := expr.CmpOpNeq
+	if op == expr.CmpOpNeq {
+		cmpOp = expr.CmpOpEq
+	}
+
+	for _, state := range m.CtState.Value {
+		bit, err := getCtStateBit(state)
+		if err != nil {
+			return err
+		}
+		stateBits |= bit
+	}
+
+	rule.Exprs = append(rule.Exprs,
+		&expr.Ct{
+			Register:       1,
+			SourceRegister: false,
+			Key:            expr.CtKeySTATE,
+		},
+		&expr.Bitwise{
+			SourceRegister: 1,
+			DestRegister:   1,
+			Len:            4,
+			Mask:           binaryutil.NativeEndian.PutUint32(stateBits),
+			Xor:            []byte{0x0, 0x0, 0x0, 0x0},
+		},
+		&expr.Cmp{
+			Op:       cmpOp,
+			Register: 1,
+			Data:     []byte{0, 0, 0, 0},
+		},
+	)
+	return nil
+}
+
+func getCtStateBit(state firewallv1beta1.CtStateValue) (uint32, error) {
+	switch state {
+	case firewallv1beta1.CtStateNew:
+		return expr.CtStateBitNEW, nil
+	case firewallv1beta1.CtStateEstablished:
+		return expr.CtStateBitESTABLISHED, nil
+	case firewallv1beta1.CtStateRelated:
+		return expr.CtStateBitRELATED, nil
+	case firewallv1beta1.CtStateInvalid:
+		return expr.CtStateBitINVALID, nil
+	case firewallv1beta1.CtStateUntracked:
+		return expr.CtStateBitUNTRACKED, nil
+	default:
+		return 0, fmt.Errorf("invalid ctstate value %s", state)
+	}
 }


### PR DESCRIPTION
# Description

This pull request introduces support for matching connection tracking states (`ctstate`) in firewall rules. The changes span API, CRD, and implementation layers, allowing users to specify connection tracking states as match criteria in firewall configurations.

This feature extends the firewalling functionalities proposed in the PR #2966, but these two PRs are independent so there is no need to merge #2966 before.

With this update, it is possible to add "ctstate" to the "match" field of a filter rule, for example:

```yaml
apiVersion: networking.liqo.io/v1beta1
kind: FirewallConfiguration
metadata:
  labels:
    liqo.io/managed: "true"
    networking.liqo.io/firewall-category: gateway
    networking.liqo.io/firewall-subcategory: fabric
spec:
  table:
    family: IPV4
    name: test-table
    chains:
      - hook: postrouting
        name: test-chain
        policy: accept
        priority: 99
        type: filter
        rules:
          filterRules:
            - action: accept
              match:
                - ctstate:
                     value:
                       - established
                       - related
                  op: eq
```

The operations supported are:
- eq, if the ctstate of the packet is in one of the values
- new, if the ctstate is not in any of the values

# How Has This Been Tested?

This feature was tested with a firewall configuration that blocks incoming connections from a specific subnet. Without the rule to accept established or related connections, outgoing connections to that subnet were also blocked because responses were not able to pass through. By adding the match rule with ctstate to allow established and related connections, it was possible to block connections in only one direction.

In addition, the result was checked in nftables, ensuring that the rule was actually added to the chain.
