### PR TITLE
fix: disable apiserver proxy IP when liqo-proxy disabled

### DIFF
--- a/cmd/liqo-controller-manager/main.go
+++ b/cmd/liqo-controller-manager/main.go
@@ -262,14 +262,14 @@ func run(cmd *cobra.Command, _ []string) error {
 			return fmt.Errorf("unable to start the configuration reconciler: %w", err)
 		}
 
-		if opts.EnableAPIServerIPRemapping {
-			if err := ipamips.EnforceAPIServerIPRemapping(cmd.Context(), uncachedClient, opts.LiqoNamespace); err != nil {
-				return fmt.Errorf("unable to enforce the API server IP remapping: %w", err)
-			}
+		if err := ipamips.EnforceAPIServerIPRemapping(cmd.Context(), uncachedClient, opts.LiqoNamespace); err != nil {
+			return fmt.Errorf("unable to enforce the API server IP remapping: %w", err)
 		}
 
-		if err := ipamips.EnforceAPIServerProxyIPRemapping(cmd.Context(), uncachedClient, opts.LiqoNamespace); err != nil {
-			return fmt.Errorf("unable to enforce the API server proxy IP remapping: %w", err)
+		if opts.EnableAPIServerProxyIPRemapping {
+			if err := ipamips.EnforceAPIServerProxyIPRemapping(cmd.Context(), uncachedClient, opts.LiqoNamespace); err != nil {
+				return fmt.Errorf("unable to enforce the API server proxy IP remapping: %w", err)
+			}
 		}
 	}
 

--- a/deployments/liqo/templates/liqo-controller-manager-deployment.yaml
+++ b/deployments/liqo/templates/liqo-controller-manager-deployment.yaml
@@ -131,7 +131,7 @@ spec:
           {{- if gt .Values.controllerManager.replicas 1.0 }}
           - --enable-leader-election=true
           {{- end }}
-          - --enable-api-server-ip-remapping={{ .Values.proxy.enabled }}
+          - --enable-api-server-proxy-ip-remapping={{ .Values.proxy.enabled }}
         env:
           - name: CLUSTER_ID
             valueFrom:

--- a/pkg/liqo-controller-manager/flags.go
+++ b/pkg/liqo-controller-manager/flags.go
@@ -112,5 +112,5 @@ func InitFlags(flagset *pflag.FlagSet, opts *Options) {
 		"Prevents the usage of direct connections between provider clusters.")
 
 	// Cross module
-	flagset.BoolVar(&opts.EnableAPIServerIPRemapping, "enable-api-server-ip-remapping", true, "Enable the API server IP remapping")
+	flagset.BoolVar(&opts.EnableAPIServerProxyIPRemapping, "enable-api-server-proxy-ip-remapping", true, "Enable the API server proxy IP remapping")
 }

--- a/pkg/liqo-controller-manager/options.go
+++ b/pkg/liqo-controller-manager/options.go
@@ -80,7 +80,7 @@ type Options struct {
 	DenyDirectConnections       bool
 
 	// Cross module
-	EnableAPIServerIPRemapping bool
+	EnableAPIServerProxyIPRemapping bool
 }
 
 // NewOptions creates a new Options struct with default values.


### PR DESCRIPTION
# Description

This PR fixes the `proxy.enabled` helm value. Previously, if `false` it prevented the API Server IP from being created. Instead it should guard the API Server Proxy IP, which has the liqo-proxy service as targets.

Now you can disable all liqo-proxy components and its associated IP when setting `proxy.enabled=false` 