### PR TITLE
Added paragraph about how to create links in the documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@ The Liqo documentation is built with [Read the Docs](https://readthedocs.org/) a
 ## How to add/update documentation
 
 The documentation content is hosted in the Liqo repository and Read the Docs is in charge of building the documentation for you.
-When your PR is merged in master, the documentation will be available on [doc.liqo.io](https://doc.liqo.io).
+When your PR is merged in master, the documentation will be available on [doc.liqo.io](https://doc.liqo.io) or [docs.liqo.io](https://docs.liqo.io).
 
 ### Pages
 
@@ -27,6 +27,16 @@ index.md              <-- /
 ### Images
 
 Images should be put in the [docs/_static/images folder](docs/_static/images).
+
+### Links
+
+To create cross-references within the Liqo documentation:
+
+- Add a link to a specific **page**: just add the link to that page, using the full path from within the documentation mail folder. For example to create a link towards page *installation/install.md*, you just create ```[your link text](/installation/install.md)```
+- Add a link to a specific **section** within a page:
+
+  - first option: similar to the previous case, you can add an explicit link to a sub-section. For example, to create a link towards the *multiple-virtualnodes* anchor within the *advanced/peering/offloading-in-depth.md* page, your link will look like ```[your link text](/advanced/peering/offloading-in-depth.md#multiple-virtualnodes)```
+  - second option: you need to define a custom anchor in the target page, then you create a link using directly that anchor. For example, you can add the following anchor within a page ```(YourNamedAnchor)=```, then you can refer to it within another page by creating this link: ```[your link text](YourNamedAnchor)```
 
 ## Local testing
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@ The Liqo documentation is built with [Read the Docs](https://readthedocs.org/) a
 ## How to add/update documentation
 
 The documentation content is hosted in the Liqo repository and Read the Docs is in charge of building the documentation for you.
-When your PR is merged in master, the documentation will be available on [doc.liqo.io](https://doc.liqo.io) or [docs.liqo.io](https://docs.liqo.io).
+When your PR is merged in master, the documentation will be available on [docs.liqo.io](https://docs.liqo.io).
 
 ### Pages
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,11 +32,11 @@ Images should be put in the [docs/_static/images folder](docs/_static/images).
 
 To create cross-references within the Liqo documentation:
 
-- Add a link to a specific **page**: just add the link to that page, using the full path from within the documentation mail folder. For example to create a link towards page *installation/install.md*, you just create ```[your link text](/installation/install.md)```
+- Add a link to a specific **page**: just add the link to that page, using the full path from within the documentation root folder. For example to create a link towards page *installation/install.md*, you just create ```[your link text](/installation/install.md)```
 - Add a link to a specific **section** within a page:
 
-  - first option: similar to the previous case, you can add an explicit link to a sub-section. For example, to create a link towards the *multiple-virtualnodes* anchor within the *advanced/peering/offloading-in-depth.md* page, your link will look like ```[your link text](/advanced/peering/offloading-in-depth.md#multiple-virtualnodes)```
-  - second option: you need to define a custom anchor in the target page, then you create a link using directly that anchor. For example, you can add the following anchor within a page ```(YourNamedAnchor)=```, then you can refer to it within another page by creating this link: ```[your link text](YourNamedAnchor)```
+  - first option: similar to the previous case, you can add an explicit link to a sub-section. For example, to create a link towards the *multiple-virtualnodes* anchor within the *advanced/peering/offloading-in-depth.md* page, your link will look like `[your link text](/advanced/peering/offloading-in-depth.md#multiple-virtualnodes)`
+  - second option: you need to define a custom anchor in the target page, then you create a link using directly that anchor. For example, you can add the following anchor within a page `(YourNamedAnchor)=`, then you can refer to it within another page by creating this link: `[your link text](YourNamedAnchor)`
 
 ## Local testing
 


### PR DESCRIPTION
This pull request updates the documentation guidelines in `docs/README.md` to clarify how documentation links work and to mention the new documentation URL. The main changes focus on improving instructions for adding links within the documentation.

Documentation URL update:
* Clarified that the documentation will be available at link [docs.liqo.io](https://docs.liqo.io) after merging to master, even if [doc.liqo.io](https://doc.liqo.io) is still supported.

Improved internal linking guidelines:
* Added a new section explaining how to create cross-references within the documentation, including detailed instructions for linking to specific pages and sections, and how to use custom anchors.