### PR TITLE
fix: set labels, annots and taints from VirtualNode inception

### DIFF
--- a/cmd/virtual-kubelet/root/root.go
+++ b/cmd/virtual-kubelet/root/root.go
@@ -275,6 +275,8 @@ func runRootCommand(ctx context.Context, c *Opts) error {
 		InformerResyncPeriod: c.InformerResyncPeriod,
 		PingDisabled:         c.NodePingInterval == 0,
 		CheckNetworkStatus:   c.NodeCheckNetwork,
+
+		VirtualNode: vn,
 	}
 
 	var nodeReady chan struct{}

--- a/pkg/virtualKubelet/liqoNodeProvider/setup.go
+++ b/pkg/virtualKubelet/liqoNodeProvider/setup.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/client-go/rest"
 
 	liqov1beta1 "github.com/liqotech/liqo/apis/core/v1beta1"
+	offloadingv1beta1 "github.com/liqotech/liqo/apis/offloading/v1beta1"
 	liqoconst "github.com/liqotech/liqo/pkg/consts"
 )
 
@@ -59,6 +60,8 @@ type InitConfig struct {
 	InformerResyncPeriod time.Duration
 	PingDisabled         bool
 	CheckNetworkStatus   bool
+
+	VirtualNode offloadingv1beta1.VirtualNode
 }
 
 // NewLiqoNodeProvider creates and returns a new LiqoNodeProvider.
@@ -99,19 +102,27 @@ func node(cfg *InitConfig) *corev1.Node {
 		corev1.LabelNodeExcludeBalancers: strconv.FormatBool(true),
 		labelNodeExcludeBalancersAlpha:   strconv.FormatBool(true),
 	}
+	lbls = labels.Merge(lbls, cfg.ExtraLabels)
+	lbls = labels.Merge(lbls, cfg.VirtualNode.Spec.Labels)
+
+	annots := cfg.ExtraAnnotations
+	annots = labels.Merge(annots, cfg.VirtualNode.Spec.Annotations)
+
+	taints := []corev1.Taint{{
+		Key:    liqoconst.VirtualNodeTolerationKey,
+		Value:  strconv.FormatBool(true),
+		Effect: corev1.TaintEffectNoExecute,
+	}}
+	taints = append(taints, cfg.VirtualNode.Spec.Taints...)
 
 	return &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        cfg.NodeName,
-			Labels:      labels.Merge(lbls, cfg.ExtraLabels),
-			Annotations: cfg.ExtraAnnotations,
+			Labels:      lbls,
+			Annotations: annots,
 		},
 		Spec: corev1.NodeSpec{
-			Taints: []corev1.Taint{{
-				Key:    liqoconst.VirtualNodeTolerationKey,
-				Value:  strconv.FormatBool(true),
-				Effect: corev1.TaintEffectNoExecute,
-			}},
+			Taints: taints,
 		},
 		Status: corev1.NodeStatus{
 			NodeInfo: corev1.NodeSystemInfo{


### PR DESCRIPTION
# Description

Virtual nodes were assigned taints and labels only when the virtualnode informer actually reconcile and call `updateFromVirtualNode()`. This behaviour leads to transient states where nodes are created without the labels and taints specified in the VirtualNode CR.

This PR ensures that we set labels, annots and taints from virtual node inception rather than patching it later
