### PR TITLE
fix(vk): prevent deletion of the shadowpods on vk leader election

### DIFF
--- a/pkg/utils/virtualkubelet/virtualkubelet.go
+++ b/pkg/utils/virtualkubelet/virtualkubelet.go
@@ -27,11 +27,16 @@ type Lister[T any] interface {
 
 // List returns a list of NamespacedName objects from the given listers.
 func List[T Lister[O], O metav1.Object](listers ...T) ([]any, error) {
+	return ListWithLabelSelector(labels.Everything(), listers...)
+}
+
+// ListWithLabelSelector returns a list of NamespacedName objects from the given listers using the provided label selector.
+func ListWithLabelSelector[T Lister[O], O metav1.Object](selector labels.Selector, listers ...T) ([]any, error) {
 	var err error
 	objs := make([][]O, len(listers))
 	tot := 0
 	for i, l := range listers {
-		objs[i], err = l.List(labels.Everything())
+		objs[i], err = l.List(selector)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/virtualKubelet/reflection/generic/reflector.go
+++ b/pkg/virtualKubelet/reflection/generic/reflector.go
@@ -345,6 +345,12 @@ func (gr *reflector) handlers(keyer options.Keyer, filters ...options.EventFilte
 
 // Resync trigger a resync of the informer.
 func (gr *reflector) Resync() error {
+	// The reflector resyncs is only required when the master VirtualKubelet is elected after another VK failure termination.
+	// It's not required for resources managed per-node.
+	if gr.concurrencyMode == ConcurrencyModeAll {
+		return nil
+	}
+
 	// Trigger a resync of the namespace reflectors.
 	for k, v := range gr.reflectors {
 		objs, err := v.List()

--- a/pkg/virtualKubelet/reflection/workload/podns.go
+++ b/pkg/virtualKubelet/reflection/workload/podns.go
@@ -147,7 +147,7 @@ func (npr *NamespacedPodReflector) Handle(ctx context.Context, name string) erro
 	if !localExists {
 		defer tracer.Step("Ensured the absence of the remote object")
 		if shadowExists {
-			klog.V(4).Infof("Deleting remote shadowpod %q, since local pod %q does no longer exist", npr.RemoteRef(name), npr.LocalRef(name))
+			klog.Infof("Deleting remote shadowpod %q, since local pod %q does no longer exist", npr.RemoteRef(name), npr.LocalRef(name))
 			return npr.DeleteRemote(ctx, npr.remoteShadowPodsClient, "ShadowPod", name, shadow.GetUID())
 		}
 
@@ -777,18 +777,33 @@ func (npr *NamespacedPodReflector) InferAdditionalRestarts(local, remote *corev1
 
 // List retrieves the list of reflected pods.
 func (npr *NamespacedPodReflector) List() ([]interface{}, error) {
-	listShPod, err := virtualkubelet.List[virtualkubelet.Lister[*offloadingv1beta1.ShadowPod], *offloadingv1beta1.ShadowPod](
+	nodeSelector := labels.SelectorFromSet(labels.Set{forge.LiqoOriginClusterNodeName: forge.LiqoNodeName})
+
+	listShPod, err := virtualkubelet.ListWithLabelSelector[virtualkubelet.Lister[*offloadingv1beta1.ShadowPod]](
+		nodeSelector,
 		npr.remoteShadowPods,
 	)
+
 	if err != nil {
 		return nil, err
 	}
-	listPod, err := virtualkubelet.List[virtualkubelet.Lister[*corev1.Pod], *corev1.Pod](
+
+	listLocalPods, err := virtualkubelet.List[virtualkubelet.Lister[*corev1.Pod]](
 		npr.localPods,
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	listRemotePods, err := virtualkubelet.ListWithLabelSelector[virtualkubelet.Lister[*corev1.Pod]](
+		nodeSelector,
 		npr.remotePods,
 	)
+
 	if err != nil {
 		return nil, err
 	}
-	return append(listShPod, listPod...), nil
+
+	return append(append(listShPod, listLocalPods...), listRemotePods...), nil
 }


### PR DESCRIPTION
# Description

When multiple virtual nodes target the same cluster, one VK acts as leader and is responsible for reflecting shared resources. On leader election, the VK triggered a resync that listed all remote shadowpods in the namespace without filtering by node name. Since the local pod lister only contains pods scheduled on the current virtual node, any shadowpod belonging to another node appeared as orphaned and was incorrectly deleted.

This patch fixes this bug by:

- Fixing the List() method of NamespacedPodReflector to apply the same node-name label selector used by RemoteShadowNamespacedKeyer, so that only shadowpods and remote pods belonging to the current virtual node are enqueued during resync.

- Avoid triggering the resync in the case of non-leader reconcilers
