### PR TITLE
Expand documentation for enable-multipath-hash-policy flag

### DIFF
--- a/pkg/gateway/flags.go
+++ b/pkg/gateway/flags.go
@@ -77,7 +77,13 @@ const (
 	FlagNameDisableKernelVersionCheck FlagName = "disable-kernel-version-check"
 	// FlagNameMinimumKernelVersion is the minimum kernel version required by Liqo.
 	FlagNameMinimumKernelVersion FlagName = "minimum-kernel-version"
-	// FlagNameEnableMultipathHashPolicy sets fib_multipath_hash_policy=1 to enable 5-tuple hashing for multipath routing.
+	// FlagNameEnableMultipathHashPolicy enables 5-tuple hashing to improve ECMP load balancing.
+	// When set to true, the gateway writes 1 to /proc/sys/net/ipv4/fib_multipath_hash_policy.
+	// This allows the kernel to distribute traffic across ECMP routes based on the
+	// 5-tuple (src/dst IP, src/dst port, protocol) instead of the default L3-only hashing.
+	// Without this setting, traffic between the same IP pair always uses the same tunnel
+	// regardless of the port. Note: this setting is namespaced and only affects the
+	// gateway pod's network namespace.
 	FlagNameEnableMultipathHashPolicy FlagName = "enable-multipath-hash-policy"
 )
 

--- a/pkg/gateway/flags.go
+++ b/pkg/gateway/flags.go
@@ -77,7 +77,14 @@ const (
 	FlagNameDisableKernelVersionCheck FlagName = "disable-kernel-version-check"
 	// FlagNameMinimumKernelVersion is the minimum kernel version required by Liqo.
 	FlagNameMinimumKernelVersion FlagName = "minimum-kernel-version"
-	// FlagNameEnableMultipathHashPolicy sets fib_multipath_hash_policy=1 to enable 5-tuple hashing for multipath routing.
+	// FlagNameEnableMultipathHashPolicy enables 5-tuple hashing to improve ECMP load balancing.
+	// When set to true, the gateway writes 1 to /proc/sys/net/ipv4/fib_multipath_hash_policy.
+	// This allows the kernel to distribute traffic across ECMP routes based on the
+	// 5-tuple (src/dst IP, src/dst port, protocol) instead of the default L3-only hashing.
+	// Without this setting, traffic between the same IP pair always uses the same tunnel
+	// regardless of the port. Notes: (1) this setting is namespaced and only affects the
+	// gateway pod's network namespace; (2) this is meaningful only if the gateway uses multiple
+	// parallel tunnels to exchange date with its remote endpoint.
 	FlagNameEnableMultipathHashPolicy FlagName = "enable-multipath-hash-policy"
 )
 


### PR DESCRIPTION
# Description

The `enable-multipath-hash-policy` flag (introduced in [#3229](https://github.com/liqotech/liqo/pull/3229)) lacked detailed inline documentation, making it difficult for users to understand its practical impact.

This PR expands the documentation for this flag to make its purpose clearer for the user
