### PR TITLE
add Ports/NodePorts fields in GatewayServer and enforce (Node)Port/(Node)Ports coherence

### DIFF
--- a/apis/networking/v1beta1/gatewayserver_types.go
+++ b/apis/networking/v1beta1/gatewayserver_types.go
@@ -36,9 +36,14 @@ var GatewayServerGroupResource = schema.GroupResource{Group: GroupVersion.Group,
 var GatewayServerGroupVersionResource = GroupVersion.WithResource(GatewayServerResource)
 
 // Endpoint defines the endpoint of the gatewayserver.
+// +kubebuilder:validation:XValidation:rule="!(has(self.port)&&has(self.ports)&&self.port!=self.ports[0])",message="port must match ports[0]"
+// +kubebuilder:validation:XValidation:rule="!(has(self.nodePort)&&has(self.nodePorts)&&self.nodePort!=self.nodePorts[0])",message="nodePort must match nodePorts[0]"
 type Endpoint struct {
 	// Port specifies the port of the endpoint.
 	Port int32 `json:"port,omitempty"`
+	// Ports specifies the ports of the endpoint.
+	// This field is preferred over the legacy Port field, which is kept for backward compatibility.
+	Ports []int32 `json:"ports,omitempty"`
 	// ServiceType specifies the type of the service.
 	// +kubebuilder:default=ClusterIP
 	// +kubebuilder:validation:Enum=ClusterIP;NodePort;LoadBalancer;ExternalName
@@ -46,6 +51,10 @@ type Endpoint struct {
 	// NodePort allocates a static port for the NodePort service.
 	// +optional
 	NodePort *int32 `json:"nodePort,omitempty"`
+	// NodePorts allocates a list of static ports for the NodePort service.
+	// This field is preferred over the legacy NodePort field, which is kept for backward compatibility.
+	// +optional
+	NodePorts []int32 `json:"nodePorts,omitempty"`
 	// LoadBalancerIP override the LoadBalancer IP to use a specific IP address (e.g., static LB). It is used only if service type is LoadBalancer.
 	// LoadBalancer provider must support this feature.
 	// +optional

--- a/deployments/liqo/charts/liqo-crds/crds/networking.liqo.io_gatewayservers.yaml
+++ b/deployments/liqo/charts/liqo-crds/crds/networking.liqo.io_gatewayservers.yaml
@@ -87,10 +87,26 @@ spec:
                       service.
                     format: int32
                     type: integer
+                  nodePorts:
+                    description: |-
+                      NodePorts allocates a list of static ports for the NodePort service.
+                      This field is preferred over the legacy NodePort field, which is kept for backward compatibility.
+                    items:
+                      format: int32
+                      type: integer
+                    type: array
                   port:
                     description: Port specifies the port of the endpoint.
                     format: int32
                     type: integer
+                  ports:
+                    description: |-
+                      Ports specifies the ports of the endpoint.
+                      This field is preferred over the legacy Port field, which is kept for backward compatibility.
+                    items:
+                      format: int32
+                      type: integer
+                    type: array
                   serviceType:
                     default: ClusterIP
                     description: ServiceType specifies the type of the service.
@@ -101,6 +117,11 @@ spec:
                     - ExternalName
                     type: string
                 type: object
+                x-kubernetes-validations:
+                - message: port must match ports[0]
+                  rule: '!(has(self.port)&&has(self.ports)&&self.port!=self.ports[0])'
+                - message: nodePort must match nodePorts[0]
+                  rule: '!(has(self.nodePort)&&has(self.nodePorts)&&self.nodePort!=self.nodePorts[0])'
               mtu:
                 description: MTU specifies the MTU of the tunnel.
                 type: integer


### PR DESCRIPTION
# Description
Part of the multi-tunnel WireGuard implementation. This is the 4th PR related to issue https://github.com/liqotech/liqo/issues/3225.

The `Ports` and `NodePorts` fields were introduced in `GatewayServer`:
 - `Ports` stores the list of WireGuard listen ports that the gateway server uses internally, one per Wireguard interface. 
 - `NodePorts` is an optional list of ports used to expose the interfaces externally via the Kubernetes Service.

Like in the [previous PR](https://github.com/liqotech/liqo/pull/3233), `(Node)Ports` is not meant to replace the legacy `(Node)Port` field, which is kept for backward compatibility. The invariant is that `(Node)Ports[0]` must always be equal to `(Node)Port`.

A function analogous to the [previous PR](https://github.com/liqotech/liqo/pull/3233)'s `EnsurePortsCoherence` was added to the `ServerReconciler`. At the beginning of each reconcile cycle, it checks whether `(Node)Port` and `(Node)Ports` are consistent and normalizes them according to the following rules:
- If only `(Node)Port` is specified, `(Node)Ports` is set to `[]int32{(Node)Port}`
- If `(Node)Ports` is specified, `(Node)Port` is overwritten with `(Node)Ports[0]`
- If neither is specified, both are set to the default value (applies to `Port`/`Ports` only — `NodePort`/`NodePorts` are optional and have no default)

After normalization, the resource is updated and the reconcile cycle is requeued.

Note that `NodePorts` may be shorter or longer than `Ports`. The intended behavior during Service creation is:
- If `NodePorts` is shorter, the remaining interfaces are exposed on ports chosen by Kubernetes
- If `NodePorts` is longer, the extra entries are ignored

`numInterfaces`, mentioned in the issue, was intentionally not introduced to keep `GatewayServer` simple and avoid an additional source of truth with potential inconsistencies. Future extensions may include:
- Specifying `numInterfaces` and auto-generating the missing ports
- An external utility, possibly integrated into `liqotech peer`, to generate ports given a desired count




