### PR TITLE
fix(vk): synchronize local pods when vk miss remote pods deletion

### DIFF
--- a/pkg/virtualKubelet/forge/pods.go
+++ b/pkg/virtualKubelet/forge/pods.go
@@ -38,6 +38,9 @@ const (
 	PodOffloadingBackOffReason = "OffloadingBackOff"
 	// PodOffloadingAbortedReason -> the reason assigned to pods rejected by the virtual kubelet after offloading has started.
 	PodOffloadingAbortedReason = "OffloadingAborted"
+	// RemotePodTerminatedReason -> the reason assigned to pods in the local cluster whose remote counterpart has completed,
+	// but it wasn't possible to reflect the real status (e.g. missed completion event), and the shadow pod reports a terminal phase.
+	RemotePodTerminatedReason = "RemotePodTerminated"
 
 	// ServiceAccountVolumeName is the prefix name that will be added to volumes that mount ServiceAccount secrets.
 	// This constant is taken from kubernetes/kubernetes (plugin/pkg/admission/serviceaccount/admission.go).
@@ -142,7 +145,15 @@ func LocalRejectedPodStatus(local *corev1.PodStatus, phase corev1.PodPhase, reas
 	}
 
 	for i := range local.ContainerStatuses {
-		local.ContainerStatuses[i].Ready = false
+		TerminateContainerState(&local.ContainerStatuses[i], phase, reason)
+	}
+
+	for i := range local.InitContainerStatuses {
+		TerminateContainerState(&local.InitContainerStatuses[i], phase, reason)
+	}
+
+	for i := range local.EphemeralContainerStatuses {
+		TerminateContainerState(&local.EphemeralContainerStatuses[i], phase, reason)
 	}
 
 	return *local
@@ -240,6 +251,25 @@ func RemotePodSpec(creation bool, local, remote *corev1.PodSpec, mutators ...Rem
 	}
 
 	return *remote
+}
+
+// TerminateContainerState modifies the container status to set it in a terminated state, if not already in a terminal state.
+func TerminateContainerState(cs *corev1.ContainerStatus, phase corev1.PodPhase, reason string) {
+	cs.Ready = false
+	if cs.State.Terminated == nil && (phase == corev1.PodFailed || phase == corev1.PodSucceeded) {
+		exitCode := int32(0)
+		if phase == corev1.PodFailed {
+			exitCode = 1
+		}
+		cs.State = corev1.ContainerState{
+			Terminated: &corev1.ContainerStateTerminated{
+				ExitCode: exitCode,
+				Reason:   reason,
+			},
+			Waiting: nil,
+			Running: nil,
+		}
+	}
 }
 
 // APIServerSupportMutator is a mutator which implements the support to enable offloaded pods to interact back with the local Kubernetes API server.

--- a/pkg/virtualKubelet/forge/pods_test.go
+++ b/pkg/virtualKubelet/forge/pods_test.go
@@ -107,9 +107,26 @@ var _ = Describe("Pod forging", func() {
 			local = &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{Name: "local-name", Namespace: "local-namespace"},
 				Status: corev1.PodStatus{
-					PodIP:             "1.1.1.1",
-					Conditions:        []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}},
-					ContainerStatuses: []corev1.ContainerStatus{{Name: "foo", Ready: true}},
+					PodIP:      "1.1.1.1",
+					Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}},
+					ContainerStatuses: []corev1.ContainerStatus{
+						{
+							Name:  "foo",
+							Ready: true,
+						},
+						{
+							Name:  "bar",
+							Ready: true,
+							State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{StartedAt: metav1.Now()}},
+						},
+						{
+							Name:  "waiting",
+							Ready: false,
+							State: corev1.ContainerState{
+								Waiting: &corev1.ContainerStateWaiting{Reason: "ContainerCreating"},
+							},
+						},
+					},
 				},
 			}
 		})
