### PR TITLE
fix: avoid recreating routecfg during unpeering

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -66,7 +66,10 @@ linkcheck_ignore = [
     'https://dl.acm.org', # often 403
     'https://scholar.google.com',
     'https://kubernetes.io/docs/*',
-    'https://github.com/cilium/cilium/blob/v1.18.4/install/kubernetes/cilium/values.yaml'
+    'https://github.com/cilium/cilium/blob/v1.18.4/install/kubernetes/cilium/values.yaml',
+    'https://liqo-io.slack.com/*', # often 403
+    'https://helm.sh', # often ReadTimeout
+    'https://kind.sigs.k8s.io/docs/user/quick-start/*' # often ReadTimeout
 ]
 
 

--- a/pkg/fabric/internalfabric_controller.go
+++ b/pkg/fabric/internalfabric_controller.go
@@ -67,12 +67,7 @@ func (r *InternalFabricReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 			klog.V(6).Infof("There is no internalfabric %s", req.String())
 			return ctrl.Result{}, nil
 		}
-		return ctrl.Result{}, fmt.Errorf("unable to get the internalfabric %q: %w", req.NamespacedName, err)
-	}
-
-	internalnode := &networkingv1beta1.InternalNode{}
-	if err = r.Get(ctx, types.NamespacedName{Name: r.Options.NodeName}, internalnode); err != nil {
-		return ctrl.Result{}, fmt.Errorf("unable to get the internalnode %q: %w", r.Options.NodeName, err)
+		return ctrl.Result{}, fmt.Errorf("getting internalfabric %q: %w", req.NamespacedName, err)
 	}
 
 	klog.V(4).Infof("Reconciling internalfabric %s", req.String())
