### PR TITLE
[Networking] prevent podcidr from beeing remapped with IP

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -49,6 +49,7 @@ import (
 	"github.com/liqotech/liqo/pkg/utils/restcfg"
 	fwcfgwh "github.com/liqotech/liqo/pkg/webhooks/firewallconfiguration"
 	fcwh "github.com/liqotech/liqo/pkg/webhooks/foreigncluster"
+	ipwh "github.com/liqotech/liqo/pkg/webhooks/ip"
 	nsoffwh "github.com/liqotech/liqo/pkg/webhooks/namespaceoffloading"
 	podwh "github.com/liqotech/liqo/pkg/webhooks/pod"
 	resourceslicewh "github.com/liqotech/liqo/pkg/webhooks/resourceslice"
@@ -202,6 +203,7 @@ func main() {
 	mgr.GetWebhookServer().Register("/validate/firewallconfigurations", fwcfgwh.NewValidator(mgr.GetClient()))
 	mgr.GetWebhookServer().Register("/mutate/firewallconfigurations", fwcfgwh.NewMutator())
 	mgr.GetWebhookServer().Register("/validate/routeconfigurations", routecfgwh.NewValidator(mgr.GetClient()))
+	mgr.GetWebhookServer().Register("/validate/ip", ipwh.NewValidator(mgr.GetClient()))
 	mgr.GetWebhookServer().Register("/validate/tenants", tenantwh.NewValidator(mgr.GetClient()))
 	mgr.GetWebhookServer().Register("/mutate/tenants", tenantwh.NewMutator(mgr.GetClient()))
 

--- a/deployments/liqo/files/liqo-webhook-ClusterRole.yaml
+++ b/deployments/liqo/files/liqo-webhook-ClusterRole.yaml
@@ -77,6 +77,15 @@ rules:
   - update
   - watch
 - apiGroups:
+  - ipam.liqo.io
+  resources:
+  - ips
+  - networks
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - networking.liqo.io
   resources:
   - firewallconfigurations

--- a/deployments/liqo/templates/webhooks/liqo-validating-webhook.yaml
+++ b/deployments/liqo/templates/webhooks/liqo-validating-webhook.yaml
@@ -130,3 +130,25 @@ webhooks:
         - key: liqo.io/webhook-skip
           operator: NotIn
           values: ["true"]
+  - name: ip.validate.liqo.io
+    admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: {{ include "liqo.prefixedName" $webhookConfig }}
+        namespace: {{ .Release.Namespace }}
+        path: "/validate/ip"
+        port: {{ .Values.webhook.port }}
+    rules:
+      - operations: ["CREATE", "UPDATE"]
+        apiGroups: ["ipam.liqo.io"]
+        apiVersions: ["v1alpha1"]
+        resources: ["ips"]
+    sideEffects: None
+    failurePolicy: {{ .Values.webhook.failurePolicy }}
+    objectSelector:
+      matchExpressions:
+        - key: liqo.io/webhook-skip
+          operator: NotIn
+          values: ["true"]

--- a/pkg/webhooks/ip/doc.go
+++ b/pkg/webhooks/ip/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2019-2026 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package ip contains the logic of the IP validating webhook.
+package ip

--- a/pkg/webhooks/ip/ip.go
+++ b/pkg/webhooks/ip/ip.go
@@ -1,0 +1,142 @@
+// Copyright 2019-2026 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ip
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	ipamv1alpha1 "github.com/liqotech/liqo/apis/ipam/v1alpha1"
+	"github.com/liqotech/liqo/pkg/consts"
+	"github.com/liqotech/liqo/pkg/utils/getters"
+)
+
+// cluster-role
+// +kubebuilder:rbac:groups=ipam.liqo.io,resources=ips,verbs=get;list;watch
+// +kubebuilder:rbac:groups=ipam.liqo.io,resources=networks,verbs=get;list;watch
+
+type ipwh struct {
+	client  client.Client
+	decoder admission.Decoder
+}
+
+// NewValidator returns a new IP validating webhook.
+func NewValidator(cl client.Client) *webhook.Admission {
+	return &webhook.Admission{Handler: &ipwh{
+		client:  cl,
+		decoder: admission.NewDecoder(runtime.NewScheme()),
+	}}
+}
+
+// DecodeIP decodes the IP from the incoming request.
+func (w *ipwh) DecodeIP(obj runtime.RawExtension) (*ipamv1alpha1.IP, error) {
+	var ip ipamv1alpha1.IP
+	err := w.decoder.DecodeRaw(obj, &ip)
+	return &ip, err
+}
+
+// Handle implements the IP validating webhook logic.
+//
+//nolint:gocritic // The signature of this method is imposed by controller runtime.
+func (w *ipwh) Handle(ctx context.Context, req admission.Request) admission.Response {
+	ip, err := w.DecodeIP(req.Object)
+	if err != nil {
+		klog.Errorf("Failed decoding IP object: %v", err)
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+
+	switch req.Operation {
+	case admissionv1.Create:
+		return w.handleCreate(ctx, ip)
+	case admissionv1.Update:
+		return w.handleUpdate(ctx, ip)
+	default:
+		return admission.Allowed("")
+	}
+}
+
+func (w *ipwh) handleCreate(ctx context.Context, ip *ipamv1alpha1.IP) admission.Response {
+	// Check if the IP belongs to a pod CIDR.
+	if err := w.validateIPBelongsToPodCIDR(ctx, ip); err != nil {
+		klog.Errorf("IP %q validation failed: %v", ip.Name, err)
+		return admission.Denied(err.Error())
+	}
+	return admission.Allowed("")
+}
+
+func (w *ipwh) handleUpdate(ctx context.Context, ip *ipamv1alpha1.IP) admission.Response {
+	// For updates, only validate if the IP field has changed.
+	// The IP field is immutable, so this is just a safety check.
+	if err := w.validateIPBelongsToPodCIDR(ctx, ip); err != nil {
+		klog.Errorf("IP %q validation failed: %v", ip.Name, err)
+		return admission.Denied(err.Error())
+	}
+	return admission.Allowed("")
+}
+
+// validateIPBelongsToPodCIDR checks if the IP belongs to a pod CIDR.
+// It returns an error if the IP is found within a pod CIDR (i.e., it is already allocated).
+func (w *ipwh) validateIPBelongsToPodCIDR(ctx context.Context, ip *ipamv1alpha1.IP) error {
+	ipStr := ip.Spec.IP.String()
+	if ipStr == "" {
+		return fmt.Errorf("IP field is empty")
+	}
+
+	// Parse the IP address.
+	parsedIP := net.ParseIP(ipStr)
+	if parsedIP == nil {
+		return fmt.Errorf("invalid IP address %q", ipStr)
+	}
+
+	// Get the pod CIDR networks.
+	podCIDRNetworks, err := getters.GetNetworksByLabel(ctx, w.client,
+		labels.SelectorFromSet(map[string]string{
+			consts.NetworkTypeLabelKey: string(consts.NetworkTypePodCIDR),
+		}), "")
+	if err != nil {
+		return fmt.Errorf("failed to get pod CIDR networks: %w", err)
+	}
+
+	if len(podCIDRNetworks) == 0 {
+		return fmt.Errorf("no pod CIDR networks found")
+	}
+
+	// Check if the IP belongs to any of the pod CIDRs.
+	for i := range podCIDRNetworks {
+		if podCIDRNetworks[i].Spec.CIDR == "" {
+			continue
+		}
+		_, cidr, err := net.ParseCIDR(podCIDRNetworks[i].Spec.CIDR.String())
+		if err != nil {
+			klog.Warningf("Failed to parse CIDR %q: %v", podCIDRNetworks[i].Spec.CIDR, err)
+			continue
+		}
+		if cidr.Contains(parsedIP) {
+			return fmt.Errorf("%q cannot be remapped using IP CRD since it is already part of the pod CIDR %q", ipStr, podCIDRNetworks[i].Spec.CIDR)
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Summary

This PR adds a **validating webhook** for `IP` resources (ipam.liqo.io/v1alpha1) that **rejects** IP resource creation/updates when the requested IP address is already part of a pod CIDR network.

## Changes

### `pkg/webhooks/ip/ip.go` — New IP validation webhook

- Implements `admission.Handler` interface with `Handle()` method
- Validates on `Create` and `Update` operations
- **Rejects** the request if the IP address is found within any pod CIDR network
- **Allows** the request if the IP address is not part of any pod CIDR

### `pkg/webhooks/ip/doc.go` — Package documentation

- Standard package doc comment for the IP webhook package

### `cmd/webhook/main.go` — Webhook registration

- Registers the IP validation webhook at path `/validate/ip`
- Uses `ipwh.NewValidator(mgr.GetClient())` to create the handler

### `pkg/webhooks/ip/ip.go` — RBAC annotations

- Added kubebuilder RBAC annotations for `ipam.liqo.io` resources:
  - `ips`: `get`, `list`, `watch`
  - `networks`: `get`, `list`, `watch`
- These annotations are picked up by `make generate` to produce the ClusterRole

### `deployments/liqo/templates/webhooks/liqo-validating-webhook.yaml` — ValidatingWebhookConfiguration

- Added new webhook entry `ip.validate.liqo.io` at path `/validate/ip`
- Targets `CREATE` and `UPDATE` operations on `ips` resources in `ipam.liqo.io/v1alpha1`
- Includes `liqo.io/webhook-skip` object selector to allow skipping the webhook

> **Note:** Run `make generate` to regenerate the RBAC manifests after these changes.

## How it works

1. The webhook decodes the incoming `IP` object from the admission request
2. It parses the IP address from `ip.Spec.IP`
3. It queries all `Network` resources with label `ipam.liqo.io/network-type=pod-cidr`
4. For each pod CIDR network, it checks if the requested IP falls within the CIDR range
5. If the IP **is** found in any pod CIDR → **reject** with message `"<ip> cannot be remapped using IP CRD since it is already part of the pod CIDR <cidr>"`
6. If the IP is **not** found in any pod CIDR → **allow**

## RBAC

The webhook requires the following permissions (generated via `make generate` from kubebuilder annotations):
- `get`, `list`, `watch` on `ips` (ipam.liqo.io)
- `get`, `list`, `watch` on `networks` (ipam.liqo.io)