@@ -133,8 +150,30 @@ var _ = Describe("Pod forging", func() {
 			Expect(output.Status.Conditions[0].LastTransitionTime.Time).To(BeTemporally("~", time.Now()))
 		})
 		It("should correctly mutate the container statuses", func() {
-			Expect(output.Status.ContainerStatuses).To(HaveLen(1))
-			Expect(output.Status.ContainerStatuses[0].Ready).To(Equal(false))
+			Expect(output.Status.ContainerStatuses).To(HaveLen(len(local.Status.ContainerStatuses)))
+			for i := range output.Status.ContainerStatuses {
+				Expect(output.Status.ContainerStatuses[i].Ready).To(Equal(false))
+				Expect(output.Status.ContainerStatuses[i].State.Waiting).To(BeNil())
+				Expect(output.Status.ContainerStatuses[i].State.Running).To(BeNil())
+				Expect(output.Status.ContainerStatuses[i].State.Terminated).NotTo(BeNil())
+				Expect(output.Status.ContainerStatuses[i].State.Terminated.ExitCode).To(Equal(int32(1)))
+				Expect(output.Status.ContainerStatuses[i].State.Terminated.Reason).To(Equal(forge.PodOffloadingAbortedReason))
+			}
+		})
+
+		Context("when the container is already terminated", func() {
+			BeforeEach(func() {
+				local.Status.ContainerStatuses[0].State = corev1.ContainerState{
+					Terminated: &corev1.ContainerStateTerminated{ExitCode: 137, Reason: "OOMKilled"},
+				}
+			})
+			It("should preserve the existing terminated state", func() {
+				Expect(output.Status.ContainerStatuses[0].State.Waiting).To(BeNil())
+				Expect(output.Status.ContainerStatuses[0].State.Running).To(BeNil())
+				Expect(output.Status.ContainerStatuses[0].State.Terminated).NotTo(BeNil())
+				Expect(output.Status.ContainerStatuses[0].State.Terminated.ExitCode).To(Equal(int32(137)))
+				Expect(output.Status.ContainerStatuses[0].State.Terminated.Reason).To(Equal("OOMKilled"))
+			})
 		})
 		It("should preserve the other status fields", func() { Expect(output.Status.PodIP).To(Equal(local.Status.PodIP)) })
 	})

--- a/pkg/virtualKubelet/reflection/workload/podns.go
+++ b/pkg/virtualKubelet/reflection/workload/podns.go
@@ -183,7 +183,7 @@ func (npr *NamespacedPodReflector) Handle(ctx context.Context, name string) erro
 		}
 
 		// If the remote is already terminating, we need to reflect the status to the local one.
-		return npr.HandleStatus(ctx, local, remote, npr.RetrievePodInfo(local.GetName()))
+		return npr.HandleStatus(ctx, local, remote, shadow, npr.RetrievePodInfo(local.GetName()))
 	}
 
 	// Do not offload the pod if it was previously rejected, as new copies should have already been re-created.
@@ -282,7 +282,7 @@ func (npr *NamespacedPodReflector) Handle(ctx context.Context, name string) erro
 	}
 
 	// Reflect the status from the remote pod to the local one.
-	return npr.HandleStatus(ctx, local, remote, info)
+	return npr.HandleStatus(ctx, local, remote, shadow, info)
 }
 
 // HandleLabels mutates the local object labels, to mark the pod as offloaded and allow filtering at the informer level.
@@ -376,9 +376,32 @@ func (npr *NamespacedPodReflector) ShouldUpdateShadowPod(ctx context.Context, sh
 }
 
 // HandleStatus reflects the status from the remote Pod to the local one.
