### PR TITLE
Docs (advanced): add detailed resource reservation page

### DIFF
--- a/docs/_static/images/usage/resource-reservation/sequence.svg
+++ b/docs/_static/images/usage/resource-reservation/sequence.svg
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 820 720" font-family="Arial,Helvetica,sans-serif" font-size="12">
+  <defs>
+    <marker id="rrArrow" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#000"/>
+    </marker>
+    <marker id="rrArrowRet" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#666"/>
+    </marker>
+  </defs>
+
+  <text x="410" y="22" text-anchor="middle" font-weight="bold" font-size="14">ResourceSlice → Quota + VirtualNode</text>
+
+  <!-- Lifeline header boxes -->
+  <g>
+    <rect x="60" y="40" width="160" height="34" fill="#5b9bd5" stroke="#1f4e79"/>
+    <text x="140" y="62" text-anchor="middle" fill="white" font-weight="bold">Consumer admin</text>
+
+    <rect x="300" y="40" width="200" height="34" fill="#5b9bd5" stroke="#1f4e79"/>
+    <text x="400" y="62" text-anchor="middle" fill="white" font-weight="bold">Consumer cluster</text>
+
+    <rect x="580" y="40" width="200" height="34" fill="#5b9bd5" stroke="#1f4e79"/>
+    <text x="680" y="62" text-anchor="middle" fill="white" font-weight="bold">Provider cluster</text>
+  </g>
+
+  <!-- Lifelines (dashed gray) -->
+  <g stroke="#aaa" stroke-width="1" stroke-dasharray="5,4">
+    <line x1="140" y1="74" x2="140" y2="680"/>
+    <line x1="400" y1="74" x2="400" y2="680"/>
+    <line x1="680" y1="74" x2="680" y2="680"/>
+  </g>
+
+  <!-- Activation (execution) bars -->
+  <g fill="#70ad47">
+    <rect x="136" y="90" width="8" height="30"/>
+    <rect x="396" y="105" width="8" height="475"/>
+    <rect x="676" y="180" width="8" height="285"/>
+    <rect x="136" y="560" width="8" height="30"/>
+  </g>
+
+  <!-- M1: Consumer admin → Consumer cluster (liqoctl) -->
+  <line x1="148" y1="110" x2="396" y2="110" stroke="#000" stroke-width="1.5" marker-end="url(#rrArrow)"/>
+  <text x="272" y="103" text-anchor="middle" font-size="11">liqoctl peer  /  liqoctl create resourceslice</text>
+
+  <!-- A1: ResourceSlice creation on consumer -->
+  <text x="412" y="140" font-size="11" font-weight="600">creates ResourceSlice (spec.resources)</text>
+  <text x="412" y="156" font-size="10" fill="#666" font-style="italic">in liqo-tenant-&lt;provider&gt; namespace, on the consumer cluster</text>
+
+  <!-- M2: forward replication -->
+  <line x1="404" y1="185" x2="676" y2="185" stroke="#000" stroke-width="1.5" marker-end="url(#rrArrow)"/>
+  <text x="540" y="178" text-anchor="middle" font-size="11">crd-replicator: copy ResourceSlice spec → provider</text>
+
+  <!-- ALT fragment: class controller branch -->
+  <g>
+    <rect x="555" y="205" width="240" height="180" fill="#ffffff" stroke="#888" stroke-width="1"/>
+    <polygon points="555,205 600,205 605,213 605,221 555,221" fill="#4472c4"/>
+    <text x="580" y="218" text-anchor="middle" fill="white" font-size="10" font-weight="bold">alt</text>
+    <text x="615" y="218" font-size="11" fill="#000">[class = default]</text>
+    <text x="565" y="244" font-size="10">RemoteResourceSliceReconciler fills</text>
+    <text x="565" y="258" font-size="10">status.resources =</text>
+    <text x="565" y="272" font-size="10">spec.resources ∪ defaultNodeResources</text>
+    <line x1="555" y1="295" x2="795" y2="295" stroke="#888" stroke-dasharray="3,3"/>
+    <text x="615" y="312" font-size="11" fill="#000">[class = custom]</text>
+    <text x="565" y="338" font-size="10">external controller decides:</text>
+    <text x="565" y="352" font-size="10">accept / deny / partial,</text>
+    <text x="565" y="366" font-size="10">writes status.resources</text>
+  </g>
+
+  <!-- A2: QuotaCreator creates Quota on provider -->
+  <text x="572" y="410" font-size="11" font-weight="600">QuotaCreator creates Quota</text>
+  <text x="572" y="426" font-size="10" fill="#666" font-style="italic">in liqo-tenant-&lt;consumer&gt; namespace, on the provider cluster</text>
+  <text x="572" y="440" font-size="10" fill="#666" font-style="italic">.spec = (resources, limitsEnforcement, cordoned)</text>
+
+  <!-- M3: backward replication of status -->
+  <line x1="676" y1="475" x2="404" y2="475" stroke="#666" stroke-width="1.5" stroke-dasharray="6,4" marker-end="url(#rrArrowRet)"/>
+  <text x="540" y="468" text-anchor="middle" font-size="11">crd-replicator: ResourceSlice status → consumer</text>
+
+  <!-- A3: VirtualNode creation on consumer -->
+  <text x="412" y="503" font-size="11" font-weight="600">VirtualNodeCreator creates VirtualNode</text>
+  <text x="412" y="519" font-size="10" fill="#666" font-style="italic">in liqo-tenant-&lt;provider&gt; namespace, on the consumer cluster</text>
+  <text x="412" y="533" font-size="10" fill="#666" font-style="italic">.spec.resourceQuota.hard = status.resources</text>
+
+  <!-- A4: K8s Node materializes -->
+  <text x="412" y="558" font-size="11">virtual-kubelet exposes a K8s Node "Ready"</text>
+
+  <!-- M4: return to consumer admin -->
+  <line x1="396" y1="585" x2="148" y2="585" stroke="#666" stroke-width="1.5" stroke-dasharray="6,4" marker-end="url(#rrArrowRet)"/>
+  <text x="272" y="578" text-anchor="middle" font-size="11">kubectl get nodes  →  VirtualNode Ready</text>
+
+  <!-- Section divider + footnote -->
+  <line x1="40" y1="625" x2="800" y2="625" stroke="#bbb" stroke-dasharray="2,2"/>
+  <text x="410" y="645" text-anchor="middle" font-size="11" font-style="italic" fill="#444">Once Ready, pods scheduled on the VirtualNode go through ShadowPod admission against the Quota.</text>
+
+  <!-- Lifeline end X marks -->
+  <g stroke="#888" stroke-width="2">
+    <line x1="134" y1="670" x2="146" y2="685"/>
+    <line x1="146" y1="670" x2="134" y2="685"/>
+    <line x1="394" y1="670" x2="406" y2="685"/>
+    <line x1="406" y1="670" x2="394" y2="685"/>
+    <line x1="674" y1="670" x2="686" y2="685"/>
+    <line x1="686" y1="670" x2="674" y2="685"/>
+  </g>
+</svg>

