### PR TITLE
add ECMP support for <remote-cluster-id>-gw-ext RouteConfiguration

### DIFF
--- a/apis/networking/v1beta1/routeconfiguration_types.go
+++ b/apis/networking/v1beta1/routeconfiguration_types.go
@@ -56,6 +56,9 @@ type NextHop struct {
 	// Gw is the gateway (next hop) IP address.
 	// +kubebuilder:validation:Required
 	Gw IP `json:"gw"`
+	// Dev is the local network interface through which this next-hop is reachable.
+	// +kubebuilder:validation:Required
+	Dev string `json:"dev"`
 	// Weight is the weight of this next-hop for load balancing.
 	// Lower weight means more traffic.
 	// Default is 0, which is translated to a kernel weight of 1.

--- a/apis/networking/v1beta1/routeconfiguration_types.go
+++ b/apis/networking/v1beta1/routeconfiguration_types.go
@@ -51,7 +51,22 @@ const (
 	NowhereScope Scope = "nowhere"
 )
 
+// NextHop is a single next-hop in a multipath route (ECMP).
+type NextHop struct {
+	// Gw is the gateway (next hop) IP address.
+	// +kubebuilder:validation:Required
+	Gw IP `json:"gw"`
+	// Weight is the weight of this next-hop for load balancing.
+	// Lower weight means more traffic.
+	// Default is 0, which is translated to a kernel weight of 1.
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=255
+	// +kubebuilder:default=0
+	Weight *int `json:"weight,omitempty"`
+}
+
 // Route is the route of the RouteConfiguration.
+// +kubebuilder:validation:XValidation:rule="!(has(self.gw) && has(self.nextHops))",message="cannot specify both gw and nextHops"
 type Route struct {
 	// Dst is the destination of the RouteConfiguration.
 	Dst *CIDR `json:"dst"`
@@ -59,9 +74,13 @@ type Route struct {
 	Src *IP `json:"src,omitempty"`
 	// Gw is the gateway of the RouteConfiguration.
 	Gw *IP `json:"gw,omitempty"`
+	// NextHops is the list of next-hops for ECMP (Equal-Cost Multi-Path) routing.
+	// Mutually exclusive with Gw.
+	// +optional
+	NextHops []NextHop `json:"nextHops,omitempty"`
 	// Dev is the device of the RouteConfiguration.
 	Dev *string `json:"dev,omitempty"`
-	// Onlink enables the onlink falg inside the route.
+	// Onlink enables the onlink flag inside the route.
 	Onlink *bool `json:"onlink,omitempty"`
 	// Scope is the scope of the RouteConfiguration.
 	// +kubebuilder:validation:Enum=global;link;host;site;nowhere

--- a/apis/networking/v1beta1/routeconfiguration_types.go
+++ b/apis/networking/v1beta1/routeconfiguration_types.go
@@ -51,7 +51,25 @@ const (
 	NowhereScope Scope = "nowhere"
 )
 
+// NextHop is a single next-hop in a multipath route (ECMP).
+type NextHop struct {
+	// Gw is the gateway (next hop) IP address.
+	// +kubebuilder:validation:Required
+	Gw IP `json:"gw"`
+	// Dev is the local network interface through which this next-hop is reachable.
+	// +kubebuilder:validation:Required
+	Dev string `json:"dev"`
+	// Weight is the weight of this next-hop for load balancing.
+	// Higher weight means more traffic.
+	// Default is 0, which is translated to a kernel weight of 1.
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=255
+	// +kubebuilder:default=0
+	Weight *int `json:"weight,omitempty"`
+}
+
 // Route is the route of the RouteConfiguration.
+// +kubebuilder:validation:XValidation:rule="!(has(self.gw) && has(self.nextHops))",message="cannot specify both gw and nextHops"
 type Route struct {
 	// Dst is the destination of the RouteConfiguration.
 	Dst *CIDR `json:"dst"`
@@ -59,9 +77,13 @@ type Route struct {
 	Src *IP `json:"src,omitempty"`
 	// Gw is the gateway of the RouteConfiguration.
 	Gw *IP `json:"gw,omitempty"`
+	// NextHops is the list of next-hops for ECMP (Equal-Cost Multi-Path) routing.
+	// Mutually exclusive with Gw.
+	// +optional
+	NextHops []NextHop `json:"nextHops,omitempty"`
 	// Dev is the device of the RouteConfiguration.
 	Dev *string `json:"dev,omitempty"`
-	// Onlink enables the onlink falg inside the route.
+	// Onlink enables the onlink flag inside the route.
 	Onlink *bool `json:"onlink,omitempty"`
 	// Scope is the scope of the RouteConfiguration.
 	// +kubebuilder:validation:Enum=global;link;host;site;nowhere

--- a/deployments/liqo/charts/liqo-crds/crds/networking.liqo.io_routeconfigurations.yaml
+++ b/deployments/liqo/charts/liqo-crds/crds/networking.liqo.io_routeconfigurations.yaml
@@ -104,6 +104,10 @@ spec:
                                   description: NextHop is a single next-hop in a multipath
                                     route (ECMP).
                                   properties:
+                                    dev:
+                                      description: Dev is the local network interface
+                                        through which this next-hop is reachable.
+                                      type: string
                                     gw:
                                       description: Gw is the gateway (next hop) IP
                                         address.
@@ -119,6 +123,7 @@ spec:
                                       minimum: 0
                                       type: integer
                                   required:
+                                  - dev
                                   - gw
                                   type: object
                                 type: array

--- a/deployments/liqo/charts/liqo-crds/crds/networking.liqo.io_routeconfigurations.yaml
+++ b/deployments/liqo/charts/liqo-crds/crds/networking.liqo.io_routeconfigurations.yaml
@@ -96,8 +96,34 @@ spec:
                                 description: Gw is the gateway of the RouteConfiguration.
                                 format: ipv4
                                 type: string
+                              nextHops:
+                                description: |-
+                                  NextHops is the list of next-hops for ECMP (Equal-Cost Multi-Path) routing.
+                                  Mutually exclusive with Gw.
+                                items:
+                                  description: NextHop is a single next-hop in a multipath
+                                    route (ECMP).
+                                  properties:
+                                    gw:
+                                      description: Gw is the gateway (next hop) IP
+                                        address.
+                                      format: ipv4
+                                      type: string
+                                    weight:
+                                      default: 0
+                                      description: |-
+                                        Weight is the weight of this next-hop for load balancing.
+                                        Lower weight means more traffic.
+                                        Default is 0, which is translated to a kernel weight of 1.
+                                      maximum: 255
+                                      minimum: 0
+                                      type: integer
+                                  required:
+                                  - gw
+                                  type: object
+                                type: array
                               onlink:
-                                description: Onlink enables the onlink falg inside
+                                description: Onlink enables the onlink flag inside
                                   the route.
                                 type: boolean
                               scope:
@@ -161,6 +187,9 @@ spec:
                             required:
                             - dst
                             type: object
+                            x-kubernetes-validations:
+                            - message: cannot specify both gw and nextHops
+                              rule: '!(has(self.gw) && has(self.nextHops))'
                           type: array
                         src:
                           description: Src is the source of the Rule.

--- a/deployments/liqo/charts/liqo-crds/crds/networking.liqo.io_routeconfigurations.yaml
+++ b/deployments/liqo/charts/liqo-crds/crds/networking.liqo.io_routeconfigurations.yaml
@@ -96,8 +96,39 @@ spec:
                                 description: Gw is the gateway of the RouteConfiguration.
                                 format: ipv4
                                 type: string
+                              nextHops:
+                                description: |-
+                                  NextHops is the list of next-hops for ECMP (Equal-Cost Multi-Path) routing.
+                                  Mutually exclusive with Gw.
+                                items:
+                                  description: NextHop is a single next-hop in a multipath
+                                    route (ECMP).
+                                  properties:
+                                    dev:
+                                      description: Dev is the local network interface
+                                        through which this next-hop is reachable.
+                                      type: string
+                                    gw:
+                                      description: Gw is the gateway (next hop) IP
+                                        address.
+                                      format: ipv4
+                                      type: string
+                                    weight:
+                                      default: 0
+                                      description: |-
+                                        Weight is the weight of this next-hop for load balancing.
+                                        Higher weight means more traffic.
+                                        Default is 0, which is translated to a kernel weight of 1.
+                                      maximum: 255
+                                      minimum: 0
+                                      type: integer
+                                  required:
+                                  - dev
+                                  - gw
+                                  type: object
+                                type: array
                               onlink:
-                                description: Onlink enables the onlink falg inside
+                                description: Onlink enables the onlink flag inside
                                   the route.
                                 type: boolean
                               scope:
@@ -161,6 +192,9 @@ spec:
                             required:
                             - dst
                             type: object
+                            x-kubernetes-validations:
+                            - message: cannot specify both gw and nextHops
+                              rule: '!(has(self.gw) && has(self.nextHops))'
                           type: array
                         src:
                           description: Src is the source of the Rule.

--- a/pkg/route/route.go
+++ b/pkg/route/route.go
@@ -261,22 +261,17 @@ func forgeNetlinkRoute(route *networkingv1beta1.Route, tableID uint32) (*netlink
 				weight = *nh.Weight
 			}
 
-			routes, err := netlink.RouteGet(nextHopGw)
+			link, err := netlink.LinkByName(nh.Dev)
 			if err != nil {
-				return nil, fmt.Errorf("cannot get route for next-hop %s: %w", nextHopGw, err)
-			}
-			if len(routes) == 0 {
-				return nil, fmt.Errorf("no route found for next-hop %s", nextHopGw)
-			}
-
-			r := routes[0]
-			if r.LinkIndex == 0 {
-				return nil, fmt.Errorf("inferred route for next-hop %s has no link index", nextHopGw)
+				if errors.As(err, &netlink.LinkNotFoundError{}) {
+					return nil, fmt.Errorf("link %s not found: %w", nh.Dev, err)
+				}
+				return nil, fmt.Errorf("getting link %s: %w", nh.Dev, err)
 			}
 
 			multiPath[i] = &netlink.NexthopInfo{
 				Gw:        nextHopGw,
-				LinkIndex: r.LinkIndex,
+				LinkIndex: link.Attrs().Index,
 				Hops:      weight,
 			}
 		}

--- a/pkg/route/route.go
+++ b/pkg/route/route.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
+	"k8s.io/utils/ptr"
 
 	networkingv1beta1 "github.com/liqotech/liqo/apis/networking/v1beta1"
 )
@@ -123,18 +124,16 @@ func IsEqualRoute(route1, route2 *netlink.Route) bool {
 	if route1.Flags != route2.Flags {
 		return false
 	}
-
-	multipath1 := len(route1.MultiPath)
-	multipath2 := len(route2.MultiPath)
-	if multipath1 > 0 && multipath2 > 0 {
-		if multipath1 != multipath2 {
+	multipathLen1 := len(route1.MultiPath)
+	multipathLen2 := len(route2.MultiPath)
+	if multipathLen1 > 0 || multipathLen2 > 0 {
+		if multipathLen1 != multipathLen2 {
 			return false
 		}
-
 		for _, nh1 := range route1.MultiPath {
 			found := false
 			for _, nh2 := range route2.MultiPath {
-				if nh1.Gw.String() == nh2.Gw.String() && nh1.Hops == nh2.Hops && nh1.LinkIndex == nh2.LinkIndex {
+				if nh1.Equal(*nh2) {
 					found = true
 					break
 				}
@@ -143,13 +142,7 @@ func IsEqualRoute(route1, route2 *netlink.Route) bool {
 				return false
 			}
 		}
-		return true
 	}
-
-	if (multipath1 > 0) != (multipath2 > 0) {
-		return false
-	}
-
 	return true
 }
 
@@ -217,14 +210,10 @@ func forgeNetlinkRoute(route *networkingv1beta1.Route, tableID uint32) (*netlink
 	}
 
 	if route.Dev != nil {
-		link, err := netlink.LinkByName(*route.Dev)
+		linkIndex, err = getLinkIDByName(*route.Dev)
 		if err != nil {
-			if errors.As(err, &netlink.LinkNotFoundError{}) {
-				return nil, fmt.Errorf("link %s not found: %w", *route.Dev, err)
-			}
-			return nil, fmt.Errorf("getting link %s: %w", *route.Dev, err)
+			return nil, err
 		}
-		linkIndex = link.Attrs().Index
 	}
 
 	if route.Onlink != nil && *route.Onlink {
@@ -255,22 +244,15 @@ func forgeNetlinkRoute(route *networkingv1beta1.Route, tableID uint32) (*netlink
 		multiPath = make([]*netlink.NexthopInfo, len(route.NextHops))
 		for i, nh := range route.NextHops {
 			nextHopGw := net.ParseIP(nh.Gw.String())
-			weight := 0
-			if nh.Weight != nil {
-				weight = *nh.Weight
-			}
-
-			link, err := netlink.LinkByName(nh.Dev)
+			weight := ptr.Deref(nh.Weight, 0)
+			linkID, err := getLinkIDByName(nh.Dev)
 			if err != nil {
-				if errors.As(err, &netlink.LinkNotFoundError{}) {
-					return nil, fmt.Errorf("link %s not found: %w", nh.Dev, err)
-				}
-				return nil, fmt.Errorf("getting link %s: %w", nh.Dev, err)
+				return nil, fmt.Errorf("getting link for nexthop %d: %w", i, err)
 			}
 
 			multiPath[i] = &netlink.NexthopInfo{
 				Gw:        nextHopGw,
-				LinkIndex: link.Attrs().Index,
+				LinkIndex: linkID,
 				Hops:      weight,
 			}
 		}
@@ -286,4 +268,15 @@ func forgeNetlinkRoute(route *networkingv1beta1.Route, tableID uint32) (*netlink
 		Flags:     flags,
 		Scope:     scope,
 	}, nil
+}
+
+func getLinkIDByName(name string) (int, error) {
+	link, err := netlink.LinkByName(name)
+	if err != nil {
+		if errors.As(err, &netlink.LinkNotFoundError{}) {
+			return 0, fmt.Errorf("link %s not found: %w", name, err)
+		}
+		return 0, fmt.Errorf("getting link with name %q: %w", name, err)
+	}
+	return link.Attrs().Index, nil
 }

--- a/pkg/route/route.go
+++ b/pkg/route/route.go
@@ -108,6 +108,7 @@ func ExistsRoute(route *networkingv1beta1.Route, tableID uint32) (*netlink.Route
 
 // IsEqualRoute checks if the two routes are equal.
 func IsEqualRoute(route1, route2 *netlink.Route) bool {
+
 	if route1.Dst != nil && route2.Dst != nil && route1.Dst.String() != route2.Dst.String() {
 		return false
 	}
@@ -123,6 +124,33 @@ func IsEqualRoute(route1, route2 *netlink.Route) bool {
 	if route1.Flags != route2.Flags {
 		return false
 	}
+
+	multipath1 := len(route1.MultiPath)
+	multipath2 := len(route2.MultiPath)
+	if multipath1 > 0 && multipath2 > 0 {
+		if multipath1 != multipath2 {
+			return false
+		}
+
+		for _, nh1 := range route1.MultiPath {
+			found := false
+			for _, nh2 := range route2.MultiPath {
+				if nh1.Gw.String() == nh2.Gw.String() && nh1.Hops == nh2.Hops && nh1.LinkIndex == nh2.LinkIndex {
+					found = true
+					break
+				}
+			}
+			if !found {
+				return false
+			}
+		}
+		return true
+	}
+
+	if (multipath1 > 0) != (multipath2 > 0) {
+		return false
+	}
+
 	return true
 }
 
@@ -219,10 +247,45 @@ func forgeNetlinkRoute(route *networkingv1beta1.Route, tableID uint32) (*netlink
 		default:
 		}
 	}
+	var multiPath []*netlink.NexthopInfo
+	if len(route.NextHops) > 0 {
+		// MultiPath (ECMP) routes must not have a main gateway or a main link index
+		// All next-hop specific information is contained within the MultiPath slice.
+		gw = nil
+		linkIndex = 0
+		multiPath = make([]*netlink.NexthopInfo, len(route.NextHops))
+		for i, nh := range route.NextHops {
+			nextHopGw := net.ParseIP(nh.Gw.String())
+			weight := 0
+			if nh.Weight != nil {
+				weight = *nh.Weight
+			}
+
+			routes, err := netlink.RouteGet(nextHopGw)
+			if err != nil {
+				return nil, fmt.Errorf("cannot get route for next-hop %s: %w", nextHopGw, err)
+			}
+			if len(routes) == 0 {
+				return nil, fmt.Errorf("no route found for next-hop %s", nextHopGw)
+			}
+
+			r := routes[0]
+			if r.LinkIndex == 0 {
+				return nil, fmt.Errorf("inferred route for next-hop %s has no link index", nextHopGw)
+			}
+
+			multiPath[i] = &netlink.NexthopInfo{
+				Gw:        nextHopGw,
+				LinkIndex: r.LinkIndex,
+				Hops:      weight,
+			}
+		}
+	}
 
 	return &netlink.Route{
 		Dst:       dst,
 		Gw:        gw,
+		MultiPath: multiPath,
 		Src:       src,
 		LinkIndex: linkIndex,
 		Table:     int(tableID),

--- a/pkg/route/route.go
+++ b/pkg/route/route.go
@@ -108,7 +108,6 @@ func ExistsRoute(route *networkingv1beta1.Route, tableID uint32) (*netlink.Route
 
 // IsEqualRoute checks if the two routes are equal.
 func IsEqualRoute(route1, route2 *netlink.Route) bool {
-
 	if route1.Dst != nil && route2.Dst != nil && route1.Dst.String() != route2.Dst.String() {
 		return false
 	}

--- a/pkg/route/route.go
+++ b/pkg/route/route.go
@@ -18,10 +18,13 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"slices"
+	"strings"
 	"syscall"
 
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
+	"k8s.io/utils/ptr"
 
 	networkingv1beta1 "github.com/liqotech/liqo/apis/networking/v1beta1"
 )
@@ -133,7 +136,40 @@ func IsEqualRoute(route1, route2 *netlink.Route) bool {
 	if route1.Flags != route2.Flags {
 		return false
 	}
+	multipathLen1 := len(route1.MultiPath)
+	multipathLen2 := len(route2.MultiPath)
+	if multipathLen1 > 0 || multipathLen2 > 0 {
+		if multipathLen1 != multipathLen2 {
+			return false
+		}
+		sorted1 := sortNextHops(route1.MultiPath)
+		sorted2 := sortNextHops(route2.MultiPath)
+
+		for i := range sorted1 {
+			if !sorted1[i].Equal(*sorted2[i]) {
+				return false
+			}
+		}
+	}
 	return true
+}
+
+// sortNextHops returns a sorted copy of the given multipath next-hops,
+// ordered by Gw, then LinkIndex, then Hops, so that two semantically
+// equal multipath sets can be compared positionally regardless of the
+// original ordering (and are robust to duplicate entries).
+func sortNextHops(nextHops []*netlink.NexthopInfo) []*netlink.NexthopInfo {
+	sorted := slices.Clone(nextHops)
+	slices.SortFunc(sorted, func(a, b *netlink.NexthopInfo) int {
+		if c := strings.Compare(a.Gw.String(), b.Gw.String()); c != 0 {
+			return c
+		}
+		if a.LinkIndex != b.LinkIndex {
+			return a.LinkIndex - b.LinkIndex
+		}
+		return a.Hops - b.Hops
+	})
+	return sorted
 }
 
 // CleanRoutes cleans the routes that are not contained in the given route list.
@@ -196,14 +232,10 @@ func forgeNetlinkRoute(route *networkingv1beta1.Route, tableID uint32) (*netlink
 	}
 
 	if route.Dev != nil {
-		link, err := netlink.LinkByName(*route.Dev)
+		linkIndex, err = getLinkIDByName(*route.Dev)
 		if err != nil {
-			if errors.As(err, &netlink.LinkNotFoundError{}) {
-				return nil, fmt.Errorf("link %s not found: %w", *route.Dev, err)
-			}
-			return nil, fmt.Errorf("getting link %s: %w", *route.Dev, err)
+			return nil, err
 		}
-		linkIndex = link.Attrs().Index
 	}
 
 	if route.Onlink != nil && *route.Onlink {
@@ -225,14 +257,48 @@ func forgeNetlinkRoute(route *networkingv1beta1.Route, tableID uint32) (*netlink
 		default:
 		}
 	}
+	var multiPath []*netlink.NexthopInfo
+	if len(route.NextHops) > 0 {
+		// MultiPath (ECMP) routes must not have a main gateway or a main link index
+		// All next-hop specific information is contained within the MultiPath slice.
+		gw = nil
+		linkIndex = 0
+		multiPath = make([]*netlink.NexthopInfo, len(route.NextHops))
+		for i, nh := range route.NextHops {
+			nextHopGw := net.ParseIP(nh.Gw.String())
+			weight := ptr.Deref(nh.Weight, 0)
+			linkID, err := getLinkIDByName(nh.Dev)
+			if err != nil {
+				return nil, fmt.Errorf("getting link for nexthop %d: %w", i, err)
+			}
+
+			multiPath[i] = &netlink.NexthopInfo{
+				Gw:        nextHopGw,
+				LinkIndex: linkID,
+				Hops:      weight,
+			}
+		}
+	}
 
 	return &netlink.Route{
 		Dst:       dst,
 		Gw:        gw,
+		MultiPath: multiPath,
 		Src:       src,
 		LinkIndex: linkIndex,
 		Table:     int(tableID),
 		Flags:     flags,
 		Scope:     scope,
 	}, nil
+}
+
+func getLinkIDByName(name string) (int, error) {
+	link, err := netlink.LinkByName(name)
+	if err != nil {
+		if errors.As(err, &netlink.LinkNotFoundError{}) {
+			return 0, fmt.Errorf("link %s not found: %w", name, err)
+		}
+		return 0, fmt.Errorf("getting link with name %q: %w", name, err)
+	}
+	return link.Attrs().Index, nil
 }


### PR DESCRIPTION
# Description
Part of the multi-tunnel WireGuard implementation. This is the 5th PR related to issue #3225.

This PR extends the semantics of the `RouteConfiguration` CR by introducing a new `NextHop` struct used to specify the hops of a multipath route. The struct contains a gateway IP and an associated weight. The weight indicates how much traffic should pass through that hop.
A new field, `NextHops []NextHop`, has been added to the `Route` struct as an alternative to the existing `Gw` field. This allows configuring multiple paths for the same destination.

The `pkg/route/route.go` file has been updated, specifically:
* `forgeNetlinkRoute` now translates routes including next-hops using the `netlink.NexthopInfo` struct.
* `IsEqualRoute` has been enhanced to handle deep comparison for multipath routes.

This is the first step. The next step involves deciding how and when to update the CR.
