### PR TITLE
feat(gateway): add fib_multipath_hash_policy support for L4-aware ECMP flow distribution

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -118,6 +118,12 @@ func run(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
+	// Enable Multipath Hash Policy if required.
+	if connoptions.GwOptions.EnableMultipathHashPolicy {
+		if err = kernel.EnableMultipathHashPolicy(); err != nil {
+			return fmt.Errorf("failed to enable multipath hash policy: %w", err)
+		}
+	}
 	// Set controller-runtime logger.
 	log.SetLogger(klog.NewKlogr())
 

--- a/pkg/gateway/flags.go
+++ b/pkg/gateway/flags.go
@@ -77,6 +77,8 @@ const (
 	FlagNameDisableKernelVersionCheck FlagName = "disable-kernel-version-check"
 	// FlagNameMinimumKernelVersion is the minimum kernel version required by Liqo.
 	FlagNameMinimumKernelVersion FlagName = "minimum-kernel-version"
+	// FlagNameEnableMultipathHashPolicy sets fib_multipath_hash_policy=1 to enable 5-tuple hashing for multipath routing.
+	FlagNameEnableMultipathHashPolicy FlagName = "enable-multipath-hash-policy"
 )
 
 // RequiredFlags contains the list of the mandatory flags.
@@ -125,6 +127,8 @@ func InitFlags(flagset *pflag.FlagSet, opts *Options) {
 
 	flagset.BoolVar(&opts.DisableKernelVersionCheck, FlagNameDisableKernelVersionCheck.String(), false, "Disable the kernel version check")
 	flagset.Var(&opts.MinimumKernelVersion, FlagNameMinimumKernelVersion.String(), "Minimum kernel version required by Liqo")
+	flagset.BoolVar(&opts.EnableMultipathHashPolicy, FlagNameEnableMultipathHashPolicy.String(), false,
+		"Set fib_multipath_hash_policy=1 to use 5-tuple hashing for multipath routing")
 }
 
 // MarkFlagsRequired marks the flags as required.

--- a/pkg/gateway/options.go
+++ b/pkg/gateway/options.go
@@ -51,6 +51,7 @@ type Options struct {
 
 	DisableKernelVersionCheck bool
 	MinimumKernelVersion      kernelversion.KernelVersion
+	EnableMultipathHashPolicy bool
 }
 
 // NewOptions returns a new Options struct.

--- a/pkg/utils/kernel/multipathpolicy.go
+++ b/pkg/utils/kernel/multipathpolicy.go
@@ -1,0 +1,36 @@
+// Copyright 2019-2026 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kernel
+
+import (
+	"fmt"
+	"os"
+)
+
+const multipathpolicyFile = "/proc/sys/net/ipv4/fib_multipath_hash_policy"
+
+// EnableMultipathHashPolicy enables 5-tuple hashing for multipath routing by writing 1 to /proc/sys/net/ipv4/fib_multipath_hash_policy.
+func EnableMultipathHashPolicy() error {
+	file, err := os.OpenFile(multipathpolicyFile, os.O_WRONLY, 0o600)
+	if err != nil {
+		return fmt.Errorf("failed to open multipath policy file %s: %w", multipathpolicyFile, err)
+	}
+	defer file.Close()
+
+	if _, err := file.WriteString("1\n"); err != nil {
+		return fmt.Errorf("failed to write to multipath policy file %s: %w", multipathpolicyFile, err)
+	}
+	return nil
+}


### PR DESCRIPTION
# Description

Part of the multi-tunnel WireGuard implementation. This is the second PR related to issue https://github.com/liqotech/liqo/issues/3225.

This PR adds the `enable-multipath-hash-policy` flag to the gateway. When set to `true`, the gateway writes `1` to `/proc/sys/net/ipv4/fib_multipath_hash_policy`, enabling 5-tuple (src/dst IP, src/dst port, protocol) hashing for multipath routing instead of L3-only (src/dst IP) hashing.

This is necessary to properly exploit ECMP across multiple WireGuard tunnels: without this setting, traffic between the same src/dst IP pair will always hash to the same tunnel regardless of the port, limiting the effectiveness of ECMP for those flows.

The flag defaults to `false`. The intended usage is to set it to `true` via a proper template when the number of interfaces specified in the `GatewayClient` or `GatewayServer` CRD is greater than one.

Since `/proc/sys/net/ipv4/fib_multipath_hash_policy` is namespaced, this setting only affects the network namespace of the gateway pod and has no impact on the host node.

If the write fails, the gateway returns an error and stops the execution to ensure the policy is strictly applied

A new file `pkg/utils/kernel/multipathpolicy.go` was added to implement the low-level write.


