### PR TITLE
[Networking] wireguard-go embedded in liqo gateway

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ docs/_build
 /tmp
 /graphviz
 /k3s-ansible
+
+# claude
+.claude

--- a/build/liqo/Dockerfile
+++ b/build/liqo/Dockerfile
@@ -9,26 +9,6 @@ RUN if [ "$COMPONENT" = "geneve" ] || [ "$COMPONENT" = "wireguard" ] || [ "$COMP
     apk add --no-cache iproute2 nftables bash wireguard-tools tcpdump conntrack-tools curl iputils; \
     fi
 
-RUN if [ "$COMPONENT" = "wireguard" ]; then \
-    set -e; \
-    apk add --no-cache git curl; \
-    GO_VERSION=1.22.4; \
-    # Map Docker TARGETARCH to Go architecture names \
-    case "$TARGETARCH" in \
-        amd64) GO_ARCH=amd64 ;; \
-        arm64) GO_ARCH=arm64 ;; \
-        arm) GO_ARCH=armv6l ;; \
-        *) echo "Unsupported architecture: $TARGETARCH" && exit 1 ;; \
-    esac; \
-    curl -L https://go.dev/dl/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz | tar -C /usr/local -xz; \
-    export PATH="/usr/local/go/bin:$PATH"; \
-    git clone https://git.zx2c4.com/wireguard-go; cd wireguard-go; git checkout f333402bd9cbe0f3eeb02507bd14e23d7d639280; \
-    CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH /usr/local/go/bin/go build -ldflags="-s -w" -o /usr/bin/wireguard-go; \
-    cd .. && rm -rf wireguard-go; \
-    rm -rf /usr/local/go; \
-    apk del git curl; \
-    fi
-
 # Copy the correct binary for the architecture
 COPY ./bin/${TARGETARCH}/${COMPONENT}_linux_${TARGETARCH} /usr/bin/${COMPONENT}
 RUN chmod +x /usr/bin/${COMPONENT}

--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	golang.org/x/mod v0.29.0
 	golang.org/x/sync v0.18.0
 	golang.org/x/sys v0.38.0
+	golang.zx2c4.com/wireguard v0.0.0-20220904105730-b51010ba13f0
 	golang.zx2c4.com/wireguard/wgctrl v0.0.0-20220504211119-3d4a969bb56b
 	gomodules.xyz/jsonpatch/v2 v2.4.0
 	google.golang.org/api v0.206.0
