### PR TITLE
feat(firewall): add named sets to FirewallConfiguration

### DIFF
--- a/apis/networking/v1beta1/firewall/common_types.go
+++ b/apis/networking/v1beta1/firewall/common_types.go
@@ -26,6 +26,8 @@ const (
 	IPValueTypeVoid IPValueType = "void"
 	// IPValueTypeRange is a string representing a range of IPs (eg. 10.0.0.1-10.0.0.20).
 	IPValueTypeRange IPValueType = "range"
+	// IPValueTypeNamedSet is a string representing the name of an IP set (eg. @my_ip_set).
+	IPValueTypeNamedSet IPValueType = "namedset"
 )
 
 // PortValueType is the type of the match value.

--- a/apis/networking/v1beta1/firewall/set_types.go
+++ b/apis/networking/v1beta1/firewall/set_types.go
@@ -20,7 +20,7 @@ type SetDataType string
 
 // Possible SetDataType values.
 const (
-	SetTypeIPAddr SetDataType = "ipv4_addr"
+	SetDataTypeIPAddr SetDataType = "ipv4_addr"
 )
 
 // Set represents a nftables set

--- a/apis/networking/v1beta1/firewall/set_types.go
+++ b/apis/networking/v1beta1/firewall/set_types.go
@@ -1,0 +1,56 @@
+// Copyright 2019-2025 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package firewall
+
+// SetDataType is the type of a set element
+// +kubebuilder:validation:Enum="ipv4_addr"
+type SetDataType string
+
+// Possible SetDataType values.
+const (
+	SetTypeIPAddr SetDataType = "ipv4_addr"
+)
+
+// Set represents a nftables set
+// +kubebuilder:object:generate=true
+type Set struct {
+	// Name is the name of the set.
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=200
+	// +kubebuilder:validation:Pattern=`^[a-zA-Z][a-zA-Z0-9/\\_.]*$`
+	Name string `json:"name"`
+
+	// KeyType is the type of the set keys.
+	KeyType SetDataType `json:"keyType"`
+
+	// DataType is the type of the set data.
+	// +kubebuilder:validation:Optional
+	DataType *SetDataType `json:"dataType,omitempty"`
+
+	// Elements are the elements of the set.
+	// +kubebuilder:validation:Optional
+	Elements []SetElement `json:"elements,omitempty"`
+}
+
+// SetElement represents an element of a nftables set
+// +kubebuilder:object:generate=true
+type SetElement struct {
+	// Key is the key of the set element.
+	Key string `json:"key"`
+
+	// Data is the data of the set element.
+	// +kubebuilder:validation:Optional
+	Data *string `json:"data,omitempty"`
+}

--- a/apis/networking/v1beta1/firewall/set_types.go
+++ b/apis/networking/v1beta1/firewall/set_types.go
@@ -15,13 +15,14 @@
 package firewall
 
 // SetDataType is the type of a set element
-// +kubebuilder:validation:Enum=integer;ipv4_addr
+// +kubebuilder:validation:Enum=integer;ipv4_addr;ipv4_cidr
 type SetDataType string
 
 // Possible SetDataType values.
 const (
 	SetDataTypeInteger SetDataType = "integer"
 	SetDataTypeIPAddr  SetDataType = "ipv4_addr"
+	SetDataTypeIPCIDR  SetDataType = "ipv4_cidr"
 )
 
 // Set represents a nftables set

--- a/apis/networking/v1beta1/firewall/set_types.go
+++ b/apis/networking/v1beta1/firewall/set_types.go
@@ -1,4 +1,4 @@
-// Copyright 2019-2025 The Liqo Authors
+// Copyright 2019-2026 The Liqo Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/networking/v1beta1/firewall/set_types.go
+++ b/apis/networking/v1beta1/firewall/set_types.go
@@ -15,12 +15,13 @@
 package firewall
 
 // SetDataType is the type of a set element
-// +kubebuilder:validation:Enum="ipv4_addr"
+// +kubebuilder:validation:Enum=integer;ipv4_addr
 type SetDataType string
 
 // Possible SetDataType values.
 const (
-	SetDataTypeIPAddr SetDataType = "ipv4_addr"
+	SetDataTypeInteger SetDataType = "integer"
+	SetDataTypeIPAddr  SetDataType = "ipv4_addr"
 )
 
 // Set represents a nftables set

--- a/apis/networking/v1beta1/firewall/table_types.go
+++ b/apis/networking/v1beta1/firewall/table_types.go
@@ -39,4 +39,7 @@ type Table struct {
 	// Family is the family of the table.
 	// +kubebuilder:validation:Enum="INET";"IPV4";"IPV6";"ARP";"NETDEV";"BRIDGE"
 	Family *TableFamily `json:"family"`
+	// Sets is a list of sets to be applied to the table.
+	// +kubebuilder:validation:Optional
+	Sets []Set `json:"sets,omitempty"`
 }

--- a/deployments/liqo/charts/liqo-crds/crds/networking.liqo.io_firewallconfigurations.yaml
+++ b/deployments/liqo/charts/liqo-crds/crds/networking.liqo.io_firewallconfigurations.yaml
@@ -419,6 +419,48 @@ spec:
                   name:
                     description: Name is the name of the table.
                     type: string
+                  sets:
+                    description: Sets is a list of sets to be applied to the table.
+                    items:
+                      description: Set represents a nftables set
+                      properties:
+                        dataType:
+                          description: DataType is the type of the set data.
+                          enum:
+                          - ipv4_addr
+                          type: string
+                        elements:
+                          description: Elements are the elements of the set.
+                          items:
+                            description: SetElement represents an element of a nftables
+                              set
+                            properties:
+                              data:
+                                description: Data is the data of the set element.
+                                type: string
+                              key:
+                                description: Key is the key of the set element.
+                                type: string
+                            required:
+                            - key
+                            type: object
+                          type: array
+                        keyType:
+                          description: KeyType is the type of the set keys.
+                          enum:
+                          - ipv4_addr
+                          type: string
+                        name:
+                          description: Name is the name of the set.
+                          maxLength: 200
+                          minLength: 1
+                          pattern: ^[a-zA-Z][a-zA-Z0-9/\\_.]*$
+                          type: string
+                      required:
+                      - keyType
+                      - name
+                      type: object
+                    type: array
                 required:
                 - family
                 - name

