### PR TITLE
fix: TolerateNoHandshake ResourceSlice approval

### DIFF
--- a/pkg/liqo-controller-manager/authentication/csr.go
+++ b/pkg/liqo-controller-manager/authentication/csr.go
@@ -130,8 +130,17 @@ func CheckCSRForControlPlane(csr, publicKeyDER []byte, remoteClusterID liqov1bet
 }
 
 // CheckCSRForResourceSlice checks a CSR for a resource slice.
-func CheckCSRForResourceSlice(publicKeyDER []byte, resourceSlice *authv1beta1.ResourceSlice, checkPublicKey bool) error {
-	return checkCSR(resourceSlice.Spec.CSR, publicKeyDER, checkPublicKey,
+func CheckCSRForResourceSlice(tenantPublicKey []byte, resourceSlice *authv1beta1.ResourceSlice, checkPublicKey bool) error {
+	var parsedPublicKey []byte
+	if checkPublicKey {
+		_, parsedPublicKeyDER, err := ParseTenantPublicKey(tenantPublicKey)
+		if err != nil {
+			return fmt.Errorf("failed to parse tenant public key: %w", err)
+		}
+		parsedPublicKey = parsedPublicKeyDER
+	}
+
+	return checkCSR(resourceSlice.Spec.CSR, parsedPublicKey, checkPublicKey,
 		func(x509Csr *x509.CertificateRequest) error {
 			if x509Csr.Subject.CommonName != CommonNameResourceSliceCSR(resourceSlice) {
 				return fmt.Errorf("invalid common name")

--- a/pkg/liqo-controller-manager/authentication/remoteresourceslice-controller/remoteresourceslice_controller.go
+++ b/pkg/liqo-controller-manager/authentication/remoteresourceslice-controller/remoteresourceslice_controller.go
@@ -182,12 +182,7 @@ func (r *RemoteResourceSliceReconciler) handleAuthenticationStatus(ctx context.C
 	// check that the CSR is valid
 	shouldCheckPublicKey := authv1beta1.GetAuthzPolicyValue(tenant.Spec.AuthzPolicy) != authv1beta1.TolerateNoHandshake
 
-	_, publicKeyDER, err := authentication.ParseTenantPublicKey(tenant.Spec.PublicKey)
-	if err != nil {
-		return fmt.Errorf("failed to parse public key in Tenant resource %q: %w", tenant.Name, err)
-	}
-
-	if err := authentication.CheckCSRForResourceSlice(publicKeyDER, resourceSlice, shouldCheckPublicKey); err != nil {
+	if err := authentication.CheckCSRForResourceSlice(tenant.Spec.PublicKey, resourceSlice, shouldCheckPublicKey); err != nil {
 		klog.Errorf("Invalid CSR for the ResourceSlice %q: %s", client.ObjectKeyFromObject(resourceSlice), err)
 		r.eventRecorder.Event(resourceSlice, corev1.EventTypeWarning, "InvalidCSR", err.Error())
 		denyAuthentication(resourceSlice, r.eventRecorder)


### PR DESCRIPTION
# Description

Due to the Tenant public keys refactoring, a bug on the ResourceSlice approval has been introduced when authentication was checked, and the Tenant was configured in TolerateNoHandshake mode. In that case, as the controller tried to parse the empty Tenant public key, it failed.

```
E1217 13:47:29.765056       1 controller.go:353] "Reconciler error" err="failed to parse public key in Tenant resource \"...\": invalid public key format" controller="resourceslice_remote" controllerGroup="authentication.liqo.io"
```
