### PR TITLE
fix: backward compatibility with ed25519-only keys clusters

### DIFF
--- a/pkg/liqo-controller-manager/authentication/forge/tenant.go
+++ b/pkg/liqo-controller-manager/authentication/forge/tenant.go
@@ -15,6 +15,8 @@
 package forge
 
 import (
+	"encoding/pem"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
@@ -26,8 +28,9 @@ import (
 // TenantForRemoteCluster forges a Tenant resource to be applied on a remote cluster.
 func TenantForRemoteCluster(localClusterID liqov1beta1.ClusterID,
 	publicKey, csr, signature []byte, namespace, proxyURL *string) *authv1beta1.Tenant {
+	pemPubKey := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: publicKey})
 	tenant := Tenant(localClusterID, namespace)
-	MutateTenant(tenant, localClusterID, publicKey, csr, signature, proxyURL)
+	MutateTenant(tenant, localClusterID, pemPubKey, csr, signature, proxyURL)
 
 	return tenant
 }

--- a/pkg/liqo-controller-manager/authentication/keys.go
+++ b/pkg/liqo-controller-manager/authentication/keys.go
@@ -111,13 +111,8 @@ func SignNonce(priv crypto.PrivateKey, nonce []byte) ([]byte, error) {
 
 // VerifyNonce verifies the signature of a nonce using the PKIX-encoded public key bytes of the cluster.
 // The public key can be Ed25519, RSA, or ECDSA.
-func VerifyNonce(pubKeyPKIX, nonce, signature []byte) (bool, error) {
-	pub, err := x509.ParsePKIXPublicKey(pubKeyPKIX)
-	if err != nil {
-		return false, fmt.Errorf("failed to parse public key: %w", err)
-	}
-
-	switch pk := pub.(type) {
+func VerifyNonce(publicKey crypto.PublicKey, nonce, signature []byte) (bool, error) {
+	switch pk := publicKey.(type) {
 	case ed25519.PublicKey:
 		return ed25519.Verify(pk, nonce, signature), nil
 	case *rsa.PublicKey:
@@ -133,7 +128,7 @@ func VerifyNonce(pubKeyPKIX, nonce, signature []byte) (bool, error) {
 		}
 		return false, nil
 	default:
-		return false, fmt.Errorf("unsupported public key type %T", pub)
+		return false, fmt.Errorf("unsupported public key type %T", publicKey)
 	}
 }
 


### PR DESCRIPTION
# Description

This PR fixes the backward compatibility of liqoctl with the clusters using  only ed25519 keys.
When upgrading from 1.0.1 to 1.0.2 and a new resource slice was created, then the controller manager returned an error as the Tenant resource contained a PublicKey with an different format.

This includes:
- Write in the tenant the Public Key in PEM format instead of the raw key bytes
- Fallback to the old ed25519 key parsing if the PEM parsing fails