--- a/deployments/liqo/charts/liqo-crds/crds/networking.liqo.io_firewallconfigurations.yaml
+++ b/deployments/liqo/charts/liqo-crds/crds/networking.liqo.io_firewallconfigurations.yaml
@@ -427,7 +427,9 @@ spec:
                         dataType:
                           description: DataType is the type of the set data.
                           enum:
+                          - integer
                           - ipv4_addr
+                          - ipv4_cidr
                           type: string
                         elements:
                           description: Elements are the elements of the set.
@@ -448,7 +450,9 @@ spec:
                         keyType:
                           description: KeyType is the type of the set keys.
                           enum:
+                          - integer
                           - ipv4_addr
+                          - ipv4_cidr
                           type: string
                         name:
                           description: Name is the name of the set.

--- a/pkg/firewall/firewallconfiguration_controller.go
+++ b/pkg/firewall/firewallconfiguration_controller.go
@@ -141,7 +141,7 @@ func (r *FirewallConfigurationReconciler) Reconcile(ctx context.Context, req ctr
 		return ctrl.Result{}, fmt.Errorf("cleaning table %s: %w", ptr.Deref(fwcfg.Spec.Table.Name, ""), err)
 	}
 
-	// We need to flush the updates to allow the recreation of updated chains/rules.
+	// We need to flush the updates to allow the recreation of updated chains/rules and the usage of sets in rules.
 	if err = r.NftConnection.Flush(); err != nil {
 		return ctrl.Result{}, fmt.Errorf("flushing nftables connection: %w", err)
 	}
