### PR TITLE
fix: avoid transient Ready nodes when networking is down

### DIFF
--- a/apis/core/v1beta1/foreigncluster_types.go
+++ b/apis/core/v1beta1/foreigncluster_types.go
@@ -46,6 +46,11 @@ const (
 
 // ForeignClusterStatus defines the observed state of ForeignCluster.
 type ForeignClusterStatus struct {
+	// ObservedGeneration is the most recent generation observed by the controller.
+	// Zero means the controller has never reconciled this resource.
+	// +kubebuilder:validation:Optional
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
+
 	// Role of the ForeignCluster.
 	// +kubebuilder:validation:Enum="Consumer";"Provider";"ConsumerAndProvider";"Unknown"
 	// +kubebuilder:default="Unknown"

--- a/deployments/liqo/charts/liqo-crds/crds/core.liqo.io_foreignclusters.yaml
+++ b/deployments/liqo/charts/liqo-crds/crds/core.liqo.io_foreignclusters.yaml
@@ -322,6 +322,12 @@ spec:
                 - networking
                 - offloading
                 type: object
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the most recent generation observed by the controller.
+                  Zero means the controller has never reconciled this resource.
+                format: int64
+                type: integer
               role:
                 default: Unknown
                 description: Role of the ForeignCluster.

--- a/pkg/liqo-controller-manager/core/foreigncluster-controller/foreigncluster_controller.go
+++ b/pkg/liqo-controller-manager/core/foreigncluster-controller/foreigncluster_controller.go
@@ -150,6 +150,8 @@ func (r *ForeignClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		return res, err
 	}
 
+	foreignCluster.Status.ObservedGeneration = foreignCluster.Generation
+
 	klog.V(4).Infof("ForeignCluster %s successfully reconciled", foreignCluster.Name)
 
 	return ctrl.Result{Requeue: true, RequeueAfter: r.ResyncPeriod}, nil

--- a/pkg/utils/testutil/liqo.go
+++ b/pkg/utils/testutil/liqo.go
@@ -162,9 +162,10 @@ func FakeForeignCluster(
 			ClusterID: clusterID,
 		},
 		Status: liqov1beta1.ForeignClusterStatus{
-			Modules:      *modules,
-			Role:         liqov1beta1.UnknownRole,
-			APIServerURL: ForeignAPIServerURL,
+			ObservedGeneration: 1,
+			Modules:            *modules,
+			Role:               liqov1beta1.UnknownRole,
+			APIServerURL:       ForeignAPIServerURL,
 		},
 	}
 }

--- a/pkg/virtualKubelet/liqoNodeProvider/nodeProvider.go
+++ b/pkg/virtualKubelet/liqoNodeProvider/nodeProvider.go
@@ -51,7 +51,7 @@ type LiqoNodeProvider struct {
 	pingDisabled       bool
 	checkNetworkStatus bool
 
-	networkModuleEnabled bool
+	networkModuleEnabled *bool // nil = ForeignCluster not yet observed
 	networkReady         bool
 
 	onNodeChangeCallback func(*corev1.Node)

--- a/pkg/virtualKubelet/liqoNodeProvider/nodeProvider_test.go
+++ b/pkg/virtualKubelet/liqoNodeProvider/nodeProvider_test.go
@@ -298,6 +298,47 @@ var _ = Describe("NodeProvider", func() {
 				ConditionMatcher(v1.NodeNetworkUnavailable, v1.ConditionFalse),
 			},
 		}),
