### PR TITLE
fix: handle "network is unreachable" errors

### DIFF
--- a/pkg/route/route.go
+++ b/pkg/route/route.go
@@ -18,11 +18,16 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"syscall"
 
 	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
 
 	networkingv1beta1 "github.com/liqotech/liqo/apis/networking/v1beta1"
 )
+
+// ErrNetworkUnreachable is returned when a route cannot because the network gateway is not reachable.
+var ErrNetworkUnreachable = errors.New("network unreachable")
 
 // EnsureRoutesPresence ensures the presence of the given routes.
 func EnsureRoutesPresence(routes []networkingv1beta1.Route, tableID uint32) error {
@@ -38,11 +43,17 @@ func EnsureRoutesPresence(routes []networkingv1beta1.Route, tableID uint32) erro
 		if exists {
 			if !IsEqualRoute(route, existingroute) {
 				if err := netlink.RouteReplace(route); err != nil {
+					if isNetworkUnreachableError(err) {
+						return fmt.Errorf("%w: error replacing route %v: %w", ErrNetworkUnreachable, route, err)
+					}
 					return fmt.Errorf("error replacing route %v: %w", route, err)
 				}
 			}
 		} else {
 			if err := netlink.RouteAdd(route); err != nil {
+				if isNetworkUnreachableError(err) {
+					return fmt.Errorf("%w: error adding route %v: %w", ErrNetworkUnreachable, route, err)
+				}
 				return fmt.Errorf("error adding route %v: %w", route, err)
 			}
 		}
@@ -141,6 +152,16 @@ func IsContainedRoute(route *netlink.Route, routes []networkingv1beta1.Route) bo
 		if IsEqualRoute(route, r) {
 			return true
 		}
+	}
+	return false
+}
+
+// isNetworkUnreachableError returns true if the network is unreachable (gateway not reachable).
+func isNetworkUnreachableError(err error) bool {
+	var errno syscall.Errno
+	if errors.As(err, &errno) {
+		// ENETUNREACH: network is unreachable (gateway not reachable)
+		return errno == unix.ENETUNREACH
 	}
 	return false
 }

--- a/pkg/route/routeconfiguration_controller.go
+++ b/pkg/route/routeconfiguration_controller.go
@@ -176,6 +176,10 @@ func (r *RouteConfigurationReconciler) Reconcile(ctx context.Context, req ctrl.R
 				klog.V(3).Infof("Link not found for routeconfiguration %s, requeuing: %v", req.String(), err)
 				return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
 			}
+			if errors.Is(err, ErrNetworkUnreachable) {
+				klog.Warningf("Network is unreachable for routeconfiguration %s, requeuing: %v", req.String(), err)
+				return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
+			}
 			return ctrl.Result{}, fmt.Errorf("ensuring routes presence: %w", err)
 		}
 	}


### PR DESCRIPTION
# Description

This PR changes how we handle netlink errors arising when applying routes whose gw hop still needs to be created. This is an example of an error:

```
E0529 09:05:25.234138       1 controller.go:495] "Reconciler error" err="ensuring routes presence: error adding route {Ifindex: 10 Dst: 10.70.0.0/32 Src: <nil> Gw: 10.80.0.8 Flags: [] Table: 944268565 Realm: 0}: network is unreachable" controller="routeconfiguration" controllerGroup="networking.liqo.io" controllerKind="RouteConfiguration" RouteConfiguration="..." namespace="..." name="..." reconcileID="..."
```

Since this error can happen several times during peering bootstrap, the controller returns with the default exponential backoff. When the next hop is actually present, the route gets applied much later because of this.

Solution: detect and handle this error by printing a warning and retrying with a fixed interval requeue, instead of exponential backoff error