### PR TITLE
feat: add remote cluster Liqo version detection

### DIFF
--- a/apis/authentication/v1beta1/tenant_types.go
+++ b/apis/authentication/v1beta1/tenant_types.go
@@ -76,6 +76,14 @@ type TenantSpec struct {
 	// +kubebuilder:validation:Enum=Active;Cordoned;Drained
 	// +kubebuilder:default=Active
 	TenantCondition TenantCondition `json:"tenantCondition,omitempty"`
+	// ConsumerAPIServerURL is the URL of the consumer cluster's API server.
+	// This is used by the provider cluster to fetch the consumer's Liqo version.
+	// +kubebuilder:validation:Optional
+	ConsumerAPIServerURL string `json:"consumerAPIServerURL,omitempty"`
+	// ConsumerVersionReaderToken is the token used to authenticate when fetching the consumer's Liqo version.
+	// This should be the token from the liqo-version-reader ServiceAccount on the consumer cluster.
+	// +kubebuilder:validation:Optional
+	ConsumerVersionReaderToken string `json:"consumerVersionReaderToken,omitempty"`
 }
 
 // TenantCondition contains the conditions of the tenant.

--- a/apis/core/v1beta1/foreigncluster_types.go
+++ b/apis/core/v1beta1/foreigncluster_types.go
@@ -67,6 +67,10 @@ type ForeignClusterStatus struct {
 	// +kubebuilder:validation:Optional
 	TenantNamespace TenantNamespaceType `json:"tenantNamespace"`
 
+	// RemoteVersion is the Liqo version running on the remote cluster.
+	// +kubebuilder:validation:Optional
+	RemoteVersion string `json:"remoteVersion,omitempty"`
+
 	// Generic conditions related to the foreign cluster.
 	Conditions []Condition `json:"conditions,omitempty"`
 }

--- a/deployments/liqo/charts/liqo-crds/crds/authentication.liqo.io_tenants.yaml
+++ b/deployments/liqo/charts/liqo-crds/crds/authentication.liqo.io_tenants.yaml
@@ -66,6 +66,16 @@ spec:
                 x-kubernetes-validations:
                 - message: ClusterID is immutable
                   rule: self == oldSelf
+              consumerAPIServerURL:
+                description: |-
+                  ConsumerAPIServerURL is the URL of the consumer cluster's API server.
+                  This is used by the provider cluster to fetch the consumer's Liqo version.
+                type: string
+              consumerVersionReaderToken:
+                description: |-
+                  ConsumerVersionReaderToken is the token used to authenticate when fetching the consumer's Liqo version.
+                  This should be the token from the liqo-version-reader ServiceAccount on the consumer cluster.
+                type: string
               csr:
                 description: CSR is the Certificate Signing Request of the tenant
                   cluster.

--- a/deployments/liqo/charts/liqo-crds/crds/core.liqo.io_foreignclusters.yaml
+++ b/deployments/liqo/charts/liqo-crds/crds/core.liqo.io_foreignclusters.yaml
@@ -322,6 +322,10 @@ spec:
                 - networking
                 - offloading
                 type: object
+              remoteVersion:
+                description: RemoteVersion is the Liqo version running on the remote
+                  cluster.
+                type: string
               role:
                 default: Unknown
                 description: Role of the ForeignCluster.

--- a/deployments/liqo/files/liqo-controller-manager-ClusterRole.yaml
+++ b/deployments/liqo/files/liqo-controller-manager-ClusterRole.yaml
@@ -2,6 +2,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - configmaps
+  verbs:
+  - create
+  - get
+  - update
+- apiGroups:
+  - ""
+  resources:
   - events
   - namespaces
   - persistentvolumeclaims
@@ -334,6 +342,14 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  verbs:
+  - create
+  - get
+  - update
 - apiGroups:
   - storage
   - storage.k8s.io

