### PR TITLE
fix: fix a bug that CN should be consumer cluster id

### DIFF
--- a/pkg/liqo-controller-manager/authentication/localrenwer-controller/localrenewer_controller.go
+++ b/pkg/liqo-controller-manager/authentication/localrenwer-controller/localrenewer_controller.go
@@ -268,7 +268,7 @@ func (r *LocalRenewerReconciler) enforceRenew(ctx context.Context, identity *aut
 		switch identity.Spec.Type {
 		case authv1beta1.ControlPlaneIdentityType:
 			// Generate a CSR for the remote cluster.
-			CSR, err := authentication.GenerateCSRForControlPlane(privateKey, identity.Spec.ClusterID)
+			CSR, err := authentication.GenerateCSRForControlPlane(privateKey, r.LocalClusterID)
 			if err != nil {
 				return fmt.Errorf("unable to generate CSR: %w", err)
 			}


### PR DESCRIPTION
# Description

When to generate csr for controlplane identity, the CN used to generate CSR should be the consumer cluster id

Fixes #(issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B
