### PR TITLE
[CORE] Prevent pod recreation when pod reached terminal state

### DIFF
--- a/pkg/liqo-controller-manager/offloading/shadowpod-controller/shadowpod_controller.go
+++ b/pkg/liqo-controller-manager/offloading/shadowpod-controller/shadowpod_controller.go
@@ -77,12 +77,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{}, err
 	}
 
-	if shadowPod.Spec.Pod.RestartPolicy == corev1.RestartPolicyNever &&
-		(shadowPod.Status.Phase == corev1.PodSucceeded || shadowPod.Status.Phase == corev1.PodFailed) {
-		klog.V(4).Infof("skip: shadowpod %s already succeeded or failed and restart policy set to Never", shadowPod.GetName())
-		return ctrl.Result{}, nil
-	} else if shadowPod.Spec.Pod.RestartPolicy == corev1.RestartPolicyOnFailure && shadowPod.Status.Phase == corev1.PodSucceeded {
-		klog.V(4).Infof("skip: shadowpod %s already succeeded and restart policy set to OnFailure", shadowPod.GetName())
+	if shadowPod.Status.Phase == corev1.PodSucceeded || shadowPod.Status.Phase == corev1.PodFailed {
+		klog.V(4).Infof("skip: shadowpod %s already in terminal phase %s", shadowPod.GetName(), shadowPod.Status.Phase)
 		return ctrl.Result{}, nil
 	}
 

--- a/pkg/virtualKubelet/reflection/workload/podns.go
+++ b/pkg/virtualKubelet/reflection/workload/podns.go
@@ -201,7 +201,10 @@ func (npr *NamespacedPodReflector) Handle(ctx context.Context, name string) erro
 
 	// Skip reflection for pods in a terminal phase (Succeeded or Failed).
 	// Avoid recreating ShadowPods and changing local pod status when the workload already completed.
-	if local.Status.Phase == corev1.PodSucceeded || local.Status.Phase == corev1.PodFailed {
+	isTerminalPhase := local.Status.Phase == corev1.PodSucceeded || local.Status.Phase == corev1.PodFailed
+	// Make sure the remote pod is also in terminal state, to avoid mismatches between local and remote state when the status is not reflected anymore.
+	isSynced := remote == nil || remote.Status.Phase == local.Status.Phase
+	if isSynced && isTerminalPhase {
 		klog.V(4).Infof("Skipping reflection of local pod %q as it is in terminal phase %q", npr.LocalRef(name), local.Status.Phase)
 		return nil
 	}


### PR DESCRIPTION
# Description

Whenever a remote pod completes but has restart policy Always or OnFailure and pods status is set to `Completed` or  `Failed`, the shadow pod controller syncs this terminal phase to `ShadowPod.Status.Phase`. The actual pod is then deleted as part of the drain. This can happen, for example, when a node in the remote cluster is drained and pods in that node terminated.

On the next reconciliation, the shadow pod controller finds no existing pod but the shadow pod still exists. The old skip logic only prevented recreation for `restartPolicy: Never` and `restartPolicy: OnFailure` ( and pod Succeeded). For `restartPolicy: Always`, no skip was applied, so the controller created a brand new pod from the stale shadow pod spec: https://github.com/liqotech/liqo/blob/master/pkg/liqo-controller-manager/offloading/shadowpod-controller/shadowpod_controller.go#L80

This resulted in:
- An orphaned pod running in the remote cluster, untracked by liqo (the local one remains in Complete/Failed state)
- The local pod stuck in `Failed` state (the pod reflector skips terminal pods)

## Fix

Skip shadow pod reconciliation whenever `ShadowPod.Status.Phase` is terminal (`Failed` or `Succeeded`), regardless of the restart policy. Container restarts (e.g. `restartPolicy: Always`) are handled by the kubelet within a living pod, once the pod object itself is deleted, recreation should be driven by the local cluster's workload controller (Deployment/ReplicaSet) through the normal flow: new local pod -> new shadow pod -> new remote pod.