--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -30,6 +30,7 @@ subtrees:
   - caption: Usage
     entries:
       - file: usage/peer.md
+      - file: usage/resource-reservation.md
       - file: usage/namespace-offloading.md
       - file: usage/reflection.md
       - file: usage/stateful-applications.md

--- a/docs/advanced/peering/offloading-in-depth.md
+++ b/docs/advanced/peering/offloading-in-depth.md
@@ -333,19 +333,4 @@ There are two strategies to create `VirtualNodes` associated with the same provi
 
 ## Resource Enforcement
 
-To ensure that the pods scheduled on a Liqo virtual node do not exceed the resources granted by the ResourceSlice, pods should have resource `limits` set. This allows the consumer cluster scheduler to be aware of how many resources have already been allocated, and it can select another node for scheduling.
-
-By default, Liqo enables a server-side check that ensures the requests of the pod do not exceed the quota (`controllerManager.config.enableResourceEnforcement` option enabled).
-However, this is not a guarantee that the consumer is not using more than expected, as if limits are higher than requests or if the user does not set limits and requests at all, a consumer cluster can use more than the quota.
-To define how strict is the server-side resources enforcement, ensuring that the consumer cluster never exceeds the quota, it is possible to act on the `controllerManager.config.defaultLimitsEnforcement` option, which can assume the following values:
-
-* **None** (default): the offloaded pods might not have the resource `requests` or `limits`. Which involves that the consumer cluster might use more than the resources negotiated via the `ResourceSlice`.
-* **Soft**: it forces the offloaded pods to have the `requests` set, which implies that pre-allocated resources will never go over the quota, but if the pods go over the requests, the total used resources might go over the quota.
-* **Hard**: it forces the offloaded pods to have both `limits` and `requests` set, with `limits` equal to the `requests`. **This is the safest mode** as the consumer cluster cannot go over the quota negotiated via the `ResourceSlice`.
-
-These options [need to be set at installation time](../../installation/install.md#customization-options), by defining them in the `values.yaml` or providing them via the `--set` argument to `helm install` or `liqoctl install`.
-For example, to set the `defaultLimitsEnforcement` to `Hard`:
-
-```bash
-liqoctl install [...ARGS] --set controllerManager.config.defaultLimitsEnforcement=Hard
-```
+The `controllerManager.config.enableResourceEnforcement` and `controllerManager.config.defaultLimitsEnforcement` options control how strictly the provider enforces the `Quota` granted by a `ResourceSlice` at runtime. The two options, the three enforcement modes (`None`, `Soft`, `Hard`), and how to set them are described in detail in the [Resource quota enforcement](/usage/resource-reservation.md#resource-quota-enforcement) section of the resource reservation page.

--- a/docs/usage/peer.md
+++ b/docs/usage/peer.md
@@ -244,61 +244,7 @@ liqoctl info peer cl01 --get authentication.resourceslices
 
 ## Defining the amount of resources to share
 
-By default, the `liqoctl peer` command requests the provider a default amount of resources, defined at installation time, which are:
-
-- cpu: "4"
-- memory: "8Gi"
-- pods: "110"
-- ephemeral-storage: "20Gi"
-
-```{admonition} Tip
-These defaults [can be changed](../installation/install.md#customization-options) by customizing the value of the `offloading.defaultNodeResources` option.
-```
-
-To define different values for a specific peering, you can provide the `--cpu`, `--memory`, and `--pods` arguments to the `liqoctl peer` command:
-
-```bash
-liqoctl peer \
-  --kubeconfig=$CONSUMER_KUBECONFIG_PATH \
-  --remote-kubeconfig=$PROVIDER_KUBECONFIG_PATH \
-  --cpu=2 \
-  --memory=2Gi
-```
-
-Other non-standard resources can be defined via the `--resource` flag:
-
-```bash
-liqoctl peer \
-  --kubeconfig=$CONSUMER_KUBECONFIG_PATH \
-  --remote-kubeconfig=$PROVIDER_KUBECONFIG_PATH \
-  --cpu=2 \
-  --memory=2Gi \
-  --resource=nvidia.com/gpu=2 \
-  --resource=custom=2Gi
-```
-
-```{warning}
-To make sure the consumer cluster does not exceed the quota of shared resources, the offloaded pods need to be created with the resources `limits` set.
-
-Check the [resource enforcement section](../advanced/peering/offloading-in-depth.md#resource-enforcement) to know more about how to configure Liqo to enforce the quota of resources that the provider has granted to the consumer cluster.
-```
-
-### Defining custom resources
-
-If you would ask for resources other than CPUs and memory, such as GPUs, you will need to create the peering connection without requesting resources, which can be done by providing the `--create-resource-slice=false` option:
-
-```bash
-liqoctl peer \
-  --kubeconfig=$CONSUMER_KUBECONFIG_PATH \
-  --remote-kubeconfig=$PROVIDER_KUBECONFIG_PATH \
-  --create-resource-slice=false
-```
-
-The command above creates a peering connection, but **the provider cluster is currently not sharing resources**.
-
-**To request resources** from a provider cluster, **you will need to create a `ResourceSlice`**, where you specify the amount of resources you would like the provider to share with the consumer, including your custom resources.
-
-You can check [here to learn how to create a `ResourceSlice`](../advanced/peering/offloading-in-depth.md#create-resourceslice).
+The default amounts requested by `liqoctl peer`, how to configure them, how to override them at peering time, and how to request custom resources are all described in detail in the [resource reservation](/usage/resource-reservation.md) page.
 
 ## Bidirectional peering
 

--- a/docs/usage/peer.md
+++ b/docs/usage/peer.md
@@ -244,7 +244,7 @@ liqoctl info peer cl01 --get authentication.resourceslices
 
 ## Defining the amount of resources to share
 
-The default amounts requested by `liqoctl peer`, how to configure them, how to override them at peering time, and how to request custom resources are all described in detail in the proper section of the [resource reservation](/usage/resource-reservation.md#ResourceReservationDefaultSlice) page.
+The default amounts requested by `liqoctl peer`, how to configure them, how to override them at peering time, and how to request custom resources are all described in detail in the proper section of the [resource reservation](ResourceReservationDefaultSlice) page.
 
 ## Bidirectional peering
 

--- a/docs/usage/peer.md
+++ b/docs/usage/peer.md
@@ -244,7 +244,7 @@ liqoctl info peer cl01 --get authentication.resourceslices
 
 ## Defining the amount of resources to share
 
-The default amounts requested by `liqoctl peer`, how to configure them, how to override them at peering time, and how to request custom resources are all described in detail in the [resource reservation](/usage/resource-reservation.md) page.
+The default amounts requested by `liqoctl peer`, how to configure them, how to override them at peering time, and how to request custom resources are all described in detail in the proper section of the [resource reservation](/usage/resource-reservation.md#ResourceReservationDefaultSlice) page.
 
 ## Bidirectional peering
 

--- a/docs/usage/resource-reservation.md
+++ b/docs/usage/resource-reservation.md
@@ -335,4 +335,3 @@ This section lists some information and/or actions that may be required, and tha
 * **Provision the capacity advertised by the provider.**
   The provider must actually have the physical or cloud capacity to honor what `offloading.defaultNodeResources` and granted `ResourceSlice` objects promise.
   The default class controller does not verify against real capacity, so over-promising surfaces only at runtime with pods resulting in a `Pending` state; cluster sizing — whether manual, via `cluster-autoscaler` or Karpenter, or through cloud quota requests — is the provider operator's job.
-

--- a/docs/usage/resource-reservation.md
+++ b/docs/usage/resource-reservation.md
@@ -1,0 +1,337 @@
+# Resources sharing and reservation
+
+Liqo enables a cluster, named *consumer*, to acquire resources from another remote cluster, named *provider*.
+This happens through an explicitly negotiated **slice** of the provider cluster: the `ResourceSlice` resource carries the request, the `Quota` resource enforces it on the provider, and the `VirtualNode` resource exposes it on the consumer.
+
+However, some questions arise, such as *how many resources are desired* (by the consumer), *how resources are reserved* (by the provider), *how can we guarantee that the consumer does not consume more resources than planned*, and more.
+
+This section of the documentation presents a detailed view about how resource reservation is handled with Liqo, and the possible limitations of the current approach.
+Particularly, it describes how that slice is reserved end-to-end, from both the *provider* and the *consumer* point of view: how to configure the default slice size, how to request a specific amount, how strictly the provider enforces it at runtime, and how to suspend or reclaim a reservation that is no longer needed.
+
+## Overview
+
+A reservation in Liqo is the result of an exchange between two clusters:
+
+* The **consumer** declares how much it would like to obtain by creating a `ResourceSlice` in its tenant namespace, with the requested quantities in `spec.resources`.
+* The **provider** decides how much it actually grants by writing the accepted quantities back into `status.resources` of the same object (the slice is replicated across clusters by the *crd-replicator*).
+
+Once the slice is `Accepted`, two derived resources materialize the reservation:
+
+* On the **provider**, a `Quota` (`offloading.liqo.io/Quota`) is created in the tenant namespace, mirroring the accepted resources and the desired enforcement strictness.
+* On the **consumer**, a `VirtualNode` is created with `spec.resourceQuota.hard` set to the same quantities, and the corresponding Kubernetes `Node` advertises that capacity to the local scheduler.
+
+By default, a single `ResourceSlice` is shared across all of the consumer's [offloaded namespaces](/usage/namespace-offloading.md): pods consume from the same `Quota` regardless of which offloaded namespace they live in. With multiple `VirtualNode`s (one per `ResourceSlice`), pods route to slices by the `VirtualNode` they are scheduled on, not by namespace.
+
+The diagram below summarizes the flow and makes explicit on which cluster each object is created.
+
+```{figure} /_static/images/usage/resource-reservation/sequence.svg
+:align: center
+:alt: Sequence diagram of the ResourceSlice to Quota and VirtualNode flow across the consumer and provider clusters.
+```
+
+From that point on, the reservation has two enforcement points:
+
+* the **consumer's Kubernetes scheduler**, which sees the Liqo virtual `Node` as a node with finite capacity;
+* the **provider's `ShadowPod` admission webhook**, which rejects offloaded pods that would push the consumer past its `Quota`.
+This double mechanism prevents *consumers* from using more resources than what was negotiated with the provider cluster.
+
+```{warning}
+To make sure the consumer cluster does not exceed the quota of shared resources, the offloaded pods need to be created with the resources `limits` set.
+
+Check the [Resource quota enforcement](#resource-quota-enforcement) section to know more about how to configure Liqo to enforce the quota of resources that the provider has granted to the consumer cluster.
+```
+
+(ResourceReservationDefaultSlice)=
+
+## Defining the amount of resources to share
+
+By default, the `liqoctl peer` command requests the provider a default amount of resources, defined at installation time on the provider, which are:
+
+* cpu: "4"
+* memory: "8Gi"
+* pods: "110"
+* ephemeral-storage: "20Gi"
+
+These defaults only apply to resource keys the consumer did not explicitly request.
+For example, if a consumer asks for `cpu: "8"` and nothing else, the resulting `Quota` will have `cpu: "8"` from the request and `memory: "8Gi"`, `pods: "110"`, `ephemeral-storage: "20Gi"` from the defaults.
+
+```{admonition} Note
+Setting `offloading.defaultNodeResources` to a small value is the simplest way to limit how much capacity an unconfigured peering can claim: a consumer that does not explicitly negotiate larger amounts will always receive the defaults.
+```
+
+These defaults are configured through the Helm value `offloading.defaultNodeResources`:
+
+```{code-block} yaml
+:caption: "values.yaml (provider)"
+offloading:
+  defaultNodeResources:
+    cpu: "4"
+    memory: "8Gi"
+    pods: "110"
+    ephemeral-storage: "20Gi"
+```
+
+The default resources can be customized during installation or later with an upgrade, by setting the `offloading.defaultNodeResources` value. This can be done using either `liqoctl install` or Helm (`helm install`/`helm upgrade`). For more details, see the [customization options](/installation/install.md#customization-options) page.
+
+```{code-block} bash
+:caption: "Cluster provider"
+liqoctl install [...ARGS] \
+  --set offloading.defaultNodeResources.cpu="2" \
+  --set offloading.defaultNodeResources.memory="4Gi"
+```
+
+### Overriding the defaults at peering time
+
+To define different values for a specific peering, the consumer can provide the `--cpu`, `--memory`, `--pods`, and `--resource` arguments to the `liqoctl peer` command:
+
+```{code-block} bash
+:caption: "Cluster consumer"
+liqoctl peer \
+  --kubeconfig=$CONSUMER_KUBECONFIG_PATH \
+  --remote-kubeconfig=$PROVIDER_KUBECONFIG_PATH \
+  --cpu=8 \
+  --memory=16Gi \
+  --pods=200 \
+  --resource=nvidia.com/gpu=2
+```
+
+Any resource key supported by the Kubernetes `ResourceList` can be requested through the `--resource` command line parameter (repeatable), including extended resources advertised by the provider (e.g. `nvidia.com/gpu`).
+
+## Request a slice after peering
+
+After a peering has been established, a consumer can change the amount of resources granted by either editing an existing `ResourceSlice` or creating a new one.
+
+### By editing an existing `ResourceSlice`
+
+The amount of resources granted by an existing slice can be increased or decreased by updating its `spec.resources`.
+The provider re-evaluates the request, the `Quota` is updated to match `status.resources`, and the `VirtualNode` reflects the new capacity.
+If the provider rejects the new request — only possible with a [custom class controller](#custom-resource-allocation-policies), since the default class always accepts — the `ResourceSlice`'s `Resources` condition transitions to `Denied`, the existing `Quota` is left unchanged, and the `VirtualNode` continues to expose the previously granted capacity.
+
+```{warning}
+Reducing the granted resources below what the consumer is currently using will not evict pods immediately: existing offloaded pods continue to run, but new pods that would exceed the new `Quota` will be denied at admission.
+For an immediate effect, see the [suspending and reclaiming a reservation](#suspend-and-reclaim-a-reservation) section below.
+```
+
+### After peering, with a separate `ResourceSlice`
+
+When the peering already exists, additional capacity can be requested by creating a new `ResourceSlice`.
+This is also the right path when you want a separate slice and a separate `VirtualNode` for a distinct pool of resources — for example, a dedicated GPU pool kept apart from the main CPU/memory slice — rather than enlarging the original slice:
+
+`````{tab-set}
+
+````{tab-item} liqoctl
+
+```{code-block} bash
+:caption: "Cluster consumer"
+liqoctl create resourceslice gpu-pool \
+  --remote-cluster-id cool-firefly \
+  --cpu 4 --memory 8Gi --pods 30 \
+  --resource nvidia.com/gpu=2
+```
+````
+
+````{tab-item} YAML
+
+```{code-block} yaml
+:caption: "Cluster consumer"
+apiVersion: authentication.liqo.io/v1beta1
+kind: ResourceSlice
+metadata:
+  name: gpu-pool
+  namespace: liqo-tenant-cool-firefly
+  labels:
+    liqo.io/remote-cluster-id: cool-firefly
+    liqo.io/replication: "true"
+spec:
+  class: default
+  providerClusterID: cool-firefly
+  resources:
+    cpu: "4"
+    memory: 8Gi
+    pods: "30"
+    nvidia.com/gpu: "2"
+```
+````
+
+`````
+
+Each `ResourceSlice` is associated with one `Quota` on the provider, and with one or more `VirtualNodes` on the consumer (one by default); multiple slices toward the same provider originate multiple virtual nodes, which can be also useful to expose heterogeneous resources (for example, separate ARM and x86 pools — see the [multiple virtual nodes](/advanced/peering/offloading-in-depth.md#multiple-virtualnodes) section).
+
+## Inspect the reservation
+
+On the **consumer**, the resulting Liqo virtual `Node` exposes the granted capacity to the local scheduler as a regular node.
+`liqoctl info peer` shows the info about the shared resource and of the peering status:
+
+```{code-block} bash
+:caption: "Cluster consumer"
+liqoctl info peer cool-firefly --get authentication.resourceslices
+```
+
+```text
+─ Resource slices ──────────────────────────────────────────────
+  ─ gpu-pool ──────────────────────────────────────────────────
+    ✔  Resource slice accepted
+    Action: Create
+    ─ Resources ──────────────────────────────────────────────
+      cpu:               4
+      memory:            8Gi
+      pods:              30
+      nvidia.com/gpu:    2
+```
+
+```{admonition} Pro tip
+For lower-level debugging, the underlying `ResourceSlice` (on the consumer) and `Quota` (on the provider) custom resources can also be inspected directly with `kubectl`.
+```
+
+On the **consumer**, the `ResourceSlice` shows what was requested and whether it was accepted:
+
+```{code-block} bash
+:caption: "Cluster consumer"
+kubectl get resourceslices.authentication.liqo.io -A
+```
+
+```text
+NAMESPACE                  NAME       AUTHENTICATION   RESOURCES   AGE
+liqo-tenant-cool-firefly   gpu-pool   Accepted         Accepted    21s
+```
+
+On the **provider**, the `Quota` shows what is being enforced:
+
+```{code-block} bash
+:caption: "Cluster provider"
+kubectl get quotas.offloading.liqo.io -A
+```
+
+```text
+NAMESPACE                   NAME                    ENFORCEMENT   CORDONED   AGE
+liqo-tenant-wispy-firefly   gpu-pool-c34af51dd912   None                     35s
+```
+
+## Resource quota enforcement
+
+A `Quota` defines an upper bound, but whether the consumer can ever exceed it at runtime depends on two further options on the provider, both under `controllerManager.config`:
+
+* `enableResourceEnforcement` (default `true`): turns on the `ShadowPod` validating webhook that rejects new offloaded pods if they would push the consumer past its `Quota`. However, this is not on its own a strict guarantee: if `limits` are higher than `requests` or if neither is set at all, the consumer can still consume more than the quota at runtime.
+* `defaultLimitsEnforcement` (default `None`): controls how strictly the webhook interprets the `requests` and `limits` of each offloaded pod. It can take three values:
+
+  * **`None`** (default): offloaded pods may have neither `requests` nor `limits` set, so the consumer might end up using more than the resources negotiated via the `ResourceSlice`.
+  * **`Soft`**: offloaded pods must declare `requests`; pre-allocated resources stay within the quota, but if a pod uses more than its `requests` (because `limits` are higher or unset), actual usage can drift over.
+  * **`Hard`**: offloaded pods must declare both `requests` and `limits`, with `limits == requests`. This is the strictest mode and the only one that turns the per-peering quota into a runtime guarantee, since the kubelet on the provider will throttle or kill containers that try to exceed their declared `limits`.
+
+The selected mode is propagated to every `Quota` created on the provider via the `Quota.spec.limitsEnforcement` field. Both options can be set at installation time or updated later. For example, to set `defaultLimitsEnforcement` to `Hard`:
+
+```{code-block} bash
+:caption: "Cluster provider"
+liqoctl install [...ARGS] --set controllerManager.config.defaultLimitsEnforcement=Hard
+```
+
+```{warning}
+Switching to `Hard` enforcement after workloads are already being offloaded will cause new `ShadowPod` admissions to fail for any pod that does not declare matching `requests` and `limits`.
+Verify that the workloads being offloaded already comply, or set sensible defaults via a mutating policy, before applying this change to a production provider.
+```
+
+## Custom resource allocation policies
+
+By default, the `ResourceSlice` class controller shipped with Liqo accepts every incoming request and only fills in the missing keys with `offloading.defaultNodeResources`. This behavior can be customized by defining a **custom `ResourceSlice` class** to implement stricter or cluster-wide policies (for example, capping the total accepted slices at a fraction of cluster capacity, or per-tenant quotas).
+
+A reusable starting point is provided by the [resource-slice-class-controller-template](https://github.com/liqotech/resource-slice-class-controller-template) repository, and the general mechanics of class controllers are described in the [Custom Resource Allocation](/advanced/peering/offloading-in-depth.md#custom-resource-allocation) section of the offloading-in-depth page.
+
+```{warning}
+The class is chosen by the **consumer**, and the built-in default class controller is always running alongside any custom one — Liqo does not provide a built-in way to disable it.
+A consumer can therefore bypass a strict custom controller simply by selecting `class: default` (or omitting the class), which routes the request to the lenient built-in controller.
+To actually enforce a stricter policy at the provider, the custom controller must be paired with an external mechanism that prevents the lenient path from being used — for example, a Kubernetes admission webhook on the provider that rejects or rewrites the `spec.class` of incoming `ResourceSlice` objects.
+```
+
+(ResourceReservationSuspendReclaim)=
+
+## Suspend and reclaim a reservation
+
+Liqo exposes two operations to act on an active reservation without unpeering: **cordon** (stop new allocations, keep existing ones) and **drain** (reject new allocations and revoke existing ones).
+Both operations can be applied at the granularity of a single `ResourceSlice` or of an entire `Tenant` (which covers all slices of that consumer).
+
+### Cordon a `ResourceSlice`
+
+Cordoning a slice prevents the provider from accepting new resource requests on that slice while leaving existing offloaded workloads running:
+
+```{code-block} bash
+:caption: "Cluster provider"
+liqoctl cordon resourceslice gpu-pool --remote-cluster-id cool-firefly
+```
+
+Internally, this adds the `liqo.io/cordoned-resource` annotation to the slice, which causes the `Quota` to be marked `cordoned: true`.
+The `ShadowPod` admission webhook then rejects any new offloaded pod from that consumer.
+The reverse operation is `liqoctl uncordon resourceslice`.
+
+### Cordon a `Tenant`
+
+Cordoning a tenant has the same effect as cordoning all of its slices, plus it stops the provider from accepting **new** `ResourceSlice` objects from that consumer:
+
+```{code-block} bash
+:caption: "Cluster provider"
+liqoctl cordon tenant cool-firefly
+```
+
+This sets `spec.tenantCondition` to `Cordoned` on the provider's `Tenant` (`authentication.liqo.io/Tenant`) for that consumer.
+The `RemoteResourceSliceReconciler` honors the condition by leaving previously-accepted slices untouched and denying new ones.
+
+### Drain a `Tenant`
+
+Draining is the strongest operation: it suspends new allocations *and* invalidates existing ones, so that the provider stops admitting offloaded pods for that consumer altogether:
+
+```{code-block} bash
+:caption: "Cluster provider"
+liqoctl drain tenant cool-firefly
+```
+
+This sets `spec.tenantCondition` to `Drained` on the same `Tenant`; the `RemoteResourceSliceReconciler` then denies the resources of all existing slices.
+The reverse operation is `liqoctl uncordon tenant`, which restores the tenant to `Active`.
+
+The full reference for these commands is available on the [`liqoctl cordon`](/usage/liqoctl/liqoctl_cordon.md), [`liqoctl drain`](/usage/liqoctl/liqoctl_drain.md), and [`liqoctl uncordon`](/usage/liqoctl/liqoctl_uncordon.md) pages.
+
+```{important}
+Cordon and drain are administrative operations on the **provider**: they affect what the provider is willing to grant.
+Cordoning a tenant on the provider does not unpeer the consumer nor remove its `VirtualNode`.
+In other words, pods scheduled on the virtual node may still appear `Running` until they are evicted or the slice is fully released.
+```
+
+## Limitations
+
+A few aspects of the current design are worth keeping in mind when designing a reservation policy:
+
+* The default `ResourceSlice` class controller does not perform a **cluster-wide capacity check**: it accepts every request and may therefore grant more resources than the provider physically has, leaving the final arbitration to the standard Kubernetes scheduler on the provider. Cross-peering reservation requires a custom class controller **paired with an admission webhook (or equivalent mechanism) that prevents consumers from selecting the lenient default class** — Liqo does not ship that mechanism.
+* Reducing the granted resources on a slice does not evict pods that are already running; cordon and drain are the supported way to actively reclaim capacity.
+
+## What Liqo does not
+
+Liqo provides the basic mechanisms to negotiate and reserve resources, but a full-functional service may require the cooperation between Liqo and external components that take care of some preconditions that are out of scope for Liqo.
+This section lists some information and/or actions that may be required, and that must be carried out outside Liqo; skipping them may cause the reservation to fail or to complete with incorrect outcomes.
+
+* **Discover what to ask for.**
+  The consumer must learn from the provider (out of band) which amounts and resource types are actually available before creating a `ResourceSlice`.
+  Liqo has no inventory advertisement and the default class (on the provider side) accepts any request, so an improper reservation is automatically accepted by Liqo, and only manifests later with pods that may not be able to start (hence, in `Pending` state) on the provider cluster.
+
+* **Exchange cluster identities and peering credentials.**
+  Cluster IDs and a peering kubeconfig (typically generated on the provider with `liqoctl generate peering-user`) must be exchanged through a secure channel before `liqoctl peer` runs.
+  Liqo provides no directory or discovery service across clusters.
+
+* **Authorize the peering relationship.**
+  Someone with organizational authority must decide that the consumer is allowed to peer at all.
+  Liqo's handshake verifies *who* a peer is, not *whether they should be admitted*; there is no built-in approval workflow or admission queue at the organization level. A custom `ResourceSlice` class controller can implement such a workflow by accepting or denying slices based on organizational policy.
+
+* **Choose the provider's reservation posture.**
+  The provider operator must set the Helm chart values `offloading.defaultNodeResources` and `controllerManager.config.defaultLimitsEnforcement` before any consumer peers.
+  Both can be updated later via a Helm upgrade: `defaultLimitsEnforcement` then propagates to existing `Quota` objects on the next reconciliation, while `defaultNodeResources` only affects future slice negotiations — slices already accepted retain the amounts they were granted.
+  The chart ships defaults suited to demos (4 CPU, 8Gi, `None` enforcement); using them unchanged in production typically grants more than the operator intends and enforces nothing at runtime.
+
+* **Agree on what each resource key physically represents.**
+  Kubernetes resource keys (`cpu`, `memory`, `nvidia.com/gpu`, ...) are opaque strings — a limitation of how resource allocation worked in Kubernetes prior to Dynamic Resource Allocation (DRA), which Liqo inherits. What `nvidia.com/gpu=2` actually means — A100s versus H100s, full cards versus MIG slices, with or without NVLink — must be agreed out of band.
+  Such a mismatch — for example, the consumer asking for `nvidia.com/gpu=2` expecting two H100 cards while the provider grants two A100 cards under the same key — is accepted at negotiation and only surfaces as wrong performance or runtime failure once workloads are scheduled.
+
+* **Ensure offloaded pods comply with the enforcement mode.**
+  When `defaultLimitsEnforcement` is `Soft` or `Hard`, the consumer's pods must declare `requests` (Soft) or matching `requests` and `limits` (Hard) before being offloaded (see [Resource quota enforcement](#resource-quota-enforcement) for the per-mode semantics).
+  The `ShadowPod` admission webhook rejects non-compliant pods at the provider, leaving the local pod in `Pending` state; making pod specs compliant is the consumer application teams' responsibility, not Liqo's.
+
+* **Provision the capacity advertised by the provider.**
+  The provider must actually have the physical or cloud capacity to honor what `offloading.defaultNodeResources` and granted `ResourceSlice` objects promise.
+  The default class controller does not verify against real capacity, so over-promising surfaces only at runtime with pods resulting in a `Pending` state; cluster sizing — whether manual, via `cluster-autoscaler` or Karpenter, or through cloud quota requests — is the provider operator's job.
+

--- a/docs/usage/resource-reservation.md
+++ b/docs/usage/resource-reservation.md
@@ -20,7 +20,8 @@ Once the slice is `Accepted`, two derived resources materialize the reservation:
 * On the **provider**, a `Quota` (`offloading.liqo.io/Quota`) is created in the tenant namespace, mirroring the accepted resources and the desired enforcement strictness.
 * On the **consumer**, a `VirtualNode` is created with `spec.resourceQuota.hard` set to the same quantities, and the corresponding Kubernetes `Node` advertises that capacity to the local scheduler.
 
-By default, a single `ResourceSlice` is shared across all of the consumer's [offloaded namespaces](/usage/namespace-offloading.md): pods consume from the same `Quota` regardless of which offloaded namespace they live in. With multiple `VirtualNode`s (one per `ResourceSlice`), pods route to slices by the `VirtualNode` they are scheduled on, not by namespace.
+By default, a single `ResourceSlice` is shared across all of the consumer's [offloaded namespaces](/usage/namespace-offloading.md): pods consume from the same `Quota` regardless of which offloaded namespace they live in.
+When multiple `VirtualNode`s are created (one per `ResourceSlice`), pods consume the quota based on the `VirtualNode` they are scheduled on, not by namespace.
 
 The diagram below summarizes the flow and makes explicit on which cluster each object is created.
 


### PR DESCRIPTION
# Description

This PR adds a new documentation page `docs/advanced/resource-reservation.md` describing how to reserve and bound the slice of provider capacity exchanged through `ResourceSlice`, addressed from both the provider and the consumer sides.

The underlying mechanisms — `offloading.defaultNodeResources`, custom `ResourceSlice` class controllers, `Quota` enforcement modes (`None` / `Soft` / `Hard`), the `ShadowPod` admission webhook, and `Tenant` / `ResourceSlice` cordon/drain — are already documented per-piece across the existing docs, but never as a single end-to-end workflow. This page assembles them.

Also included:
- A sequence diagram (`docs/_static/images/advanced/resource-reservation/sequence.svg`) making   explicit on which cluster each object (`ResourceSlice`, `Quota`, `VirtualNode`) is created.
- A "Prerequisites outside Liqo" section listing what the operator must arrange themselves (capacity discovery, peering credentials, gateway reachability, hardware-shape agreement, etc.) for the reservation flow to work end-to-end.
- An entry under "Advanced usage" in `docs/_toc.yml`.

No source code changes, no new dependencies.

Fixes N/A — opportunistic documentation contribution, not tied to a tracked issue.

# How Has This Been Tested?

- [x] `cd docs && make html` builds with no new warnings on the page.
- [x] Cross-references and external links resolve in the rendered HTML.
- [x] Sidebar placement and visual rendering consistent with sibling pages.