### PR TITLE
fix: check for ipam pools overlaps

### DIFF
--- a/pkg/ipam/core/ipam.go
+++ b/pkg/ipam/core/ipam.go
@@ -213,6 +213,15 @@ func checkRoots(roots []netip.Prefix) error {
 			return err
 		}
 	}
+
+	for i := range roots {
+		for j := i + 1; j < len(roots); j++ {
+			if roots[i].Overlaps(roots[j]) {
+				return fmt.Errorf("pools %s and %s overlap", roots[i], roots[j])
+			}
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/ipam/core/ipam_test.go
+++ b/pkg/ipam/core/ipam_test.go
@@ -80,6 +80,26 @@ var _ = Describe("Ipam", func() {
 				}
 			})
 		})
+
+		When("Using overlapping pools", func() {
+			It("should return an error if one pool contains another", func() {
+				_, err := NewIpam([]netip.Prefix{
+					netip.MustParsePrefix("10.0.0.0/8"),
+					netip.MustParsePrefix("10.0.0.0/16"),
+				})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("overlap"))
+			})
+
+			It("should return an error if pools partially overlap", func() {
+				_, err := NewIpam([]netip.Prefix{
+					netip.MustParsePrefix("10.0.0.0/15"),
+					netip.MustParsePrefix("10.1.0.0/16"),
+				})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("overlap"))
+			})
+		})
 	})
 
 	Context("Ipam utilities", func() {

--- a/pkg/liqoctl/install/gke/provider.go
+++ b/pkg/liqoctl/install/gke/provider.go
@@ -128,9 +128,6 @@ func (o *Options) Values() map[string]interface{} {
 	return map[string]interface{}{
 		"ipam": map[string]interface{}{
 			"pools": []interface{}{
-				"10.0.0.0/8",
-				"192.168.0.0/16",
-				"172.16.0.0/12",
 				"34.118.224.0/20",
 			},
 		},


### PR DESCRIPTION
# Description

Check and return error if ipam pools overlaps. If pools overlap they are counted twice, hence any CIDR reservation will not work since there can be multiple pools for the same CIDR