### PR TITLE
test(cni): update Cilium CLI version to v0.18.8

### DIFF
--- a/test/e2e/pipeline/infra/cni.sh
+++ b/test/e2e/pipeline/infra/cni.sh
@@ -80,7 +80,7 @@ function install_cilium() {
     if [ ! -f "${BINDIR}/cilium}" ]; then
         setup_arch_and_os
         local CILIUM_CLI_VERSION
-        CILIUM_CLI_VERSION="v0.15.11"
+        CILIUM_CLI_VERSION="v0.18.8"
 
         echo "Downloading Cilium CLI ${CILIUM_CLI_VERSION} for ${OS}-${ARCH}"
         curl -L --remote-name-all "https://github.com/cilium/cilium-cli/releases/download/${CILIUM_CLI_VERSION}/cilium-${OS}-${ARCH}.tar.gz{,.sha256sum}"


### PR DESCRIPTION
# Description

This pr bumps the cilium version in the liqo test
