### PR TITLE
fix(networking): use returned route when deleting routes

### DIFF
--- a/pkg/route/route.go
+++ b/pkg/route/route.go
@@ -56,21 +56,13 @@ func EnsureRoutesAbsence(routes []networkingv1beta1.Route, tableID uint32) error
 		if routes[i].Dst == nil {
 			continue
 		}
-		_, dst, err := net.ParseCIDR(routes[i].Dst.String())
+		existingRoute, exists, err := ExistsRoute(&routes[i], tableID)
 		if err != nil {
-			return err
-		}
-		route := &netlink.Route{
-			Dst: dst,
-		}
-
-		_, exists, err := ExistsRoute(&routes[i], tableID)
-		if err != nil {
-			return err
+			return fmt.Errorf("checking route existence: %w", err)
 		}
 		if exists {
-			if err := netlink.RouteDel(route); err != nil {
-				return err
+			if err := netlink.RouteDel(existingRoute); err != nil {
+				return fmt.Errorf("deleting route: %w", err)
 			}
 		}
 	}


### PR DESCRIPTION
# Description

This PR fixes `EnsureRoutesAbsence` failing with `ESRCH: no such process` when deleting routes during RouteConfiguration finalization

## Cause

`EnsureRoutesAbsence` was constructing a minimal `netlink.Route` with only `Dst` set for the `RouteDel` call, while ignoring the full route object returned by `ExistsRoute`. The kernel's route deletion performs a strict match that includes attributes like `scope`, `dev`, and `gw`. When the actual route had `scope link` (253) but the deletion request defaulted to `scope universe` (0), the kernel couldn't find a matching entry and returned `ESRCH`.

## Fix

Use the actual `*netlink.Route` returned by `ExistsRoute` (which comes from `RouteListFiltered` and contains all kernel-resolved attributes) as the argument to `RouteDel`, ensuring an exact match.
