### PR TITLE
add Ports field in GatewayClient and enforce Port/Ports coherence

### DIFF
--- a/apis/networking/v1beta1/gatewayserver_types.go
+++ b/apis/networking/v1beta1/gatewayserver_types.go
@@ -66,6 +66,7 @@ type GatewayServerSpec struct {
 }
 
 // EndpointStatus defines the observed state of the endpoint.
+// +kubebuilder:validation:XValidation:rule="!(has(self.port)&&has(self.ports)&&self.port!=self.ports[0])",message="port must match ports[0]"
 type EndpointStatus struct {
 	// Addresses specifies the addresses of the endpoint.
 	Addresses []string `json:"addresses,omitempty"`
@@ -74,6 +75,9 @@ type EndpointStatus struct {
 	// Protocol specifies the protocol of the endpoint.
 	// +kubebuilder:validation:Enum=TCP;UDP
 	Protocol *corev1.Protocol `json:"protocol,omitempty"`
+	// Ports specifies the ports of the endpoint.
+	// This field is preferred over the legacy Port field, which is kept for backward compatibility.
+	Ports []int32 `json:"ports,omitempty"`
 }
 
 // InternalGatewayEndpoint defines the endpoint for the internal network.

--- a/deployments/liqo/charts/liqo-crds/crds/networking.liqo.io_gatewayclients.yaml
+++ b/deployments/liqo/charts/liqo-crds/crds/networking.liqo.io_gatewayclients.yaml
@@ -130,6 +130,14 @@ spec:
                     description: Port specifies the port of the endpoint.
                     format: int32
                     type: integer
+                  ports:
+                    description: |-
+                      Ports specifies the ports of the endpoint.
+                      This field is preferred over the legacy Port field, which is kept for backward compatibility.
+                    items:
+                      format: int32
+                      type: integer
+                    type: array
                   protocol:
                     description: Protocol specifies the protocol of the endpoint.
                     enum:
@@ -137,6 +145,9 @@ spec:
                     - UDP
                     type: string
                 type: object
+                x-kubernetes-validations:
+                - message: port must match ports[0]
+                  rule: '!(has(self.port)&&has(self.ports)&&self.port!=self.ports[0])'
               mtu:
                 description: MTU specifies the MTU of the tunnel.
                 type: integer

--- a/deployments/liqo/charts/liqo-crds/crds/networking.liqo.io_gatewayservers.yaml
+++ b/deployments/liqo/charts/liqo-crds/crds/networking.liqo.io_gatewayservers.yaml
@@ -180,6 +180,14 @@ spec:
                     description: Port specifies the port of the endpoint.
                     format: int32
                     type: integer
+                  ports:
+                    description: |-
+                      Ports specifies the ports of the endpoint.
+                      This field is preferred over the legacy Port field, which is kept for backward compatibility.
+                    items:
+                      format: int32
+                      type: integer
+                    type: array
                   protocol:
                     description: Protocol specifies the protocol of the endpoint.
                     enum:
@@ -187,6 +195,9 @@ spec:
                     - UDP
                     type: string
                 type: object
+                x-kubernetes-validations:
+                - message: port must match ports[0]
+                  rule: '!(has(self.port)&&has(self.ports)&&self.port!=self.ports[0])'
               internalEndpoint:
                 description: InternalEndpoint specifies the endpoint for the internal
                   network.

--- a/deployments/liqo/charts/liqo-crds/crds/networking.liqo.io_wggatewayservers.yaml
+++ b/deployments/liqo/charts/liqo-crds/crds/networking.liqo.io_wggatewayservers.yaml
@@ -10447,6 +10447,14 @@ spec:
                     description: Port specifies the port of the endpoint.
                     format: int32
                     type: integer
+                  ports:
+                    description: |-
+                      Ports specifies the ports of the endpoint.
+                      This field is preferred over the legacy Port field, which is kept for backward compatibility.
+                    items:
+                      format: int32
+                      type: integer
+                    type: array
                   protocol:
                     description: Protocol specifies the protocol of the endpoint.
                     enum:
@@ -10454,6 +10462,9 @@ spec:
                     - UDP
                     type: string
                 type: object
+                x-kubernetes-validations:
+                - message: port must match ports[0]
+                  rule: '!(has(self.port)&&has(self.ports)&&self.port!=self.ports[0])'
               internalEndpoint:
                 description: InternalEndpoint specifies the endpoint for the internal
                   network.


### PR DESCRIPTION
# Description

Part of the multi-tunnel WireGuard implementation. This is the 3rd PR related to issue https://github.com/liqotech/liqo/issues/3225.

The `Ports` field was introduced in `GatewayClientSpec`. The idea is to store the list of endpoint ports that the gateway server has exposed for the WireGuard interfaces. `Ports` is not meant to replace the legacy `Port` field, which is kept for backward compatibility. The invariant is that `Ports[0]` must always be equal to `Port`.

To enforce this, a new function `EnsurePortsCoherence` was added to the `ClientReconciler`. At the beginning of each reconcile cycle, this function checks whether `Port` and `Ports` are consistent. If not, it normalizes them according to the following rules:
- If only `Port` is specified, `Ports` is set to `[]int32{Port}`
- If `Ports` is specified, `Port` is overwritten with `Ports[0]`
- If neither is specified, both are set to the default value

After normalization, the resource is updated and the reconcile cycle is requeued.