--- a/docs/usage/version-detection.md
+++ b/docs/usage/version-detection.md
@@ -1,0 +1,42 @@
+## Summary
+Enables querying a remote Liqo cluster's version without establishing full peering, using only a minimal authentication token.
+
+## Motivation
+Before initiating peering, administrators need to check version compatibility between clusters. This feature allows version queries without full peering setup.
+
+## Changes
+
+### Version Query Infrastructure
+- Added `QueryRemoteVersion()` function for standalone version queries
+- Created `liqo-version` ConfigMap to expose local cluster version
+- Set up `liqo-version-reader` ServiceAccount with minimal RBAC permissions
+- Added token-based authentication for reading version ConfigMap
+
+### Helper Functions
+- `GetLocalVersion()`: Retrieve local cluster version from ConfigMap
+- `GetVersionReaderToken()`: Extract token from secret
+- `GetRemoteVersionWithToken()`: Query remote version with minimal auth
+
+### Supporting Features
+- Version resources auto-created at liqo-controller-manager startup
+- ForeignCluster auto-creation for tenant consumers (enables bidirectional detection)
+- Comprehensive unit tests (21 test specs)
+
+## Testing
+- ✅ All version package unit tests pass (17/17 specs)
+- ✅ Tenant controller tests added
+- ✅ `make generate` runs successfully
+- ✅ RBAC auto-generated correctly
+
+## Usage Example
+```bash
+# Extract token from consumer cluster
+kubectl get secret -n liqo liqo-version-reader-token \
+  -o jsonpath='{.data.token}' | base64 -d > token
+
+# Query version from any cluster
+kubectl --server=https://consumer-cluster:6443 \
+  --token="$(cat token)" \
+  --insecure-skip-tls-verify \
+  get configmap liqo-version -n liqo \
+  -o jsonpath='{.data.version}'

--- a/pkg/liqo-controller-manager/authentication/forge/tenant.go
+++ b/pkg/liqo-controller-manager/authentication/forge/tenant.go
@@ -25,9 +25,9 @@ import (
 
 // TenantForRemoteCluster forges a Tenant resource to be applied on a remote cluster.
 func TenantForRemoteCluster(localClusterID liqov1beta1.ClusterID,
-	publicKey, csr, signature []byte, namespace, proxyURL *string) *authv1beta1.Tenant {
+	publicKey, csr, signature []byte, namespace, proxyURL *string, apiServerURL, versionReaderToken string) *authv1beta1.Tenant {
 	tenant := Tenant(localClusterID, namespace)
-	MutateTenant(tenant, localClusterID, publicKey, csr, signature, proxyURL)
+	MutateTenant(tenant, localClusterID, publicKey, csr, signature, proxyURL, apiServerURL, versionReaderToken)
 
 	return tenant
 }
@@ -48,7 +48,7 @@ func Tenant(remoteClusterID liqov1beta1.ClusterID, namespace *string) *authv1bet
 
 // MutateTenant mutates a Tenant resource.
 func MutateTenant(tenant *authv1beta1.Tenant, remoteClusterID liqov1beta1.ClusterID,
-	publicKey, csr, signature []byte, proxyURL *string) {
+	publicKey, csr, signature []byte, proxyURL *string, apiServerURL, versionReaderToken string) {
 	if tenant.Labels == nil {
 		tenant.Labels = map[string]string{}
 	}
@@ -60,10 +60,12 @@ func MutateTenant(tenant *authv1beta1.Tenant, remoteClusterID liqov1beta1.Cluste
 	}
 
 	tenant.Spec = authv1beta1.TenantSpec{
-		ClusterID: remoteClusterID,
-		PublicKey: publicKey,
-		CSR:       csr,
-		Signature: signature,
-		ProxyURL:  proxyURLPtr,
+		ClusterID:                  remoteClusterID,
+		PublicKey:                  publicKey,
+		CSR:                        csr,
+		Signature:                  signature,
+		ProxyURL:                   proxyURLPtr,
+		ConsumerAPIServerURL:       apiServerURL,
+		ConsumerVersionReaderToken: versionReaderToken,
 	}
 }

--- a/pkg/liqo-controller-manager/authentication/tenant-controller/tenant_controller_test.go
+++ b/pkg/liqo-controller-manager/authentication/tenant-controller/tenant_controller_test.go
@@ -1,0 +1,126 @@
+// Copyright 2019-2025 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tenantcontroller
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	authv1beta1 "github.com/liqotech/liqo/apis/authentication/v1beta1"
+	liqov1beta1 "github.com/liqotech/liqo/apis/core/v1beta1"
+)
+
+func TestTenantController(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "TenantController Suite")
+}
+
+var _ = Describe("ensureForeignCluster", func() {
+	var (
+		ctx              context.Context
+		fakeClient       client.Client
+		tenantReconciler *TenantReconciler
+		testTenant       *authv1beta1.Tenant
+		testClusterID    liqov1beta1.ClusterID
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		testClusterID = "test-cluster"
+
+		s := runtime.NewScheme()
+		Expect(authv1beta1.AddToScheme(s)).To(Succeed())
+		Expect(liqov1beta1.AddToScheme(s)).To(Succeed())
+		Expect(scheme.AddToScheme(s)).To(Succeed())
+
+		fakeClient = fake.NewClientBuilder().WithScheme(s).Build()
+
+		tenantReconciler = &TenantReconciler{
+			Client: fakeClient,
+			Scheme: s,
+		}
+
+		testTenant = &authv1beta1.Tenant{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      string(testClusterID),
+				Namespace: "test-namespace",
+			},
+			Spec: authv1beta1.TenantSpec{
+				ClusterID: testClusterID,
+			},
+		}
+	})
+
+	It("should create a ForeignCluster when it doesn't exist", func() {
+		err := tenantReconciler.ensureForeignCluster(ctx, testTenant)
+		Expect(err).ToNot(HaveOccurred())
+
+		var fc liqov1beta1.ForeignCluster
+		err = fakeClient.Get(ctx, client.ObjectKey{Name: string(testClusterID)}, &fc)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(fc.Spec.ClusterID).To(Equal(testClusterID))
+		Expect(fc.Labels).To(HaveKeyWithValue("liqo.io/remote-cluster-id", string(testClusterID)))
+	})
+
+	It("should not error when ForeignCluster already exists", func() {
+		existingFC := &liqov1beta1.ForeignCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: string(testClusterID),
+			},
+			Spec: liqov1beta1.ForeignClusterSpec{
+				ClusterID: testClusterID,
+			},
+		}
+		Expect(fakeClient.Create(ctx, existingFC)).To(Succeed())
+
+		err := tenantReconciler.ensureForeignCluster(ctx, testTenant)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("should handle multiple calls idempotently", func() {
+		// First call
+		err := tenantReconciler.ensureForeignCluster(ctx, testTenant)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Second call should not error
+		err = tenantReconciler.ensureForeignCluster(ctx, testTenant)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Verify only one ForeignCluster exists
+		var fcList liqov1beta1.ForeignClusterList
+		err = fakeClient.List(ctx, &fcList)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(fcList.Items).To(HaveLen(1))
+	})
+
+	It("should create ForeignCluster with correct labels", func() {
+		err := tenantReconciler.ensureForeignCluster(ctx, testTenant)
+		Expect(err).ToNot(HaveOccurred())
+
+		var fc liqov1beta1.ForeignCluster
+		err = fakeClient.Get(ctx, client.ObjectKey{Name: string(testClusterID)}, &fc)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(fc.Labels).ToNot(BeNil())
+		Expect(fc.Labels["liqo.io/remote-cluster-id"]).To(Equal(string(testClusterID)))
+	})
+})

--- a/pkg/liqo-controller-manager/authentication/utils/tenant.go
+++ b/pkg/liqo-controller-manager/authentication/utils/tenant.go
@@ -18,12 +18,20 @@ import (
 	"context"
 	"fmt"
 
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	authv1beta1 "github.com/liqotech/liqo/apis/authentication/v1beta1"
 	liqov1beta1 "github.com/liqotech/liqo/apis/core/v1beta1"
+	"github.com/liqotech/liqo/pkg/consts"
 	"github.com/liqotech/liqo/pkg/liqo-controller-manager/authentication"
 	"github.com/liqotech/liqo/pkg/liqo-controller-manager/authentication/forge"
+	versionpkg "github.com/liqotech/liqo/pkg/liqo-controller-manager/version"
+	"github.com/liqotech/liqo/pkg/utils/restcfg"
 )
 
 // GenerateTenant generates a Tenant resource to be applied on a remote cluster.
@@ -46,6 +54,57 @@ func GenerateTenant(ctx context.Context, cl client.Client,
 		return nil, fmt.Errorf("unable to generate CSR: %w", err)
 	}
 
+	// Get the local cluster's API server URL from the kubeconfig in the auth secret.
+	apiServerURL, err := getLocalAPIServerURL(ctx, cl, liqoNamespace)
+	if err != nil {
+		// Log error but continue - API server URL is optional
+		fmt.Printf("Warning: unable to get local API server URL: %v\n", err)
+		apiServerURL = ""
+	}
+
+	// Get the version reader token from the secret.
+	// Use the in-cluster clientset for this
+	var versionReaderToken string
+	clientset, err := kubernetes.NewForConfig(restcfg.SetRateLimiter(ctrl.GetConfigOrDie()))
+	if err == nil {
+		versionReaderToken, err = versionpkg.GetVersionReaderToken(ctx, clientset, liqoNamespace)
+		if err != nil {
+			// Log error but continue - version reader token is optional
+			fmt.Printf("Warning: unable to get version reader token: %v\n", err)
+			versionReaderToken = ""
+		}
+	}
+
 	// Forge tenant resource for the remote cluster.
-	return forge.TenantForRemoteCluster(localClusterID, publicKey, CSR, signature, &remoteTenantNamespace, proxyURL), nil
+	return forge.TenantForRemoteCluster(localClusterID, publicKey, CSR, signature, &remoteTenantNamespace, proxyURL, apiServerURL, versionReaderToken), nil
+}
+
+// getLocalAPIServerURL retrieves the local cluster's API server URL from the auth secret.
+func getLocalAPIServerURL(ctx context.Context, cl client.Client, liqoNamespace string) (string, error) {
+	// Get the auth secret containing the kubeconfig
+	var secret corev1.Secret
+	if err := cl.Get(ctx, types.NamespacedName{
+		Namespace: liqoNamespace,
+		Name:      consts.AuthKeysSecretName,
+	}, &secret); err != nil {
+		return "", fmt.Errorf("unable to get auth secret: %w", err)
+	}
+
+	// Extract the API server URL from the kubeconfig
+	kubeconfigData, ok := secret.Data[consts.KubeconfigSecretField]
+	if !ok {
+		return "", fmt.Errorf("kubeconfig not found in auth secret")
+	}
+
+	// Parse the kubeconfig to get the API server URL
+	config, err := clientcmd.RESTConfigFromKubeConfig(kubeconfigData)
+	if err != nil {
+		return "", fmt.Errorf("unable to parse kubeconfig: %w", err)
+	}
+
+	if config.Host == "" {
+		return "", fmt.Errorf("API server URL not found in kubeconfig")
+	}
+
+	return config.Host, nil
 }

--- a/pkg/liqo-controller-manager/core/foreigncluster-controller/forge.go
+++ b/pkg/liqo-controller-manager/core/foreigncluster-controller/forge.go
@@ -1,0 +1,37 @@
+// Copyright 2019-2025 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package foreignclustercontroller
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	liqov1beta1 "github.com/liqotech/liqo/apis/core/v1beta1"
+	"github.com/liqotech/liqo/pkg/consts"
+)
+
+// ForgeForeignCluster creates a new ForeignCluster resource for the given cluster ID.
+func ForgeForeignCluster(clusterID liqov1beta1.ClusterID) *liqov1beta1.ForeignCluster {
+	return &liqov1beta1.ForeignCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: string(clusterID),
+			Labels: map[string]string{
+				consts.RemoteClusterID: string(clusterID),
+			},
+		},
+		Spec: liqov1beta1.ForeignClusterSpec{
+			ClusterID: clusterID,
+		},
+	}
+}

--- a/pkg/liqo-controller-manager/core/foreigncluster-controller/remoteversion.go
+++ b/pkg/liqo-controller-manager/core/foreigncluster-controller/remoteversion.go
@@ -1,0 +1,117 @@
+// Copyright 2019-2025 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package foreignclustercontroller
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+
+	authv1beta1 "github.com/liqotech/liqo/apis/authentication/v1beta1"
+	liqov1beta1 "github.com/liqotech/liqo/apis/core/v1beta1"
+	versionpkg "github.com/liqotech/liqo/pkg/liqo-controller-manager/version"
+)
+
+// handleRemoteVersion attempts to fetch the remote cluster's Liqo version
+// and update it in the ForeignCluster status.
+// It handles both consumer and provider scenarios:
+// - Consumer: Uses Identity credentials to fetch provider version
+// - Provider: Uses Tenant's consumer token to fetch consumer version
+func (r *ForeignClusterReconciler) handleRemoteVersion(ctx context.Context, fc *liqov1beta1.ForeignCluster) {
+	clusterID := fc.Spec.ClusterID
+
+	// Try consumer approach first: use Identity credentials
+	remoteVersion := r.getRemoteVersionAsConsumer(ctx, clusterID)
+
+	// If consumer approach didn't work, try provider approach: use Tenant credentials
+	if remoteVersion == "" {
+		remoteVersion = r.getRemoteVersionAsProvider(ctx, clusterID)
+	}
+
+	// Update the ForeignCluster status if version changed
+	if remoteVersion != "" && remoteVersion != fc.Status.RemoteVersion {
+		klog.Infof("Updated remote version for ForeignCluster %q: %s", clusterID, remoteVersion)
+	}
+
+	fc.Status.RemoteVersion = remoteVersion
+}
+
+// getRemoteVersionAsConsumer fetches the provider's version using Identity credentials.
+// This is used when the local cluster is a consumer.
+func (r *ForeignClusterReconciler) getRemoteVersionAsConsumer(ctx context.Context, clusterID liqov1beta1.ClusterID) string {
+	if r.IdentityManager == nil {
+		klog.V(6).Infof("IdentityManager not available, skipping consumer version fetch for cluster %q", clusterID)
+		return ""
+	}
+
+	// Try to get a config for the remote cluster using the identity manager.
+	// We use corev1.NamespaceAll to search across all tenant namespaces.
+	config, err := r.IdentityManager.GetConfig(clusterID, corev1.NamespaceAll)
+	if err != nil {
+		// If we can't get a config, it means we don't have credentials for this cluster yet.
+		// This is expected during the initial peering phase or for provider clusters.
+		klog.V(6).Infof("Unable to get Identity config for remote cluster %q: %v", clusterID, err)
+		return ""
+	}
+
+	// Create a clientset to access the remote cluster.
+	remoteClientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		klog.V(4).Infof("Failed to create clientset from Identity for remote cluster %q: %v", clusterID, err)
+		return ""
+	}
+
+	// Fetch the remote version.
+	return versionpkg.GetRemoteVersion(ctx, remoteClientset, r.LiqoNamespace)
+}
+
+// getRemoteVersionAsProvider fetches the consumer's version using Tenant's version reader token.
+// This is used when the local cluster is a provider.
+func (r *ForeignClusterReconciler) getRemoteVersionAsProvider(ctx context.Context, clusterID liqov1beta1.ClusterID) string {
+	// Get the Tenant resource for this cluster
+	tenant, err := r.getTenantByClusterID(ctx, clusterID)
+	if err != nil {
+		klog.V(6).Infof("Unable to get Tenant for cluster %q: %v", clusterID, err)
+		return ""
+	}
+
+	// Check if the Tenant has the consumer's API server URL and token
+	if tenant.Spec.ConsumerAPIServerURL == "" || tenant.Spec.ConsumerVersionReaderToken == "" {
+		klog.V(6).Infof("Tenant for cluster %q does not have consumer API server URL or version reader token", clusterID)
+		return ""
+	}
+
+	// Fetch the remote version using the token
+	return versionpkg.GetRemoteVersionWithToken(ctx, tenant.Spec.ConsumerAPIServerURL, tenant.Spec.ConsumerVersionReaderToken, r.LiqoNamespace)
+}
+
+// getTenantByClusterID retrieves the Tenant resource for the given cluster ID.
+func (r *ForeignClusterReconciler) getTenantByClusterID(ctx context.Context, clusterID liqov1beta1.ClusterID) (*authv1beta1.Tenant, error) {
+	var tenantList authv1beta1.TenantList
+	if err := r.List(ctx, &tenantList); err != nil {
+		return nil, fmt.Errorf("failed to list Tenants: %w", err)
+	}
+
+	for i := range tenantList.Items {
+		if tenantList.Items[i].Spec.ClusterID == clusterID {
+			return &tenantList.Items[i], nil
+		}
+	}
+
+	return nil, fmt.Errorf("tenant not found for cluster %q", clusterID)
+}

--- a/pkg/liqo-controller-manager/core/foreigncluster-controller/status.go
+++ b/pkg/liqo-controller-manager/core/foreigncluster-controller/status.go
@@ -301,7 +301,7 @@ func (r *ForeignClusterReconciler) handleAuthenticationModuleStatus(ctx context.
 		)
 
 		// Check whether there is no identity but the if the cluster has been configured with a control plane secret.
-		cfg, err := r.identityManager.GetConfig(fc.Spec.ClusterID, corev1.NamespaceAll)
+		cfg, err := r.IdentityManager.GetConfig(fc.Spec.ClusterID, corev1.NamespaceAll)
 		switch {
 		case errors.IsNotFound(err):
 			klog.V(6).Infof("No credentials found for ForeignCluster %q", clusterID)

--- a/pkg/liqo-controller-manager/version/version.go
+++ b/pkg/liqo-controller-manager/version/version.go
@@ -1,0 +1,410 @@
+// Copyright 2019-2025 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package version
+
+// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get
+// +kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;create;update
+// +kubebuilder:rbac:groups=core,resources=serviceaccounts,verbs=get;create;update
+// +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;create;update
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles,verbs=get;create;update
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;create;update
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/klog/v2"
+
+	"github.com/liqotech/liqo/pkg/utils/resource"
+	"github.com/liqotech/liqo/pkg/utils/restcfg"
+)
+
+const (
+	// LiqoVersionConfigMapName is the name of the ConfigMap containing the Liqo version.
+	LiqoVersionConfigMapName = "liqo-version"
+	// LiqoVersionReaderRoleName is the name of the Role that allows reading the liqo-version ConfigMap.
+	LiqoVersionReaderRoleName = "liqo-version-reader"
+	// LiqoVersionReaderRoleBindingName is the name of the RoleBinding for the liqo-version-reader Role.
+	LiqoVersionReaderRoleBindingName = "liqo-version-reader-binding"
+	// LiqoVersionReaderServiceAccountName is the name of the ServiceAccount that can read the liqo-version ConfigMap.
+	LiqoVersionReaderServiceAccountName = "liqo-version-reader"
+	// LiqoVersionReaderSecretName is the name of the Secret containing the token for the version reader ServiceAccount.
+	LiqoVersionReaderSecretName = "liqo-version-reader-token"
+	// LiqoVersionKey is the key in the ConfigMap data where the version is stored.
+	LiqoVersionKey = "version"
+	// VersionReaderGroupName is the RBAC group name that can read the version ConfigMap.
+	// Using system:authenticated allows any authenticated user to read the version.
+	VersionReaderGroupName = "system:authenticated"
+)
+
+// GetVersionFromDeployment reads the liqo-controller-manager deployment and extracts
+// the version from its container image tag.
+func GetVersionFromDeployment(ctx context.Context, clientset kubernetes.Interface, namespace, deploymentName string) string {
+	deployment, err := clientset.AppsV1().Deployments(namespace).Get(ctx, deploymentName, metav1.GetOptions{})
+	if err != nil {
+		klog.Warningf("Failed to get deployment %s/%s: %v", namespace, deploymentName, err)
+		return ""
+	}
+
+	if len(deployment.Spec.Template.Spec.Containers) == 0 {
+		klog.Warning("No containers found in deployment")
+		return ""
+	}
+
+	image := deployment.Spec.Template.Spec.Containers[0].Image
+
+	// Extract the tag from the image (format: registry/org/image:tag)
+	parts := strings.Split(image, ":")
+	if len(parts) < 2 {
+		klog.Warningf("Image %q does not contain a tag, cannot determine Liqo version", image)
+		return ""
+	}
+
+	tag := parts[len(parts)-1]
+	klog.Infof("Detected Liqo version from deployment: %s", tag)
+	return tag
+}
+
+// SetupVersionResources creates or updates the ConfigMap, Role, RoleBinding, ServiceAccount, and Secret
+// for exposing the Liqo version to remote clusters.
+func SetupVersionResources(ctx context.Context, clientset kubernetes.Interface, liqoNamespace, version string) error {
+	if version == "" {
+		klog.Warning("Liqo version is empty, skipping version resources setup")
+		return nil
+	}
+
+	// Create or update the ConfigMap
+	if err := createOrUpdateVersionConfigMap(ctx, clientset, liqoNamespace, version); err != nil {
+		return fmt.Errorf("failed to create/update version ConfigMap: %w", err)
+	}
+
+	// Create or update the ServiceAccount
+	if err := createOrUpdateVersionReaderServiceAccount(ctx, clientset, liqoNamespace); err != nil {
+		return fmt.Errorf("failed to create/update version reader ServiceAccount: %w", err)
+	}
+
+	// Create or update the Role
+	if err := createOrUpdateVersionReaderRole(ctx, clientset, liqoNamespace); err != nil {
+		return fmt.Errorf("failed to create/update version reader Role: %w", err)
+	}
+
+	// Create or update the RoleBinding
+	if err := createOrUpdateVersionReaderRoleBinding(ctx, clientset, liqoNamespace); err != nil {
+		return fmt.Errorf("failed to create/update version reader RoleBinding: %w", err)
+	}
+
+	// Create or update the Secret with long-lived token
+	if err := createOrUpdateVersionReaderSecret(ctx, clientset, liqoNamespace); err != nil {
+		return fmt.Errorf("failed to create/update version reader Secret: %w", err)
+	}
+
+	klog.Infof("Successfully set up version resources (version: %s) in namespace %s", version, liqoNamespace)
+	return nil
+}
+
+// createOrUpdateVersionConfigMap creates or updates the ConfigMap containing the Liqo version.
+func createOrUpdateVersionConfigMap(ctx context.Context, clientset kubernetes.Interface, liqoNamespace, version string) error {
+	configMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      LiqoVersionConfigMapName,
+			Namespace: liqoNamespace,
+		},
+		Data: map[string]string{
+			LiqoVersionKey: version,
+		},
+	}
+
+	resource.AddGlobalLabels(configMap)
+
+	_, err := clientset.CoreV1().ConfigMaps(liqoNamespace).Get(ctx, LiqoVersionConfigMapName, metav1.GetOptions{})
+	if err != nil {
+		// ConfigMap doesn't exist, create it
+		_, err = clientset.CoreV1().ConfigMaps(liqoNamespace).Create(ctx, configMap, metav1.CreateOptions{})
+		if err != nil {
+			return fmt.Errorf("failed to create ConfigMap %s/%s: %w", liqoNamespace, LiqoVersionConfigMapName, err)
+		}
+		klog.Infof("Created ConfigMap %s/%s with version %s", liqoNamespace, LiqoVersionConfigMapName, version)
+	} else {
+		// ConfigMap exists, update it
+		_, err = clientset.CoreV1().ConfigMaps(liqoNamespace).Update(ctx, configMap, metav1.UpdateOptions{})
+		if err != nil {
+			return fmt.Errorf("failed to update ConfigMap %s/%s: %w", liqoNamespace, LiqoVersionConfigMapName, err)
+		}
+		klog.Infof("Updated ConfigMap %s/%s with version %s", liqoNamespace, LiqoVersionConfigMapName, version)
+	}
+
+	return nil
+}
+
+// createOrUpdateVersionReaderRole creates or updates the Role that allows reading the liqo-version ConfigMap.
+func createOrUpdateVersionReaderRole(ctx context.Context, clientset kubernetes.Interface, liqoNamespace string) error {
+	role := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      LiqoVersionReaderRoleName,
+			Namespace: liqoNamespace,
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups:     []string{""},
+				Resources:     []string{"configmaps"},
+				ResourceNames: []string{LiqoVersionConfigMapName},
+				Verbs:         []string{"get"},
+			},
+		},
+	}
+
+	resource.AddGlobalLabels(role)
+
+	_, err := clientset.RbacV1().Roles(liqoNamespace).Get(ctx, LiqoVersionReaderRoleName, metav1.GetOptions{})
+	if err != nil {
+		// Role doesn't exist, create it
+		_, err = clientset.RbacV1().Roles(liqoNamespace).Create(ctx, role, metav1.CreateOptions{})
+		if err != nil {
+			return fmt.Errorf("failed to create Role %s/%s: %w", liqoNamespace, LiqoVersionReaderRoleName, err)
+		}
+		klog.Infof("Created Role %s/%s", liqoNamespace, LiqoVersionReaderRoleName)
+	} else {
+		// Role exists, update it
+		_, err = clientset.RbacV1().Roles(liqoNamespace).Update(ctx, role, metav1.UpdateOptions{})
+		if err != nil {
+			return fmt.Errorf("failed to update Role %s/%s: %w", liqoNamespace, LiqoVersionReaderRoleName, err)
+		}
+		klog.V(6).Infof("Updated Role %s/%s", liqoNamespace, LiqoVersionReaderRoleName)
+	}
+
+	return nil
+}
+
+// createOrUpdateVersionReaderRoleBinding creates or updates the RoleBinding for the liqo-version-reader Role.
+func createOrUpdateVersionReaderRoleBinding(ctx context.Context, clientset kubernetes.Interface, liqoNamespace string) error {
+	roleBinding := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      LiqoVersionReaderRoleBindingName,
+			Namespace: liqoNamespace,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:     "Group",
+				Name:     VersionReaderGroupName,
+				APIGroup: "rbac.authorization.k8s.io",
+			},
+			{
+				Kind:      "ServiceAccount",
+				Name:      LiqoVersionReaderServiceAccountName,
+				Namespace: liqoNamespace,
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			Kind:     "Role",
+			Name:     LiqoVersionReaderRoleName,
+			APIGroup: "rbac.authorization.k8s.io",
+		},
+	}
+
+	resource.AddGlobalLabels(roleBinding)
+
+	_, err := clientset.RbacV1().RoleBindings(liqoNamespace).Get(ctx, LiqoVersionReaderRoleBindingName, metav1.GetOptions{})
+	if err != nil {
+		// RoleBinding doesn't exist, create it
+		_, err = clientset.RbacV1().RoleBindings(liqoNamespace).Create(ctx, roleBinding, metav1.CreateOptions{})
+		if err != nil {
+			return fmt.Errorf("failed to create RoleBinding %s/%s: %w", liqoNamespace, LiqoVersionReaderRoleBindingName, err)
+		}
+		klog.Infof("Created RoleBinding %s/%s for ServiceAccount %s", liqoNamespace, LiqoVersionReaderRoleBindingName, LiqoVersionReaderServiceAccountName)
+	} else {
+		// RoleBinding exists, update it
+		_, err = clientset.RbacV1().RoleBindings(liqoNamespace).Update(ctx, roleBinding, metav1.UpdateOptions{})
+		if err != nil {
+			return fmt.Errorf("failed to update RoleBinding %s/%s: %w", liqoNamespace, LiqoVersionReaderRoleBindingName, err)
+		}
+		klog.V(6).Infof("Updated RoleBinding %s/%s", liqoNamespace, LiqoVersionReaderRoleBindingName)
+	}
+
+	return nil
+}
+
+// createOrUpdateVersionReaderServiceAccount creates or updates the ServiceAccount for reading the liqo-version ConfigMap.
+func createOrUpdateVersionReaderServiceAccount(ctx context.Context, clientset kubernetes.Interface, liqoNamespace string) error {
+	sa := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      LiqoVersionReaderServiceAccountName,
+			Namespace: liqoNamespace,
+		},
+	}
+
+	resource.AddGlobalLabels(sa)
+
+	_, err := clientset.CoreV1().ServiceAccounts(liqoNamespace).Get(ctx, LiqoVersionReaderServiceAccountName, metav1.GetOptions{})
+	if err != nil {
+		// ServiceAccount doesn't exist, create it
+		_, err = clientset.CoreV1().ServiceAccounts(liqoNamespace).Create(ctx, sa, metav1.CreateOptions{})
+		if err != nil {
+			return fmt.Errorf("failed to create ServiceAccount %s/%s: %w", liqoNamespace, LiqoVersionReaderServiceAccountName, err)
+		}
+		klog.Infof("Created ServiceAccount %s/%s", liqoNamespace, LiqoVersionReaderServiceAccountName)
+	} else {
+		// ServiceAccount exists, update it
+		_, err = clientset.CoreV1().ServiceAccounts(liqoNamespace).Update(ctx, sa, metav1.UpdateOptions{})
+		if err != nil {
+			return fmt.Errorf("failed to update ServiceAccount %s/%s: %w", liqoNamespace, LiqoVersionReaderServiceAccountName, err)
+		}
+		klog.V(6).Infof("Updated ServiceAccount %s/%s", liqoNamespace, LiqoVersionReaderServiceAccountName)
+	}
+
+	return nil
+}
+
+// createOrUpdateVersionReaderSecret creates or updates the Secret containing a long-lived token for the version reader ServiceAccount.
+func createOrUpdateVersionReaderSecret(ctx context.Context, clientset kubernetes.Interface, liqoNamespace string) error {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      LiqoVersionReaderSecretName,
+			Namespace: liqoNamespace,
+			Annotations: map[string]string{
+				corev1.ServiceAccountNameKey: LiqoVersionReaderServiceAccountName,
+			},
+		},
+		Type: corev1.SecretTypeServiceAccountToken,
+	}
+
+	resource.AddGlobalLabels(secret)
+
+	_, err := clientset.CoreV1().Secrets(liqoNamespace).Get(ctx, LiqoVersionReaderSecretName, metav1.GetOptions{})
+	if err != nil {
+		// Secret doesn't exist, create it
+		_, err = clientset.CoreV1().Secrets(liqoNamespace).Create(ctx, secret, metav1.CreateOptions{})
+		if err != nil {
+			return fmt.Errorf("failed to create Secret %s/%s: %w", liqoNamespace, LiqoVersionReaderSecretName, err)
+		}
+		klog.Infof("Created Secret %s/%s for ServiceAccount token", liqoNamespace, LiqoVersionReaderSecretName)
+	} else {
+		// Secret already exists
+		klog.V(6).Infof("Secret %s/%s already exists", liqoNamespace, LiqoVersionReaderSecretName)
+	}
+
+	return nil
+}
+
+// GetRemoteVersion retrieves the Liqo version from a remote cluster using the provided clientset.
+// It returns an empty string if the ConfigMap doesn't exist or if there's an error.
+func GetRemoteVersion(ctx context.Context, remoteClientset kubernetes.Interface, liqoNamespace string) string {
+	configMap, err := remoteClientset.CoreV1().ConfigMaps(liqoNamespace).Get(ctx, LiqoVersionConfigMapName, metav1.GetOptions{})
+	if err != nil {
+		klog.V(4).Infof("Failed to get remote version ConfigMap: %v", err)
+		return ""
+	}
+
+	version, found := configMap.Data[LiqoVersionKey]
+	if !found {
+		klog.V(4).Infof("Version key not found in remote ConfigMap")
+		return ""
+	}
+
+	return version
+}
+
+// GetRemoteVersionWithToken retrieves the Liqo version from a remote cluster using API server URL and token.
+// This is used for non-peered clusters or when only minimal authentication is available.
+func GetRemoteVersionWithToken(ctx context.Context, apiServerURL, token, liqoNamespace string) string {
+	if apiServerURL == "" || token == "" {
+		klog.V(4).Info("API server URL or token is empty, cannot fetch remote version")
+		return ""
+	}
+
+	// Create a REST config using the token
+	config := restcfg.SetRateLimiter(&rest.Config{
+		Host:        apiServerURL,
+		BearerToken: token,
+		TLSClientConfig: rest.TLSClientConfig{
+			Insecure: true, // In production, you may want to handle CA certificates properly
+		},
+	})
+
+	// Create a clientset
+	remoteClientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		klog.V(4).Infof("Failed to create clientset for remote cluster: %v", err)
+		return ""
+	}
+
+	// Use the existing GetRemoteVersion function
+	return GetRemoteVersion(ctx, remoteClientset, liqoNamespace)
+}
+
+// GetVersionReaderToken retrieves the version reader token from the secret.
+// It waits briefly for the token to be populated if the secret exists but is empty.
+// Returns the token string or empty string if not available.
+func GetVersionReaderToken(ctx context.Context, clientset kubernetes.Interface, liqoNamespace string) (string, error) {
+	secret, err := clientset.CoreV1().Secrets(liqoNamespace).Get(ctx, LiqoVersionReaderSecretName, metav1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("unable to get version reader secret: %w", err)
+	}
+
+	token, ok := secret.Data[corev1.ServiceAccountTokenKey]
+	if !ok || len(token) == 0 {
+		return "", fmt.Errorf("token not found or empty in version reader secret")
+	}
+
+	return string(token), nil
+}
+
+// GetLocalVersion retrieves the Liqo version from the local cluster's ConfigMap.
+// This can be used to check the local version without needing to query the deployment.
+func GetLocalVersion(ctx context.Context, clientset kubernetes.Interface, liqoNamespace string) (string, error) {
+	configMap, err := clientset.CoreV1().ConfigMaps(liqoNamespace).Get(ctx, LiqoVersionConfigMapName, metav1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("failed to get local version ConfigMap: %w", err)
+	}
+
+	version, found := configMap.Data[LiqoVersionKey]
+	if !found {
+		return "", fmt.Errorf("version key not found in local ConfigMap")
+	}
+
+	return version, nil
+}
+
+// QueryRemoteVersion is a standalone function to query a remote cluster's Liqo version
+// without establishing a full peering relationship. It requires:
+// - apiServerURL: The API server URL of the remote cluster
+// - token: A bearer token with read access to the liqo-version ConfigMap (e.g., from liqo-version-reader ServiceAccount)
+// - liqoNamespace: The namespace where Liqo is installed on the remote cluster (typically "liqo")
+//
+// Returns the remote cluster's Liqo version string or an error if the query fails.
+// This is useful for checking version compatibility before initiating peering.
+func QueryRemoteVersion(ctx context.Context, apiServerURL, token, liqoNamespace string) (string, error) {
+	if apiServerURL == "" {
+		return "", fmt.Errorf("API server URL is required")
+	}
+	if token == "" {
+		return "", fmt.Errorf("authentication token is required")
+	}
+	if liqoNamespace == "" {
+		return "", fmt.Errorf("Liqo namespace is required")
+	}
+
+	version := GetRemoteVersionWithToken(ctx, apiServerURL, token, liqoNamespace)
+	if version == "" {
+		return "", fmt.Errorf("failed to retrieve remote version (check API server URL, token validity, and network connectivity)")
+	}
+
+	return version, nil
+}

--- a/pkg/liqo-controller-manager/version/version_test.go
+++ b/pkg/liqo-controller-manager/version/version_test.go
@@ -1,0 +1,327 @@
+// Copyright 2019-2025 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package version
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestVersion(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Version Suite")
+}
+
+var _ = Describe("GetVersionFromDeployment", func() {
+	var (
+		ctx       context.Context
+		clientset *fake.Clientset
+		namespace string
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		clientset = fake.NewSimpleClientset()
+		namespace = "liqo"
+	})
+
+	It("should extract version from deployment image tag", func() {
+		deployment := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "liqo-controller-manager",
+				Namespace: namespace,
+			},
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:  "controller-manager",
+								Image: "ghcr.io/liqotech/liqo-controller-manager:v0.10.3",
+							},
+						},
+					},
+				},
+			},
+		}
+		_, err := clientset.AppsV1().Deployments(namespace).Create(ctx, deployment, metav1.CreateOptions{})
+		Expect(err).ToNot(HaveOccurred())
+
+		version := GetVersionFromDeployment(ctx, clientset, namespace, "liqo-controller-manager")
+		Expect(version).To(Equal("v0.10.3"))
+	})
+
+	It("should return empty string when deployment doesn't exist", func() {
+		version := GetVersionFromDeployment(ctx, clientset, namespace, "nonexistent")
+		Expect(version).To(BeEmpty())
+	})
+
+	It("should return empty string when no containers in deployment", func() {
+		deployment := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "liqo-controller-manager",
+				Namespace: namespace,
+			},
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{},
+					},
+				},
+			},
+		}
+		_, err := clientset.AppsV1().Deployments(namespace).Create(ctx, deployment, metav1.CreateOptions{})
+		Expect(err).ToNot(HaveOccurred())
+
+		version := GetVersionFromDeployment(ctx, clientset, namespace, "liqo-controller-manager")
+		Expect(version).To(BeEmpty())
+	})
+
+	It("should return empty string when image has no tag", func() {
+		deployment := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "liqo-controller-manager",
+				Namespace: namespace,
+			},
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:  "controller-manager",
+								Image: "ghcr.io/liqotech/liqo-controller-manager",
+							},
+						},
+					},
+				},
+			},
+		}
+		_, err := clientset.AppsV1().Deployments(namespace).Create(ctx, deployment, metav1.CreateOptions{})
+		Expect(err).ToNot(HaveOccurred())
+
+		version := GetVersionFromDeployment(ctx, clientset, namespace, "liqo-controller-manager")
+		Expect(version).To(BeEmpty())
+	})
+})
+
+var _ = Describe("QueryRemoteVersion", func() {
+	It("should return error when API server URL is empty", func() {
+		ctx := context.Background()
+		_, err := QueryRemoteVersion(ctx, "", "token", "liqo")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("API server URL is required"))
+	})
+
+	It("should return error when token is empty", func() {
+		ctx := context.Background()
+		_, err := QueryRemoteVersion(ctx, "https://example.com", "", "liqo")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("authentication token is required"))
+	})
+
+	It("should return error when namespace is empty", func() {
+		ctx := context.Background()
+		_, err := QueryRemoteVersion(ctx, "https://example.com", "token", "")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("Liqo namespace is required"))
+	})
+})
+
+var _ = Describe("GetLocalVersion", func() {
+	var (
+		ctx       context.Context
+		clientset *fake.Clientset
+		namespace string
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		clientset = fake.NewSimpleClientset()
+		namespace = "liqo"
+	})
+
+	It("should retrieve version from ConfigMap", func() {
+		configMap := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      LiqoVersionConfigMapName,
+				Namespace: namespace,
+			},
+			Data: map[string]string{
+				LiqoVersionKey: "v0.10.3",
+			},
+		}
+		_, err := clientset.CoreV1().ConfigMaps(namespace).Create(ctx, configMap, metav1.CreateOptions{})
+		Expect(err).ToNot(HaveOccurred())
+
+		version, err := GetLocalVersion(ctx, clientset, namespace)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(version).To(Equal("v0.10.3"))
+	})
+
+	It("should return error when ConfigMap doesn't exist", func() {
+		_, err := GetLocalVersion(ctx, clientset, namespace)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("failed to get local version ConfigMap"))
+	})
+
+	It("should return error when version key is missing", func() {
+		configMap := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      LiqoVersionConfigMapName,
+				Namespace: namespace,
+			},
+			Data: map[string]string{},
+		}
+		_, err := clientset.CoreV1().ConfigMaps(namespace).Create(ctx, configMap, metav1.CreateOptions{})
+		Expect(err).ToNot(HaveOccurred())
+
+		_, err = GetLocalVersion(ctx, clientset, namespace)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("version key not found"))
+	})
+})
+
+var _ = Describe("GetRemoteVersion", func() {
+	var (
+		ctx       context.Context
+		clientset *fake.Clientset
+		namespace string
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		clientset = fake.NewSimpleClientset()
+		namespace = "liqo"
+	})
+
+	It("should retrieve version from remote ConfigMap", func() {
+		configMap := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      LiqoVersionConfigMapName,
+				Namespace: namespace,
+			},
+			Data: map[string]string{
+				LiqoVersionKey: "v0.10.3",
+			},
+		}
+		_, err := clientset.CoreV1().ConfigMaps(namespace).Create(ctx, configMap, metav1.CreateOptions{})
+		Expect(err).ToNot(HaveOccurred())
+
+		version := GetRemoteVersion(ctx, clientset, namespace)
+		Expect(version).To(Equal("v0.10.3"))
+	})
+
+	It("should return empty string when ConfigMap doesn't exist", func() {
+		version := GetRemoteVersion(ctx, clientset, namespace)
+		Expect(version).To(BeEmpty())
+	})
+
+	It("should return empty string when version key is missing", func() {
+		configMap := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      LiqoVersionConfigMapName,
+				Namespace: namespace,
+			},
+			Data: map[string]string{},
+		}
+		_, err := clientset.CoreV1().ConfigMaps(namespace).Create(ctx, configMap, metav1.CreateOptions{})
+		Expect(err).ToNot(HaveOccurred())
+
+		version := GetRemoteVersion(ctx, clientset, namespace)
+		Expect(version).To(BeEmpty())
+	})
+})
+
+var _ = Describe("GetVersionReaderToken", func() {
+	var (
+		ctx       context.Context
+		clientset *fake.Clientset
+		namespace string
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		clientset = fake.NewSimpleClientset()
+		namespace = "liqo"
+	})
+
+	It("should retrieve token from secret", func() {
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      LiqoVersionReaderSecretName,
+				Namespace: namespace,
+			},
+			Type: corev1.SecretTypeServiceAccountToken,
+			Data: map[string][]byte{
+				corev1.ServiceAccountTokenKey: []byte("test-token-value"),
+			},
+		}
+		_, err := clientset.CoreV1().Secrets(namespace).Create(ctx, secret, metav1.CreateOptions{})
+		Expect(err).ToNot(HaveOccurred())
+
+		token, err := GetVersionReaderToken(ctx, clientset, namespace)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(token).To(Equal("test-token-value"))
+	})
+
+	It("should return error when secret doesn't exist", func() {
+		_, err := GetVersionReaderToken(ctx, clientset, namespace)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("unable to get version reader secret"))
+	})
+
+	It("should return error when token key is missing", func() {
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      LiqoVersionReaderSecretName,
+				Namespace: namespace,
+			},
+			Type: corev1.SecretTypeServiceAccountToken,
+			Data: map[string][]byte{},
+		}
+		_, err := clientset.CoreV1().Secrets(namespace).Create(ctx, secret, metav1.CreateOptions{})
+		Expect(err).ToNot(HaveOccurred())
+
+		_, err = GetVersionReaderToken(ctx, clientset, namespace)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("token not found or empty"))
+	})
+
+	It("should return error when token is empty", func() {
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      LiqoVersionReaderSecretName,
+				Namespace: namespace,
+			},
+			Type: corev1.SecretTypeServiceAccountToken,
+			Data: map[string][]byte{
+				corev1.ServiceAccountTokenKey: []byte(""),
+			},
+		}
+		_, err := clientset.CoreV1().Secrets(namespace).Create(ctx, secret, metav1.CreateOptions{})
+		Expect(err).ToNot(HaveOccurred())
+
+		_, err = GetVersionReaderToken(ctx, clientset, namespace)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("token not found or empty"))
+	})
+})


### PR DESCRIPTION
Description
This PR adds the ability to query a Liqo cluster's version without establishing full peering, using minimal token-based authentication.

Summary of Changes
Version Query Infrastructure:

Created liqo-version ConfigMap to expose cluster version
Set up liqo-version-reader ServiceAccount with minimal RBAC (read access restricted to one specific ConfigMap only)
Auto-generated long-lived token stored in liqo-version-reader-token Secret
All resources created automatically at liqo-controller-manager startup
Public API Functions:

QueryRemoteVersion(): Query remote cluster version with API URL + token
GetLocalVersion(): Retrieve local cluster version from ConfigMap
GetVersionReaderToken(): Extract token from Secret for sharing
Security:

Token restricted to read ONE ConfigMap (liqo-version) in liqo namespace
No list, create, update, or delete permissions
Cannot access any other resources
Motivation
Administrators need to check version compatibility between clusters before initiating peering. This feature enables version queries using only a read-only token, without requiring full peering setup or exchanging cluster credentials.

Fixes # (no related issue)

How Has This Been Tested?
Unit Tests

All 17 version package unit tests pass

Tenant controller unit tests added
Integration Testing

Version resources (ConfigMap, Secret, Role, RoleBinding) created automatically on startup

Token successfully extracted from Secret

Token restricted to read only [object Object] ConfigMap (tested with kubectl)

Token cannot access other ConfigMaps or resources (verified permission denied)

RBAC auto-generated correctly via [object Object]
Test Configuration
Environment: k3s cluster
Liqo installation: liqoctl + custom build script
Kubernetes version: v1.31+
