### PR TITLE
feat: add providerID to VirtualNodes

### DIFF
--- a/apis/offloading/v1beta1/virtualnode_types.go
+++ b/apis/offloading/v1beta1/virtualnode_types.go
@@ -55,6 +55,10 @@ type DeploymentTemplate struct {
 type VirtualNodeSpec struct {
 	// ClusterID contains the id of the remote cluster targeted by the created virtualKubelet.
 	ClusterID liqov1beta1.ClusterID `json:"clusterID,omitempty"`
+	// ProviderID to assigned to the node. It can be empty or in the format: <ProviderName>://<ProviderSpecificNodeID>.
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf || oldSelf == \"\"",message="ProviderID is immutable once set"
+	// +optional
+	ProviderID string `json:"providerID,omitempty"`
 	// Template contains the deployment of the created virtualKubelet.
 	// +optional
 	Template *DeploymentTemplate `json:"template,omitempty"`

--- a/deployments/liqo/charts/liqo-crds/crds/offloading.liqo.io_virtualnodes.yaml
+++ b/deployments/liqo/charts/liqo-crds/crds/offloading.liqo.io_virtualnodes.yaml
@@ -435,6 +435,13 @@ spec:
                       type: object
                     type: array
                 type: object
+              providerID:
+                description: 'ProviderID to assigned to the node. It can be empty
+                  or in the format: <ProviderName>://<ProviderSpecificNodeID>.'
+                type: string
+                x-kubernetes-validations:
+                - message: ProviderID is immutable once set
+                  rule: self == oldSelf || oldSelf == ""
               resourceQuota:
                 description: ResourceQuota contains the quantity of resources assigned
                   to the VirtualNode.

--- a/pkg/virtualKubelet/liqoNodeProvider/nodeProvider.go
+++ b/pkg/virtualKubelet/liqoNodeProvider/nodeProvider.go
@@ -121,6 +121,7 @@ func (p *LiqoNodeProvider) hydrate(
 
 	if virtualNode != nil {
 		p.applyVirtualNodeMetadata(virtualNode)
+		p.setProviderID(virtualNode)
 		p.applyVirtualNodeStatus(virtualNode)
 	}
 	if foreignCluster != nil {

--- a/pkg/virtualKubelet/liqoNodeProvider/reconciler.go
+++ b/pkg/virtualKubelet/liqoNodeProvider/reconciler.go
@@ -106,6 +106,7 @@ func (p *LiqoNodeProvider) updateFromVirtualNode(ctx context.Context,
 		return err
 	}
 
+	p.setProviderID(virtualNode)
 	p.applyVirtualNodeStatus(virtualNode)
 
 	return p.updateNode()

--- a/pkg/virtualKubelet/liqoNodeProvider/utils.go
+++ b/pkg/virtualKubelet/liqoNodeProvider/utils.go
@@ -64,6 +64,10 @@ func desiredVirtualNodeMetadata(
 	return labels, annotations, taints
 }
 
+func (p *LiqoNodeProvider) setProviderID(virtualNode *offloadingv1beta1.VirtualNode) {
+	p.node.Spec.ProviderID = virtualNode.Spec.ProviderID
+}
+
 func (p *LiqoNodeProvider) applyVirtualNodeMetadata(virtualNode *offloadingv1beta1.VirtualNode) {
 	labels, annotations, taints := desiredVirtualNodeMetadata(virtualNode)
 


### PR DESCRIPTION
# Description

This PR adds the possibility to specify a `providerID` to the liqo nodes. You can set the providerID through VirtualNode CR under `.spec.providerID` 