@@ -83,18 +78,18 @@ func (r *InternalFabricReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	switch {
 	case !deleting && !containsFinalizer:
 		if err = r.ensureinternalfabricFinalizerPresence(ctx, internalfabric); err != nil {
-			return ctrl.Result{}, err
+			return ctrl.Result{}, fmt.Errorf("ensuring finalizer presence: %w", err)
 		}
 
 		return ctrl.Result{}, nil
 
 	case deleting && containsFinalizer:
 		if err := geneve.EnsureGeneveInterfaceAbsence(internalfabric.Spec.Interface.Node.Name); err != nil {
-			return ctrl.Result{}, fmt.Errorf("unable to ensure the geneve interface absence: %w", err)
+			return ctrl.Result{}, fmt.Errorf("ensuring the geneve interface absence: %w", err)
 		}
 
 		if err = r.ensureinternalfabricFinalizerAbsence(ctx, internalfabric); err != nil {
-			return ctrl.Result{}, err
+			return ctrl.Result{}, fmt.Errorf("ensuring finalizer absence: %w", err)
 		}
 
 		klog.V(2).Infof("InternalFabric %s deleted", req.String())
@@ -103,6 +98,11 @@ func (r *InternalFabricReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 
 	case deleting && !containsFinalizer:
 		return ctrl.Result{}, nil
+	}
+
+	internalnode := &networkingv1beta1.InternalNode{}
+	if err = r.Get(ctx, types.NamespacedName{Name: r.Options.NodeName}, internalnode); err != nil {
+		return ctrl.Result{}, fmt.Errorf("getting internalnode %q: %w", r.Options.NodeName, err)
 	}
 
 	id, err := geneve.GetGeneveTunnelID(ctx, r.Client, internalfabric.Name, r.Options.NodeName)
@@ -123,7 +123,7 @@ func (r *InternalFabricReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		internalfabric.Spec.MTU,
 		r.Options.GenevePort,
 	); err != nil {
-		return ctrl.Result{}, fmt.Errorf("unable to ensure the geneve interface presence: %w", err)
+		return ctrl.Result{}, fmt.Errorf("ensuring the geneve interface presence: %w", err)
 	}
 
 	klog.Infof("Enforced interface %s for internalfabric %s", internalfabric.Spec.Interface.Node.Name, internalfabric.Name)

--- a/pkg/liqo-controller-manager/networking/internal-network/internalfabric-controller/internalfabric_controller.go
+++ b/pkg/liqo-controller-manager/networking/internal-network/internalfabric-controller/internalfabric_controller.go
@@ -59,43 +59,43 @@ func NewInternalFabricReconciler(cl client.Client, s *runtime.Scheme, routeConfi
 // +kubebuilder:rbac:groups=networking.liqo.io,resources=internalnodes/finalizers,verbs=update
 
 // Reconcile manage InternalFabric lifecycle.
-func (r *InternalFabricReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res ctrl.Result, err error) {
+func (r *InternalFabricReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	internalFabric := &networkingv1beta1.InternalFabric{}
-	if err = r.Get(ctx, req.NamespacedName, internalFabric); err != nil {
+	if err := r.Get(ctx, req.NamespacedName, internalFabric); err != nil {
 		if apierrors.IsNotFound(err) {
-			klog.Infof("InternalFabric %q not found", req.NamespacedName)
+			klog.V(6).Infof("InternalFabric %q not found", req.NamespacedName)
 			return ctrl.Result{}, nil
 		}
-		klog.Errorf("Unable to get the InternalFabric %q: %s", req.NamespacedName, err)
-		return ctrl.Result{}, err
+		return ctrl.Result{}, fmt.Errorf("getting InternalFabric: %w", err)
 	}
 
-	if !internalFabric.DeletionTimestamp.IsZero() && controllerutil.ContainsFinalizer(internalFabric, consts.InternalFabricGeneveTunnelFinalizer) {
-		if err = deleteGeneveTunnels(ctx, r.Client, internalFabric); err != nil {
-			klog.Errorf("Unable to delete GeneveTunnels: %s", err)
-			return ctrl.Result{}, err
+	if !internalFabric.DeletionTimestamp.IsZero() {
+		if controllerutil.ContainsFinalizer(internalFabric, consts.InternalFabricGeneveTunnelFinalizer) {
+			if err := deleteGeneveTunnels(ctx, r.Client, internalFabric); err != nil {
+				return ctrl.Result{}, fmt.Errorf("deleting Geneve tunnels: %w", err)
+			}
 		}
+		return ctrl.Result{}, nil
 	}
 
 	// route configuration
 
-	if err = r.ensureRouteConfiguration(ctx, internalFabric); err != nil {
-		return ctrl.Result{}, err
+	if err := r.ensureRouteConfiguration(ctx, internalFabric); err != nil {
+		return ctrl.Result{}, fmt.Errorf("ensuring route configuration: %w", err)
 	}
 
-	// geneve tunnel
+	// geneve tunnels
 
 	var internalNodeList networkingv1beta1.InternalNodeList
-	if err = r.List(ctx, &internalNodeList); err != nil {
-		klog.Errorf("Unable to list InternalNodes: %s", err)
-		return ctrl.Result{}, err
+	if err := r.List(ctx, &internalNodeList); err != nil {
+		return ctrl.Result{}, fmt.Errorf("listing InternalNodes: %w", err)
 	}
 
-	if err = ensureGeneveTunnels(ctx, r.Client, r.Scheme, internalFabric, &internalNodeList); err != nil {
+	if err := ensureGeneveTunnels(ctx, r.Client, r.Scheme, internalFabric, &internalNodeList); err != nil {
 		return ctrl.Result{}, fmt.Errorf("ensuring GeneveTunnels: %w", err)
 	}
 
-	if err = cleanupGeneveTunnels(ctx, r.Client, internalFabric, &internalNodeList); err != nil {
+	if err := cleanupGeneveTunnels(ctx, r.Client, internalFabric, &internalNodeList); err != nil {
 		return ctrl.Result{}, fmt.Errorf("cleaning up GeneveTunnels: %w", err)
 	}
 

--- a/pkg/route/finalizer.go
+++ b/pkg/route/finalizer.go
@@ -28,13 +28,13 @@ const (
 )
 
 func (r *RouteConfigurationReconciler) ensureRouteConfigurationFinalizerPresence(
-	ctx context.Context, fwcfg *networkingv1beta1.RouteConfiguration) error {
-	ctrlutil.AddFinalizer(fwcfg, routeconfigurationControllerFinalizer)
-	return r.Client.Update(ctx, fwcfg)
+	ctx context.Context, routecfg *networkingv1beta1.RouteConfiguration) error {
+	ctrlutil.AddFinalizer(routecfg, routeconfigurationControllerFinalizer)
+	return r.Update(ctx, routecfg)
 }
 
 func (r *RouteConfigurationReconciler) ensureRouteConfigurationFinalizerAbsence(
-	ctx context.Context, fwcfg *networkingv1beta1.RouteConfiguration) error {
-	ctrlutil.RemoveFinalizer(fwcfg, routeconfigurationControllerFinalizer)
-	return r.Client.Update(ctx, fwcfg)
+	ctx context.Context, routecfg *networkingv1beta1.RouteConfiguration) error {
+	ctrlutil.RemoveFinalizer(routecfg, routeconfigurationControllerFinalizer)
+	return r.Update(ctx, routecfg)
 }


### PR DESCRIPTION
# Description

Fixes possible stuck tenant namespace deletion during unpeering / network reset.

When a tenant namespace is deleted, three resources were left with unremoved finalizers (`FirewallConfiguration`, `RouteConfiguration`, `InternalFabric`), keeping the namespace stuck in `Terminating` state indefinitely.

**Problem:**

- **CM InternalFabric controller** (`internalfabric_cm`): after handling deletion (deleting GeneveTunnels and removing its own finalizer), the reconciler fell through to `ensureRouteConfiguration` and `ensureGeneveTunnels`, which attempted to create resources in the terminating namespace. This caused an infinite error loop: `"ensuring GeneveTunnels: ... is forbidden: unable to create new content in namespace ... because it is being terminated"`.

**Fix:**
- Add early return after deletion handling in the CM controller, so `ensureRouteConfiguration`/`ensureGeneveTunnels` are never called on a deleting resource.

## Other improvements:
- **Fabric DaemonSet InternalFabric controller**: the `InternalNode` Get was performed **before** the deletion check. Fixing it by moving it below the deletion switch in the fabric controller, since the deletion path doesn't need it and would stall if for any reason the InternalNode CR is not present.