+
+		Entry("ForeignCluster not yet reconciled (ObservedGeneration=0), Offloading enabled", nodeProviderTestcase{
+			foreignCluster: func() *liqov1beta1.ForeignCluster {
+				fc := testutil.FakeForeignCluster(foreignClusterID, &liqov1beta1.Modules{
+					Offloading: liqov1beta1.Module{
+						Enabled: true,
+					},
+					Networking: liqov1beta1.Module{
+						Enabled: false,
+					},
+					Authentication: liqov1beta1.Module{
+						Enabled: true,
+					},
+				})
+				fc.Status.ObservedGeneration = 0
+				return fc
+			}(),
+			virtualNode: &offloadingv1beta1.VirtualNode{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "VirtualNode",
+					APIVersion: offloadingv1beta1.VirtualNodeGroupVersionResource.GroupVersion().String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      nodeName,
+					Namespace: kubeletNamespace,
+				},
+				Spec: offloadingv1beta1.VirtualNodeSpec{
+					ClusterID: "remote-id",
+					ResourceQuota: v1.ResourceQuotaSpec{
+						Hard: v1.ResourceList{
+							v1.ResourceCPU:    *resource.NewQuantity(2, resource.DecimalSI),
+							v1.ResourceMemory: *resource.NewQuantity(3, resource.DecimalSI),
+						},
+					},
+				},
+			},
+			expectedConditions: []types.GomegaMatcher{
+				ConditionMatcher(v1.NodeReady, v1.ConditionFalse),
+				ConditionMatcher(v1.NodeNetworkUnavailable, v1.ConditionTrue),
+			},
+		}),
 	)
 
 	It("Labels patch", func() {

--- a/pkg/virtualKubelet/liqoNodeProvider/reconciler.go
+++ b/pkg/virtualKubelet/liqoNodeProvider/reconciler.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
 
 	liqov1beta1 "github.com/liqotech/liqo/apis/core/v1beta1"
 	offloadingv1beta1 "github.com/liqotech/liqo/apis/offloading/v1beta1"
@@ -149,22 +150,36 @@ func (p *LiqoNodeProvider) updateFromForeignCluster(foreigncluster *liqov1beta1.
 	p.updateMutex.Lock()
 	defer p.updateMutex.Unlock()
 
-	p.networkModuleEnabled = fcutils.IsNetworkingModuleEnabled(foreigncluster)
+	// Only trust Networking.Enabled once the FC controller has reconciled the status.
+	// Before that, the field is a zero value and indistinguishable from "networking disabled".
+	if foreigncluster.Status.ObservedGeneration > 0 {
+		p.networkModuleEnabled = ptr.To(fcutils.IsNetworkingModuleEnabled(foreigncluster))
+	}
 	p.networkReady = fcutils.IsNetworkingEstablished(foreigncluster)
+
 	return p.updateNode()
 }
 
 func (p *LiqoNodeProvider) updateNode() error {
-	resourcesReady := areResourcesReady(p.node.Status.Allocatable)
-	networkReady := p.networkReady || !p.checkNetworkStatus || !p.networkModuleEnabled
+	// we assume the networking module to be enabled until confirmed otherwise (p.networkModuleEnabled == false),
+	// to avoid transient states where the node is ready but the network condition is not set
+	// because the ForeignCluster has not been observed yet.
+	networkModuleEnabled := ptr.Deref(p.networkModuleEnabled, true)
 
+	// we have to set the network condition if we have to check the network status and the network module is enabled
+	shouldSetNetworkCond := p.checkNetworkStatus && networkModuleEnabled
+
+	// check the network status only if we have to set the network condition, otherwise consider it ready
+	networkReady := p.networkReady || !shouldSetNetworkCond
+
+	resourcesReady := areResourcesReady(p.node.Status.Allocatable)
 	UpdateNodeCondition(p.node, v1.NodeReady, nodeReadyStatus(resourcesReady && networkReady))
 	UpdateNodeCondition(p.node, v1.NodeMemoryPressure, nodeMemoryPressureStatus(!resourcesReady))
 	UpdateNodeCondition(p.node, v1.NodeDiskPressure, nodeDiskPressureStatus(!resourcesReady))
 	UpdateNodeCondition(p.node, v1.NodePIDPressure, nodePIDPressureStatus(!resourcesReady))
-	if p.checkNetworkStatus && p.networkModuleEnabled {
+	if shouldSetNetworkCond {
 		UpdateNodeCondition(p.node, v1.NodeNetworkUnavailable, nodeNetworkUnavailableStatus(!networkReady))
-	} else if !p.networkModuleEnabled || !p.checkNetworkStatus {
+	} else {
 		deleteCondition(p.node, v1.NodeNetworkUnavailable)
 	}
 

--- a/pkg/virtualKubelet/liqoNodeProvider/setup.go
+++ b/pkg/virtualKubelet/liqoNodeProvider/setup.go
@@ -72,7 +72,7 @@ func NewLiqoNodeProvider(cfg *InitConfig) *LiqoNodeProvider {
 		terminating:       false,
 		lastAppliedLabels: map[string]string{},
 
-		networkModuleEnabled: false,
+		networkModuleEnabled: nil, // set once ForeignCluster is first observed
 		networkReady:         false,
 		resyncPeriod:         cfg.InformerResyncPeriod,
 		pingDisabled:         cfg.PingDisabled,


### PR DESCRIPTION
# Description

When virtualnode conditions are forged, we check if networking is enabled or not (networking module completely disabled or peering without networking) to understand if we need to put the `NetworkUnavailable` condition or not.
The problem is that there could be a small transient phase where it is indistinguishable to determine if the peering was established with or without networking. This can happen if:
1. VK foreigncluster informer has not triggered a reconciliation yet, hence `p.networkModuleEnabled=false`
2. liqo-controller-manager foreigncluster controller has not reconciled yet, hence `.status.modules.networking.enabled=false`

If one of these two happens, the previous logic was blindly skipping the `NetworkUnavailable` condition,  hence the node could go Ready even if few seconds later networking resources shows up and switch immediately to `NotReady`.


When forging virtualnode conditions, we check whether networking is disabled (networking module completely disabled or peering without networking) to decide if the NetworkUnavailable condition should be set or not. The problem is there's a brief window where "networking disabled" and "networking not yet determined" are indistinguishable — both look like false. This happens when:

a. The VK's ForeignCluster informer hasn't triggered a reconciliation yet (`p.networkModuleEnabled` == false)
b. The liqo-controller-manager's ForeignCluster controller hasn't reconciled yet (`.status.modules.networking.enabled` is still a zero value, hence `false`)

During this window, the old logic would skip setting `NetworkUnavailable`, letting the node briefly go Ready. Seconds later, once networking resources appear and aren't ready yet, it would flip to NotReady.

## Implementation

- Fix for case (a): Distinguish "not yet known" from "disabled" — networkModuleEnabled is now a *bool (nil = not yet observed) instead of a plain bool. Until we get a confirmed value, we default to assuming networking is enabled, which keeps NetworkUnavailable set and prevents the transient Ready blip.
- Fix for case (b): Know when the FC controller has actually reconciled — added observedGeneration to ForeignClusterStatus. The VK only trusts `.status`networking.enabled` once `observedGeneration` > 0, meaning the FC controller has run at least once, and the field reflects intent rather than a zero value.
- Simplified condition logic — collapsed the redundant if/else if into a single shouldSetNetworkCond flag, which is easier to follow.
