### PR TITLE
feat: access API server from remote through EndpointSlices

### DIFF
--- a/cmd/liqo-controller-manager/main.go
+++ b/cmd/liqo-controller-manager/main.go
@@ -262,8 +262,26 @@ func run(cmd *cobra.Command, _ []string) error {
 			return fmt.Errorf("unable to start the configuration reconciler: %w", err)
 		}
 
-		if err := ipamips.EnforceAPIServerIPRemapping(cmd.Context(), uncachedClient, opts.LiqoNamespace); err != nil {
-			return fmt.Errorf("unable to enforce the API server IP remapping: %w", err)
+		if !opts.APIServerIPUseEndpointSlices {
+			if err := ipamips.EnforceAPIServerIPRemapping(cmd.Context(), uncachedClient, opts.LiqoNamespace); err != nil {
+				return fmt.Errorf("unable to enforce the API server IP remapping: %w", err)
+			}
+		} else {
+			// To not watch all the EndpointSlices in the cluster, we create custom cache to watch only endpointslices in default namespace.
+			// Additionally we add a predicate to filter only endpointslices associated to the kubernetes service, which is the only one we are interested in.
+			endpointSliceReconciler, err := ipmapping.NewEndpointSliceIPReconciler(
+				cmd.Context(),
+				mgr.GetScheme(),
+				mgr.GetRESTMapper(),
+				config,
+				opts.LiqoNamespace,
+			)
+			if err != nil {
+				return fmt.Errorf("creating endpointslice reconciler: %w", err)
+			}
+			if err := endpointSliceReconciler.SetupWithManager(mgr); err != nil {
+				return fmt.Errorf("unable to start the endpointslice reconciler: %w", err)
+			}
 		}
 
 		if opts.EnableAPIServerProxyIPRemapping {

--- a/deployments/liqo/README.md
+++ b/deployments/liqo/README.md
@@ -91,6 +91,7 @@
 | metrics.enabled | bool | `false` | Enable/Disable the metrics server in every liqo component. |
 | metrics.prometheusOperator.enabled | bool | `false` | Enable/Disable the creation of a Prometheus servicemonitor/podmonitor for the metrics servers. Turn on this flag when the Prometheus Operator runs in your cluster. |
 | nameOverride | string | `""` | Override the standard name used by Helm and associated to Kubernetes/Liqo resources. |
+| networking.apiServerAccessThroughEndpointSlices | bool | `false` | Access remote API server through its Kubernetes service EndpointSlices instead of its ClusterIP. This is useful when the consumer CNI or VPC security groups are preventing the access to the remote API server through its ClusterIP service; known examples are GKE dataplane v2 and EKS. When enabled, the consumer cluster will access the remote API server through the endpointslices of the Kubernetes service. |
 | networking.clientResources | list | `[{"apiVersion":"networking.liqo.io/v1beta1","resource":"wggatewayclients"}]` | Set the list of resources that implement the GatewayClient |
 | networking.denyDirectConnections | bool | `false` | Prevents the usage of direct connections by provider clusters. When enabled, the provider cluster will not route traffic directed to another provider through their direct connection. |
 | networking.enabled | bool | `true` | Use the default Liqo networking module. |

--- a/deployments/liqo/templates/liqo-controller-manager-deployment.yaml
+++ b/deployments/liqo/templates/liqo-controller-manager-deployment.yaml
@@ -132,6 +132,9 @@ spec:
           - --enable-leader-election=true
           {{- end }}
           - --enable-api-server-proxy-ip-remapping={{ .Values.proxy.enabled }}
+          {{- if .Values.networking.apiServerAccessThroughEndpointSlices }}
+          - --api-server-ip-use-endpointslices=true
+          {{- end }}
         env:
           - name: CLUSTER_ID
             valueFrom:

--- a/deployments/liqo/values.yaml
+++ b/deployments/liqo/values.yaml
@@ -59,6 +59,10 @@ networking:
   # -- Prevents the usage of direct connections by provider clusters.
   # When enabled, the provider cluster will not route traffic directed to another provider through their direct connection.
   denyDirectConnections: false
+  # -- Access remote API server through its Kubernetes service EndpointSlices instead of its ClusterIP.
+  # This is useful when the consumer CNI or VPC security groups are preventing the access to the remote API server through its ClusterIP service; known examples are GKE dataplane v2 and EKS.
+  # When enabled, the consumer cluster will access the remote API server through the endpointslices of the Kubernetes service.
+  apiServerAccessThroughEndpointSlices: false
   # -- The port used by the geneve tunnels.
   genevePort: 6091
   # -- Set the list of resources that implement the GatewayServer

--- a/pkg/consts/controllers.go
+++ b/pkg/consts/controllers.go
@@ -81,4 +81,5 @@ const (
 	CtrlResourceSliceVNCreator    = "resourceslice_vncreator"
 	CtrlPodIPMapping              = "pod_ipmapping"
 	CtrlConfigurationIPMapping    = "configuration_ipmapping"
+	CtrlEndpointSlice             = "endpointslice"
 )

--- a/pkg/consts/ipam.go
+++ b/pkg/consts/ipam.go
@@ -56,6 +56,9 @@ const (
 	// IPTypeAPIServerProxy is the constant representing an IP of type APIServerProxy.
 	IPTypeAPIServerProxy = "api-server-proxy"
 
+	// IPEndpointSliceNameLabelKey is the label key used to indicate the name of the EndpointSlice from which an IP was created.
+	IPEndpointSliceNameLabelKey = "ipam.liqo.io/endpointslice"
+
 	// NetworkNamespaceLabelKey is the label key used to indicate the namespace of a Network.
 	NetworkNamespaceLabelKey = "ipam.liqo.io/network-namespace"
 	// NetworkNameLabelKey is the label key used to indicate the name of a Network.

--- a/pkg/firewall/firewallconfiguration_controller.go
+++ b/pkg/firewall/firewallconfiguration_controller.go
@@ -35,11 +35,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	networkingv1beta1 "github.com/liqotech/liqo/apis/networking/v1beta1"
 	"github.com/liqotech/liqo/pkg/consts"
 	"github.com/liqotech/liqo/pkg/utils/network/netmonitor"
+	utilspredicates "github.com/liqotech/liqo/pkg/utils/predicates"
 )
 
 // FirewallConfigurationReconciler manage Configuration lifecycle.
@@ -168,10 +168,7 @@ func (r *FirewallConfigurationReconciler) Reconcile(ctx context.Context, req ctr
 func (r *FirewallConfigurationReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager,
 	enableNftMonitor bool, reconcileTimeout time.Duration) error {
 	klog.Infof("Starting FirewallConfiguration controller with labels %v", r.LabelsSets)
-	filterByLabelsPredicate, err := forgeLabelsPredicate(r.LabelsSets)
-	if err != nil {
-		return err
-	}
+	filterByLabelsPredicate := utilspredicates.NewAnyLabelsSetPredicate(r.LabelsSets)
 
 	klog.Infof("nftables monitor enabled: %t", enableNftMonitor)
 	src := make(chan event.GenericEvent)
@@ -188,18 +185,6 @@ func (r *FirewallConfigurationReconciler) SetupWithManager(ctx context.Context, 
 			ReconciliationTimeout: reconcileTimeout,
 		}).
 		Complete(r)
-}
-
-// forgeLabelsPredicate returns a predicate that filters the resources based on the given labels.
-func forgeLabelsPredicate(labelsSets []labels.Set) (predicate.Predicate, error) {
-	var err error
-	labelPredicates := make([]predicate.Predicate, len(labelsSets))
-	for i := range labelsSets {
-		if labelPredicates[i], err = predicate.LabelSelectorPredicate(metav1.LabelSelector{MatchLabels: labelsSets[i]}); err != nil {
-			return nil, err
-		}
-	}
-	return predicate.Or(labelPredicates...), nil
 }
 
 func getConditionRef(fwcfg *networkingv1beta1.FirewallConfiguration, podname string) *networkingv1beta1.FirewallConfigurationStatusCondition {

--- a/pkg/liqo-controller-manager/flags.go
+++ b/pkg/liqo-controller-manager/flags.go
@@ -113,4 +113,6 @@ func InitFlags(flagset *pflag.FlagSet, opts *Options) {
 
 	// Cross module
 	flagset.BoolVar(&opts.EnableAPIServerProxyIPRemapping, "enable-api-server-proxy-ip-remapping", true, "Enable the API server proxy IP remapping")
+	flagset.BoolVar(&opts.APIServerIPUseEndpointSlices, "api-server-ip-use-endpointslices", false,
+		"Access the API server from offloaded pods through IP remapped on Kubernetes service endpointslices instead of ClusterIP")
 }

--- a/pkg/liqo-controller-manager/ipmapping/endpointslice_controller.go
+++ b/pkg/liqo-controller-manager/ipmapping/endpointslice_controller.go
@@ -1,0 +1,218 @@
+// Copyright 2019-2026 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ipmapping
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	discoveryv1 "k8s.io/api/discovery/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
+	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	ipamv1alpha1 "github.com/liqotech/liqo/apis/ipam/v1alpha1"
+	networkingv1beta1 "github.com/liqotech/liqo/apis/networking/v1beta1"
+	"github.com/liqotech/liqo/pkg/consts"
+	clientutils "github.com/liqotech/liqo/pkg/utils/clients"
+	utilpredicates "github.com/liqotech/liqo/pkg/utils/predicates"
+	"github.com/liqotech/liqo/pkg/utils/resource"
+)
+
+const (
+	kubernetesServiceName      = "kubernetes"
+	kubernetesServiceNamespace = "default"
+)
+
+// EndpointSliceIPReconciler reconciles an EndpointSlice and create the corresponding IP resource.
+type EndpointSliceIPReconciler struct {
+	Client client.Client
+	Scheme *runtime.Scheme
+	Cache  cache.Cache
+
+	labelsSetsFilter []labels.Set
+	namespacesFilter []string
+	ipNamespace      string
+}
+
+// NewEndpointSliceIPReconciler returns a new EndpointSliceIPReconciler.
+// It initializes a dedicated cache scoped to the given namespaces and label sets for EndpointSlices.
+func NewEndpointSliceIPReconciler(ctx context.Context, scheme *runtime.Scheme, mapper apimeta.RESTMapper,
+	conf *rest.Config, ipNamespace string) (*EndpointSliceIPReconciler, error) {
+	labelsSets := []labels.Set{{discoveryv1.LabelServiceName: kubernetesServiceName}}
+	namespaces := []string{kubernetesServiceNamespace}
+
+	// Create a dedicated cache for EndpointSlices in the specified namespaces.
+	namespacesConfig := make(map[string]cache.Config, len(namespaces))
+	for _, ns := range namespaces {
+		namespacesConfig[ns] = cache.Config{}
+	}
+	cacheOptions := &cache.Options{
+		Scheme: scheme,
+		Mapper: mapper,
+		ByObject: map[client.Object]cache.ByObject{
+			&discoveryv1.EndpointSlice{}: {
+				Namespaces: namespacesConfig,
+			},
+		},
+	}
+
+	epsClient, epsCache, err := clientutils.GetCachedClientAndCacheWithConfig(ctx, scheme, mapper, conf, cacheOptions)
+	if err != nil {
+		return nil, fmt.Errorf("creating endpointslice scoped client: %w", err)
+	}
+
+	return &EndpointSliceIPReconciler{
+		Client: epsClient,
+		Cache:  epsCache,
+		Scheme: scheme,
+
+		labelsSetsFilter: labelsSets,
+		namespacesFilter: namespaces,
+		ipNamespace:      ipNamespace,
+	}, nil
+}
+
+// +kubebuilder:rbac:groups=discovery.k8s.io,resources=endpointslices,verbs=get;list;watch
+// +kubebuilder:rbac:groups=ipam.liqo.io,resources=ips,verbs=get;list;watch;create;update;patch;delete
+
+// Reconcile reconciles an EndpointSlice and creates the corresponding IP resource.
+func (r *EndpointSliceIPReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	var eps discoveryv1.EndpointSlice
+	if err := r.Client.Get(ctx, req.NamespacedName, &eps); err != nil {
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, fmt.Errorf("getting endpointslice %q: %w", req.NamespacedName, err)
+	}
+
+	klog.V(4).Infof("Reconciling EndpointSlice %q", req.String())
+
+	// Common labels for all the IPs created from this EndpointSlice.
+	commonLabels := map[string]string{
+		consts.IPEndpointSliceNameLabelKey: eps.Name,
+	}
+
+	if !eps.DeletionTimestamp.IsZero() {
+		if err := r.Client.DeleteAllOf(ctx, &ipamv1alpha1.IP{}, client.InNamespace(r.ipNamespace), client.MatchingLabels(commonLabels)); err != nil {
+			return ctrl.Result{}, fmt.Errorf("deleting IPs for EndpointSlice %q: %w", req.NamespacedName, err)
+		}
+		return ctrl.Result{}, nil
+	}
+
+	ipLabels := commonLabels
+	if eps.Labels[discoveryv1.LabelServiceName] == kubernetesServiceName {
+		ipLabels[consts.IPTypeLabelKey] = consts.IPTypeAPIServer
+	}
+
+	annots := map[string]string{
+		consts.PreinstalledAnnotKey: consts.PreinstalledAnnotValue,
+	}
+
+	expectedIPs := make(map[string]struct{})
+	for _, endpoint := range eps.Endpoints {
+		for _, addr := range endpoint.Addresses {
+			name := forgeIPname(&eps, addr)
+			expectedIPs[name] = struct{}{}
+			op, err := r.ensureIP(ctx, name, r.ipNamespace, addr, ipLabels, annots)
+			if err != nil {
+				return ctrl.Result{}, fmt.Errorf("ensuring IP for EndpointSlice %q: %w", req.NamespacedName, err)
+			}
+			if op != controllerutil.OperationResultNone {
+				klog.Infof("IP %q %s", name, op)
+			}
+		}
+	}
+
+	var ipList ipamv1alpha1.IPList
+	if err := r.Client.List(ctx, &ipList, client.InNamespace(r.ipNamespace), client.MatchingLabels(commonLabels)); err != nil {
+		return ctrl.Result{}, fmt.Errorf("listing IPs for EndpointSlice %q: %w", req.NamespacedName, err)
+	}
+	for i := range ipList.Items {
+		ip := &ipList.Items[i]
+		if _, ok := expectedIPs[ip.Name]; ok {
+			continue
+		}
+		err := r.Client.Delete(ctx, ip)
+		if client.IgnoreNotFound(err) != nil {
+			return ctrl.Result{}, fmt.Errorf("deleting stale IP %q for EndpointSlice %q: %w", ip.Name, req.NamespacedName, err)
+		}
+		if err == nil {
+			klog.Infof("Deleted stale IP %q for EndpointSlice %q", ip.Name, req.NamespacedName)
+		}
+	}
+
+	klog.V(4).Infof("Ensured IPs for EndpointSlice %q", req.String())
+	return ctrl.Result{}, nil
+}
+
+// SetupWithManager registers the EndpointSliceAPIServerReconciler to the manager.
+// The watch is restricted to EndpointSlices in the specified namespaces targeting the endpointslices
+// with labels matching the labelsSets provided to the reconciler.
+func (r *EndpointSliceIPReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	predicates := predicate.And(
+		utilpredicates.NewTypedAnyNamespacePredicate[*discoveryv1.EndpointSlice](r.namespacesFilter),
+		utilpredicates.NewTypedAnyLabelsSetPredicate[*discoveryv1.EndpointSlice](r.labelsSetsFilter),
+		predicate.TypedGenerationChangedPredicate[*discoveryv1.EndpointSlice]{})
+
+	return ctrl.NewControllerManagedBy(mgr).Named(consts.CtrlEndpointSlice).
+		WatchesRawSource(source.Kind(r.Cache, &discoveryv1.EndpointSlice{},
+			&handler.TypedEnqueueRequestForObject[*discoveryv1.EndpointSlice]{}, predicates)).
+		Complete(r)
+}
+
+func forgeIPname(eps *discoveryv1.EndpointSlice, address string) string {
+	// Replace dots with dashes to make the name DNS-1123 compliant.
+	return eps.Name + "-" + strings.ReplaceAll(address, ".", "-")
+}
+
+func (r *EndpointSliceIPReconciler) ensureIP(ctx context.Context,
+	name, namespace, endpoint string, lbls, annots map[string]string) (controllerutil.OperationResult, error) {
+	ip := ipamv1alpha1.IP{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+	return resource.CreateOrUpdate(ctx, r.Client, &ip, func() error {
+		if ip.Labels == nil {
+			ip.Labels = map[string]string{}
+		}
+		ip.Labels = labels.Merge(ip.Labels, lbls)
+
+		if ip.Annotations == nil {
+			ip.Annotations = map[string]string{}
+		}
+		ip.Annotations = labels.Merge(ip.Annotations, annots)
+
+		ip.Spec.IP = networkingv1beta1.IP(endpoint)
+		ip.Spec.Masquerade = ptr.To(true)
+
+		return nil
+	})
+}

--- a/pkg/liqo-controller-manager/networking/internal-network/route/internalnode_k8s.go
+++ b/pkg/liqo-controller-manager/networking/internal-network/route/internalnode_k8s.go
@@ -56,7 +56,7 @@ func enforceRouteWithConntrackPresence(ctx context.Context, cl client.Client,
 
 	if _, err := resource.CreateOrUpdate(ctx, cl, fwcfg,
 		forgeFirewallConfigurationMutateFunction(internalnode, fwcfg, mark, nodePortSrcIP)); err != nil {
-		return fmt.Errorf("an error occurred while creating or updating the firewall configuration: %w", err)
+		return fmt.Errorf("ensuring firewall configuration %q: %w", fwcfg.Name, err)
 	}
 
 	routecfg := &networkingv1beta1.RouteConfiguration{
@@ -65,7 +65,7 @@ func enforceRouteWithConntrackPresence(ctx context.Context, cl client.Client,
 
 	if _, err := resource.CreateOrUpdate(ctx, cl, routecfg,
 		forgeRouteConfigurationMutateFunction(internalnode, routecfg, scheme, mark, nodePortSrcIP)); err != nil {
-		return fmt.Errorf("an error occurred while creating or updating the route configuration: %w", err)
+		return fmt.Errorf("ensuring route configuration %q: %w", routecfg.Name, err)
 	}
 
 	return nil
@@ -80,18 +80,18 @@ func enforceRouteWithConntrackAbsence(ctx context.Context, cl client.Client,
 		// If the firewall configuration does not exist no needs to clean things up.
 		return nil
 	} else if err != nil {
-		return fmt.Errorf("unable to get firewall configuration: %w", err)
+		return fmt.Errorf("getting firewall configuration %q: %w", configurationNameSvc, err)
 	}
 
 	// We need to remove from the firewall configurations all the rules related to the InternalNode to be remove
 	cleanFirewallConfigurationChains(fwcfg, internalnode)
 	if err := cl.Update(ctx, fwcfg); err != nil {
-		return fmt.Errorf("an error occurred while cleaning the firewall configuration: %w", err)
+		return fmt.Errorf("cleaning firewall configuration %q: %w", fwcfg.Name, err)
 	}
 
 	// If there are no firewall configurations left, delete the resource
 	if err := deleteVoidFwcfg(ctx, cl, fwcfg); err != nil {
-		return fmt.Errorf("an error occurred while deleting the firewall configuration: %w", err)
+		return fmt.Errorf("deleting firewall configuration %q: %w", fwcfg.Name, err)
 	}
 
 	// We don't need to clean routeconfigurations since they have an owner reference on the node.
@@ -101,7 +101,7 @@ func enforceRouteWithConntrackAbsence(ctx context.Context, cl client.Client,
 func deleteVoidFwcfg(ctx context.Context, cl client.Client, fwcfg *networkingv1beta1.FirewallConfiguration) error {
 	if len(fwcfg.Spec.Table.Chains) > 0 && len(fwcfg.Spec.Table.Chains[0].Rules.FilterRules) == 0 {
 		if err := cl.Delete(ctx, fwcfg); err != nil {
-			return fmt.Errorf("an error occurred while deleting the firewall configuration: %w", err)
+			return fmt.Errorf("deleting firewall configuration %q: %w", fwcfg.Name, err)
 		}
 	}
 	return nil
@@ -273,7 +273,7 @@ func enforceRouteConfigurationExtCIDR(ctx context.Context, cl client.Client,
 
 	if _, err := resource.CreateOrUpdate(ctx, cl, routecfg,
 		forgeRouteConfigurationExtCIDRMutateFunction(internalnode, routecfg, configurations, ips, scheme)); err != nil {
-		return fmt.Errorf("an error occurred while creating or updating the route configuration: %w", err)
+		return fmt.Errorf("ensuring route configuration %q: %w", routecfg.Name, err)
 	}
 	return nil
 }

--- a/pkg/liqo-controller-manager/offloading/shadowpod-controller/shadowpod_controller.go
+++ b/pkg/liqo-controller-manager/offloading/shadowpod-controller/shadowpod_controller.go
@@ -197,8 +197,6 @@ func (r *Reconciler) mutatePodSpec(ctx context.Context,
 
 		// Update the HostAliases with the remapped IP.
 		podSpec.HostAliases[i].IP = rIP
-
-		return nil
 	}
 
 	return nil

--- a/pkg/liqo-controller-manager/options.go
+++ b/pkg/liqo-controller-manager/options.go
@@ -81,6 +81,7 @@ type Options struct {
 
 	// Cross module
 	EnableAPIServerProxyIPRemapping bool
+	APIServerIPUseEndpointSlices    bool
 }
 
 // NewOptions creates a new Options struct with default values.

--- a/pkg/route/routeconfiguration_controller.go
+++ b/pkg/route/routeconfiguration_controller.go
@@ -34,11 +34,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	networkingv1beta1 "github.com/liqotech/liqo/apis/networking/v1beta1"
 	"github.com/liqotech/liqo/pkg/consts"
 	"github.com/liqotech/liqo/pkg/utils/network/netmonitor"
+	utilpredicates "github.com/liqotech/liqo/pkg/utils/predicates"
 )
 
 // RouteConfigurationReconciler manage Configuration lifecycle.
@@ -202,10 +202,7 @@ func (r *RouteConfigurationReconciler) SetupWithManager(ctx context.Context, mgr
 		}()
 	}
 
-	filterByLabelsPredicate, err := forgeLabelsPredicate(r.LabelsSets)
-	if err != nil {
-		return err
-	}
+	filterByLabelsPredicate := utilpredicates.NewAnyLabelsSetPredicate(r.LabelsSets)
 
 	return ctrl.NewControllerManagedBy(mgr).Named(consts.CtrlRouteConfiguration).
 		For(&networkingv1beta1.RouteConfiguration{}, builder.WithPredicates(filterByLabelsPredicate)).
@@ -214,18 +211,6 @@ func (r *RouteConfigurationReconciler) SetupWithManager(ctx context.Context, mgr
 			ReconciliationTimeout: reconcileTimeout,
 		}).
 		Complete(r)
-}
-
-// forgeLabelsPredicate returns a predicate that filters the resources based on the given labels.
-func forgeLabelsPredicate(labelsSets []labels.Set) (predicate.Predicate, error) {
-	var err error
-	labelPredicates := make([]predicate.Predicate, len(labelsSets))
-	for i := range labelsSets {
-		if labelPredicates[i], err = predicate.LabelSelectorPredicate(metav1.LabelSelector{MatchLabels: labelsSets[i]}); err != nil {
-			return nil, err
-		}
-	}
-	return predicate.Or(labelPredicates...), nil
 }
 
 func getConditionRef(rcfg *networkingv1beta1.RouteConfiguration, podname string) *networkingv1beta1.RouteConfigurationStatusCondition {

--- a/pkg/utils/clients/get_cached_client.go
+++ b/pkg/utils/clients/get_cached_client.go
@@ -32,29 +32,38 @@ import (
 // the scheme. The necessary rest.Config is passed as third parameter, it must not be nil.
 func GetCachedClientWithConfig(ctx context.Context,
 	scheme *runtime.Scheme, mapper meta.RESTMapper, conf *rest.Config, cacheOptions *ctrlcache.Options) (client.Client, error) {
+	cl, _, err := GetCachedClientAndCacheWithConfig(ctx, scheme, mapper, conf, cacheOptions)
+	return cl, err
+}
+
+// GetCachedClientAndCacheWithConfig returns a controller runtime client with the cache initialized only for the resources
+// added to the scheme, together with the underlying cache. The necessary rest.Config is passed as third parameter, it must
+// not be nil.
+func GetCachedClientAndCacheWithConfig(ctx context.Context,
+	scheme *runtime.Scheme, mapper meta.RESTMapper, conf *rest.Config, cacheOptions *ctrlcache.Options) (client.Client, ctrlcache.Cache, error) {
 	cache, err := ctrlcache.New(conf, *cacheOptions)
 	if err != nil {
-		return nil, fmt.Errorf("unable to create the pod cache: %w", err)
+		return nil, nil, fmt.Errorf("unable to create the cache: %w", err)
 	}
 
 	go func() {
-		klog.Info("starting pod cache")
+		klog.Info("starting cache")
 		if err := cache.Start(ctx); err != nil {
-			klog.Errorf("error starting pod cache: %s", err)
+			klog.Errorf("error starting cache: %s", err)
 			os.Exit(1)
 		}
 	}()
 
-	klog.Info("waiting for pod cache sync")
+	klog.Info("waiting for cache sync")
 
 	if ok := cache.WaitForCacheSync(ctx); !ok {
-		return nil, fmt.Errorf("unable to sync pod cache")
+		return nil, nil, fmt.Errorf("unable to sync cache")
 	}
 
-	klog.Info("pod cache synced")
+	klog.Info("cache synced")
 
 	if conf == nil {
-		return nil, fmt.Errorf("the rest.Config parameter is nil")
+		return nil, nil, fmt.Errorf("the rest.Config parameter is nil")
 	}
 
 	cl, err := client.New(conf, client.Options{
@@ -66,8 +75,8 @@ func GetCachedClientWithConfig(ctx context.Context,
 	})
 
 	if err != nil {
-		return nil, fmt.Errorf("unable to create the client: %w", err)
+		return nil, nil, fmt.Errorf("unable to create the client: %w", err)
 	}
 
-	return cl, nil
+	return cl, cache, nil
 }

--- a/pkg/utils/predicates/predicates.go
+++ b/pkg/utils/predicates/predicates.go
@@ -1,0 +1,59 @@
+// Copyright 2019-2026 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package predicates contains utility methods to create predicates.
+package predicates
+
+import (
+	"k8s.io/apimachinery/pkg/labels"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+// NewAnyLabelsSetPredicate returns a predicate that filters objects based on a list of label sets.
+// The predicate will return true if the object matches at least one of the label sets.
+func NewAnyLabelsSetPredicate(labelsSets []labels.Set) predicate.Predicate {
+	return NewTypedAnyLabelsSetPredicate[client.Object](labelsSets)
+}
+
+// NewTypedAnyLabelsSetPredicate returns a typed predicate that filters objects based on a list of label sets.
+// The predicate will return true if the object matches at least one of the label sets.
+func NewTypedAnyLabelsSetPredicate[T client.Object](labelsSets []labels.Set) predicate.TypedPredicate[T] {
+	labelPredicates := make([]predicate.TypedPredicate[T], len(labelsSets))
+	for i := range labelsSets {
+		labelPredicates[i] = predicate.NewTypedPredicateFuncs(func(obj T) bool {
+			selector := labels.SelectorFromValidatedSet(labelsSets[i])
+			return selector.Matches(labels.Set(obj.GetLabels()))
+		})
+	}
+	return predicate.Or(labelPredicates...)
+}
+
+// NewAnyNamespacePredicate returns a predicate that filters objects based on a list of namespaces.
+// The predicate will return true if the object is in at least one of the namespaces.
+func NewAnyNamespacePredicate(namespaces []string) predicate.Predicate {
+	return NewTypedAnyNamespacePredicate[client.Object](namespaces)
+}
+
+// NewTypedAnyNamespacePredicate returns a typed predicate that filters objects based on a list of namespaces.
+// The predicate will return true if the object is in at least one of the namespaces.
+func NewTypedAnyNamespacePredicate[T client.Object](namespaces []string) predicate.TypedPredicate[T] {
+	namespacePredicates := make([]predicate.TypedPredicate[T], len(namespaces))
+	for i := range namespaces {
+		namespacePredicates[i] = predicate.NewTypedPredicateFuncs(func(obj T) bool {
+			return obj.GetNamespace() == namespaces[i]
+		})
+	}
+	return predicate.Or(namespacePredicates...)
+}

--- a/pkg/virtualKubelet/forge/pods.go
+++ b/pkg/virtualKubelet/forge/pods.go
@@ -77,8 +77,9 @@ type RemotePodStatusMutator func(remote *corev1.PodStatus)
 // SASecretRetriever defines the function to retrieve the secret associated with a given service account.
 type SASecretRetriever func(string) string
 
-// KubernetesServiceIPGetter defines the function to get the remapped IP associated with the local kubernetes.default service.
-type KubernetesServiceIPGetter func() string
+// KubernetesServiceIPGetter defines the function to get the remapped IP associated with the local kubernetes.default service
+// or its endpointslices.
+type KubernetesServiceIPGetter func() []string
 
 // LocalPod forges the object meta and status of the local pod, given the remote one.
 func LocalPod(local, remote *corev1.Pod, translator PodIPTranslator, restarts int32, mutators ...RemotePodStatusMutator) *corev1.Pod {
@@ -523,13 +524,18 @@ func RemoteContainerEnvVariablesAPIServerSupport(envs []corev1.EnvVar, saName, h
 // RemoteHostAliasesAPIServerSupport forges the host aliases to override the IP address associated with the kubernetes.default
 // service to enable offloaded containers to contact back the local API server, instead of the remote one.
 func RemoteHostAliasesAPIServerSupport(aliases []corev1.HostAlias, retriever KubernetesServiceIPGetter) []corev1.HostAlias {
-	address := retriever()
-	if address == "" {
+	addresses := retriever()
+	if len(addresses) == 0 {
 		return aliases
 	}
 
-	return append(aliases, corev1.HostAlias{
-		IP: address, Hostnames: []string{KubernetesAPIService, KubernetesAPIService + ".svc"}})
+	for _, address := range addresses {
+		if address != "" {
+			aliases = append(aliases, corev1.HostAlias{
+				IP: address, Hostnames: []string{KubernetesAPIService, KubernetesAPIService + ".svc"}})
+		}
+	}
+	return aliases
 }
 
 // RemoteTolerations forges the tolerations for a reflected pod.

--- a/pkg/virtualKubelet/forge/pods_test.go
+++ b/pkg/virtualKubelet/forge/pods_test.go
@@ -39,7 +39,7 @@ import (
 var _ = Describe("Pod forging", func() {
 	Translator := func(input string) string { return input + "-reflected" }
 	SASecretRetriever := func(input string) string { return input + "-secret" }
-	KubernetesServiceIPGetter := func() string { return "k8ssvcaddr" }
+	KubernetesServiceIPGetter := func() []string { return []string{"k8ssvcaddr-1", "k8ssvcaddr-2"} }
 
 	Describe("the LocalPod function", func() {
 		const restarts = 3
@@ -853,9 +853,14 @@ var _ = Describe("Pod forging", func() {
 
 		It("should preserve the existing aliases", func() { Expect(output).To(ContainElements(aliases)) })
 		It("should append the alias corresponding to the kubernetes.default service", func() {
-			Expect(output).To(ContainElement(corev1.HostAlias{
-				Hostnames: []string{"kubernetes.default", "kubernetes.default.svc"}, IP: KubernetesServiceIPGetter(),
-			}))
+			ips := KubernetesServiceIPGetter()
+			expectedAliases := []corev1.HostAlias{}
+			for _, ip := range ips {
+				expectedAliases = append(expectedAliases, corev1.HostAlias{
+					Hostnames: []string{"kubernetes.default", "kubernetes.default.svc"}, IP: ip,
+				})
+			}
+			Expect(output).To(ContainElements(expectedAliases))
 		})
 	})
 

--- a/pkg/virtualKubelet/provider/provider.go
+++ b/pkg/virtualKubelet/provider/provider.go
@@ -120,17 +120,27 @@ func NewLiqoProvider(ctx context.Context, cfg *InitConfig, eb record.EventBroadc
 		DisableIPReflection: cfg.DisableIPReflection,
 		HomeAPIServerHost:   cfg.HomeAPIServerHost,
 		HomeAPIServerPort:   cfg.HomeAPIServerPort,
-		KubernetesServiceIPMapper: func(ctx context.Context) (string, error) {
-			ip, err := localLiqoClient.IpamV1alpha1().IPs(cfg.LiqoNamespace).Get(ctx, consts.IPTypeAPIServer, metav1.GetOptions{})
+		KubernetesServiceIPMapper: func(ctx context.Context) ([]string, error) {
+			ips, err := localLiqoClient.IpamV1alpha1().IPs(cfg.LiqoNamespace).List(ctx, metav1.ListOptions{
+				LabelSelector: consts.IPTypeLabelKey + "=" + consts.IPTypeAPIServer,
+			})
 			if err != nil {
-				return "", err
+				return nil, err
 			}
 
-			if ip.Status.IP == "" {
-				return "", errors.New("no IP mapping found for the remote cluster API server")
+			var result []string
+			for i := range ips.Items {
+				ip := ips.Items[i].Status.IP.String()
+				if ip != "" {
+					result = append(result, ip)
+				}
 			}
 
-			return string(ip.Status.IP), nil
+			if len(result) == 0 {
+				return nil, errors.New("no IP mapping found for the remote cluster API server")
+			}
+
+			return result, nil
 		},
 		NetConfiguration: cfg.NetConfiguration,
 	}

--- a/pkg/virtualKubelet/reflection/workload/pod.go
+++ b/pkg/virtualKubelet/reflection/workload/pod.go
@@ -95,7 +95,7 @@ type PodReflectorConfig struct {
 	HomeAPIServerHost   string
 	HomeAPIServerPort   string
 
-	KubernetesServiceIPMapper func(context.Context) (string, error)
+	KubernetesServiceIPMapper func(context.Context) ([]string, error)
 	NetConfiguration          *networkingv1beta1.Configuration
 }
 
@@ -246,26 +246,26 @@ func (pr *PodReflector) Stats(ctx context.Context) (*statsv1alpha1.Summary, erro
 }
 
 // KubernetesServiceIPGetter returns a function to retrieve the IP associated with the kubernetes.default service.
-func (pr *PodReflector) KubernetesServiceIPGetter() func(ctx context.Context) (string, error) {
-	var address string
+func (pr *PodReflector) KubernetesServiceIPGetter() func(ctx context.Context) ([]string, error) {
+	var addresses []string
 	var lock sync.Mutex
 
-	return func(ctx context.Context) (string, error) {
+	return func(ctx context.Context) ([]string, error) {
 		lock.Lock()
 		defer lock.Unlock()
 
-		// If the address has already been saved in cache, then return it directly.
-		if address != "" {
-			return address, nil
+		// If the addresses have already been saved in cache, then return them directly.
+		if len(addresses) > 0 {
+			return addresses, nil
 		}
 
 		var err error
-		address, err = pr.config.KubernetesServiceIPMapper(ctx)
+		addresses, err = pr.config.KubernetesServiceIPMapper(ctx)
 		if err != nil {
-			return "", err
+			return nil, err
 		}
 
-		return address, nil
+		return addresses, nil
 	}
 }
 

--- a/pkg/virtualKubelet/reflection/workload/pod_test.go
+++ b/pkg/virtualKubelet/reflection/workload/pod_test.go
@@ -50,7 +50,7 @@ var _ = Describe("Pod Reflection Tests", func() {
 				Type:       root.DefaultReflectorsTypes[resources.Pod],
 			}
 			reflector := workload.NewPodReflector(nil, nil,
-				&workload.PodReflectorConfig{forge.APIServerSupportDisabled, false, "", "", fakeAPIServerRemapping(""), nil}, &reflectorConfig)
+				&workload.PodReflectorConfig{forge.APIServerSupportDisabled, false, "", "", fakeAPIServerRemapping([]string{""}), nil}, &reflectorConfig)
 			Expect(reflector).ToNot(BeNil())
 			Expect(reflector.Reflector).ToNot(BeNil())
 		})
@@ -58,9 +58,9 @@ var _ = Describe("Pod Reflection Tests", func() {
 
 	Describe("kubernetes.default service IP remapping", func() {
 		var (
-			kubernetesServiceIPGetter func(ctx context.Context) (string, error)
+			kubernetesServiceIPGetter func(ctx context.Context) ([]string, error)
 
-			output string
+			output []string
 			err    error
 		)
 
@@ -72,7 +72,7 @@ var _ = Describe("Pod Reflection Tests", func() {
 			}
 			reflector := workload.NewPodReflector(nil, metricsFactory,
 				&workload.PodReflectorConfig{forge.APIServerSupportDisabled, false, "", "",
-					fakeAPIServerRemapping("192.168.200.1"), &networkingv1beta1.Configuration{
+					fakeAPIServerRemapping([]string{"192.168.200.1", "192.168.200.2"}), &networkingv1beta1.Configuration{
 						ObjectMeta: metav1.ObjectMeta{Generation: 1},
 						Spec: networkingv1beta1.ConfigurationSpec{
 							Remote: networkingv1beta1.ClusterConfig{
@@ -106,7 +106,7 @@ var _ = Describe("Pod Reflection Tests", func() {
 
 		Context("the IP resource is correctly set", func() {
 			It("should succeed", func() { Expect(err).ToNot(HaveOccurred()) })
-			It("should return the correct IP address", func() { Expect(output).To(BeIdenticalTo("192.168.200.1")) })
+			It("should return the correct IP address", func() { Expect(output).To(Equal([]string{"192.168.200.1", "192.168.200.2"})) })
 
 			When("retrieving again the remapped IP address", func() {
 				JustBeforeEach(func() {
@@ -115,7 +115,7 @@ var _ = Describe("Pod Reflection Tests", func() {
 
 				// The IPAMClient is configured to return an error if the same translation is requested twice.
 				It("should succeed (i.e., use the cached values)", func() { Expect(err).ToNot(HaveOccurred()) })
-				It("should return the same translations", func() { Expect(output).To(BeIdenticalTo("192.168.200.1")) })
+				It("should return the same translations", func() { Expect(output).To(Equal([]string{"192.168.200.1", "192.168.200.2"})) })
 			})
 		})
 	})
@@ -145,7 +145,7 @@ var _ = Describe("Pod Reflection Tests", func() {
 				Type:       root.DefaultReflectorsTypes[resources.Pod],
 			}
 			reflector = workload.NewPodReflector(nil, nil,
-				&workload.PodReflectorConfig{forge.APIServerSupportDisabled, false, "", "", fakeAPIServerRemapping(""), nil}, &reflectorConfig)
+				&workload.PodReflectorConfig{forge.APIServerSupportDisabled, false, "", "", fakeAPIServerRemapping([]string{""}), nil}, &reflectorConfig)
 
 			opts := options.New(client, factory.Core().V1().Pods()).
 				WithHandlerFactory(FakeEventHandler).

--- a/pkg/virtualKubelet/reflection/workload/podns.go
+++ b/pkg/virtualKubelet/reflection/workload/podns.go
@@ -96,7 +96,7 @@ type NamespacedPodReflector struct {
 
 	config *PodReflectorConfig
 
-	kubernetesServiceIPGetter func(context.Context) (string, error)
+	kubernetesServiceIPGetter func(context.Context) ([]string, error)
 	pods                      sync.Map /* implicit signature: map[string]*PodInfo */
 }
 
@@ -327,21 +327,21 @@ func (npr *NamespacedPodReflector) ForgeShadowPod(ctx context.Context, local *co
 		// The function will never be invoked
 	}
 
-	// Wrap the kubernetes service remapped IP retrieval, so that we do not have to handle errors in the forge logic.
-	ipGetter := func() (ip string) {
+	// Wrap the kubernetes service/endpointslices remapped IP retrieval, so that we do not have to handle errors in the forge logic.
+	ipsGetter := func() (ips []string) {
 		if npr.config.NetConfiguration == nil {
-			return ""
+			return nil
 		}
 
-		ip, kserr = npr.kubernetesServiceIPGetter(ctx)
-		return ip
+		ips, kserr = npr.kubernetesServiceIPGetter(ctx)
+		return ips
 	}
 
 	var mutators []forge.RemotePodSpecMutator
 
 	mutators = append(mutators,
 		forge.APIServerSupportMutator(npr.config.APIServerSupport, local.Annotations, pod.ServiceAccountName(local),
-			saSecretRetriever, ipGetter, npr.config.HomeAPIServerHost, npr.config.HomeAPIServerPort),
+			saSecretRetriever, ipsGetter, npr.config.HomeAPIServerHost, npr.config.HomeAPIServerPort),
 		forge.ServiceAccountMutator(npr.config.APIServerSupport, local.Annotations))
 
 	if forgingOpts != nil {

--- a/pkg/virtualKubelet/reflection/workload/podns_test.go
+++ b/pkg/virtualKubelet/reflection/workload/podns_test.go
@@ -102,7 +102,7 @@ var _ = Describe("Namespaced Pod Reflection Tests", func() {
 				Type:       root.DefaultReflectorsTypes[resources.Pod],
 			}
 			rfl := workload.NewPodReflector(nil, metricsFactory,
-				&workload.PodReflectorConfig{forge.APIServerSupportTokenAPI, false, "", "", fakeAPIServerRemapping(""), netConfig}, &reflectorConfig)
+				&workload.PodReflectorConfig{forge.APIServerSupportTokenAPI, false, "", "", fakeAPIServerRemapping([]string{""}), netConfig}, &reflectorConfig)
 			rfl.Start(ctx, options.New(client, factory.Core().V1().Pods()).WithEventBroadcaster(broadcaster))
 			reflector = rfl.NewNamespaced(options.NewNamespaced().
 				WithLocal(LocalNamespace, client, factory).WithLiqoLocal(liqoClient, liqoFactory).

--- a/pkg/virtualKubelet/reflection/workload/workload_suite_test.go
+++ b/pkg/virtualKubelet/reflection/workload/workload_suite_test.go
@@ -51,9 +51,9 @@ var (
 	ctx    context.Context
 	cancel context.CancelFunc
 
-	fakeAPIServerRemapping = func(ip string) func(ctx context.Context) (string, error) {
-		return func(ctx context.Context) (string, error) {
-			return ip, nil
+	fakeAPIServerRemapping = func(ips []string) func(ctx context.Context) ([]string, error) {
+		return func(ctx context.Context) ([]string, error) {
+			return ips, nil
 		}
 	}
 )


### PR DESCRIPTION
# Description

## Problem                                                                                                                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                                                                         
Offloaded pods on the consumer cluster reach the provider cluster's API server via the `kubernetes` Service ClusterIP, which Liqo remaps to a local IP through a static IP resource.

This approach does not work on some Kubernetes providers (known ones are GKE dataplane v2 and EKS), due to the CNI or VPC security groups layer.                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                                                         
## Approach                                                                                                                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                                                                                         
Instead of remapping the Service ClusterIP, watch the Kubernetes Service's EndpointSlices in the consumer's default namespace, and create one IP resource per backing address. Each of those IPs is marked with Masquerade: true so that, when the packet leaves the consumer node, it gets SNATed to the node IP — bypassing the CNI's          
ClusterIP-based filtering that causes the drop on EKS-like providers.                                                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                                                                                         
To preserve redundancy across multiple endpoints, all the remapped IPs are injected as HostAlias entries pointing at kubernetes / kubernetes.default.svc, so the pod can reach the API server through any of them.                                                                                                                                      
                                                                                                                                                                                                                                                                                                                                                         
The behavior is opt-in behind a new flag, defaulting to the existing ClusterIP-based remapping so nothing changes for clusters that are not affected    

## Backwards compatibility                                                                                                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                                                                         
This mode is off by default. Existing clusters continue to use the ClusterIP remapping exactly as before. To opt in:                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                                                                         
 ```yaml                                                                                                                                                                                                                                                                                                                                                 
   networking:                                                                                                                                                                                                                                                                                                                                           
     apiServerAccessThroughEndpointSlices: true        
```