### PR TITLE
fix(vk): create node with VirtualNode and ForeignCluster info

### DIFF
--- a/cmd/virtual-kubelet/root/root.go
+++ b/cmd/virtual-kubelet/root/root.go
@@ -258,32 +258,32 @@ func runRootCommand(ctx context.Context, c *Opts) error {
 		metrics.SetupMetricHandler(c.MetricsAddress)
 	}
 
-	// Initialize the node provider
-	nodecfg := nodeprovider.InitConfig{
-		HomeConfig:      localConfig,
-		RemoteConfig:    remoteConfig,
-		HomeClusterID:   c.HomeCluster.GetClusterID(),
-		RemoteClusterID: c.ForeignCluster.GetClusterID(),
-		Namespace:       c.TenantNamespace,
-
-		NodeName:         c.NodeName,
-		InternalIP:       c.NodeIP,
-		DaemonPort:       c.ListenPort,
-		Version:          getVersion(localConfig),
-		ExtraLabels:      c.NodeExtraLabels.StringMap,
-		ExtraAnnotations: c.NodeExtraAnnotations.StringMap,
-
-		InformerResyncPeriod: c.InformerResyncPeriod,
-		PingDisabled:         c.NodePingInterval == 0,
-		CheckNetworkStatus:   c.NodeCheckNetwork,
-
-		VirtualNode: vn,
-	}
-
-	var nodeReady chan struct{}
-	var nodeRunner *node.NodeController
-
 	if c.CreateNode {
+		var nodeReady chan struct{}
+		var nodeRunner *node.NodeController
+		// Initialize the node provider
+		nodecfg := nodeprovider.InitConfig{
+			HomeConfig:      localConfig,
+			RemoteConfig:    remoteConfig,
+			HomeClusterID:   c.HomeCluster.GetClusterID(),
+			RemoteClusterID: c.ForeignCluster.GetClusterID(),
+			Namespace:       c.TenantNamespace,
+
+			NodeName:         c.NodeName,
+			InternalIP:       c.NodeIP,
+			DaemonPort:       c.ListenPort,
+			Version:          getVersion(localConfig),
+			ExtraLabels:      c.NodeExtraLabels.StringMap,
+			ExtraAnnotations: c.NodeExtraAnnotations.StringMap,
+
+			InformerResyncPeriod: c.InformerResyncPeriod,
+			PingDisabled:         c.NodePingInterval == 0,
+			CheckNetworkStatus:   c.NodeCheckNetwork,
+
+			VirtualNode:    &vn,
+			ForeignCluster: foreignCluster,
+		}
+
 		nodeProvider := nodeprovider.NewLiqoNodeProvider(&nodecfg)
 		nodeReady = nodeProvider.StartProvider(ctx)
 

--- a/pkg/virtualKubelet/liqoNodeProvider/nodeProvider.go
+++ b/pkg/virtualKubelet/liqoNodeProvider/nodeProvider.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/klog/v2"
 
 	liqov1beta1 "github.com/liqotech/liqo/apis/core/v1beta1"
+	offloadingv1beta1 "github.com/liqotech/liqo/apis/offloading/v1beta1"
 	foreignclusterutils "github.com/liqotech/liqo/pkg/utils/foreigncluster"
 )
 
