### PR TITLE
docs(advanced): rename "Custom Resource Allocation" section to "Custom ResourceSlice classes"

### DIFF
--- a/docs/advanced/peering/offloading-in-depth.md
+++ b/docs/advanced/peering/offloading-in-depth.md
@@ -113,7 +113,7 @@ cluster-1-md-0-dzl4s            Ready    <none>          29m   v1.27.4
 mypool                          Ready    agent           67s   v1.27.4
 ```
 
-### Custom Resource Allocation
+### Custom ResourceSlice classes
 
 The amount of resources shared by the provider cluster is managed by the _ResourceSlice class controller_, which decides whether to accept or deny a ResourceSlice based on a set of criteria and the available resources in the cluster.
 
@@ -123,7 +123,7 @@ While this might seem problematic, it can be **useful in scenarios where the clu
 
 To support more complex scenarios and specific use cases, Liqo allows the definition of _custom ResourceSlice classes_.
 These classes enable the implementation of **custom logic to determine whether to accept or reject a ResourceSlice** (e.g., based on a tenant's resource quota) and how much resources the provider cluster can share.
-**This logic should be implemented in a _custom ResourceSlice class controller_**, whose template is available [in this repository](https://github.com/liqotech/resource-slice-class-controller-template).
+**This logic should be implemented in a _custom ResourceSlice class controller_**, whose template and implementation guide are available in the [resource-slice-class-controller-template](https://github.com/liqotech/resource-slice-class-controller-template) repository.
 
 The ResourceSlice class can be specified either in the YAML manifest or by using the `--class` flag with `liqoctl`:
 
@@ -152,10 +152,6 @@ spec:
 Once a custom class is defined in the `ResourceSlice` spec, the custom ResourceSlice controller will be responsible for accepting or denying the ResourceSlices and updating their status with the amount of granted resources.
 The custom controller might deny the request, fully accept it, or partially accept it by providing only a portion of the requested resources.
 The `VirtualNode` in the consumer cluster and the `Quota` in the provider cluster will be created based on the resources granted by the custom controller.
-
-This approach allows for more flexible and dynamic resource allocation based on specific policies or requirements defined by the provider cluster.
-
-For more information on implementing a custom Resource Slice controller, refer to the [Liqo Resource Slice Controller template repository](https://github.com/liqotech/resource-slice-class-controller-template).
 
 ### Delete ResourceSlice
 

--- a/docs/usage/resource-reservation.md
+++ b/docs/usage/resource-reservation.md
@@ -235,7 +235,7 @@ Verify that the workloads being offloaded already comply, or set sensible defaul
 
 By default, the `ResourceSlice` class controller shipped with Liqo accepts every incoming request and only fills in the missing keys with `offloading.defaultNodeResources`. This behavior can be customized by defining a **custom `ResourceSlice` class** to implement stricter or cluster-wide policies (for example, capping the total accepted slices at a fraction of cluster capacity, or per-tenant quotas).
 
-A reusable starting point is provided by the [resource-slice-class-controller-template](https://github.com/liqotech/resource-slice-class-controller-template) repository, and the general mechanics of class controllers are described in the [Custom Resource Allocation](/advanced/peering/offloading-in-depth.md#custom-resource-allocation) section of the offloading-in-depth page.
+A reusable starting point is provided by the [resource-slice-class-controller-template](https://github.com/liqotech/resource-slice-class-controller-template) repository, and the general mechanics of class controllers are described in the [Custom ResourceSlice classes](/advanced/peering/offloading-in-depth.md#custom-resourceslice-classes) section of the offloading-in-depth page.
 
 ```{warning}
 The class is chosen by the **consumer**, and the built-in default class controller is always running alongside any custom one — Liqo does not provide a built-in way to disable it.


### PR DESCRIPTION
# Description

Follow-up to the review feedback (@claudiolor) on #3283: the `Custom Resource Allocation`
section in `offloading-in-depth.md` is mis-titled — it's about custom
`ResourceSlice` class controllers, not resource allocation in general.

This renames the section in place (no new page) with minimal changes:

- Rename `### Custom Resource Allocation` → `### Custom ResourceSlice classes`.
- Point the template-repo link to the repository as the *implementation guide*,
  and remove a second, duplicate link to the same repo plus a redundant
  closing sentence.
- Update the inbound link from the resource-reservation page to the new anchor.

No new prose was added on purpose: the implementation details live in the
[resource-slice-class-controller-template](https://github.com/liqotech/resource-slice-class-controller-template)
repo and the policy/enforcement angle in the resource-reservation page, so
expanding here would only duplicate existing content.

Docs-only change.

# How Has This Been Tested?

- [x] `make dummy` (Sphinx build with `-W`) passes with no warnings.
- [x] Renamed-section anchor and the updated inbound link resolve.