### PR TITLE
feat: handle creation and configuration of multiple WireGuard tunnels

### DIFF
--- a/apis/networking/v1beta1/gatewayserver_types.go
+++ b/apis/networking/v1beta1/gatewayserver_types.go
@@ -36,16 +36,32 @@ var GatewayServerGroupResource = schema.GroupResource{Group: GroupVersion.Group,
 var GatewayServerGroupVersionResource = GroupVersion.WithResource(GatewayServerResource)
 
 // Endpoint defines the endpoint of the gatewayserver.
+// +kubebuilder:validation:XValidation:rule="!(has(self.port) && has(self.ports))",message="port and ports are mutually exclusive"
+// +kubebuilder:validation:XValidation:rule="!(has(self.nodePort) && has(self.nodePorts))",message="nodePort and nodePorts are mutually exclusive"
+// +kubebuilder:validation:XValidation:rule="has(self.port) || (has(self.ports) && size(self.ports) > 0)",message="at least one of port or ports must be set"
+// +kubebuilder:validation:XValidation:rule="!(has(self.ports)) || self.ports.all(p, self.ports.filter(q, q == p).size() == 1)",message="ports must not contain duplicates"
+// +kubebuilder:validation:XValidation:rule="!(has(self.nodePorts)) || self.nodePorts.all(p, self.nodePorts.filter(q, q == p).size() == 1)",message="nodePorts must not contain duplicates"
+//
+//nolint:lll // ignore long lines given by Kubebuilder marker annotations
 type Endpoint struct {
+	// Deprecated: use Ports instead
 	// Port specifies the port of the endpoint.
 	Port int32 `json:"port,omitempty"`
+	// Ports specifies the ports of the endpoint.
+	// +kubebuilder:validation:MaxItems=64
+	Ports []int32 `json:"ports,omitempty"`
 	// ServiceType specifies the type of the service.
 	// +kubebuilder:default=ClusterIP
 	// +kubebuilder:validation:Enum=ClusterIP;NodePort;LoadBalancer;ExternalName
 	ServiceType corev1.ServiceType `json:"serviceType,omitempty"`
+	// Deprecated: use NodePorts instead
 	// NodePort allocates a static port for the NodePort service.
 	// +optional
 	NodePort *int32 `json:"nodePort,omitempty"`
+	// NodePorts allocates a list of static ports for the NodePort service.
+	// +optional
+	// +kubebuilder:validation:MaxItems=64
+	NodePorts []int32 `json:"nodePorts,omitempty"`
 	// LoadBalancerIP override the LoadBalancer IP to use a specific IP address (e.g., static LB). It is used only if service type is LoadBalancer.
 	// LoadBalancer provider must support this feature.
 	// +optional
@@ -74,14 +90,23 @@ type GatewayServerSpec struct {
 }
 
 // EndpointStatus defines the observed state of the endpoint.
+// +kubebuilder:validation:XValidation:rule="!(has(self.port) && has(self.ports))",message="port and ports are mutually exclusive"
+// +kubebuilder:validation:XValidation:rule="has(self.port) || (has(self.ports) && size(self.ports) > 0)",message="at least one of port or ports must be set"
+// +kubebuilder:validation:XValidation:rule="!(has(self.ports)) || self.ports.all(p, self.ports.filter(q, q == p).size() == 1)",message="ports must not contain duplicates"
+//
+//nolint:lll // ignore long lines given by Kubebuilder marker annotations
 type EndpointStatus struct {
 	// Addresses specifies the addresses of the endpoint.
 	Addresses []string `json:"addresses,omitempty"`
+	// Deprecated: use Ports instead
 	// Port specifies the port of the endpoint.
 	Port int32 `json:"port,omitempty"`
 	// Protocol specifies the protocol of the endpoint.
 	// +kubebuilder:validation:Enum=TCP;UDP
 	Protocol *corev1.Protocol `json:"protocol,omitempty"`
+	// Ports specifies the ports of the endpoint.
+	// +kubebuilder:validation:MaxItems=64
+	Ports []int32 `json:"ports,omitempty"`
 }
 
 // InternalGatewayEndpoint defines the endpoint for the internal network.

--- a/cmd/gateway/wireguard/main.go
+++ b/cmd/gateway/wireguard/main.go
@@ -148,10 +148,18 @@ func run(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("unable to load keys: %w", err)
 	}
 
-	// Create the wg-liqo interface and init the wireguard configuration depending on the mode (client/server).
-	if err := wireguard.InitWireguardLink(cmd.Context(), options); err != nil {
-		return fmt.Errorf("unable to init wireguard link: %w", err)
+	// Get interface list
+	ports, err := wireguard.GetWireguardPorts(options)
+	if err != nil {
+		return fmt.Errorf("failed to parse wireguard ports: %w", err)
 	}
+	// Create the wg-liqo interface and init the wireguard configuration depending on the mode (client/server).
+	for i := range ports {
+		if err := wireguard.InitWireguardLink(cmd.Context(), options, i); err != nil {
+			return fmt.Errorf("failed to create WireGuard interface %d/%d: %w", i+1, len(ports), err)
+		}
+	}
+	klog.Infof("Successfully setup %d WireGuard interfaces", len(ports))
 
 	// Create the Prometheus collector and register it inside the controller-runtime metrics server.
 	promcollect, err := wireguard.NewPrometheusCollector(mgr.GetClient(), &wireguard.MetricsOptions{

--- a/deployments/liqo/charts/liqo-crds/crds/networking.liqo.io_gatewayclients.yaml
+++ b/deployments/liqo/charts/liqo-crds/crds/networking.liqo.io_gatewayclients.yaml
@@ -127,9 +127,18 @@ spec:
                       type: string
                     type: array
                   port:
-                    description: Port specifies the port of the endpoint.
+                    description: |-
+                      Deprecated: use Ports instead
+                      Port specifies the port of the endpoint.
                     format: int32
                     type: integer
+                  ports:
+                    description: Ports specifies the ports of the endpoint.
+                    items:
+                      format: int32
+                      type: integer
+                    maxItems: 64
+                    type: array
                   protocol:
                     description: Protocol specifies the protocol of the endpoint.
                     enum:
@@ -137,6 +146,14 @@ spec:
                     - UDP
                     type: string
                 type: object
+                x-kubernetes-validations:
+                - message: port and ports are mutually exclusive
+                  rule: '!(has(self.port) && has(self.ports))'
+                - message: at least one of port or ports must be set
+                  rule: has(self.port) || (has(self.ports) && size(self.ports) > 0)
+                - message: ports must not contain duplicates
+                  rule: '!(has(self.ports)) || self.ports.all(p, self.ports.filter(q,
+                    q == p).size() == 1)'
               mtu:
                 description: MTU specifies the MTU of the tunnel.
                 type: integer

--- a/deployments/liqo/charts/liqo-crds/crds/networking.liqo.io_gatewayservers.yaml
+++ b/deployments/liqo/charts/liqo-crds/crds/networking.liqo.io_gatewayservers.yaml
@@ -83,14 +83,32 @@ spec:
                       LoadBalancer provider must support this feature.
                     type: string
                   nodePort:
-                    description: NodePort allocates a static port for the NodePort
-                      service.
+                    description: |-
+                      Deprecated: use NodePorts instead
+                      NodePort allocates a static port for the NodePort service.
                     format: int32
                     type: integer
+                  nodePorts:
+                    description: NodePorts allocates a list of static ports for the
+                      NodePort service.
+                    items:
+                      format: int32
+                      type: integer
+                    maxItems: 64
+                    type: array
                   port:
-                    description: Port specifies the port of the endpoint.
+                    description: |-
+                      Deprecated: use Ports instead
+                      Port specifies the port of the endpoint.
                     format: int32
                     type: integer
+                  ports:
+                    description: Ports specifies the ports of the endpoint.
+                    items:
+                      format: int32
+                      type: integer
+                    maxItems: 64
+                    type: array
                   serviceType:
                     default: ClusterIP
                     description: ServiceType specifies the type of the service.
@@ -101,6 +119,19 @@ spec:
                     - ExternalName
                     type: string
                 type: object
+                x-kubernetes-validations:
+                - message: port and ports are mutually exclusive
+                  rule: '!(has(self.port) && has(self.ports))'
+                - message: nodePort and nodePorts are mutually exclusive
+                  rule: '!(has(self.nodePort) && has(self.nodePorts))'
+                - message: at least one of port or ports must be set
+                  rule: has(self.port) || (has(self.ports) && size(self.ports) > 0)
+                - message: ports must not contain duplicates
+                  rule: '!(has(self.ports)) || self.ports.all(p, self.ports.filter(q,
+                    q == p).size() == 1)'
+                - message: nodePorts must not contain duplicates
+                  rule: '!(has(self.nodePorts)) || self.nodePorts.all(p, self.nodePorts.filter(q,
+                    q == p).size() == 1)'
               mtu:
                 description: MTU specifies the MTU of the tunnel.
                 type: integer