@@ -151,6 +151,12 @@ func (r *FirewallConfigurationReconciler) Reconcile(ctx context.Context, req ctr
 	// Enforce table existence.
 	table := addTable(r.NftConnection, &fwcfg.Spec.Table)
 
+	// Add the missing sets
+	if err = addSets(r.NftConnection, fwcfg.Spec.Table.Sets, table); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// Add the missing chains and rules.
 	if err = addChains(r.NftConnection, fwcfg.Spec.Table.Chains, table); err != nil {
 		return ctrl.Result{}, fmt.Errorf("adding chains to table %s: %w", ptr.Deref(fwcfg.Spec.Table.Name, ""), err)
 	}

--- a/pkg/firewall/set.go
+++ b/pkg/firewall/set.go
@@ -230,7 +230,7 @@ func getSetDataType(dataType *firewallapi.SetDataType) (nftables.SetDatatype, er
 	}
 
 	switch *dataType {
-	case firewallapi.SetTypeIPAddr:
+	case firewallapi.SetDataTypeIPAddr:
 		return nftables.TypeIPAddr, nil
 	default:
 		return nftables.SetDatatype{}, fmt.Errorf("unsupported set data type: %s", *dataType)

--- a/pkg/firewall/set.go
+++ b/pkg/firewall/set.go
@@ -232,6 +232,8 @@ func getSetDataType(dataType *firewallapi.SetDataType) (nftables.SetDatatype, er
 	switch *dataType {
 	case firewallapi.SetDataTypeIPAddr:
 		return nftables.TypeIPAddr, nil
+	case firewallapi.SetDataTypeInteger:
+		return nftables.TypeInteger, nil
 	default:
 		return nftables.SetDatatype{}, fmt.Errorf("unsupported set data type: %s", *dataType)
 	}

--- a/pkg/firewall/set.go
+++ b/pkg/firewall/set.go
@@ -1,0 +1,238 @@
+// Copyright 2019-2025 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package firewall
+
+import (
+	"fmt"
+
+	"github.com/google/nftables"
+	firewallapi "github.com/liqotech/liqo/apis/networking/v1beta1/firewall"
+	"github.com/liqotech/liqo/pkg/firewall/utils"
+)
+
+// cleanSets removes the sets that are no longer used in the firewall configuration and updates the existing ones if their elements differ from the wanted elements.
+func cleanSets(nftconn *nftables.Conn, table *firewallapi.Table) error {
+	// Find the table by name and family
+	nftTables, err := nftconn.ListTablesOfFamily(getTableFamily(*table.Family))
+	if err != nil {
+		return err
+	}
+
+	var nftTable *nftables.Table
+	for _, t := range nftTables {
+		if t.Name == *table.Name {
+			nftTable = t
+			break
+		}
+	}
+
+	if nftTable == nil {
+		// Table does not exist, nothing to clean
+		return nil
+	}
+
+	// Get all existing sets in the table
+	nftSets, err := nftconn.GetSets(nftTable)
+	if err != nil {
+		return err
+	}
+
+	// Remove sets that are no longer used.
+	if err := removeOutdatedSets(nftconn, nftSets, table); err != nil {
+		return err
+	}
+
+	// Update existing sets if their elements differ from the wanted elements.
+	if err := updateSetElements(nftconn, nftSets, table); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// removeOutdatedSets removes the sets that are no longer used in the firewall configuration.
+func removeOutdatedSets(nftconn *nftables.Conn, nftSets []*nftables.Set, table *firewallapi.Table) error {
+	// Delete sets that are not used anymore in the table
+	usedSetNames := make(map[string]interface{})
+	for _, set := range table.Sets {
+		usedSetNames[set.Name] = nil
+	}
+
+	for _, nftSet := range nftSets {
+		if _, used := usedSetNames[nftSet.Name]; !used {
+			// Set is not used anymore, delete it
+			nftconn.DelSet(nftSet)
+		}
+	}
+
+	return nil
+}
+
+// updateSetElements updates the elements of an existing set, if they differ from the wanted elements.
+func updateSetElements(nftconn *nftables.Conn, nftSets []*nftables.Set, table *firewallapi.Table) error {
+	for _, set := range table.Sets {
+		// Find the corresponding nftables.Set
+		var nftSet *nftables.Set
+		for _, ns := range nftSets {
+			if ns.Name == set.Name {
+				nftSet = ns
+				break
+			}
+		}
+
+		if nftSet == nil {
+			// Set does not exist, skip
+			continue
+		}
+
+		// Get existing elements of the set
+		existingElements, err := nftconn.GetSetElements(nftSet)
+		if err != nil {
+			return err
+		}
+
+		// Get wanted elements of the set
+		wantedElements, err := genSetElements(&set)
+		if err != nil {
+			return err
+		}
+
+		// Check if the set is outdated
+		if isSetOutdated(existingElements, wantedElements) {
+			// Remove the existing elements and add the wanted ones
+			if err := nftconn.SetDeleteElements(nftSet, existingElements); err != nil {
+				return err
+			}
+			if err := nftconn.SetAddElements(nftSet, wantedElements); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// isSetOutdated checks if the existing set elements differ from the wanted set elements.
+func isSetOutdated(existingElements []nftables.SetElement, wantedElements []nftables.SetElement) bool {
+	// If the lengths differ, the set is outdated.
+	if len(existingElements) != len(wantedElements) {
+		return true
+	}
+
+	// Build a map of existing elements for quick lookup.
+	existingElementsMap := make(map[string]string)
+	for _, element := range existingElements {
+		existingElementsMap[string(element.Key)] = string(element.Val)
+	}
+
+	// Check if any wanted element is missing or differs in value.
+	for _, wantedElement := range wantedElements {
+		val, exists := existingElementsMap[string(wantedElement.Key)]
+		if !exists || val != string(wantedElement.Val) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// addSets adds the sets that are missing in the nftables configuration.
+func addSets(nftconn *nftables.Conn, sets []firewallapi.Set, nftTable *nftables.Table) error {
+	nftSets, err := nftconn.GetSets(nftTable)
+	if err != nil {
+		return err
+	}
+	existingSetNames := make(map[string]struct{})
+	for _, nftSet := range nftSets {
+		existingSetNames[nftSet.Name] = struct{}{}
+	}
+
+	for _, set := range sets {
+		if _, exists := existingSetNames[set.Name]; !exists {
+			_, err := addSet(nftconn, nftTable, &set)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// addSet adds a new set to the nftables configuration.
+func addSet(nftconn *nftables.Conn, table *nftables.Table, set *firewallapi.Set) (*nftables.Set, error) {
+	dataType, err := getSetDataType(set.DataType)
+	if err != nil {
+		return nil, err
+	}
+
+	keyType, err := getSetDataType(&set.KeyType)
+	if err != nil {
+		return nil, err
+	}
+
+	nftSet := &nftables.Set{
+		Table:    table,
+		Name:     set.Name,
+		KeyType:  keyType,
+		DataType: dataType,
+	}
+
+	setData, err := genSetElements(set)
+	if err != nil {
+		return nil, err
+	}
+
+	err = nftconn.AddSet(nftSet, setData)
+	if err != nil {
+		return nil, err
+	}
+
+	return nftSet, nil
+}
+
+func genSetElements(set *firewallapi.Set) ([]nftables.SetElement, error) {
+	setData := make([]nftables.SetElement, len(set.Elements))
+	for i, element := range set.Elements {
+		data, err := utils.ConvertSetData(element.Data, set.DataType)
+		if err != nil {
+			return nil, fmt.Errorf("unable to convert set element data: %v", err)
+		}
+
+		key, err := utils.ConvertSetData(&element.Key, &set.KeyType)
+		if err != nil {
+			return nil, fmt.Errorf("unable to convert set element key: %v", err)
+		}
+
+		setData[i] = nftables.SetElement{
+			Key: key,
+			Val: data,
+		}
+	}
+
+	return setData, nil
+}
+
+func getSetDataType(dataType *firewallapi.SetDataType) (nftables.SetDatatype, error) {
+	if dataType == nil {
+		return nftables.SetDatatype{}, nil
+	}
+
+	switch *dataType {
+	case firewallapi.SetTypeIPAddr:
+		return nftables.TypeIPAddr, nil
+	default:
+		return nftables.SetDatatype{}, fmt.Errorf("unsupported set data type: %s", *dataType)
+	}
+}

--- a/pkg/firewall/set.go
+++ b/pkg/firewall/set.go
@@ -1,4 +1,4 @@
-// Copyright 2019-2025 The Liqo Authors
+// Copyright 2019-2026 The Liqo Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,11 +18,13 @@ import (
 	"fmt"
 
 	"github.com/google/nftables"
+
 	firewallapi "github.com/liqotech/liqo/apis/networking/v1beta1/firewall"
 	"github.com/liqotech/liqo/pkg/firewall/utils"
 )
 
-// cleanSets removes the sets that are no longer used in the firewall configuration and updates the existing ones if their elements differ from the wanted elements.
+// cleanSets removes the sets that are no longer used in the firewall configuration
+// and updates the existing ones if their elements differ from the wanted elements.
 func cleanSets(nftconn *nftables.Conn, table *firewallapi.Table) error {
 	// Find the table by name and family
 	nftTables, err := nftconn.ListTablesOfFamily(getTableFamily(*table.Family))
@@ -125,7 +127,7 @@ func updateSetElements(nftconn *nftables.Conn, nftSets []*nftables.Set, table *f
 }
 
 // isSetOutdated checks if the existing set elements differ from the wanted set elements.
-func isSetOutdated(existingElements []nftables.SetElement, wantedElements []nftables.SetElement) bool {
+func isSetOutdated(existingElements, wantedElements []nftables.SetElement) bool {
 	// If the lengths differ, the set is outdated.
 	if len(existingElements) != len(wantedElements) {
 		return true
@@ -133,14 +135,14 @@ func isSetOutdated(existingElements []nftables.SetElement, wantedElements []nfta
 
 	// Build a map of existing elements for quick lookup.
 	existingElementsMap := make(map[string]string)
-	for _, element := range existingElements {
-		existingElementsMap[string(element.Key)] = string(element.Val)
+	for i := range existingElements {
+		existingElementsMap[string(existingElements[i].Key)] = string(existingElements[i].Val)
 	}
 
 	// Check if any wanted element is missing or differs in value.
-	for _, wantedElement := range wantedElements {
-		val, exists := existingElementsMap[string(wantedElement.Key)]
-		if !exists || val != string(wantedElement.Val) {
+	for i := range wantedElements {
+		val, exists := existingElementsMap[string(wantedElements[i].Key)]
+		if !exists || val != string(wantedElements[i].Val) {
 			return true
 		}
 	}
@@ -208,12 +210,12 @@ func genSetElements(set *firewallapi.Set) ([]nftables.SetElement, error) {
 	for _, element := range set.Elements {
 		data, _, err := utils.ConvertSetData(element.Data, set.DataType)
 		if err != nil {
-			return nil, fmt.Errorf("unable to convert set element data: %v", err)
+			return nil, fmt.Errorf("unable to convert set element data: %w", err)
 		}
 
 		key, keyEnd, err := utils.ConvertSetData(&element.Key, &set.KeyType)
 		if err != nil {
-			return nil, fmt.Errorf("unable to convert set element key: %v", err)
+			return nil, fmt.Errorf("unable to convert set element key: %w", err)
 		}
 
 		setData = append(setData, nftables.SetElement{

--- a/pkg/firewall/table.go
+++ b/pkg/firewall/table.go
@@ -78,6 +78,12 @@ func cleanTable(nftconn *nftables.Conn, table *firewallapi.Table) error {
 			return err
 		}
 	}
+
+	// Delete sets that are not used anymore in the table.
+	if err := cleanSets(nftconn, table); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/pkg/firewall/utils/common.go
+++ b/pkg/firewall/utils/common.go
@@ -50,6 +50,11 @@ func GetIPValueType(value *string) (firewallv1beta1.IPValueType, error) {
 		return firewallv1beta1.IPValueTypeRange, nil
 	}
 
+	// Check if the value is a named set.
+	if _, err := GetIPValueNamedSet(*value); err == nil {
+		return firewallv1beta1.IPValueTypeNamedSet, nil
+	}
+
 	return firewallv1beta1.IPValueTypeVoid, fmt.Errorf("invalid match value IP %s", *value)
 }
 
@@ -84,6 +89,20 @@ func GetIPValueRange(s string) (address1, address2 net.IP, err error) {
 	}
 
 	return startIP, endIP, nil
+}
+
+// GetIPValueNamedSet parses the match value and returns the set name.
+func GetIPValueNamedSet(s string) (string, error) {
+	if !strings.HasPrefix(s, "@") {
+		return "", fmt.Errorf("invalid named set format: %s", s)
+	}
+
+	setName := strings.TrimPrefix(s, "@")
+	if setName == "" {
+		return "", fmt.Errorf("empty named set name in value: %s", s)
+	}
+
+	return setName, nil
 }
 
 // GetPortValueType parses the match value and returns the type of the value.

--- a/pkg/firewall/utils/common.go
+++ b/pkg/firewall/utils/common.go
@@ -214,19 +214,19 @@ func compareRuleExpressions(ruleName string, currentrule, newrule *nftables.Rule
 }
 
 // GetCIDRRange calculates the start and end IP addresses of a CIDR block.
-func GetCIDRRange(cidr string) (net.IP, net.IP, error) {
+func GetCIDRRange(cidr string) (start net.IP, end net.IP, err error) {
 	ip, ipNet, err := net.ParseCIDR(cidr)
 	if err != nil {
 		return nil, nil, fmt.Errorf("invalid CIDR format: %s", cidr)
 	}
 
-	startIP := ip.Mask(ipNet.Mask)
-	endIP := make(net.IP, len(startIP))
-	copy(endIP, startIP)
+	start = ip.Mask(ipNet.Mask)
+	end = make(net.IP, len(start))
+	copy(end, start)
 
-	for i := range endIP {
-		endIP[i] |= ^ipNet.Mask[i]
+	for i := range end {
+		end[i] |= ^ipNet.Mask[i]
 	}
 
-	return startIP, endIP, nil
+	return start, end, nil
 }

--- a/pkg/firewall/utils/common.go
+++ b/pkg/firewall/utils/common.go
@@ -214,7 +214,7 @@ func compareRuleExpressions(ruleName string, currentrule, newrule *nftables.Rule
 }
 
 // GetCIDRRange calculates the start and end IP addresses of a CIDR block.
-func GetCIDRRange(cidr string) (start net.IP, end net.IP, err error) {
+func GetCIDRRange(cidr string) (start, end net.IP, err error) {
 	ip, ipNet, err := net.ParseCIDR(cidr)
 	if err != nil {
 		return nil, nil, fmt.Errorf("invalid CIDR format: %s", cidr)

--- a/pkg/firewall/utils/common.go
+++ b/pkg/firewall/utils/common.go
@@ -212,3 +212,21 @@ func compareRuleExpressions(ruleName string, currentrule, newrule *nftables.Rule
 	klog.V(4).Infof("Rule %s: all expressions match, rules are equal", ruleName)
 	return true
 }
+
+// GetCIDRRange calculates the start and end IP addresses of a CIDR block.
+func GetCIDRRange(cidr string) (net.IP, net.IP, error) {
+	ip, ipNet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return nil, nil, fmt.Errorf("invalid CIDR format: %s", cidr)
+	}
+
+	startIP := ip.Mask(ipNet.Mask)
+	endIP := make(net.IP, len(startIP))
+	copy(endIP, startIP)
+
+	for i := range endIP {
+		endIP[i] |= ^ipNet.Mask[i]
+	}
+
+	return startIP, endIP, nil
+}

--- a/pkg/firewall/utils/match.go
+++ b/pkg/firewall/utils/match.go
@@ -289,10 +289,7 @@ func applyMatchIPRange(m *firewallv1beta1.Match, rule *nftables.Rule, op expr.Cm
 }
 
 func applyMatchIPNamedSet(m *firewallv1beta1.Match, rule *nftables.Rule, op expr.CmpOp) error {
-	invert := false
-	if op == expr.CmpOpNeq {
-		invert = true
-	}
+	invert := op == expr.CmpOpNeq
 
 	posOffset, err := getMatchIPPositionOffset(m)
 	if err != nil {

--- a/pkg/firewall/utils/set.go
+++ b/pkg/firewall/utils/set.go
@@ -34,7 +34,7 @@ func ConvertSetData(data *string, dataType *firewallapi.SetDataType) ([]byte, er
 	}
 
 	switch *dataType {
-	case firewallapi.SetTypeIPAddr:
+	case firewallapi.SetDataTypeIPAddr:
 		ip := net.ParseIP(*data)
 		if ip == nil {
 			return nil, fmt.Errorf("set element has invalid IP value %s", *data)

--- a/pkg/firewall/utils/set.go
+++ b/pkg/firewall/utils/set.go
@@ -17,6 +17,7 @@ package utils
 import (
 	"fmt"
 	"net"
+	"strconv"
 
 	firewallapi "github.com/liqotech/liqo/apis/networking/v1beta1/firewall"
 )
@@ -40,6 +41,18 @@ func ConvertSetData(data *string, dataType *firewallapi.SetDataType) ([]byte, er
 			return nil, fmt.Errorf("set element has invalid IP value %s", *data)
 		}
 		return ip.To4(), nil
+
+	case firewallapi.SetDataTypeInteger:
+		intValue, err := strconv.Atoi(*data)
+		if err != nil {
+			return nil, fmt.Errorf("set element has invalid integer value %s", *data)
+		}
+		return []byte{
+			byte((intValue >> 24) & 0xFF),
+			byte((intValue >> 16) & 0xFF),
+			byte((intValue >> 8) & 0xFF),
+			byte(intValue & 0xFF),
+		}, nil
 
 	default:
 		return nil, fmt.Errorf("invalid set value type %s", *dataType)

--- a/pkg/firewall/utils/set.go
+++ b/pkg/firewall/utils/set.go
@@ -1,0 +1,47 @@
+// Copyright 2019-2025 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"fmt"
+	"net"
+
+	firewallapi "github.com/liqotech/liqo/apis/networking/v1beta1/firewall"
+)
+
+func ConvertSetData(data *string, dataType *firewallapi.SetDataType) ([]byte, error) {
+	if dataType == nil {
+		if data != nil {
+			return nil, fmt.Errorf("set element has data but no data type is specified")
+		}
+		return []byte{}, nil
+	}
+
+	if data == nil {
+		return nil, fmt.Errorf("set element has nil data for data type %s", *dataType)
+	}
+
+	switch *dataType {
+	case firewallapi.SetTypeIPAddr:
+		ip := net.ParseIP(*data)
+		if ip == nil {
+			return nil, fmt.Errorf("set element has invalid IP value %s", *data)
+		}
+		return ip.To4(), nil
+
+	default:
+		return nil, fmt.Errorf("invalid set value type %s", *dataType)
+	}
+}

--- a/pkg/firewall/utils/set.go
+++ b/pkg/firewall/utils/set.go
@@ -23,7 +23,7 @@ import (
 )
 
 // ConvertSetData converts the set element data to the appropriate byte representation based on the set data type.
-func ConvertSetData(data *string, dataType *firewallapi.SetDataType) ([]byte, []byte, error) {
+func ConvertSetData(data *string, dataType *firewallapi.SetDataType) (start, end []byte, err error) {
 	if dataType == nil {
 		if data != nil {
 			return nil, nil, fmt.Errorf("set element has data but no data type is specified")

--- a/pkg/firewall/utils/set.go
+++ b/pkg/firewall/utils/set.go
@@ -1,4 +1,4 @@
-// Copyright 2019-2025 The Liqo Authors
+// Copyright 2019-2026 The Liqo Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import (
 	firewallapi "github.com/liqotech/liqo/apis/networking/v1beta1/firewall"
 )
 
+// ConvertSetData converts the set element data to the appropriate byte representation based on the set data type.
 func ConvertSetData(data *string, dataType *firewallapi.SetDataType) ([]byte, []byte, error) {
 	if dataType == nil {
 		if data != nil {
@@ -45,7 +46,7 @@ func ConvertSetData(data *string, dataType *firewallapi.SetDataType) ([]byte, []
 	case firewallapi.SetDataTypeIPCIDR:
 		startIP, endIP, err := GetCIDRRange(*data)
 		if err != nil {
-			return nil, nil, fmt.Errorf("set element has invalid CIDR value %s: %v", *data, err)
+			return nil, nil, fmt.Errorf("set element has invalid CIDR value %s: %w", *data, err)
 		}
 		return startIP.To4(), endIP.To4(), nil
 

--- a/pkg/webhooks/firewallconfiguration/filterrule.go
+++ b/pkg/webhooks/firewallconfiguration/filterrule.go
@@ -15,12 +15,9 @@
 package firewallconfiguration
 
 import (
-	"bytes"
 	"fmt"
-	"net"
 
 	firewallapi "github.com/liqotech/liqo/apis/networking/v1beta1/firewall"
-	fwutils "github.com/liqotech/liqo/pkg/firewall/utils"
 )
 
 func checkFilterRules(rules []firewallapi.FilterRule) error {
@@ -33,11 +30,12 @@ func checkFilterRules(rules []firewallapi.FilterRule) error {
 }
 
 func checkFilterRule(r *firewallapi.FilterRule) error {
+	if r.Name == nil {
+		return fmt.Errorf("filterrule has nil name")
+	}
 	for _, match := range r.Match {
-		if match.IP != nil {
-			if err := checkFilterRuleIPValue(match.IP); err != nil {
-				return fmt.Errorf("filterrule ip value: %w", err)
-			}
+		if err := checkRuleMatch(&match); err != nil {
+			return fmt.Errorf("filterrule %s: %v", *r.Name, err)
 		}
 	}
 
@@ -56,46 +54,4 @@ func checkFilterRuleTCPMssClamp(r *firewallapi.FilterRule) error {
 		}
 	}
 	return fmt.Errorf("tcp mss clamp rule should have a match for tcp protocol")
-}
-
-func checkFilterRuleIPValue(mIP *firewallapi.MatchIP) error {
-	IPValueType, err := fwutils.GetIPValueType(&mIP.Value)
-	if err != nil {
-		return err
-	}
-
-	switch IPValueType {
-	case firewallapi.IPValueTypeIP:
-		if net.ParseIP(mIP.Value) == nil {
-			return fmt.Errorf("invalid IP %s", mIP.Value)
-		}
-	case firewallapi.IPValueTypeSubnet:
-		if _, _, err := net.ParseCIDR(mIP.Value); err != nil {
-			return fmt.Errorf("invalid subnet %s", mIP.Value)
-		}
-	case firewallapi.IPValueTypeRange:
-		if err := checkGranularRangeIP(mIP); err != nil {
-			return fmt.Errorf("invalid range %s", mIP.Value)
-		}
-	default:
-		return fmt.Errorf("invalid IP value type %s", IPValueType)
-	}
-	return nil
-}
-
-func checkGranularRangeIP(mIP *firewallapi.MatchIP) error {
-	addr1, addr2, err := fwutils.GetIPValueRange(mIP.Value)
-	if err != nil {
-		return err
-	}
-
-	if addr1 == nil || addr2 == nil {
-		return fmt.Errorf("missing one of the IPs in range: %s", mIP.Value)
-	}
-
-	if bytes.Compare(addr1, addr2) > 0 {
-		return fmt.Errorf("invalid IP range (start > end): %s", mIP.Value)
-	}
-
-	return nil
 }

--- a/pkg/webhooks/firewallconfiguration/filterrule.go
+++ b/pkg/webhooks/firewallconfiguration/filterrule.go
@@ -20,28 +20,29 @@ import (
 	firewallapi "github.com/liqotech/liqo/apis/networking/v1beta1/firewall"
 )
 
-func checkFilterRules(rules []firewallapi.FilterRule) error {
-	for i := range rules {
-		if err := checkFilterRule(&rules[i]); err != nil {
+func checkFilterRulesInChain(chain *firewallapi.Chain, sets []firewallapi.Set) error {
+	filterRules := chain.Rules.FilterRules
+	for i := range filterRules {
+		if err := checkFilterRule(&filterRules[i], sets); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func checkFilterRule(r *firewallapi.FilterRule) error {
-	if r.Name == nil {
+func checkFilterRule(filterRule *firewallapi.FilterRule, sets []firewallapi.Set) error {
+	if filterRule.Name == nil {
 		return fmt.Errorf("filterrule has nil name")
 	}
-	for _, match := range r.Match {
-		if err := checkRuleMatch(&match); err != nil {
-			return fmt.Errorf("filterrule %s: %v", *r.Name, err)
+	for _, match := range filterRule.Match {
+		if err := checkRuleMatch(&match, sets); err != nil {
+			return fmt.Errorf("filterrule %s: %v", *filterRule.Name, err)
 		}
 	}
 
-	switch r.Action {
+	switch filterRule.Action {
 	case firewallapi.ActionTCPMssClamp:
-		return checkFilterRuleTCPMssClamp(r)
+		return checkFilterRuleTCPMssClamp(filterRule)
 	default:
 		return nil
 	}

--- a/pkg/webhooks/firewallconfiguration/filterrule.go
+++ b/pkg/webhooks/firewallconfiguration/filterrule.go
@@ -36,7 +36,7 @@ func checkFilterRule(filterRule *firewallapi.FilterRule, sets []firewallapi.Set)
 	}
 	for _, match := range filterRule.Match {
 		if err := checkRuleMatch(&match, sets); err != nil {
-			return fmt.Errorf("filterrule %s: %v", *filterRule.Name, err)
+			return fmt.Errorf("filterrule %s: %w", *filterRule.Name, err)
 		}
 	}
 

--- a/pkg/webhooks/firewallconfiguration/firewallconfiguration.go
+++ b/pkg/webhooks/firewallconfiguration/firewallconfiguration.go
@@ -129,6 +129,10 @@ func (w *webhookValidate) Handle(ctx context.Context, req admission.Request) adm
 		return admission.Denied(err.Error())
 	}
 
+	if err := checkSetsInTable(firewallConfiguration.Spec.Table.Sets); err != nil {
+		return admission.Denied(err.Error())
+	}
+
 	for i := range chains {
 		chain := chains[i]
 
@@ -142,11 +146,11 @@ func (w *webhookValidate) Handle(ctx context.Context, req admission.Request) adm
 
 		switch chain.Type {
 		case firewallapi.ChainTypeNAT:
-			if err := checkNatRulesInChain(&chain); err != nil {
+			if err := checkNatRulesInChain(&chain, firewallConfiguration.Spec.Table.Sets); err != nil {
 				return admission.Denied(forgeChainError(&chain, err).Error())
 			}
 		case firewallapi.ChainTypeFilter:
-			if err := checkFilterRules(chain.Rules.FilterRules); err != nil {
+			if err := checkFilterRulesInChain(&chain, firewallConfiguration.Spec.Table.Sets); err != nil {
 				return admission.Denied(forgeChainError(&chain, err).Error())
 			}
 		}

--- a/pkg/webhooks/firewallconfiguration/match.go
+++ b/pkg/webhooks/firewallconfiguration/match.go
@@ -57,7 +57,7 @@ func checkMatchIPValue(mIP *firewallapi.MatchIP, sets []firewallapi.Set) error {
 			return fmt.Errorf("named set %s does not exist", mIP.Value)
 		}
 
-		if matchedSet.KeyType != firewallapi.SetTypeIPAddr {
+		if matchedSet.KeyType != firewallapi.SetDataTypeIPAddr {
 			return fmt.Errorf("named set %s is not of type IP", mIP.Value)
 		}
 	default:

--- a/pkg/webhooks/firewallconfiguration/match.go
+++ b/pkg/webhooks/firewallconfiguration/match.go
@@ -57,7 +57,7 @@ func checkMatchIPValue(mIP *firewallapi.MatchIP, sets []firewallapi.Set) error {
 			return fmt.Errorf("named set %s does not exist", mIP.Value)
 		}
 
-		if matchedSet.KeyType != firewallapi.SetDataTypeIPAddr {
+		if matchedSet.KeyType != firewallapi.SetDataTypeIPAddr && matchedSet.KeyType != firewallapi.SetDataTypeIPCIDR {
 			return fmt.Errorf("named set %s is not of type IP", mIP.Value)
 		}
 	default:

--- a/pkg/webhooks/firewallconfiguration/match.go
+++ b/pkg/webhooks/firewallconfiguration/match.go
@@ -1,4 +1,4 @@
-// Copyright 2019-2025 The Liqo Authors
+// Copyright 2019-2026 The Liqo Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/webhooks/firewallconfiguration/match.go
+++ b/pkg/webhooks/firewallconfiguration/match.go
@@ -1,0 +1,75 @@
+// Copyright 2019-2025 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package firewallconfiguration
+
+import (
+	"bytes"
+	"fmt"
+	"net"
+
+	firewallapi "github.com/liqotech/liqo/apis/networking/v1beta1/firewall"
+	fwutils "github.com/liqotech/liqo/pkg/firewall/utils"
+)
+
+func checkRuleMatch(matchRule *firewallapi.Match) error {
+	if matchRule.IP != nil {
+		if err := checkMatchIPValue(matchRule.IP); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func checkMatchIPValue(mIP *firewallapi.MatchIP) error {
+	IPValueType, err := fwutils.GetIPValueType(&mIP.Value)
+	if err != nil {
+		return err
+	}
+
+	switch IPValueType {
+	case firewallapi.IPValueTypeIP:
+		if net.ParseIP(mIP.Value) == nil {
+			return fmt.Errorf("invalid IP %s", mIP.Value)
+		}
+	case firewallapi.IPValueTypeSubnet:
+		if _, _, err := net.ParseCIDR(mIP.Value); err != nil {
+			return fmt.Errorf("invalid subnet %s", mIP.Value)
+		}
+	case firewallapi.IPValueTypeRange:
+		if err := checkGranularRangeIP(mIP); err != nil {
+			return fmt.Errorf("invalid range %s", mIP.Value)
+		}
+	default:
+		return fmt.Errorf("invalid IP value type %s", IPValueType)
+	}
+	return nil
+}
+
+func checkGranularRangeIP(mIP *firewallapi.MatchIP) error {
+	addr1, addr2, err := fwutils.GetIPValueRange(mIP.Value)
+	if err != nil {
+		return err
+	}
+
+	if addr1 == nil || addr2 == nil {
+		return fmt.Errorf("missing one of the IPs in range: %s", mIP.Value)
+	}
+
+	if bytes.Compare(addr1, addr2) > 0 {
+		return fmt.Errorf("invalid IP range (start > end): %s", mIP.Value)
+	}
+
+	return nil
+}

--- a/pkg/webhooks/firewallconfiguration/natrule.go
+++ b/pkg/webhooks/firewallconfiguration/natrule.go
@@ -29,6 +29,11 @@ func checkNatRulesInChain(chain *firewallapi.Chain) error {
 		if err := checkNatRuleTo(&natrules[i]); err != nil {
 			return err
 		}
+		for _, match := range natrules[i].Match {
+			if err := checkRuleMatch(&match); err != nil {
+				return fmt.Errorf("natrule %s: %v", *natrules[i].Name, err)
+			}
+		}
 	}
 	return nil
 }

--- a/pkg/webhooks/firewallconfiguration/natrule.go
+++ b/pkg/webhooks/firewallconfiguration/natrule.go
@@ -20,7 +20,7 @@ import (
 	firewallapi "github.com/liqotech/liqo/apis/networking/v1beta1/firewall"
 )
 
-func checkNatRulesInChain(chain *firewallapi.Chain) error {
+func checkNatRulesInChain(chain *firewallapi.Chain, sets []firewallapi.Set) error {
 	natrules := chain.Rules.NatRules
 	for i := range natrules {
 		if err := checkNatRuleChainHook(*chain.Hook, &natrules[i]); err != nil {
@@ -30,7 +30,7 @@ func checkNatRulesInChain(chain *firewallapi.Chain) error {
 			return err
 		}
 		for _, match := range natrules[i].Match {
-			if err := checkRuleMatch(&match); err != nil {
+			if err := checkRuleMatch(&match, sets); err != nil {
 				return fmt.Errorf("natrule %s: %v", *natrules[i].Name, err)
 			}
 		}

--- a/pkg/webhooks/firewallconfiguration/natrule.go
+++ b/pkg/webhooks/firewallconfiguration/natrule.go
@@ -31,7 +31,7 @@ func checkNatRulesInChain(chain *firewallapi.Chain, sets []firewallapi.Set) erro
 		}
 		for _, match := range natrules[i].Match {
 			if err := checkRuleMatch(&match, sets); err != nil {
-				return fmt.Errorf("natrule %s: %v", *natrules[i].Name, err)
+				return fmt.Errorf("natrule %s: %w", *natrules[i].Name, err)
 			}
 		}
 	}

--- a/pkg/webhooks/firewallconfiguration/set.go
+++ b/pkg/webhooks/firewallconfiguration/set.go
@@ -59,7 +59,7 @@ func checkSetElements(set *firewallapi.Set) error {
 	for i := range set.Elements {
 		element := set.Elements[i]
 
-		if _, err := firewallutils.ConvertSetData(&element.Key, &set.KeyType); err != nil {
+		if _, _, err := firewallutils.ConvertSetData(&element.Key, &set.KeyType); err != nil {
 			return err
 		}
 
@@ -68,7 +68,7 @@ func checkSetElements(set *firewallapi.Set) error {
 				return fmt.Errorf("set element with key %s has nil data", element.Key)
 			}
 
-			if _, err := firewallutils.ConvertSetData(element.Data, set.DataType); err != nil {
+			if _, _, err := firewallutils.ConvertSetData(element.Data, set.DataType); err != nil {
 				return err
 			}
 		} else {

--- a/pkg/webhooks/firewallconfiguration/set.go
+++ b/pkg/webhooks/firewallconfiguration/set.go
@@ -1,0 +1,82 @@
+// Copyright 2019-2025 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package firewallconfiguration
+
+import (
+	"fmt"
+
+	firewallapi "github.com/liqotech/liqo/apis/networking/v1beta1/firewall"
+	firewallutils "github.com/liqotech/liqo/pkg/firewall/utils"
+)
+
+func checkSetsInTable(sets []firewallapi.Set) error {
+	err := checkUniqueSetNames(sets)
+	if err != nil {
+		return err
+	}
+
+	for i := range sets {
+		if err := checkSetElements(&sets[i]); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func checkUniqueSetNames(sets []firewallapi.Set) error {
+	names := map[string]interface{}{}
+	for i := range sets {
+		name := sets[i].Name
+		if name == "" {
+			return fmt.Errorf("set name is empty")
+		}
+
+		if _, ok := names[name]; ok {
+			return fmt.Errorf("set name %v is duplicated", name)
+		}
+
+		names[name] = nil
+	}
+	return nil
+}
+
+func checkSetElements(set *firewallapi.Set) error {
+	shouldHaveData := set.DataType != nil
+
+	for i := range set.Elements {
+		element := set.Elements[i]
+
+		if _, err := firewallutils.ConvertSetData(&element.Key, &set.KeyType); err != nil {
+			return err
+		}
+
+		if shouldHaveData {
+			if element.Data == nil {
+				return fmt.Errorf("set element with key %s has nil data", element.Key)
+			}
+
+			if _, err := firewallutils.ConvertSetData(element.Data, set.DataType); err != nil {
+				return err
+			}
+		} else {
+			if element.Data != nil {
+				return fmt.Errorf("set element with key %s should not have data", element.Key)
+			}
+		}
+	}
+
+	return nil
+}

--- a/pkg/webhooks/firewallconfiguration/set.go
+++ b/pkg/webhooks/firewallconfiguration/set.go
@@ -1,4 +1,4 @@
-// Copyright 2019-2025 The Liqo Authors
+// Copyright 2019-2026 The Liqo Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -71,10 +71,8 @@ func checkSetElements(set *firewallapi.Set) error {
 			if _, _, err := firewallutils.ConvertSetData(element.Data, set.DataType); err != nil {
 				return err
 			}
-		} else {
-			if element.Data != nil {
-				return fmt.Errorf("set element with key %s should not have data", element.Key)
-			}
+		} else if element.Data != nil {
+			return fmt.Errorf("set element with key %s should not have data", element.Key)
 		}
 	}
 


### PR DESCRIPTION
# Description

This Pull Request (PR) extends the functionality introduced in **PR  #2966** (firewalling rules implementation within `FirewallConfiguration`).

The primary goal of these changes is to enable the creation and utilization of **named sets** within the `FirewallConfiguration` Custom Resource (CR) to support the definition of more complex **nftables** rules. Named sets significantly improve the readability and management of firewall rules, especially when dealing with large lists of IP addresses or other match criteria.

# Changes

## Mandatory Modifications

* **`sets` Field Addition:** The `FirewallConfiguration` CR now includes a new field, `sets`, allowing users to specify a list of sets to be created and used. This includes defining the key and value types for each set (at the moment only `ipv4_addr` is supported).
* **Reconciler Logic Update:** The `FirewallConfiguration` reconciler logic has been updated to handle the **addition, modification, and removal** of these named sets within the firewall configuration.
* **IP Address Matching Update:** The logic for matching IP addresses has been modified to support the use of named sets. Users can now reference a set by writing **`@<set_name>`** in the match value.
* **Webhook Validation:** The validation webhook has been updated to properly validate the defined sets and ensure that set names referenced in match rules are valid and defined.

## Strongly Recommended Modification (Separate Commit)

* A dedicated commit has been introduced to **modify the webhook validation for NAT rules**. This change now enforces the same **IP address match validation** for NAT rules that was already in place for filtering rules, ensuring consistent configuration integrity.

# Example Usage

This example demonstrates how to define and use a named set (`test_set`) containing multiple IPv4 addresses within a `filterRule`.

```yaml
apiVersion: networking.liqo.io/v1beta1
kind: FirewallConfiguration
metadata:
  labels:
    liqo.io/managed: "true"
    networking.liqo.io/firewall-category: gateway
    networking.liqo.io/firewall-subcategory: fabric
  name: test
  namespace: liqo-tenant-milan
spec:
  table:
    name: test_table
    family: IPV4
    # New 'sets' field to define named sets
    sets:
      - name: test_set
        keyType: ipv4_addr
        elements:
          - key: "8.8.8.4"
          - key: "8.8.8.8"
    chains:
      - hook: postrouting
        name: test_chain
        policy: accept
        priority: 99
        type: filter
        rules:
          filterRules:
            - action: drop
              match:
                - ip:
                    # Referencing the named set using @<set_name>
                    value: "@test_set"
                    position: "dst"
                  op: "eq"
```