-func (npr *NamespacedPodReflector) HandleStatus(ctx context.Context, local, remote *corev1.Pod, info *PodInfo) error {
-	// Do not handle the status in case the remote pod has not yet been created, or already terminated.
+func (npr *NamespacedPodReflector) HandleStatus(ctx context.Context, local, remote *corev1.Pod,
+	shadow *offloadingv1beta1.ShadowPod, info *PodInfo) error {
+	// The remote pod does not exist yet, or has been deleted.
 	if remote == nil {
+		localPodRef := npr.LocalRef(local.GetName())
+		switch {
+		case shadow == nil:
+			// Shadow pod still does not exist, wait for resources propagation.
+			klog.V(4).Infof("Remote pod %q and shadowpod do not exist, skipping status update", localPodRef)
+		case shadow.Status.Phase == corev1.PodSucceeded || shadow.Status.Phase == corev1.PodFailed:
+			// If the shadow pod reports a terminal phase, the real pod completed normally we need to
+			// manage the orphan pod.
+			phase := shadow.Status.Phase
+			po := forge.LocalRejectedPod(local, phase, forge.RemotePodTerminatedReason)
+			if reflect.DeepEqual(local.Status, po.Status) {
+				klog.V(4).Infof("Skipping local pod %q status update, as already synced", localPodRef)
+				return nil
+			}
+
+			klog.Infof("Updating local pod %q status to %q since the remote pod is no longer available", localPodRef, phase)
+			if _, err := npr.localPodsClient.UpdateStatus(ctx, po, metav1.UpdateOptions{FieldManager: forge.ReflectionFieldManager}); err != nil {
+				klog.Errorf("Failed to update local pod %q status: %v", localPodRef, err)
+				return fmt.Errorf("updating local pod %q status: %w", localPodRef, err)
+			}
+		}
+
 		return nil
 	}
 

--- a/pkg/virtualKubelet/reflection/workload/podns_test.go
+++ b/pkg/virtualKubelet/reflection/workload/podns_test.go
@@ -413,6 +413,7 @@ var _ = Describe("Namespaced Pod Reflection Tests", func() {
 
 			var (
 				local, remote *corev1.Pod
+				shadow        *offloadingv1beta1.ShadowPod
 				podInfo       workload.PodInfo
 				err           error
 			)
@@ -427,13 +428,14 @@ var _ = Describe("Namespaced Pod Reflection Tests", func() {
 						Conditions:        []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}},
 					},
 				}
+				shadow = nil
 				podInfo = workload.PodInfo{}
 			})
 
 			JustBeforeEach(func() {
 				CreatePod(client, local)
 				err = reflector.(*workload.NamespacedPodReflector).HandleStatus(
-					trace.ContextWithTrace(ctx, trace.New("Pod")), local, remote, &podInfo)
+					trace.ContextWithTrace(ctx, trace.New("Pod")), local, remote, shadow, &podInfo)
 			})
 
 			When("the local pod has remote unavailable label", func() {
@@ -493,7 +495,7 @@ var _ = Describe("Namespaced Pod Reflection Tests", func() {
 				JustBeforeEach(func() {
 					remote.SetUID("something-different")
 					err = reflector.(*workload.NamespacedPodReflector).HandleStatus(
-						trace.ContextWithTrace(ctx, trace.New("Pod")), local, remote, &podInfo)
+						trace.ContextWithTrace(ctx, trace.New("Pod")), local, remote, shadow, &podInfo)
 				})
 
 				It("should succeed", func() { Expect(err).ToNot(HaveOccurred()) })
@@ -506,16 +508,56 @@ var _ = Describe("Namespaced Pod Reflection Tests", func() {
 			})
 
 			When("the remote pod is nil", func() {
-				BeforeEach(func() {
-					remote = nil
+				BeforeEach(func() { remote = nil })
 
-					// Here, we create a modified fake client which returns an error when trying to perform an update operation.
-					client.PrependReactor("update", "*", func(action testing.Action) (handled bool, _ runtime.Object, err error) {
-						return true, nil, errors.New("should not call update")
+				When("the local pod is pending with no container statuses", func() {
+					BeforeEach(func() {
+						local.Status.Phase = corev1.PodPending
+
+						// No update should be issued: the real pod has not been created yet.
+						client.PrependReactor("update", "*", func(action testing.Action) (handled bool, _ runtime.Object, err error) {
+							return true, nil, errors.New("should not call update")
+						})
 					})
+
+					It("should succeed", func() { Expect(err).ToNot(HaveOccurred()) })
 				})
 
-				It("should succeed", func() { Expect(err).ToNot(HaveOccurred()) })
+				When("the shadow pod is in a terminal phase", func() {
+					BeforeEach(func() {
+						local.Status.Phase = corev1.PodRunning
+					})
+
+					When("the shadow pod succeeded", func() {
+						BeforeEach(func() {
+							shadow = &offloadingv1beta1.ShadowPod{
+								Status: offloadingv1beta1.ShadowPodStatus{Phase: corev1.PodSucceeded},
+							}
+						})
+
+						It("should succeed", func() { Expect(err).ToNot(HaveOccurred()) })
+						It("should mark the local pod as succeeded", func() {
+							localAfter := GetPod(client, LocalNamespace, PodName)
+							Expect(localAfter.Status.Phase).To(BeIdenticalTo(corev1.PodSucceeded))
+							Expect(localAfter.Status.Reason).To(BeIdenticalTo(forge.RemotePodTerminatedReason))
+						})
+					})
+
+					When("the shadow pod failed", func() {
+						BeforeEach(func() {
+							shadow = &offloadingv1beta1.ShadowPod{
+								Status: offloadingv1beta1.ShadowPodStatus{Phase: corev1.PodFailed},
+							}
+						})
+
+						It("should succeed", func() { Expect(err).ToNot(HaveOccurred()) })
+						It("should mark the local pod as failed", func() {
+							localAfter := GetPod(client, LocalNamespace, PodName)
+							Expect(localAfter.Status.Phase).To(BeIdenticalTo(corev1.PodFailed))
+							Expect(localAfter.Status.Reason).To(BeIdenticalTo(forge.RemotePodTerminatedReason))
+						})
+					})
+				})
 			})
 		})
 


### PR DESCRIPTION
# Description

When the remote real pod is deleted while the local pod appears Running, the virtual kubelet's HandleStatus returns nil without updating the local pod status. The local pod stays Running indefinitely because the VK has no real pod to reflect from. This prevents Deployment controllers from creating replacements and makes pod logs inaccessible.

## Fix

If the shadow pod is in a terminal phase (Succeeded/Failed): propagates that phase to the local pod with the new RemotePodCompletedReason reason, allowing the workload controller to react correctly.