@@ -191,9 +222,18 @@ spec:
                       type: string
                     type: array
                   port:
-                    description: Port specifies the port of the endpoint.
+                    description: |-
+                      Deprecated: use Ports instead
+                      Port specifies the port of the endpoint.
                     format: int32
                     type: integer
+                  ports:
+                    description: Ports specifies the ports of the endpoint.
+                    items:
+                      format: int32
+                      type: integer
+                    maxItems: 64
+                    type: array
                   protocol:
                     description: Protocol specifies the protocol of the endpoint.
                     enum:
@@ -201,6 +241,14 @@ spec:
                     - UDP
                     type: string
                 type: object
+                x-kubernetes-validations:
+                - message: port and ports are mutually exclusive
+                  rule: '!(has(self.port) && has(self.ports))'
+                - message: at least one of port or ports must be set
+                  rule: has(self.port) || (has(self.ports) && size(self.ports) > 0)
+                - message: ports must not contain duplicates
+                  rule: '!(has(self.ports)) || self.ports.all(p, self.ports.filter(q,
+                    q == p).size() == 1)'
               internalEndpoint:
                 description: InternalEndpoint specifies the endpoint for the internal
                   network.

--- a/deployments/liqo/charts/liqo-crds/crds/networking.liqo.io_wggatewayservers.yaml
+++ b/deployments/liqo/charts/liqo-crds/crds/networking.liqo.io_wggatewayservers.yaml
@@ -10444,9 +10444,18 @@ spec:
                       type: string
                     type: array
                   port:
