### PR TITLE
[Networking] Stop writing routing table names to /etc/iproute2/rt_tables

### DIFF
--- a/pkg/route/routeconfiguration_controller.go
+++ b/pkg/route/routeconfiguration_controller.go
@@ -131,10 +131,6 @@ func (r *RouteConfigurationReconciler) Reconcile(ctx context.Context, req ctrl.R
 			}
 		}
 
-		if err = EnsureTableAbsence(tableID); err != nil {
-			return ctrl.Result{}, fmt.Errorf("ensuring table absence: %w", err)
-		}
-
 		if err = r.ensureRouteConfigurationFinalizerAbsence(ctx, routeconfiguration); err != nil {
 			return ctrl.Result{}, fmt.Errorf("removing finalizer: %w", err)
 		}
@@ -162,10 +158,6 @@ func (r *RouteConfigurationReconciler) Reconcile(ctx context.Context, req ctrl.R
 	}
 
 	klog.V(4).Infof("Applying routeconfiguration %s", req.String())
-
-	if err = EnsureTablePresence(routeconfiguration, tableID); err != nil {
-		return ctrl.Result{}, fmt.Errorf("ensuring table presence: %w", err)
-	}
 
 	for i := range routeconfiguration.Spec.Table.Rules {
 		if err = EnsureRulePresence(&routeconfiguration.Spec.Table.Rules[i], tableID); err != nil {

--- a/pkg/route/table.go
+++ b/pkg/route/table.go
@@ -15,156 +15,22 @@
 package route
 
 import (
-	"bufio"
 	"crypto/sha256"
-	"errors"
 	"fmt"
-	"os"
-	"strconv"
-	"strings"
-
-	"k8s.io/apimachinery/pkg/util/runtime"
-
-	networkingv1beta1 "github.com/liqotech/liqo/apis/networking/v1beta1"
 )
 
-const (
-	// RTTablesDir contains path to the directory with ID to routing tables IDs mapping in Linux.
-	RTTablesDir = "/etc/iproute2"
-	// RTTablesFilename contains path to the file with ID to routing tables IDs mapping in Linux.
-	RTTablesFilename = RTTablesDir + "/rt_tables"
-)
-
-// EnsureTablePresence ensures the presence of the given table.
-func EnsureTablePresence(routeconfiguration *networkingv1beta1.RouteConfiguration, tableID uint32) error {
-	exists, err := ExistsTableID(tableID)
-	if err != nil {
-		return err
-	}
-	if !exists {
-		if err := AddTableID(tableID, routeconfiguration.Spec.Table.Name); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-// EnsureTableAbsence ensures the absence of the given table.
-func EnsureTableAbsence(tableID uint32) error {
-	exists, err := ExistsTableID(tableID)
-	if err != nil {
-		return err
-	}
-	if exists {
-		if err := DeleteTableID(tableID); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-// GetTableID returns the table ID associated with the given route.
+// GetTableID returns the iproute2 table ID for the given table name.
+// The ID is derived deterministically from the name via SHA256 and is guaranteed
+// to be in [256, 65535], avoiding OS-reserved tables (0-255) and staying within
+// the range accepted by all iproute2 versions.
+// No entry is written to /etc/iproute2/rt_tables: the kernel does not require it
+// and writing large IDs there causes iproute2 "database corrupted" errors on some
+// distributions.
 func GetTableID(tableName string) (uint32, error) {
 	if tableName == "" {
 		return 0, fmt.Errorf("table name is empty")
 	}
 	return generateTableID(tableName), nil
-}
-
-// ExistsTableID checks if the given table ID is already present in the rt_tables file.
-func ExistsTableID(tableID uint32) (exists bool, err error) {
-	if tableID == 0 {
-		return false, fmt.Errorf("table ID is empty")
-	}
-
-	file, err := os.OpenFile(RTTablesFilename, os.O_RDONLY, 0o600)
-	if errors.Is(err, os.ErrNotExist) {
-		return false, nil
-	} else if err != nil {
-		return false, err
-	}
-	defer func() {
-		runtime.Must(file.Close())
-	}()
-	scanner := bufio.NewScanner(file)
-	for scanner.Scan() {
-		entry := scanner.Text()
-		if strings.Contains(entry, fmt.Sprintf("%d", tableID)) {
-			return true, nil
-		}
-	}
-	return false, nil
-}
-
-// AddTableID adds the given table ID to the rt_tables file.
-func AddTableID(tableID uint32, tableName string) error {
-	newEntry := forgeTableEntry(tableID, tableName)
-
-	// ensure the directory existence
-	if err := os.MkdirAll(RTTablesDir, 0o700); err != nil {
-		return err
-	}
-
-	file, err := os.OpenFile(RTTablesFilename, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		runtime.Must(file.Close())
-	}()
-
-	if _, err := fmt.Fprintf(file, "%s\n", newEntry); err != nil {
-		return err
-	}
-	return nil
-}
-
-// DeleteTableID deletes the given table ID from the rt_tables file.
-func DeleteTableID(tableID uint32) error {
-	lines, err := filterDeletedLines(tableID)
-	if err != nil {
-		return err
-	}
-
-	// ensure the directory existence
-	if err := os.MkdirAll(RTTablesDir, 0o700); err != nil {
-		return err
-	}
-
-	file, err := os.OpenFile(RTTablesFilename, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o600)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		runtime.Must(file.Close())
-	}()
-	for _, line := range lines {
-		if _, err := fmt.Fprintf(file, "%s\n", line); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func filterDeletedLines(tableID uint32) ([]string, error) {
-	file, err := os.OpenFile(RTTablesFilename, os.O_RDONLY, 0o600)
-	if errors.Is(err, os.ErrNotExist) {
-		return []string{}, nil
-	} else if err != nil {
-		return nil, err
-	}
-	defer func() {
-		runtime.Must(file.Close())
-	}()
-	scanner := bufio.NewScanner(file)
-	var lines []string
-	for scanner.Scan() {
-		entry := scanner.Text()
-		if !strings.Contains(entry, fmt.Sprintf("%d", tableID)) {
-			lines = append(lines, entry)
-		}
-	}
-	return lines, nil
 }
 
 func generateTableID(name string) uint32 {
@@ -176,8 +42,4 @@ func generateTableID(name string) uint32 {
 	// make sure we won't use this range
 	id[1] |= 1
 	return uint32(hash[3])<<24 | uint32(hash[2])<<16 | uint32(hash[1])<<8 | uint32(hash[0])
-}
-
-func forgeTableEntry(tableID uint32, tableName string) string {
-	return fmt.Sprintf("%s\t%s", strconv.FormatUint(uint64(tableID), 10), tableName)
 }


### PR DESCRIPTION
## Problem

Liqo was registering its iproute2 routing table names in `/etc/iproute2/rt_tables` by writing entries like:

```
1572867497    liqo-<cluster>
```

This caused two visible errors on any node where liqo was running:

```
$ ip route show table 77
ip: database tables is corrupted at line 1

$ ip route show table 1572867497
ip: database tables is corrupted at line 1
ip: invalid argument '1572867497' to 'table'
```

The root cause is that iproute2 parses `/etc/iproute2/rt_tables` for every `ip route` invocation to build a name-to-ID mapping. When it encounters a number as large as `1572867497` it fails to parse the line and reports the file as corrupted — breaking all subsequent `ip route` commands on that node, even for unrelated tables.

## Fix

The kernel does not require entries in `/etc/iproute2/rt_tables` to use a routing table. Those entries exist purely for human-readable `ip route show table <name>` output. Since liqo uses netlink directly to manage routes and rules, the file entries serve no functional purpose.

This PR removes all logic that reads from and writes to `/etc/iproute2/rt_tables`:

- `EnsureTablePresence` and `EnsureTableAbsence` calls are removed from the reconciler.
- All related helpers (`ExistsTableID`, `AddTableID`, `DeleteTableID`, etc.) are deleted.

The routing table ID is still derived deterministically from the table name via SHA256, so behaviour is otherwise unchanged.
