### PR TITLE
fix: support more key formats

### DIFF
--- a/docs/usage/stateful-applications.md
+++ b/docs/usage/stateful-applications.md
@@ -81,7 +81,7 @@ Where:
 * `$NAMESPACE_NAME` is the name of the namespace where the *PVC* lives in.
 * `$TARGET_NODE_NAME` is the name of the node where the *PVC* will be moved to.
 
-Under the hood, the migration process leverages the Liqo cross-cluster network fabric and the [Restic project](https://restic.net/) to back up the original data in a temporary repository, and then restore it in a brand-new *PVC* forced to be created in the target cluster.
+Under the hood, the migration process leverages the Liqo cross-cluster network fabric and the [Restic project](https://github.com/restic/restic) to back up the original data in a temporary repository, and then restore it in a brand-new *PVC* forced to be created in the target cluster.
 
 ```{warning}
 *Liqo* and *liqoctl* **are not** backup tools. Make sure to properly back up important data before starting the migration process.

--- a/pkg/liqo-controller-manager/authentication/csr.go
+++ b/pkg/liqo-controller-manager/authentication/csr.go
@@ -170,13 +170,24 @@ func checkCSR(csr, publicKey []byte, checkPublicKey bool, commonName, organizati
 			return fmt.Errorf("invalid public key")
 		}
 
-		// Marshal CSR public key to PKIX DER and compare with provided PKIX public key bytes
+		// Parse the provided public key (supports PEM, PKIX DER, or raw Ed25519)
+		parsedPubKey, err := parsePublicKey(publicKey)
+		if err != nil {
+			return fmt.Errorf("failed to parse provided public key: %w", err)
+		}
+
+		// Marshal both keys to PKIX DER for comparison
 		csrPubDER, err := x509.MarshalPKIXPublicKey(x509Csr.PublicKey)
 		if err != nil {
 			return fmt.Errorf("failed to marshal CSR public key: %w", err)
 		}
 
-		if !bytes.Equal(csrPubDER, publicKey) {
+		parsedPubDER, err := x509.MarshalPKIXPublicKey(parsedPubKey)
+		if err != nil {
+			return fmt.Errorf("failed to marshal provided public key: %w", err)
+		}
+
+		if !bytes.Equal(csrPubDER, parsedPubDER) {
 			return fmt.Errorf("invalid public key")
 		}
 	}


### PR DESCRIPTION
## Problem

When establishing peering between clusters, the tenant controller fails with the following error:

```
failed to parse public key: asn1: structure error: tags don't match (16 vs {class:2 tag:29 length:53 isCompound:false})
```

## Cause

The [VerifyNonce](cci:1://file:///Users/cheina/Documents/liqo/liqo/pkg/liqo-controller-manager/authentication/keys.go:134:0-164:1) and [checkCSR](cci:1://file:///Users/cheina/Documents/liqo/liqo/pkg/liqo-controller-manager/authentication/csr.go:147:0-195:1) functions in the authentication module expected public keys to be strictly in PKIX DER-encoded format. An older version of `liqoctl` was storing the public key in a different format, causing the ASN.1 parser to fail.

## Solution

Added a [parsePublicKey](cci:1://file:///Users/cheina/Documents/liqo/liqo/pkg/liqo-controller-manager/authentication/keys.go:111:0-132:1) helper function that attempts to parse the public key from multiple formats:

1. First tries PEM decoding (if the data contains a PEM block)
2. Then tries PKIX DER parsing
3. Falls back to raw Ed25519 public key (32 bytes)

Updated both [VerifyNonce](cci:1://file:///Users/cheina/Documents/liqo/liqo/pkg/liqo-controller-manager/authentication/keys.go:134:0-164:1) and [checkCSR](cci:1://file:///Users/cheina/Documents/liqo/liqo/pkg/liqo-controller-manager/authentication/csr.go:147:0-195:1) functions to use this flexible parsing approach, ensuring backward compatibility with Tenant resources created by older `liqoctl` versions.