-                    description: Port specifies the port of the endpoint.
+                    description: |-
+                      Deprecated: use Ports instead
+                      Port specifies the port of the endpoint.
                     format: int32
                     type: integer
+                  ports:
+                    description: Ports specifies the ports of the endpoint.
+                    items:
+                      format: int32
+                      type: integer
+                    maxItems: 64
+                    type: array
                   protocol:
                     description: Protocol specifies the protocol of the endpoint.
                     enum:
@@ -10454,6 +10463,14 @@ spec:
                     - UDP
                     type: string
                 type: object
+                x-kubernetes-validations:
+                - message: port and ports are mutually exclusive
+                  rule: '!(has(self.port) && has(self.ports))'
+                - message: at least one of port or ports must be set
+                  rule: has(self.port) || (has(self.ports) && size(self.ports) > 0)
+                - message: ports must not contain duplicates
+                  rule: '!(has(self.ports)) || self.ports.all(p, self.ports.filter(q,
+                    q == p).size() == 1)'
               internalEndpoint:
                 description: InternalEndpoint specifies the endpoint for the internal
                   network.

--- a/deployments/liqo/templates/liqo-wireguard-gateway-client-template.yaml
+++ b/deployments/liqo/templates/liqo-wireguard-gateway-client-template.yaml
@@ -94,6 +94,7 @@ spec:
                 {{- end }}
                 - --enable-nft-monitor={{ .Values.networking.gatewayTemplates.nftablesMonitor }}
                 - --enable-route-monitor={{ .Values.networking.gatewayTemplates.routeMonitor }}
+                - --enable-multipath-hash-policy={{ printf "{{ if gt (len .Spec.Endpoint.Ports) 1 }}true{{ else }}false{{ end }}" }}
                 volumeMounts:
                 - name: ipc
                   mountPath: /ipc
@@ -141,7 +142,7 @@ spec:
                 - --container-name=wireguard
                 - --mtu={{"{{ .Spec.MTU }}"}}
                 - --endpoint-address={{"{{ index .Spec.Endpoint.Addresses 0 }}"}}
-                - --endpoint-port={{"{{ .Spec.Endpoint.Port }}"}}
+                - --endpoint-ports={{ printf "{{ if .Spec.Endpoint.Ports }}{{ range $i, $p := .Spec.Endpoint.Ports }}{{ if $i }},{{ end }}{{ $p }}{{ end }}{{ else }}{{ .Spec.Endpoint.Port }}{{ end }}" }}
                 {{- if .Values.metrics.enabled }}
                 - --metrics-address=:8084
                 {{- end }}
@@ -170,6 +171,7 @@ spec:
                     add:
                     - NET_ADMIN
                     - NET_RAW
+                    - "{{ "{{ if gt (len .Spec.Endpoint.Ports) 1 }}SYS_ADMIN{{ else }}NET_RAW{{ end }}" }}"
                   {{ if .Values.networking.gatewayTemplates.wireguard.implementation | eq "userspace" }}
                   privileged: true
                   {{ end }}

--- a/deployments/liqo/templates/liqo-wireguard-gateway-server-template.yaml
+++ b/deployments/liqo/templates/liqo-wireguard-gateway-server-template.yaml
@@ -114,6 +114,7 @@ spec:
                 {{- end }}
                 - --enable-nft-monitor={{ .Values.networking.gatewayTemplates.nftablesMonitor }}
                 - --enable-route-monitor={{ .Values.networking.gatewayTemplates.routeMonitor }}
+                - --enable-multipath-hash-policy={{ printf "{{ if gt (len .Spec.Endpoint.Ports) 1 }}true{{ else }}false{{ end }}" }}
                 volumeMounts:
                 - name: ipc
                   mountPath: /ipc
@@ -160,7 +161,7 @@ spec:
                 - --mode=server
                 - --container-name=wireguard
                 - --mtu={{"{{ .Spec.MTU }}"}}
-                - --listen-port={{"{{ .Spec.Endpoint.Port }}"}}
+                - --listen-ports={{ printf "{{ if .Spec.Endpoint.Ports }}{{ range $i, $p := .Spec.Endpoint.Ports }}{{ if $i }},{{ end }}{{ $p }}{{ end }}{{ else }}{{ .Spec.Endpoint.Port }}{{ end }}" }}
                 {{- if .Values.metrics.enabled }}
                 - --metrics-address=:8084
                 {{- end }}
@@ -190,6 +191,7 @@ spec:
                     add:
                     - NET_ADMIN
                     - NET_RAW
+                    - "{{ "{{ if gt (len .Spec.Endpoint.Ports) 1 }}SYS_ADMIN{{ else }}NET_RAW{{ end }}" }}"
                   {{ if .Values.networking.gatewayTemplates.wireguard.implementation | eq "userspace" }}
                   privileged: true
                   {{ end }}

