### PR TITLE
fix(networking): list LoadBalancer IPs before hostnames in GatewayServer status

### DIFF
--- a/pkg/liqo-controller-manager/networking/external-network/wireguard/wggatewayserver_controller.go
+++ b/pkg/liqo-controller-manager/networking/external-network/wireguard/wggatewayserver_controller.go
@@ -41,6 +41,7 @@ import (
 	"github.com/liqotech/liqo/pkg/gateway/forge"
 	enutils "github.com/liqotech/liqo/pkg/liqo-controller-manager/networking/external-network/utils"
 	"github.com/liqotech/liqo/pkg/utils"
+	"github.com/liqotech/liqo/pkg/utils/getters"
 	mapsutil "github.com/liqotech/liqo/pkg/utils/maps"
 	"github.com/liqotech/liqo/pkg/utils/resource"
 )
@@ -420,15 +421,7 @@ func (r *WgGatewayServerReconciler) forgeEndpointStatusLoadBalancer(service *cor
 	port := service.Spec.Ports[0].Port
 	protocol := &service.Spec.Ports[0].Protocol
 
-	var addresses []string
-	for i := range service.Status.LoadBalancer.Ingress {
-		if hostName := service.Status.LoadBalancer.Ingress[i].Hostname; hostName != "" {
-			addresses = append(addresses, hostName)
-		}
-		if ip := service.Status.LoadBalancer.Ingress[i].IP; ip != "" {
-			addresses = append(addresses, ip)
-		}
-	}
+	addresses := getters.CollectLoadBalancerAddresses(service.Status.LoadBalancer.Ingress)
 
 	return &networkingv1beta1.EndpointStatus{
 		Protocol:  protocol,

--- a/pkg/utils/getters/dataGetters.go
+++ b/pkg/utils/getters/dataGetters.go
@@ -89,6 +89,21 @@ func RetrieveEndpointFromService(svc *corev1.Service, svcType corev1.ServiceType
 	return endpointIP, endpointPort, err
 }
 
+// CollectLoadBalancerAddresses returns the addresses from the LoadBalancer ingress status,
+// listing IP addresses before hostnames for each ingress entry.
+func CollectLoadBalancerAddresses(ingress []corev1.LoadBalancerIngress) []string {
+	addresses := make([]string, 0, len(ingress))
+	for _, ing := range ingress {
+		if ip := ing.IP; ip != "" {
+			addresses = append(addresses, ip)
+		}
+		if hostName := ing.Hostname; hostName != "" {
+			addresses = append(addresses, hostName)
+		}
+	}
+	return addresses
+}
+
 // retrieveIPFromService given a service and the type of the service, the function
 // returns the ip address for the service based on the type. The nodePort service type
 // does not have a specific ip address, so we return an error.
@@ -101,21 +116,16 @@ func retrieveIPFromService(svc *corev1.Service, serviceType corev1.ServiceType) 
 		return "", fmt.Errorf("the clusterIP address for service {%s/%s} of type {%s} has not been set",
 			svc.Namespace, svc.Name, svc.Spec.Type)
 	case corev1.ServiceTypeLoadBalancer:
-		var endpointIP string
 		errorMsg := fmt.Sprintf("the ingress address for service {%s/%s} of type {%s} has not been set",
 			svc.Namespace, svc.Name, svc.Spec.Type)
 		// Check if the ingress IP has been set.
 		if len(svc.Status.LoadBalancer.Ingress) == 0 {
 			return "", errors.New(errorMsg)
 		}
-		// Retrieve the endpoint address
-		if svc.Status.LoadBalancer.Ingress[0].IP != "" {
-			endpointIP = svc.Status.LoadBalancer.Ingress[0].IP
-		} else if svc.Status.LoadBalancer.Ingress[0].Hostname != "" {
-			endpointIP = svc.Status.LoadBalancer.Ingress[0].Hostname
-		}
-		if endpointIP != "" {
-			return endpointIP, nil
+		// Retrieve the endpoint address, preferring IP over hostname.
+		addresses := CollectLoadBalancerAddresses(svc.Status.LoadBalancer.Ingress)
+		if len(addresses) > 0 {
+			return addresses[0], nil
 		}
 		return "", errors.New(errorMsg)
 	default:

--- a/pkg/utils/getters/dataGetters_test.go
+++ b/pkg/utils/getters/dataGetters_test.go
@@ -193,4 +193,40 @@ var _ = Describe("DataGetters", func() {
 		})
 
 	})
+
+	Describe("CollectLoadBalancerAddresses", func() {
+		It("should prefer IP before hostname for each ingress entry", func() {
+			addresses := getters.CollectLoadBalancerAddresses([]corev1.LoadBalancerIngress{
+				{Hostname: "a661a6e31140e48e4ba8e5e10351dfed", IP: "45.76.36.212"},
+			})
+			Expect(addresses).To(Equal([]string{"45.76.36.212", "a661a6e31140e48e4ba8e5e10351dfed"}))
+		})
+
+		It("should return hostname when IP is not set", func() {
+			addresses := getters.CollectLoadBalancerAddresses([]corev1.LoadBalancerIngress{
+				{Hostname: "gateway.example.com"},
+			})
+			Expect(addresses).To(Equal([]string{"gateway.example.com"}))
+		})
+
+		It("should return IP when hostname is not set", func() {
+			addresses := getters.CollectLoadBalancerAddresses([]corev1.LoadBalancerIngress{
+				{IP: "203.0.113.8"},
+			})
+			Expect(addresses).To(Equal([]string{"203.0.113.8"}))
+		})
+
+		It("should preserve ingress order across multiple entries", func() {
+			addresses := getters.CollectLoadBalancerAddresses([]corev1.LoadBalancerIngress{
+				{Hostname: "internal-1", IP: "1.1.1.1"},
+				{Hostname: "internal-2", IP: "2.2.2.2"},
+			})
+			Expect(addresses).To(Equal([]string{"1.1.1.1", "internal-1", "2.2.2.2", "internal-2"}))
+		})
+
+		It("should return an empty slice for empty ingress", func() {
+			Expect(getters.CollectLoadBalancerAddresses(nil)).To(BeEmpty())
+			Expect(getters.CollectLoadBalancerAddresses([]corev1.LoadBalancerIngress{})).To(BeEmpty())
+		})
+	})
 })


### PR DESCRIPTION
Fixes #3310

## Problem

Some cloud CCMs populate `service.status.loadBalancer.ingress` with both a hostname and an IP.
Liqo previously listed hostnames before IPs in `GatewayServer.status.endpoint.addresses`.
The WireGuard gateway client uses `addresses[0]`, so peering can fail when that hostname is not publicly resolvable, even though the LoadBalancer external IP is valid.

## Solution

- Add `getters.CollectLoadBalancerAddresses()` to collect ingress addresses with IPs listed before hostnames for each entry.
- Use it in `forgeEndpointStatusLoadBalancer` when building the gateway server endpoint status.
- Reuse the same helper in `retrieveIPFromService` for LoadBalancer services.

## Testing

- [x] Unit tests for `CollectLoadBalancerAddresses` (IP-only, hostname-only, both fields, multiple ingress entries)
- [x] `go test ./pkg/utils/getters/...`
- [x] Manual verification: `liqoctl peer --gw-server-service-type LoadBalancer` with a CCM that sets both hostname and IP; Connection reaches `Connected` and WireGuard handshake succeeds using the external IP.