### PR TITLE
fix(offloading): relax namespacemap count check

### DIFF
--- a/pkg/liqo-controller-manager/offloading/namespaceoffloading-controller/clusterselector.go
+++ b/pkg/liqo-controller-manager/offloading/namespaceoffloading-controller/clusterselector.go
@@ -16,6 +16,7 @@ package nsoffctrl
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
@@ -35,20 +36,21 @@ import (
 
 func (r *NamespaceOffloadingReconciler) enforceClusterSelector(ctx context.Context,
 	nsoff *offloadingv1beta1.NamespaceOffloading,
-	clusterIDMap map[string]*offloadingv1beta1.NamespaceMap) error {
+	clusterIDToNsMap map[string]*offloadingv1beta1.NamespaceMap) error {
 	virtualNodes, err := getters.ListVirtualNodesByLabels(ctx, r.Client, labels.Everything())
 	if err != nil {
 		return fmt.Errorf("failed to retrieve VirtualNodes: %w", err)
 	}
 	clusterIDs := getters.RetrieveClusterIDsFromVirtualNodes(virtualNodes)
 
-	// If the number of virtual nodes does not match that of namespacemaps, there is something wrong in the cluster.
-	if len(clusterIDs) != len(clusterIDMap) {
-		return fmt.Errorf("number of foreign clusters (%d) does not match that of NamespaceMaps (%d)",
-			len(clusterIDs), len(clusterIDMap))
+	// Check if there is a NamespaceMap for each remote cluster ID
+	for _, clusterID := range clusterIDs {
+		if _, exists := clusterIDToNsMap[clusterID]; !exists {
+			return fmt.Errorf("no NamespaceMap found for remote cluster ID: %s", clusterID)
+		}
 	}
 
-	var returnErr error
+	var errs []error
 	for i := range virtualNodes.Items {
 		match, err := MatchVirtualNodeSelectorTerms(ctx, r.Client, &virtualNodes.Items[i], &nsoff.Spec.ClusterSelector)
 		if err != nil {
@@ -57,21 +59,21 @@ func (r *NamespaceOffloadingReconciler) enforceClusterSelector(ctx context.Conte
 			return fmt.Errorf("invalid ClusterSelector: %w", err)
 		}
 
+		nm := clusterIDToNsMap[string(virtualNodes.Items[i].Spec.ClusterID)]
+
 		if match {
-			if err = addDesiredMapping(ctx, r.Client, nsoff.Namespace, r.remoteNamespaceName(nsoff),
-				clusterIDMap[string(virtualNodes.Items[i].Spec.ClusterID)]); err != nil {
-				returnErr = fmt.Errorf("failed to configure all desired mappings")
+			if err = addDesiredMapping(ctx, r.Client, nsoff.Namespace, r.remoteNamespaceName(nsoff), nm); err != nil {
+				errs = append(errs, fmt.Errorf("adding namespace %q to NamespaceMap %s: %w", nsoff.Namespace, nm.Name, err))
 			}
 		} else {
 			// Ensure old mappings are removed in case the cluster selector is updated.
-			if err = removeDesiredMapping(ctx, r.Client, nsoff.Namespace,
-				clusterIDMap[string(virtualNodes.Items[i].Spec.ClusterID)]); err != nil {
-				returnErr = fmt.Errorf("failed to configure all desired mappings")
+			if err = removeDesiredMapping(ctx, r.Client, nsoff.Namespace, nm); err != nil {
+				errs = append(errs, fmt.Errorf("removing namespace %q from NamespaceMap %s: %w", nsoff.Namespace, nm.Name, err))
 			}
 		}
 	}
 
-	return returnErr
+	return errors.Join(errs...)
 }
 
 func (r *NamespaceOffloadingReconciler) getClusterIDMap(ctx context.Context) (map[string]*offloadingv1beta1.NamespaceMap, error) {
@@ -86,14 +88,17 @@ func (r *NamespaceOffloadingReconciler) getClusterIDMap(ctx context.Context) (ma
 	}
 
 	clusterIDMap := make(map[string]*offloadingv1beta1.NamespaceMap)
-	if len(nms.Items) == 0 {
-		klog.Info("No NamespaceMaps are present at the moment in the cluster")
-		return clusterIDMap, nil
+	for i := range nms.Items {
+		nm := &nms.Items[i]
+		if v := nm.Labels[liqoconst.RemoteClusterID]; v != "" {
+			clusterIDMap[v] = nm
+		}
 	}
 
-	for i := range nms.Items {
-		clusterIDMap[nms.Items[i].Labels[liqoconst.RemoteClusterID]] = &nms.Items[i]
+	if len(clusterIDMap) == 0 {
+		klog.Info("No NamespaceMaps are present at the moment in the cluster")
 	}
+
 	return clusterIDMap, nil
 }
 

--- a/pkg/liqo-controller-manager/offloading/namespaceoffloading-controller/namespaceoffloading_controller.go
+++ b/pkg/liqo-controller-manager/offloading/namespaceoffloading-controller/namespaceoffloading_controller.go
@@ -16,9 +16,11 @@ package nsoffctrl
 
 import (
 	"context"
+	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
@@ -93,8 +95,6 @@ func (r *NamespaceOffloadingReconciler) Reconcile(ctx context.Context, req ctrl.
 			klog.Errorf("Failed to update NamespaceOffloading %q status: %v", klog.KObj(nsoff), err)
 			return
 		}
-
-		klog.Infof("NamespaceOffloading %q status correctly updated", klog.KObj(nsoff))
 	}()
 
 	// If deletion timestamp is set, it starts deletion logic and waits until all remote Namespaces
@@ -131,11 +131,19 @@ func (r *NamespaceOffloadingReconciler) SetupWithManager(mgr ctrl.Manager) error
 		return object.GetName() == consts.DefaultNamespaceOffloadingName
 	})
 
+	// Filter only Nodes created from VirtualNodes.
+	virtualNodeFilter, err := predicate.LabelSelectorPredicate(metav1.LabelSelector{MatchLabels: map[string]string{
+		consts.TypeLabel: consts.TypeNode,
+	}})
+	if err != nil {
+		return fmt.Errorf("creating virtualnode predicate filter: %w", err)
+	}
+
 	return ctrl.NewControllerManagedBy(mgr).Named(consts.CtrlNamespaceOffloading).
 		For(&offloadingv1beta1.NamespaceOffloading{}, builder.WithPredicates(filter)).
 		Watches(&offloadingv1beta1.NamespaceMap{}, r.namespaceMapHandlers()).
 		Watches(&offloadingv1beta1.VirtualNode{}, r.enqueueAll()).
-		Watches(&corev1.Node{}, r.enqueueAll()).
+		Watches(&corev1.Node{}, r.enqueueAll(), builder.WithPredicates(virtualNodeFilter)).
 		Complete(r)
 }
 

--- a/pkg/liqo-controller-manager/offloading/namespaceoffloading-controller/status.go
+++ b/pkg/liqo-controller-manager/offloading/namespaceoffloading-controller/status.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
 
@@ -29,6 +30,9 @@ import (
 // enforceStatus realigns the status of the NamespaceOffloading, depending on that of the NamespaceMaps.
 func (r *NamespaceOffloadingReconciler) enforceStatus(ctx context.Context, nsoff *offloadingv1beta1.NamespaceOffloading,
 	nsmaps map[string]*offloadingv1beta1.NamespaceMap) error {
+	// Keep track of the original status, to avoid unnecessary updates.
+	orig := nsoff.Status.DeepCopy()
+
 	nsoff.Status.RemoteNamespaceName = r.remoteNamespaceName(nsoff)
 
 	// Update the observed generation.
@@ -43,10 +47,17 @@ func (r *NamespaceOffloadingReconciler) enforceStatus(ctx context.Context, nsoff
 	// Configure the global status given the conditions.
 	setNamespaceOffloadingStatus(nsoff, required, ready, failed)
 
+	// If the status is already up-to-date, there is no need to update it.
+	if equality.Semantic.DeepEqual(orig, &nsoff.Status) {
+		// The status is already up-to-date, and there is nothing to do.
+		return nil
+	}
+
 	// Update the status just once at the end of the logic.
 	if err := r.Status().Update(ctx, nsoff); err != nil {
 		return fmt.Errorf("failed to update status: %w", err)
 	}
+	klog.Infof("NamespaceOffloading %q status correctly updated", klog.KObj(nsoff))
 
 	return nil
 }


### PR DESCRIPTION
# Description

VirtualnodeController:
- Avoid strict NamespaceMap==ForeignCluster count equality check. If one NamespaceMap does not get deleted (e.g. the remote CRDReplicator is not running or not able to delete the remote CR), the controller would block all other peerings too because of this check. Not it only check if the NamespaceMap associated with the reconciled VirtualNode is present, avoiding blocking all offloadings because of one broker peering.

NamespaceOffloading controller:
- Filter Node watches to virtual nodes only, avoiding spurious reconciliations
- Skip no-op status updates via DeepEqual check