--- a/pkg/gateway/tunnel/netlink.go
+++ b/pkg/gateway/tunnel/netlink.go
@@ -23,10 +23,24 @@ import (
 )
 
 const (
-	// ServerInterfaceIP is the IP address of the Wireguard interface in server mode.
-	ServerInterfaceIP = "169.254.18.1/30"
-	// ClientInterfaceIP is the IP address of the Wireguard interface in client mode.
-	ClientInterfaceIP = "169.254.18.2/30"
+	// wireguardNetworkBase is the base prefix of the /24 subnet reserved for Wireguard interfaces (169.254.18.0/24).
+	// Each tunnel is assigned a /30 block within this subnet.
+	wireguardNetworkBase = "169.254.18"
+	// serverOctetOffset is the offset of the server IP within each /30 block.
+	serverOctetOffset = 1
+	// clientOctetOffset is the offset of the client IP within each /30 block.
+	clientOctetOffset = 2
+	// subnetSize is the number of addresses in each /30 block, used to compute per-tunnel IP offsets.
+	subnetSize = 4
+	// MaxWireguardInterfaces is the maximum number of Wireguard interfaces that can be created,
+	// derived from the available /30 blocks in the 169.254.18.0/24 subnet.
+	MaxWireguardInterfaces = 64
+	// ServerInterfaceIP (169.254.18.1/30) is the IP address of the Wireguard interface
+	// in server mode for tunnel index 0.
+	ServerInterfaceIP = wireguardNetworkBase + ".1/30"
+	// ClientInterfaceIP (169.254.18.2/30) is the IP address of the Wireguard interface
+	// in client mode for tunnel index 0.
+	ClientInterfaceIP = wireguardNetworkBase + ".2/30"
 )
 
 // AddAddress adds an IP address to the Wireguard interface.
@@ -45,14 +59,29 @@ func GetLink(name string) (netlink.Link, error) {
 }
 
 // GetInterfaceIP returns the IP address of the Wireguard interface.