@@ -108,6 +109,25 @@ func (p *LiqoNodeProvider) IsTerminating() bool {
 // GetNode returns the node managed by the provider.
 func (p *LiqoNodeProvider) GetNode() *corev1.Node {
 	return p.node
+}
+
+// hydrate pre-populates the in-memory node state from the available source objects.
+// It does not publish node updates and does not patch the local Kubernetes Node object.
+func (p *LiqoNodeProvider) hydrate(
+	foreignCluster *liqov1beta1.ForeignCluster, virtualNode *offloadingv1beta1.VirtualNode,
+) {
+	p.updateMutex.Lock()
+	defer p.updateMutex.Unlock()
+
+	if virtualNode != nil {
+		p.applyVirtualNodeMetadata(virtualNode)
+		p.applyVirtualNodeStatus(virtualNode)
+	}
+	if foreignCluster != nil {
+		p.applyForeignCluster(foreignCluster)
+	}
+
+	p.recomputeNodeState()
 }
 
 func (p *LiqoNodeProvider) pingWithClient(ctx context.Context) error {

--- a/pkg/virtualKubelet/liqoNodeProvider/nodeProvider_test.go
+++ b/pkg/virtualKubelet/liqoNodeProvider/nodeProvider_test.go
@@ -34,6 +34,7 @@ import (
 
 	liqov1beta1 "github.com/liqotech/liqo/apis/core/v1beta1"
 	offloadingv1beta1 "github.com/liqotech/liqo/apis/offloading/v1beta1"
+	"github.com/liqotech/liqo/pkg/consts"
 	"github.com/liqotech/liqo/pkg/utils/testutil"
 )
 
@@ -44,6 +45,9 @@ const (
 	nodeName         = "node-name"
 	foreignClusterID = "foreign-id"
 	kubeletNamespace = "default"
+	taintKey         = "virtual-taint"
+	taintValue       = "taint-value"
+	trueValue        = "true"
 )
 
 func TestNodeProvider(t *testing.T) {
@@ -340,6 +344,127 @@ var _ = Describe("NodeProvider", func() {
 			},
 		}),
 	)
+
+	It("hydrates the node from virtual node and foreign cluster", func() {
+		virtualNode := &offloadingv1beta1.VirtualNode{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      nodeName,
+				Namespace: kubeletNamespace,
+			},
+			Spec: offloadingv1beta1.VirtualNodeSpec{
+				Labels: map[string]string{
+					"virtual-label": "virtual-value",
+				},
+				Annotations: map[string]string{
+					"virtual-annotation": "annotation-value",
+				},
+				Taints: []v1.Taint{{
+					Key:    taintKey,
+					Value:  taintValue,
+					Effect: v1.TaintEffectNoSchedule,
+				}},
+				StorageClasses: []liqov1beta1.StorageType{{StorageClassName: "fast"}},
+				ResourceQuota: v1.ResourceQuotaSpec{
+					Hard: v1.ResourceList{
+						v1.ResourceCPU:    resource.MustParse("2"),
+						v1.ResourceMemory: resource.MustParse("3Gi"),
+					},
+				},
+				Images: []v1.ContainerImage{{
+					Names:     []string{"nginx:latest"},
+					SizeBytes: 1234,
+				}},
+			},
+		}
+
+		foreignCluster := testutil.FakeForeignCluster(foreignClusterID, &liqov1beta1.Modules{
+			Offloading: liqov1beta1.Module{
+				Enabled: true,
+			},
+			Networking: liqov1beta1.Module{
+				Enabled: true,
+				Conditions: []liqov1beta1.Condition{{
+					Type:   liqov1beta1.NetworkConnectionStatusCondition,
+					Status: liqov1beta1.ConditionStatusEstablished,
+				}},
+			},
+		})
+		foreignCluster.Status.ObservedGeneration = 1
+
+		hydratedProvider := NewLiqoNodeProvider(&InitConfig{
+			NodeName:           nodeName,
+			Namespace:          kubeletNamespace,
+			InternalIP:         "10.2.0.1",
+			HomeConfig:         cluster.GetCfg(),
+			RemoteConfig:       cluster.GetCfg(),
+			RemoteClusterID:    foreignClusterID,
+			CheckNetworkStatus: true,
+			VirtualNode:        virtualNode,
+			ForeignCluster:     foreignCluster,
+		})
+
+		hydratedNode := hydratedProvider.GetNode()
+
+		Expect(hydratedNode.Labels).To(HaveKeyWithValue("virtual-label", "virtual-value"))
+		Expect(hydratedNode.Labels).To(HaveKeyWithValue(consts.StorageAvailableLabel, trueValue))
+		Expect(hydratedNode.Annotations).To(HaveKeyWithValue("virtual-annotation", "annotation-value"))
+		Expect(hydratedNode.Spec.Taints).To(ContainElement(v1.Taint{
+			Key:    taintKey,
+			Value:  taintValue,
+			Effect: v1.TaintEffectNoSchedule,
+		}))
+		Expect(hydratedNode.Spec.Taints).To(ContainElement(v1.Taint{
+			Key:    consts.VirtualNodeTolerationKey,
+			Value:  trueValue,
+			Effect: v1.TaintEffectNoExecute,
+		}))
+		Expect(hydratedNode.Status.Capacity.Cpu().Cmp(resource.MustParse("2"))).To(Equal(0))
+		Expect(hydratedNode.Status.Capacity.Memory().Cmp(resource.MustParse("3Gi"))).To(Equal(0))
+		Expect(hydratedNode.Status.Allocatable.Cpu().Cmp(resource.MustParse("2"))).To(Equal(0))
+		Expect(hydratedNode.Status.Allocatable.Memory().Cmp(resource.MustParse("3Gi"))).To(Equal(0))
+		Expect(hydratedNode.Status.Images).To(Equal(virtualNode.Spec.Images))
+
+		Expect(lookupCondition(hydratedNode, v1.NodeReady).Status).To(Equal(v1.ConditionTrue))
+		Expect(lookupCondition(hydratedNode, v1.NodeMemoryPressure).Status).To(Equal(v1.ConditionFalse))
+		Expect(lookupCondition(hydratedNode, v1.NodeDiskPressure).Status).To(Equal(v1.ConditionFalse))
+		Expect(lookupCondition(hydratedNode, v1.NodePIDPressure).Status).To(Equal(v1.ConditionFalse))
+		Expect(lookupCondition(hydratedNode, v1.NodeNetworkUnavailable).Status).To(Equal(v1.ConditionFalse))
+	})
+
+	It("hydrates the node when virtual node labels and annotations are nil", func() {
+		virtualNode := &offloadingv1beta1.VirtualNode{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      nodeName,
+				Namespace: kubeletNamespace,
+			},
+			Spec: offloadingv1beta1.VirtualNodeSpec{
+				ResourceQuota: v1.ResourceQuotaSpec{
+					Hard: v1.ResourceList{
+						v1.ResourceCPU:    resource.MustParse("2"),
+						v1.ResourceMemory: resource.MustParse("3Gi"),
+					},
+				},
+			},
+		}
+
+		hydratedProvider := NewLiqoNodeProvider(&InitConfig{
+			NodeName:           nodeName,
+			Namespace:          kubeletNamespace,
+			InternalIP:         "10.0.0.1",
+			HomeConfig:         cluster.GetCfg(),
+			RemoteConfig:       cluster.GetCfg(),
+			RemoteClusterID:    foreignClusterID,
+			CheckNetworkStatus: true,
+			VirtualNode:        virtualNode,
+			ForeignCluster:     nil,
+		})
+
+		hydratedNode := hydratedProvider.GetNode()
+
+		Expect(hydratedNode.Labels).To(HaveKeyWithValue(consts.StorageAvailableLabel, "false"))
+		Expect(hydratedNode.Annotations).ToNot(BeNil())
+		Expect(hydratedNode.Annotations).ToNot(HaveKey("virtual-annotation"))
+	})
 
 	It("Labels patch", func() {
 

--- a/pkg/virtualKubelet/liqoNodeProvider/reconciler.go
+++ b/pkg/virtualKubelet/liqoNodeProvider/reconciler.go
@@ -17,22 +17,15 @@ package liqonodeprovider
 import (
 	"context"
 	"errors"
-	"reflect"
-	"strconv"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/klog/v2"
-	"k8s.io/utils/ptr"
 
 	liqov1beta1 "github.com/liqotech/liqo/apis/core/v1beta1"
 	offloadingv1beta1 "github.com/liqotech/liqo/apis/offloading/v1beta1"
-	"github.com/liqotech/liqo/pkg/consts"
-	fcutils "github.com/liqotech/liqo/pkg/utils/foreigncluster"
-	"github.com/liqotech/liqo/pkg/utils/maps"
-	"github.com/liqotech/liqo/pkg/utils/slice"
 )
 
 func (p *LiqoNodeProvider) reconcileNodeFromNode(_ watch.Event) error {
@@ -96,52 +89,24 @@ func (p *LiqoNodeProvider) updateFromVirtualNode(ctx context.Context,
 	p.updateMutex.Lock()
 	defer p.updateMutex.Unlock()
 
-	lbls := virtualNode.Spec.Labels
-	if lbls == nil {
-		lbls = map[string]string{}
-	}
-	if len(virtualNode.Spec.StorageClasses) == 0 {
-		lbls[consts.StorageAvailableLabel] = "false"
-	} else {
-		lbls[consts.StorageAvailableLabel] = "true"
-	}
+	lbls, annotations, taints := desiredVirtualNodeMetadata(virtualNode)
 
 	if err := p.patchLabels(ctx, lbls); err != nil {
 		klog.Error(err)
 		return err
 	}
 
-	annotations := virtualNode.Spec.Annotations
-	if annotations == nil {
-		annotations = map[string]string{}
-	}
 	if err := p.patchAnnotations(ctx, annotations); err != nil {
 		klog.Error(err)
 		return err
 	}
 
-	taints := virtualNode.Spec.Taints
-	if taints == nil {
-		taints = []v1.Taint{}
-	}
 	if err := p.patchTaints(ctx, taints); err != nil {
 		klog.Error(err)
 		return err
 	}
 
-	if p.node.Status.Capacity == nil {
-		p.node.Status.Capacity = v1.ResourceList{}
-	}
-	if p.node.Status.Allocatable == nil {
-		p.node.Status.Allocatable = v1.ResourceList{}
-	}
-	for k, v := range virtualNode.Spec.ResourceQuota.Hard {
-		p.node.Status.Capacity[k] = v
-		p.node.Status.Allocatable[k] = v
-	}
-
-	p.node.Status.Images = []v1.ContainerImage{}
-	p.node.Status.Images = append(p.node.Status.Images, virtualNode.Spec.Images...)
+	p.applyVirtualNodeStatus(virtualNode)
 
 	return p.updateNode()
 }
@@ -150,42 +115,19 @@ func (p *LiqoNodeProvider) updateFromForeignCluster(foreigncluster *liqov1beta1.
 	p.updateMutex.Lock()
 	defer p.updateMutex.Unlock()
 
-	// Only trust Networking.Enabled once the FC controller has reconciled the status.
-	// Before that, the field is a zero value and indistinguishable from "networking disabled".
-	if foreigncluster.Status.ObservedGeneration > 0 {
-		p.networkModuleEnabled = ptr.To(fcutils.IsNetworkingModuleEnabled(foreigncluster))
-	}
-	p.networkReady = fcutils.IsNetworkingEstablished(foreigncluster)
+	p.applyForeignCluster(foreigncluster)
 
 	return p.updateNode()
 }
 
 func (p *LiqoNodeProvider) updateNode() error {
-	// we assume the networking module to be enabled until confirmed otherwise (p.networkModuleEnabled == false),
-	// to avoid transient states where the node is ready but the network condition is not set
-	// because the ForeignCluster has not been observed yet.
-	networkModuleEnabled := ptr.Deref(p.networkModuleEnabled, true)
+	p.recomputeNodeState()
 
-	// we have to set the network condition if we have to check the network status and the network module is enabled
-	shouldSetNetworkCond := p.checkNetworkStatus && networkModuleEnabled
-
-	// check the network status only if we have to set the network condition, otherwise consider it ready
-	networkReady := p.networkReady || !shouldSetNetworkCond
-
-	resourcesReady := areResourcesReady(p.node.Status.Allocatable)
-	UpdateNodeCondition(p.node, v1.NodeReady, nodeReadyStatus(resourcesReady && networkReady))
-	UpdateNodeCondition(p.node, v1.NodeMemoryPressure, nodeMemoryPressureStatus(!resourcesReady))
-	UpdateNodeCondition(p.node, v1.NodeDiskPressure, nodeDiskPressureStatus(!resourcesReady))
-	UpdateNodeCondition(p.node, v1.NodePIDPressure, nodePIDPressureStatus(!resourcesReady))
-	if shouldSetNetworkCond {
-		UpdateNodeCondition(p.node, v1.NodeNetworkUnavailable, nodeNetworkUnavailableStatus(!networkReady))
-	} else {
-		deleteCondition(p.node, v1.NodeNetworkUnavailable)
+	// Call change callback to notify the provider of the node update, if registered.
+	if p.onNodeChangeCallback != nil {
+		p.onNodeChangeCallback(p.node.DeepCopy())
 	}
 
-	p.node.Status.Addresses = []v1.NodeAddress{{Type: v1.NodeInternalIP, Address: p.nodeIP}}
-
-	p.onNodeChangeCallback(p.node.DeepCopy())
 	return nil
 }
 
@@ -203,82 +145,4 @@ func areResourcesReady(allocatable v1.ResourceList) bool {
 		return false
 	}
 	return true
-}
-
-func (p *LiqoNodeProvider) patchLabels(ctx context.Context, labels map[string]string) error {
-	if reflect.DeepEqual(labels, p.lastAppliedLabels) {
-		return nil
-	}
-	if labels == nil {
-		labels = map[string]string{}
-	}
-
-	if err := p.patchNode(ctx, func(node *v1.Node) error {
-		nodeLabels := node.GetLabels()
-		nodeLabels = maps.Sub(nodeLabels, p.lastAppliedLabels)
-		nodeLabels = maps.Merge(nodeLabels, labels)
-		node.Labels = nodeLabels
-		return nil
-	}); err != nil {
-		klog.Error(err)
-		return err
-	}
-
-	p.lastAppliedLabels = labels
-	return nil
-}
-
-func (p *LiqoNodeProvider) patchAnnotations(ctx context.Context, annotations map[string]string) error {
-	if reflect.DeepEqual(annotations, p.lastAppliedAnnotations) {
-		return nil
-	}
-	if annotations == nil {
-		annotations = map[string]string{}
-	}
-
-	if err := p.patchNode(ctx, func(node *v1.Node) error {
-		nodeAnnotations := node.GetAnnotations()
-		nodeAnnotations = maps.Sub(nodeAnnotations, p.lastAppliedAnnotations)
-		nodeAnnotations = maps.Merge(nodeAnnotations, annotations)
-		node.Annotations = nodeAnnotations
-		return nil
-	}); err != nil {
-		klog.Error(err)
-		return err
-	}
-
-	p.lastAppliedAnnotations = annotations
-	return nil
-}
-
-func (p *LiqoNodeProvider) patchTaints(ctx context.Context, taints []v1.Taint) error {
-	if taints == nil {
-		taints = []v1.Taint{}
-	}
-	taints = append(taints, v1.Taint{
-		Key:    consts.VirtualNodeTolerationKey,
-		Value:  strconv.FormatBool(true),
-		Effect: v1.TaintEffectNoExecute,
-	})
-
-	if reflect.DeepEqual(taints, p.lastAppliedTaints) {
-		return nil
-	}
-	if taints == nil {
-		taints = []v1.Taint{}
-	}
-
-	if err := p.patchNode(ctx, func(node *v1.Node) error {
-		nodeTaints := node.Spec.Taints
-		nodeTaints = slice.Sub(nodeTaints, p.lastAppliedTaints)
-		nodeTaints = slice.Merge(nodeTaints, taints)
-		node.Spec.Taints = nodeTaints
-		return nil
-	}); err != nil {
-		klog.Error(err)
-		return err
-	}
-
-	p.lastAppliedTaints = taints
-	return nil
 }

--- a/pkg/virtualKubelet/liqoNodeProvider/setup.go
+++ b/pkg/virtualKubelet/liqoNodeProvider/setup.go
@@ -61,12 +61,13 @@ type InitConfig struct {
 	PingDisabled         bool
 	CheckNetworkStatus   bool
 
-	VirtualNode offloadingv1beta1.VirtualNode
+	VirtualNode    *offloadingv1beta1.VirtualNode
+	ForeignCluster *liqov1beta1.ForeignCluster
 }
 
 // NewLiqoNodeProvider creates and returns a new LiqoNodeProvider.
 func NewLiqoNodeProvider(cfg *InitConfig) *LiqoNodeProvider {
-	return &LiqoNodeProvider{
+	nodeProvider := &LiqoNodeProvider{
 		localClient:           kubernetes.NewForConfigOrDie(cfg.HomeConfig),
 		remoteDiscoveryClient: discovery.NewDiscoveryClientForConfigOrDie(cfg.RemoteConfig),
 		dynClient:             dynamic.NewForConfigOrDie(cfg.HomeConfig),
@@ -86,6 +87,10 @@ func NewLiqoNodeProvider(cfg *InitConfig) *LiqoNodeProvider {
 		foreignClusterID: cfg.RemoteClusterID,
 		tenantNamespace:  cfg.Namespace,
 	}
+
+	nodeProvider.hydrate(cfg.ForeignCluster, cfg.VirtualNode)
+
+	return nodeProvider
 }
 
 func node(cfg *InitConfig) *corev1.Node {
@@ -103,17 +108,13 @@ func node(cfg *InitConfig) *corev1.Node {
 		labelNodeExcludeBalancersAlpha:   strconv.FormatBool(true),
 	}
 	lbls = labels.Merge(lbls, cfg.ExtraLabels)
-	lbls = labels.Merge(lbls, cfg.VirtualNode.Spec.Labels)
 
 	annots := cfg.ExtraAnnotations
-	annots = labels.Merge(annots, cfg.VirtualNode.Spec.Annotations)
-
 	taints := []corev1.Taint{{
 		Key:    liqoconst.VirtualNodeTolerationKey,
 		Value:  strconv.FormatBool(true),
 		Effect: corev1.TaintEffectNoExecute,
 	}}
-	taints = append(taints, cfg.VirtualNode.Spec.Taints...)
 
 	return &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/virtualKubelet/liqoNodeProvider/utils.go
+++ b/pkg/virtualKubelet/liqoNodeProvider/utils.go
@@ -17,13 +17,189 @@ package liqonodeprovider
 import (
 	"context"
 	"encoding/json"
+	gomaps "maps"
+	"reflect"
+	"strconv"
 
 	"gomodules.xyz/jsonpatch/v2"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
+
+	liqov1beta1 "github.com/liqotech/liqo/apis/core/v1beta1"
+	offloadingv1beta1 "github.com/liqotech/liqo/apis/offloading/v1beta1"
+	"github.com/liqotech/liqo/pkg/consts"
+	fcutils "github.com/liqotech/liqo/pkg/utils/foreigncluster"
+	"github.com/liqotech/liqo/pkg/utils/maps"
+	"github.com/liqotech/liqo/pkg/utils/slice"
 )
+
+func desiredVirtualNodeMetadata(
+	virtualNode *offloadingv1beta1.VirtualNode,
+) (labels, annotations map[string]string, taints []v1.Taint) {
+	labels = gomaps.Clone(virtualNode.Spec.Labels)
+	if labels == nil {
+		labels = map[string]string{}
+	}
+	if len(virtualNode.Spec.StorageClasses) == 0 {
+		labels[consts.StorageAvailableLabel] = "false"
+	} else {
+		labels[consts.StorageAvailableLabel] = "true"
+	}
+
+	annotations = gomaps.Clone(virtualNode.Spec.Annotations)
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+
+	taints = append([]v1.Taint{}, virtualNode.Spec.Taints...)
+	taints = append(taints, v1.Taint{
+		Key:    consts.VirtualNodeTolerationKey,
+		Value:  strconv.FormatBool(true),
+		Effect: v1.TaintEffectNoExecute,
+	})
+
+	return labels, annotations, taints
+}
+
+func (p *LiqoNodeProvider) applyVirtualNodeMetadata(virtualNode *offloadingv1beta1.VirtualNode) {
+	labels, annotations, taints := desiredVirtualNodeMetadata(virtualNode)
+
+	updatedLabels := maps.Sub(p.node.GetLabels(), p.lastAppliedLabels)
+	p.node.Labels = maps.Merge(updatedLabels, labels)
+
+	updatedAnnotations := maps.Sub(p.node.GetAnnotations(), p.lastAppliedAnnotations)
+	p.node.Annotations = maps.Merge(updatedAnnotations, annotations)
+
+	updatedTaints := slice.Sub(p.node.Spec.Taints, p.lastAppliedTaints)
+	p.node.Spec.Taints = slice.Merge(updatedTaints, taints)
+
+	p.lastAppliedLabels = labels
+	p.lastAppliedAnnotations = annotations
+	p.lastAppliedTaints = taints
+}
+
+func (p *LiqoNodeProvider) applyVirtualNodeStatus(virtualNode *offloadingv1beta1.VirtualNode) {
+	if p.node.Status.Capacity == nil {
+		p.node.Status.Capacity = v1.ResourceList{}
+	}
+	if p.node.Status.Allocatable == nil {
+		p.node.Status.Allocatable = v1.ResourceList{}
+	}
+	for key, value := range virtualNode.Spec.ResourceQuota.Hard {
+		p.node.Status.Capacity[key] = value
+		p.node.Status.Allocatable[key] = value
+	}
+
+	p.node.Status.Images = append([]v1.ContainerImage{}, virtualNode.Spec.Images...)
+}
+
+func (p *LiqoNodeProvider) applyForeignCluster(foreigncluster *liqov1beta1.ForeignCluster) {
+	// Only trust Networking.Enabled once the FC controller has reconciled the status.
+	// Before that, the field is a zero value and indistinguishable from "networking disabled".
+	if foreigncluster.Status.ObservedGeneration > 0 {
+		p.networkModuleEnabled = ptr.To(fcutils.IsNetworkingModuleEnabled(foreigncluster))
+	}
+	p.networkReady = fcutils.IsNetworkingEstablished(foreigncluster)
+}
+
+func (p *LiqoNodeProvider) recomputeNodeState() {
+	// we assume the networking module to be enabled until confirmed otherwise (p.networkModuleEnabled == false),
+	// to avoid transient states where the node is ready but the network condition is not set
+	// because the ForeignCluster has not been observed yet.
+	networkModuleEnabled := ptr.Deref(p.networkModuleEnabled, true)
+
+	// we have to set the network condition if we have to check the network status and the network module is enabled
+	shouldSetNetworkCond := p.checkNetworkStatus && networkModuleEnabled
+
+	// check the network status only if we have to set the network condition, otherwise consider it ready
+	networkReady := p.networkReady || !shouldSetNetworkCond
+
+	resourcesReady := areResourcesReady(p.node.Status.Allocatable)
+	UpdateNodeCondition(p.node, v1.NodeReady, nodeReadyStatus(resourcesReady && networkReady))
+	UpdateNodeCondition(p.node, v1.NodeMemoryPressure, nodeMemoryPressureStatus(!resourcesReady))
+	UpdateNodeCondition(p.node, v1.NodeDiskPressure, nodeDiskPressureStatus(!resourcesReady))
+	UpdateNodeCondition(p.node, v1.NodePIDPressure, nodePIDPressureStatus(!resourcesReady))
+
+	if shouldSetNetworkCond {
+		UpdateNodeCondition(p.node, v1.NodeNetworkUnavailable, nodeNetworkUnavailableStatus(!networkReady))
+	} else {
+		deleteCondition(p.node, v1.NodeNetworkUnavailable)
+	}
+
+	p.node.Status.Addresses = []v1.NodeAddress{{Type: v1.NodeInternalIP, Address: p.nodeIP}}
+}
+
+func (p *LiqoNodeProvider) patchLabels(ctx context.Context, labels map[string]string) error {
+	if reflect.DeepEqual(labels, p.lastAppliedLabels) {
+		return nil
+	}
+	if labels == nil {
+		labels = map[string]string{}
+	}
+
+	if err := p.patchNode(ctx, func(node *v1.Node) error {
+		nodeLabels := node.GetLabels()
+		nodeLabels = maps.Sub(nodeLabels, p.lastAppliedLabels)
+		nodeLabels = maps.Merge(nodeLabels, labels)
+		node.Labels = nodeLabels
+		return nil
+	}); err != nil {
+		klog.Error(err)
+		return err
+	}
+
+	p.lastAppliedLabels = labels
+	return nil
+}
+
+func (p *LiqoNodeProvider) patchAnnotations(ctx context.Context, annotations map[string]string) error {
+	if reflect.DeepEqual(annotations, p.lastAppliedAnnotations) {
+		return nil
+	}
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+
+	if err := p.patchNode(ctx, func(node *v1.Node) error {
+		nodeAnnotations := node.GetAnnotations()
+		nodeAnnotations = maps.Sub(nodeAnnotations, p.lastAppliedAnnotations)
+		nodeAnnotations = maps.Merge(nodeAnnotations, annotations)
+		node.Annotations = nodeAnnotations
+		return nil
+	}); err != nil {
+		klog.Error(err)
+		return err
+	}
+
+	p.lastAppliedAnnotations = annotations
+	return nil
+}
+
+func (p *LiqoNodeProvider) patchTaints(ctx context.Context, taints []v1.Taint) error {
+	if reflect.DeepEqual(taints, p.lastAppliedTaints) {
+		return nil
+	}
+	if taints == nil {
+		taints = []v1.Taint{}
+	}
+
+	if err := p.patchNode(ctx, func(node *v1.Node) error {
+		nodeTaints := node.Spec.Taints
+		nodeTaints = slice.Sub(nodeTaints, p.lastAppliedTaints)
+		nodeTaints = slice.Merge(nodeTaints, taints)
+		node.Spec.Taints = nodeTaints
+		return nil
+	}); err != nil {
+		klog.Error(err)
+		return err
+	}
+
+	p.lastAppliedTaints = taints
+	return nil
+}
 
 // patchNode patches the controlled node applying the provided function.
 func (p *LiqoNodeProvider) patchNode(ctx context.Context, changeFunc func(node *v1.Node) error) error {


### PR DESCRIPTION
# Description 

This PR fixes an issue with the Virtual Kubelet. When the node is created, only the VirtualNode labels are applied but the status is set to Unknown. This causes a temporary transition of the status to unknown when the VK restarts. We now make sure that when the status is created both the VirtualNode and the ForeignCluster are taken into account. Additionally it refactors the code to simplify it and  avoid code duplications. 