@@ -261,7 +262,7 @@ require (
 	golang.org/x/text v0.31.0 // indirect
 	golang.org/x/time v0.12.0 // indirect
 	golang.org/x/tools v0.38.0 // indirect
-	golang.zx2c4.com/wireguard v0.0.0-20220904105730-b51010ba13f0 // indirect
+	golang.zx2c4.com/wintun v0.0.0-20211104114900-415007cec224 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250528174236-200df99c418a // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1092,6 +1092,8 @@ golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.zx2c4.com/wintun v0.0.0-20211104114900-415007cec224 h1:Ug9qvr1myri/zFN6xL17LSCBGFDnphBBhzmILHsM5TY=
+golang.zx2c4.com/wintun v0.0.0-20211104114900-415007cec224/go.mod h1:deeaetjYA+DHMHg+sMSMI58GrEteJUUzzw7en6TJQcI=
 golang.zx2c4.com/wireguard v0.0.0-20220904105730-b51010ba13f0 h1:5ZkdpbduT/g+9OtbSDvbF3KvfQG45CtH/ppO8FUmvCQ=
 golang.zx2c4.com/wireguard v0.0.0-20220904105730-b51010ba13f0/go.mod h1:enML0deDxY1ux+B6ANGiwtg0yAJi1rctkTpcHNAVPyg=
 golang.zx2c4.com/wireguard/wgctrl v0.0.0-20220504211119-3d4a969bb56b h1:9JncmKXcUwE918my+H6xmjBdhK2jM/UTUNXxhRG1BAk=

--- a/pkg/gateway/tunnel/wireguard/netlink.go
+++ b/pkg/gateway/tunnel/wireguard/netlink.go
@@ -15,17 +15,17 @@
 package wireguard
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
-	"os/exec"
-	"time"
 
 	"github.com/vishvananda/netlink"
+	"golang.zx2c4.com/wireguard/conn"
+	"golang.zx2c4.com/wireguard/device"
+	"golang.zx2c4.com/wireguard/ipc"
+	"golang.zx2c4.com/wireguard/tun"
 	"golang.zx2c4.com/wireguard/wgctrl"
 	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 
 	"github.com/liqotech/liqo/pkg/gateway"
@@ -111,36 +111,66 @@ func createLinkKernel(options *Options) error {
 	return nil
 }
 
-// runWgUserCmd runs the wg command with the given arguments.
-func runWgUserCmd(cmd *exec.Cmd) {
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
-		outStr, errStr := stdout.String(), stderr.String()
-		fmt.Printf("out:\n%s\nerr:\n%s\n", outStr, errStr)
-		klog.Fatalf("failed to run '%s': %v", cmd.String(), err)
+// createLinkUserspace creates a new Wireguard interface using the userspace implementation (wireguard-go)
+// embedded as a library. The device is kept running in-process for the lifetime of the gateway.
+func createLinkUserspace(ctx context.Context, options *Options) error {
+	mtu := options.MTU
+	if mtu <= 0 {
+		mtu = device.DefaultMTU
 	}
-}
 
-// createLinkUserspsce creates a new Wireguard interface using the userspace implementation (wireguard-go).
-// TODO: at the moment is not possible to override the settings of the wireguard-go implementation.
-// We are planning a PR to add a flag for the MTU.
-func createLinkUserspace(ctx context.Context, _ *Options) error {
-	cmd := exec.Command("/usr/bin/wireguard-go", "-f", tunnel.TunnelInterfaceName) //nolint:gosec //we leave it as it is
-	go runWgUserCmd(cmd)
+	tunDev, err := tun.CreateTUN(tunnel.TunnelInterfaceName, mtu)
+	if err != nil {
+		return fmt.Errorf("failed to create wireguard TUN device %q: %w", tunnel.TunnelInterfaceName, err)
+	}
 
-	if err := wait.PollUntilContextTimeout(ctx, time.Second, 10*time.Second, true, func(context.Context) (done bool, err error) {
-		klog.Info("Waiting for wireguard device to be created")
-		if _, err = netlink.LinkByName(tunnel.TunnelInterfaceName); err != nil {
-			klog.Errorf("failed to get wireguard device '%s': %s", tunnel.TunnelInterfaceName, err)
-			return false, nil
+	name, err := tunDev.Name()
+	if err != nil {
+		_ = tunDev.Close()
+		return fmt.Errorf("failed to read wireguard TUN device name: %w", err)
+	}
+
+	fileUAPI, err := ipc.UAPIOpen(name)
+	if err != nil {
+		_ = tunDev.Close()
+		return fmt.Errorf("failed to open UAPI socket for %q: %w", name, err)
+	}
+
+	logger := device.NewLogger(device.LogLevelError, fmt.Sprintf("(%s) ", name))
+	wgDev := device.NewDevice(tunDev, conn.NewDefaultBind(), logger)
+
+	uapi, err := ipc.UAPIListen(name, fileUAPI)
+	if err != nil {
+		wgDev.Close()
+		return fmt.Errorf("failed to listen on UAPI socket for %q: %w", name, err)
+	}
+
+	go func() {
+		for {
+			c, err := uapi.Accept()
+			if err != nil {
+				return
+			}
+			go wgDev.IpcHandle(c)
 		}
-		return true, nil
-	}); err != nil {
-		return fmt.Errorf("failed to create wireguard device %q: %w", tunnel.TunnelInterfaceName, err)
-	}
+	}()
 
+	go func() {
+		select {
+		case <-ctx.Done():
+			if err := uapi.Close(); err != nil {
+				klog.Errorf("Error closing uapi: %v", err)
+			}
+			wgDev.Close()
+		case <-wgDev.Wait():
+			if err := uapi.Close(); err != nil {
+				klog.Errorf("Error closing uapi: %v", err)
+			}
+			klog.Fatalf("wireguard userspace device %q stopped unexpectedly", name)
+		}
+	}()
+
+	klog.Infof("wireguard userspace device %q started", name)
 	return nil
 }
 


### PR DESCRIPTION
## Summary

Replaces the external `wireguard-go` binary approach with an in-process Go library integration. Previously, the gateway container image had to download Go at build time, clone the `wireguard-go` repository, compile the binary, and then exec it at runtime as a subprocess. This PR removes all of that in favour of importing `golang.zx2c4.com/wireguard` directly as a Go dependency and running the userspace WireGuard device inside the gateway process itself.

## Changes

### `build/liqo/Dockerfile`
Removes the multi-step `wireguard` build layer that:
- installed Go 1.22.4
- cloned `git.zx2c4.com/wireguard-go` at a pinned commit
- cross-compiled the binary for the target architecture
- cleaned up Go and git from the image

The gateway binary is now self-contained; no external `wireguard-go` binary is needed in the image.

### `pkg/gateway/tunnel/wireguard/netlink.go`
Rewrites `createLinkUserspace` to use the wireguard-go library directly:

- Creates a TUN device via `tun.CreateTUN`
- Instantiates a `device.Device` with `conn.NewDefaultBind()` for the underlying socket
- Opens and listens on the UAPI socket so that `wgctrl` can still configure the interface (keys, peers, etc.) through the standard kernel-compatible API
- Serves UAPI connections in a goroutine, keeping the device running for the process lifetime
- Shuts down cleanly on context cancellation
- Respects the configured MTU (previously blocked by a TODO — it was not possible to pass MTU to the external binary)

### `go.mod` / `go.sum`
- Promotes `golang.zx2c4.com/wireguard` from indirect to a direct dependency
- Adds `golang.zx2c4.com/wintun` as a new indirect dependency (required by the wireguard library on Windows)

### `.gitignore`
Adds `.claude` directory to the ignore list.

## Motivation

- **Simpler image builds**: no need to install Go, clone repos, or cross-compile inside Docker.
- **Faster image builds**: removes a heavyweight multi-step layer from the `wireguard` component image.
- **MTU support**: the embedded device honours the `Options.MTU` field, resolving the long-standing TODO in the previous implementation.
- **Cleaner lifecycle**: the device is now tied to the gateway's context rather than being an unrelated subprocess, making shutdown and error handling more robust.
- **Fewer runtime dependencies**: the container image no longer needs the `wireguard-go` binary present at `/usr/bin/wireguard-go`.