-func GetInterfaceIP(mode gateway.Mode) string {
+func GetInterfaceIP(mode gateway.Mode, idx int) string {
+	var fourthOctet int
+
 	switch mode {
 	case gateway.ModeServer:
-		return ServerInterfaceIP
+		fourthOctet = (subnetSize * idx) + serverOctetOffset
+
 	case gateway.ModeClient:
-		return ClientInterfaceIP
+		fourthOctet = (subnetSize * idx) + clientOctetOffset
+
+	default:
+		return ""
 	}
-	return ""
+
+	return fmt.Sprintf("%s.%d/30", wireguardNetworkBase, fourthOctet)
+}
+
+// GetTunnelName returns the name of the Wireguard interface for the given index.
+func GetTunnelName(idx int) string {
+	if idx == 0 {
+		return TunnelInterfaceName
+	}
+	return fmt.Sprintf("%s%d", TunnelInterfaceName, idx)
 }
 
 // GetRemoteInterfaceIP returns the IP address of the remote Wireguard interface.

--- a/pkg/gateway/tunnel/wireguard/device.go
+++ b/pkg/gateway/tunnel/wireguard/device.go
@@ -30,7 +30,7 @@ import (
 
 var errWgEndpointPeerNotFound = errors.New("wg endpoint peer not found")
 
-func configureDevice(wgcl *wgctrl.Client, options *Options, peerPubKey wgtypes.Key) error {
+func configureDevice(wgcl *wgctrl.Client, options *Options, peerPubKey wgtypes.Key, idx int) error {
 	confdev := wgtypes.Config{
 		PrivateKey: &options.PrivateKey,
 		ListenPort: nil,
@@ -42,12 +42,13 @@ func configureDevice(wgcl *wgctrl.Client, options *Options, peerPubKey wgtypes.K
 		},
 		ReplacePeers: true,
 	}
+	name := tunnel.GetTunnelName(idx)
 
 	switch options.GwOptions.Mode {
 	case gateway.ModeServer:
-		confdev.ListenPort = &options.ListenPort
+		confdev.ListenPort = &options.ListenPorts[idx]
 		if options.PreserveClientEndpoint {
-			endpoint, err := getExistingPeerEndpoint(wgcl, peerPubKey)
+			endpoint, err := getExistingPeerEndpoint(wgcl, peerPubKey, name)
 			switch {
 			case err == nil:
 				klog.Infof("Found existing endpoint %s for current peer. Re-using it.", endpoint.String())
@@ -61,20 +62,20 @@ func configureDevice(wgcl *wgctrl.Client, options *Options, peerPubKey wgtypes.K
 	case gateway.ModeClient:
 		confdev.Peers[0].Endpoint = &net.UDPAddr{
 			IP:   options.EndpointIP,
-			Port: options.EndpointPort,
+			Port: options.EndpointPorts[idx],
 		}
 	}
 
-	if err := wgcl.ConfigureDevice(tunnel.TunnelInterfaceName, confdev); err != nil {
-		return fmt.Errorf("an error occurred while configuring the device: %w", err)
+	if err := wgcl.ConfigureDevice(name, confdev); err != nil {
+		return fmt.Errorf("configuring the device %q: %w", name, err)
 	}
-	klog.Infof("Device %s configured", tunnel.TunnelInterfaceName)
+	klog.Infof("Device %s configured", name)
 
 	return nil
 }
 
-func getExistingPeerEndpoint(wgcl *wgctrl.Client, peerPubKey wgtypes.Key) (*net.UDPAddr, error) {
-	peer, err := getExistingPeer(wgcl, peerPubKey)
+func getExistingPeerEndpoint(wgcl *wgctrl.Client, peerPubKey wgtypes.Key, name string) (*net.UDPAddr, error) {
+	peer, err := getExistingPeer(wgcl, peerPubKey, name)
 	if err != nil {
 		return nil, fmt.Errorf("getting existing peer: %w", err)
 	}
@@ -84,8 +85,8 @@ func getExistingPeerEndpoint(wgcl *wgctrl.Client, peerPubKey wgtypes.Key) (*net.
 	return peer.Endpoint, nil
 }
 
-func getExistingPeer(wgcl *wgctrl.Client, peerPubKey wgtypes.Key) (*wgtypes.Peer, error) {
-	dev, err := getExistingDevice(wgcl)
+func getExistingPeer(wgcl *wgctrl.Client, peerPubKey wgtypes.Key, name string) (*wgtypes.Peer, error) {
+	dev, err := getExistingDevice(wgcl, name)
 	if err != nil {
 		return nil, fmt.Errorf("getting existing device: %w", err)
 	}
@@ -97,11 +98,11 @@ func getExistingPeer(wgcl *wgctrl.Client, peerPubKey wgtypes.Key) (*wgtypes.Peer
 	return nil, fmt.Errorf("no matching peer: %w", errWgEndpointPeerNotFound)
 }
 
-func getExistingDevice(wgcl *wgctrl.Client) (*wgtypes.Device, error) {
-	dev, err := wgcl.Device(tunnel.TunnelInterfaceName)
+func getExistingDevice(wgcl *wgctrl.Client, name string) (*wgtypes.Device, error) {
+	dev, err := wgcl.Device(name)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return nil, fmt.Errorf("device %s not found: %w", tunnel.TunnelInterfaceName, errWgEndpointPeerNotFound)
+			return nil, fmt.Errorf("device %s not found: %w", name, errWgEndpointPeerNotFound)
 		}
 		return nil, fmt.Errorf("fetching device: %w", err)
 	}

--- a/pkg/gateway/tunnel/wireguard/flags.go
+++ b/pkg/gateway/tunnel/wireguard/flags.go
@@ -34,14 +34,14 @@ func (fn FlagName) String() string {
 const (
 	// FlagNameMTU is the MTU for the wireguard interface.
 	FlagNameMTU FlagName = "mtu"
-	// FlagNameListenPort is the listen port for the wireguard interface.
-	FlagNameListenPort FlagName = "listen-port"
+	// FlagNameListenPorts is the list of listen ports for the WireGuard interface.
+	FlagNameListenPorts FlagName = "listen-ports"
 	// FlagNameInterfaceIP is the IP of the wireguard interface.
 	FlagNameInterfaceIP FlagName = "interface-ip"
 	// FlagNameEndpointAddress is the address of the endpoint for the wireguard interface.
 	FlagNameEndpointAddress FlagName = "endpoint-address"
-	// FlagNameEndpointPort is the port of the endpoint for the wireguard interface.
-	FlagNameEndpointPort FlagName = "endpoint-port"
+	// FlagNameEndpointPorts is the list of endpoint ports for the WireGuard interface.
+	FlagNameEndpointPorts FlagName = "endpoint-ports"
 	// FlagNameKeysDir is the directory where the keys are stored.
 	FlagNameKeysDir FlagName = "keys-dir"
 
@@ -62,9 +62,9 @@ var ClientRequiredFlags = []FlagName{
 // InitFlags initializes the flags for the wireguard tunnel.
 func InitFlags(flagset *pflag.FlagSet, opts *Options) {
 	flagset.IntVar(&opts.MTU, FlagNameMTU.String(), forge.DefaultMTU, "MTU for the interface")
-	flagset.IntVar(&opts.ListenPort, FlagNameListenPort.String(), forge.DefaultGwServerPort, "Listen port (server only)")
+	flagset.IntSliceVar(&opts.ListenPorts, FlagNameListenPorts.String(), []int{forge.DefaultGwServerPort}, "List of listen ports (server only)")
 	flagset.StringVar(&opts.EndpointAddress, FlagNameEndpointAddress.String(), "", "Endpoint address (client only)")
-	flagset.IntVar(&opts.EndpointPort, FlagNameEndpointPort.String(), forge.DefaultGwServerPort, "Endpoint port (client only)")
+	flagset.IntSliceVar(&opts.EndpointPorts, FlagNameEndpointPorts.String(), []int{forge.DefaultGwServerPort}, "List of endpoint ports (client only)")
 	flagset.StringVar(&opts.KeysDir, FlagNameKeysDir.String(), forge.DefaultKeysDir, "Directory where the keys are stored")
 
 	flagset.DurationVar(&opts.DNSCheckInterval, FlagNameDNSCheckInterval.String(), 5*time.Minute, "Interval between two DNS checks")

--- a/pkg/gateway/tunnel/wireguard/netlink.go
+++ b/pkg/gateway/tunnel/wireguard/netlink.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/vishvananda/netlink"
 	"golang.zx2c4.com/wireguard/conn"
@@ -30,65 +31,68 @@ import (
 
 	"github.com/liqotech/liqo/pkg/gateway"
 	"github.com/liqotech/liqo/pkg/gateway/tunnel"
+	"github.com/liqotech/liqo/pkg/utils/kernel"
 )
 
 // InitWireguardLink inits the Wireguard interface.
-func InitWireguardLink(ctx context.Context, options *Options) error {
-	exists, err := existsLink()
+func InitWireguardLink(ctx context.Context, options *Options, idx int) error {
+	name := tunnel.GetTunnelName(idx)
+	exists, err := existsLink(name)
 	if err != nil {
-		return fmt.Errorf("cannot check if Wireguard interface exists: %w", err)
+		return fmt.Errorf("checking if Wireguard interface %q exists: %w", name, err)
 	}
 	if exists {
-		klog.Infof("Wireguard interface %q already exists", tunnel.TunnelInterfaceName)
+		klog.Infof("Wireguard interface %q already exists", name)
 		return nil
 	}
 
-	if err := createLink(ctx, options); err != nil {
-		return fmt.Errorf("cannot create Wireguard interface: %w", err)
+	if err := createLink(ctx, options, idx); err != nil {
+		return fmt.Errorf("creating Wireguard interface %q: %w", name, err)
 	}
 
-	link, err := tunnel.GetLink(tunnel.TunnelInterfaceName)
+	link, err := tunnel.GetLink(name)
 	if err != nil {
-		return fmt.Errorf("cannot get Wireguard interface: %w", err)
+		return fmt.Errorf("getting Wireguard interface %q: %w", name, err)
 	}
 
-	klog.Infof("Setting up Wireguard interface %q with IP %q", tunnel.TunnelInterfaceName, tunnel.GetInterfaceIP(options.GwOptions.Mode))
-	if err := tunnel.AddAddress(link, tunnel.GetInterfaceIP(options.GwOptions.Mode)); err != nil {
+	klog.Infof("Setting up Wireguard interface %q with IP %q", name, tunnel.GetInterfaceIP(options.GwOptions.Mode, idx))
+	if err := tunnel.AddAddress(link, tunnel.GetInterfaceIP(options.GwOptions.Mode, idx)); err != nil {
 		return err
 	}
 
 	return netlink.LinkSetUp(link)
 }
 
-// CreateLink creates a new Wireguard interface.
-func createLink(ctx context.Context, options *Options) error {
+// createLink creates a new Wireguard interface.
+func createLink(ctx context.Context, options *Options, idx int) error {
 	var err error
+	name := tunnel.GetTunnelName(idx)
 	klog.Infof("Selected wireguard %s implementation", options.Implementation)
 
 	switch options.Implementation {
 	case WgImplementationKernel:
-		err = createLinkKernel(options)
+		err = createLinkKernel(options, name)
 	case WgImplementationUserspace:
-		err = createLinkUserspace(ctx, options)
+		err = createLinkUserspace(ctx, options, name)
 	default:
 		err = fmt.Errorf("invalid wireguard implementation: %s", options.Implementation)
 	}
 
 	if err != nil {
-		return fmt.Errorf("cannot create Wireguard interface: %w", err)
+		return fmt.Errorf("cannot create Wireguard interface %q: %w", name, err)
 	}
 
 	if options.GwOptions.Mode == gateway.ModeServer {
 		wgcl, err := wgctrl.New()
 		if err != nil {
-			return fmt.Errorf("cannot create Wireguard client: %w", err)
+			return fmt.Errorf("cannot create Wireguard client (interface %q): %w", name, err)
 		}
 		defer wgcl.Close()
 
-		if err := wgcl.ConfigureDevice(tunnel.TunnelInterfaceName, wgtypes.Config{
-			ListenPort: &options.ListenPort,
+		if err := wgcl.ConfigureDevice(name, wgtypes.Config{
+			ListenPort: &options.ListenPorts[idx],
 		}); err != nil {
-			return fmt.Errorf("cannot configure Wireguard interface: %w", err)
+			return fmt.Errorf("cannot configure Wireguard interface %q: %w", name, err)
 		}
 	}
 
@@ -96,32 +100,32 @@ func createLink(ctx context.Context, options *Options) error {
 }
 
 // createLinkKernel creates a new Wireguard interface using the kernel module.
-func createLinkKernel(options *Options) error {
+func createLinkKernel(options *Options, name string) error {
 	link := netlink.Wireguard{
 		LinkAttrs: netlink.LinkAttrs{
 			MTU:  options.MTU,
-			Name: tunnel.TunnelInterfaceName,
+			Name: name,
 		},
 	}
 
 	err := netlink.LinkAdd(&link)
 	if err != nil {
-		return fmt.Errorf("cannot add Wireguard interface: %w", err)
+		return fmt.Errorf("getting Wireguard interface %q: %w", name, err)
 	}
 	return nil
 }
 
 // createLinkUserspace creates a new Wireguard interface using the userspace implementation (wireguard-go)
 // embedded as a library. The device is kept running in-process for the lifetime of the gateway.
-func createLinkUserspace(ctx context.Context, options *Options) error {
+func createLinkUserspace(ctx context.Context, options *Options, intName string) error {
 	mtu := options.MTU
 	if mtu <= 0 {
 		mtu = device.DefaultMTU
 	}
 
-	tunDev, err := tun.CreateTUN(tunnel.TunnelInterfaceName, mtu)
+	tunDev, err := tun.CreateTUN(intName, mtu)
 	if err != nil {
-		return fmt.Errorf("failed to create wireguard TUN device %q: %w", tunnel.TunnelInterfaceName, err)
+		return fmt.Errorf("creating wireguard TUN device %q: %w", intName, err)
 	}
 
 	name, err := tunDev.Name()
@@ -174,8 +178,8 @@ func createLinkUserspace(ctx context.Context, options *Options) error {
 	return nil
 }
 
-func existsLink() (bool, error) {
-	_, err := tunnel.GetLink(tunnel.TunnelInterfaceName)
+func existsLink(name string) (bool, error) {
+	_, err := tunnel.GetLink(name)
 	if err != nil {
 		if errors.As(err, &netlink.LinkNotFoundError{}) {
 			return false, nil
@@ -183,4 +187,65 @@ func existsLink() (bool, error) {
 		return false, err
 	}
 	return true, nil
+}
+
+// GetWireguardPorts returns the list of ports to be used for WireGuard interfaces.
+// The number of ports must not exceed tunnel.MaxWireguardInterfaces, otherwise an error is returned.
+func GetWireguardPorts(opts *Options) ([]int, error) {
+	var ports []int
+
+	switch opts.GwOptions.Mode {
+	case gateway.ModeClient:
+		ports = opts.EndpointPorts
+	case gateway.ModeServer:
+		ports = opts.ListenPorts
+	default:
+		return nil, fmt.Errorf("invalid mode %v", opts.GwOptions.Mode)
+	}
+	if len(ports) > tunnel.MaxWireguardInterfaces {
+		return nil, fmt.Errorf("requested %d WireGuard interfaces, maximum allowed is %d", len(ports), tunnel.MaxWireguardInterfaces)
+	}
+
+	return ports, nil
+}
+
+// EnsureThreadedNAPI enables threaded NAPI for all WireGuard interfaces.
+// Retry up to maxNAPIAttempts times per interface to handle transient failures.
+func EnsureThreadedNAPI(interfaces int) error {
+	if err := kernel.IsThreadedNAPISupported(tunnel.GetTunnelName(0)); err != nil {
+		return fmt.Errorf("checking kernel support: %w", err)
+	}
+
+	if err := kernel.RemountSysfsRW(); err != nil {
+		return fmt.Errorf("remounting sysfs as R/W: %w", err)
+	}
+	defer kernel.RemountSysfsRO()
+
+	for i := range interfaces {
+		name := tunnel.GetTunnelName(i)
+
+		var err error
+		for attempt := range maxNAPIAttempts {
+			if attempt > 0 {
+				time.Sleep(time.Duration(attempt) * napiBackoffBase)
+			}
+			var changed bool
+			changed, err = kernel.EnableWireguardThreadedMode(name)
+			if err == nil {
+				if changed {
+					klog.Infof("threaded NAPI enabled for interface %s (attempt %d/%d)", name, attempt+1, maxNAPIAttempts)
+				} else {
+					klog.Infof("threaded NAPI already enabled for interface %s", name)
+				}
+				break
+			}
+			klog.Infof("unable to enable threaded NAPI for interface %s (attempt %d/%d): %v", name, attempt+1, maxNAPIAttempts, err)
+		}
+
+		if err != nil {
+			return fmt.Errorf("configuring interface %s failed after %d attempts: %w", name, maxNAPIAttempts, err)
+		}
+	}
+
+	return nil
 }

--- a/pkg/gateway/tunnel/wireguard/options.go
+++ b/pkg/gateway/tunnel/wireguard/options.go
@@ -61,13 +61,19 @@ func (wgi WgImplementation) Type() string {
 type Options struct {
 	GwOptions *gateway.Options
 
-	MTU             int
-	PrivateKey      wgtypes.Key
-	InterfaceIP     string
-	ListenPort      int
+	MTU         int
+	PrivateKey  wgtypes.Key
+	InterfaceIP string
+
+	// ListenPorts is the list of ports used by the multi-tunnel WireGuard server.
+	ListenPorts []int
+
 	EndpointAddress string
-	EndpointPort    int
-	KeysDir         string
+
+	// EndpointPorts is the list of ports used by the multi-tunnel WireGuard client.
+	EndpointPorts []int
+
+	KeysDir string
 
 	EndpointIP      net.IP
 	EndpointIPMutex *sync.Mutex

--- a/pkg/gateway/tunnel/wireguard/publickeys_controller.go
+++ b/pkg/gateway/tunnel/wireguard/publickeys_controller.go
@@ -17,6 +17,7 @@ package wireguard
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"golang.zx2c4.com/wireguard/wgctrl"
 	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
@@ -33,6 +34,13 @@ import (
 	networkingv1beta1 "github.com/liqotech/liqo/apis/networking/v1beta1"
 	"github.com/liqotech/liqo/pkg/consts"
 	"github.com/liqotech/liqo/pkg/gateway"
+)
+
+const (
+	// maxNAPIAttempts defines the maximum number of retries to enable threaded NAPI on each interface.
+	maxNAPIAttempts = 3
+	// napiBackoffBase is the baseline duration to wait between retry attempts.
+	napiBackoffBase = 200 * time.Millisecond
 )
 
 // cluster-role
@@ -78,11 +86,23 @@ func (r *PublicKeysReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		klog.Warning("EndpointIP is not set yet. Maybe the DNS resolution is still in progress")
 		return ctrl.Result{}, nil
 	}
-
-	if err := configureDevice(r.Wgcl, r.Options, wgtypes.Key(publicKey.Spec.PublicKey)); err != nil {
-		return ctrl.Result{}, err
+	// Get interface list
+	ports, err := GetWireguardPorts(r.Options)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("parsing wireguard ports: %w", err)
+	}
+	for i := range ports {
+		if err := configureDevice(r.Wgcl, r.Options, wgtypes.Key(publicKey.Spec.PublicKey), i); err != nil {
+			return ctrl.Result{}, fmt.Errorf("configuring interface %d: %w", i, err)
+		}
 	}
 
+	// Enable threaded NAPI on kernel WireGuard interfaces only when running more than one tunnel.
+	if len(ports) > 1 && r.Options.Implementation == WgImplementationKernel {
+		if err := EnsureThreadedNAPI(len(ports)); err != nil {
+			klog.Warningf("Skipped threaded NAPI setup: %v", err)
+		}
+	}
 	return ctrl.Result{}, EnsureConnection(ctx, r.Client, r.Scheme, r.Options)
 }
 

--- a/pkg/utils/kernel/threaded.go
+++ b/pkg/utils/kernel/threaded.go
@@ -1,0 +1,98 @@
+// Copyright 2019-2026 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kernel
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"golang.org/x/sys/unix"
+	"k8s.io/klog/v2"
+)
+
+const (
+	// MaxMountAttempts is the default number of retries when remounting sysfs.
+	MaxMountAttempts = 100
+	// MountBackoffBase is the baseline duration between mount retry attempts.
+	MountBackoffBase = 100 * time.Millisecond
+)
+
+// EnableWireguardThreadedMode ensures that threaded NAPI is enabled for the given WireGuard interface.
+// It writes 1 to /sys/class/net/<ifaceName>/threaded (only if the feature is not already enabled).
+func EnableWireguardThreadedMode(ifaceName string) (bool, error) {
+	path := fmt.Sprintf("/sys/class/net/%s/threaded", ifaceName)
+
+	data, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		return false, fmt.Errorf("reading sysfs file %q: %w", path, err)
+	}
+
+	if len(data) > 0 && data[0] == '1' {
+		return false, nil
+	}
+
+	if err := os.WriteFile(path, []byte("1\n"), 0o600); err != nil {
+		return false, fmt.Errorf("writing '1' to sysfs file %q: %w", path, err)
+	}
+
+	return true, nil
+}
+
+// RemountSysfsRW remounts /sys as read-write, retrying up to 100 times.
+func RemountSysfsRW() error {
+	var err error
+	for attempt := range MaxMountAttempts {
+		if attempt > 0 {
+			time.Sleep(time.Duration(attempt) * MountBackoffBase)
+		}
+		err = unix.Mount("sysfs", "/sys", "sysfs", unix.MS_REMOUNT, "rw")
+		if err == nil {
+			klog.Infof("remounted /sys as read-write after %d/%d retries", attempt+1, MaxMountAttempts)
+			return nil
+		}
+		klog.Infof("unable to remount /sys as read-write (attempt %d/%d): %v", attempt+1, MaxMountAttempts, err)
+	}
+	return fmt.Errorf("failed after %d remounting attempts: %w", MaxMountAttempts, err)
+}
+
+// RemountSysfsRO remounts /sys as read-only for security, retrying indefinitely until successful.
+func RemountSysfsRO() {
+	for {
+		err := unix.Mount("sysfs", "/sys", "sysfs", unix.MS_REMOUNT|unix.MS_RDONLY, "")
+		if err == nil {
+			klog.Info("remounted /sys as read-only")
+			break
+		}
+
+		klog.Infof("unable to remount /sys as read-only, retrying in %v: %v", MountBackoffBase, err)
+		time.Sleep(MountBackoffBase)
+	}
+}
+
+// IsThreadedNAPISupported checks if the kernel supports threaded NAPI by probing the sysfs entry for the given interface.
+func IsThreadedNAPISupported(iface string) error {
+	path := fmt.Sprintf("/sys/class/net/%s/threaded", iface)
+	_, err := os.Stat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("threaded NAPI sysfs entry not found: %w", err)
+	}
+	if err != nil {
+		return fmt.Errorf("unexpected error probing sysfs path %q: %w", path, err)
+	}
+	return nil
+}


### PR DESCRIPTION
# Description

Part of the multi-tunnel WireGuard implementation. This is the first PR related to issue #3225.

Add `--listen-ports` and `--endpoint-ports` flags to the WireGuard container.

These flags allow specifying multiple ports for the Gateway server and client, respectively.  
The original idea was to also include the `--num-interfaces` flag to indicate the number of WireGuard interfaces to create, but it is unnecessary and redundant: the same information can be inferred from the number of ports, maintaining a single source of truth.

The existing `--listen-port` and `--endpoint-port` flags are preserved for backward compatibility and default values. They **can be ignored** if values are provided in the new multi-port flags, ensuring that the existing infrastructure continues to work without changes.





