### PR TITLE
feat(authentication): allow disabling the built-in default ResourceSlice class

### DIFF
--- a/cmd/liqo-controller-manager/modules/authentication.go
+++ b/cmd/liqo-controller-manager/modules/authentication.go
@@ -64,12 +64,13 @@ func NewAuthOption(identityProvider identitymanager.IdentityProvider, namespaceM
 		TrustedCA:                opts.TrustedCA,
 		TLSCompatibilityMode:     opts.TLSCompatibilityMode,
 		SliceStatusOptions: &remoteresourceslicecontroller.SliceStatusOptions{
-			EnableStorage:             opts.EnableStorage,
-			LocalRealStorageClassName: opts.RealStorageClassName,
-			IngressClasses:            opts.IngressClasses,
-			LoadBalancerClasses:       opts.LoadBalancerClasses,
-			ClusterLabels:             opts.ClusterLabels.StringMap,
-			DefaultResourceQuantity:   opts.DefaultNodeResources.ToResourceList(),
+			EnableStorage:                    opts.EnableStorage,
+			LocalRealStorageClassName:        opts.RealStorageClassName,
+			IngressClasses:                   opts.IngressClasses,
+			LoadBalancerClasses:              opts.LoadBalancerClasses,
+			ClusterLabels:                    opts.ClusterLabels.StringMap,
+			DefaultResourceQuantity:          opts.DefaultNodeResources.ToResourceList(),
+			DefaultResourceSliceClassEnabled: opts.DefaultResourceSliceClassEnabled,
 		},
 	}
 }

--- a/deployments/liqo/README.md
+++ b/deployments/liqo/README.md
@@ -10,6 +10,7 @@
 | authentication.awsConfig.region | string | `""` | AWS region where the clsuter is runnnig. |
 | authentication.awsConfig.secretAccessKey | string | `""` | SecretAccessKey for the Liqo user. |
 | authentication.awsConfig.useExistingSecret | bool | `false` | Use an existing secret to configure the AWS credentials. |
+| authentication.defaultResourceSliceClassEnabled | bool | `true` | Enable the built-in default ResourceSlice class. When set to false, the provider denies ResourceSlices that use the "default" class, so consumers must use an explicit, provider-approved ResourceSlice class. |
 | authentication.enabled | bool | `true` | Enable/Disable the authentication module. |
 | authentication.tlsCompatibilityMode | bool | `false` | Enable TLS compatibility mode for client certificates and keys. If set to true, Liqo will use widely supported algorithm (RSA) instead of Ed25519 (default) for generating private keys and CSRs. Enable this option to ensure compatibility with systems that do not yet support Ed25519 as signature algorithm. |
 | common.affinity | object | `{}` | Affinity for all liqo pods, excluding virtual kubelet, gateway and fabric pods. |

--- a/deployments/liqo/templates/liqo-controller-manager-deployment.yaml
+++ b/deployments/liqo/templates/liqo-controller-manager-deployment.yaml
@@ -53,6 +53,7 @@ spec:
           - --networking-enabled={{ .Values.networking.enabled }}
           - --authentication-enabled={{ .Values.authentication.enabled }}
           - --tls-compatibility-mode={{ .Values.authentication.tlsCompatibilityMode }}
+          - --default-resource-slice-class-enabled={{ .Values.authentication.defaultResourceSliceClassEnabled }}
           - --offloading-enabled={{ .Values.offloading.enabled }}
           - --default-limits-enforcement={{ .Values.controllerManager.config.defaultLimitsEnforcement }}
           {{- $d := dict "commandName" "--default-node-resources" "dictionary" .Values.offloading.defaultNodeResources -}}

--- a/deployments/liqo/values.yaml
+++ b/deployments/liqo/values.yaml
@@ -245,6 +245,10 @@ authentication:
   # Enable this option to ensure compatibility with systems that do not yet
   # support Ed25519 as signature algorithm.
   tlsCompatibilityMode: false
+  # -- Enable the built-in default ResourceSlice class. When set to false, the provider denies
+  # ResourceSlices that use the "default" class, so consumers must
+  # use an explicit, provider-approved ResourceSlice class.
+  defaultResourceSliceClassEnabled: true
   # AWS-specific configuration for the local cluster and the Liqo user.
   # This user should be able (1) to create new IAM users, (2) to create new programmatic access
   # credentials, and (3) to describe EKS clusters.

--- a/docs/usage/resource-reservation.md
+++ b/docs/usage/resource-reservation.md
@@ -238,10 +238,18 @@ By default, the `ResourceSlice` class controller shipped with Liqo accepts every
 A reusable starting point is provided by the [resource-slice-class-controller-template](https://github.com/liqotech/resource-slice-class-controller-template) repository, and the general mechanics of class controllers are described in the [Custom ResourceSlice classes](/advanced/peering/offloading-in-depth.md#custom-resourceslice-classes) section of the offloading-in-depth page.
 
 ```{warning}
-The class is chosen by the **consumer**, and the built-in default class controller is always running alongside any custom one — Liqo does not provide a built-in way to disable it.
-A consumer can therefore bypass a strict custom controller simply by selecting `class: default` (or omitting the class), which routes the request to the lenient built-in controller.
-To actually enforce a stricter policy at the provider, the custom controller must be paired with an external mechanism that prevents the lenient path from being used — for example, a Kubernetes admission webhook on the provider that rejects or rewrites the `spec.class` of incoming `ResourceSlice` objects.
+The class is chosen by the **consumer**. By default, the built-in default class controller runs alongside any custom one, so a consumer can bypass a strict custom controller simply by selecting `class: default`, which routes the request to the lenient built-in controller.
 ```
+
+To enforce a stricter policy, the **provider** can disable the built-in default class, so that only explicit, provider-approved classes are accepted. Set the following Helm value on the provider (at installation time, or later with a `helm upgrade`/`liqoctl install` upgrade):
+
+```{code-block} yaml
+:caption: "values.yaml (provider)"
+authentication:
+  defaultResourceSliceClassEnabled: false
+```
+
+When the default class is disabled, any `ResourceSlice` that uses the `default` class is denied: its `Resources` condition is set to `Denied` with an explanatory message, instead of leaving the consumer waiting until timeout. Consumers must then request an explicit class handled by a custom controller. The default value is `true`, which preserves the previous behavior.
 
 (ResourceReservationSuspendReclaim)=
 
@@ -299,7 +307,7 @@ In other words, pods scheduled on the virtual node may still appear `Running` un
 
 A few aspects of the current design are worth keeping in mind when designing a reservation policy:
 
-* The default `ResourceSlice` class controller does not perform a **cluster-wide capacity check**: it accepts every request and may therefore grant more resources than the provider physically has, leaving the final arbitration to the standard Kubernetes scheduler on the provider. Cross-peering reservation requires a custom class controller **paired with an admission webhook (or equivalent mechanism) that prevents consumers from selecting the lenient default class** — Liqo does not ship that mechanism.
+* The default `ResourceSlice` class controller does not perform a **cluster-wide capacity check**: it accepts every request and may therefore grant more resources than the provider physically has, leaving the final arbitration to the standard Kubernetes scheduler on the provider. Cross-peering reservation requires a custom class controller; to make it enforceable, the provider can disable the built-in default class (`authentication.defaultResourceSliceClassEnabled: false`) so that consumers cannot fall back to the lenient default path.
 * Reducing the granted resources on a slice does not evict pods that are already running; cordon and drain are the supported way to actively reclaim capacity.
 
 ## What Liqo does not
@@ -309,7 +317,7 @@ This section lists some information and/or actions that may be required, and tha
 
 * **Discover what to ask for.**
   The consumer must learn from the provider (out of band) which amounts and resource types are actually available before creating a `ResourceSlice`.
-  Liqo has no inventory advertisement and the default class (on the provider side) accepts any request, so an improper reservation is automatically accepted by Liqo, and only manifests later with pods that may not be able to start (hence, in `Pending` state) on the provider cluster.
+  Liqo has no inventory advertisement and the default class (on the provider side), when enabled, accepts any request, so an improper reservation is automatically accepted by Liqo, and only manifests later with pods that may not be able to start (hence, in `Pending` state) on the provider cluster.
 
 * **Exchange cluster identities and peering credentials.**
   Cluster IDs and a peering kubeconfig (typically generated on the provider with `liqoctl generate peering-user`) must be exchanged through a secure channel before `liqoctl peer` runs.

--- a/pkg/liqo-controller-manager/authentication/remoteresourceslice-controller/remoteresourceslice_controller.go
+++ b/pkg/liqo-controller-manager/authentication/remoteresourceslice-controller/remoteresourceslice_controller.go
@@ -256,6 +256,17 @@ func (r *RemoteResourceSliceReconciler) handleResourcesStatus(ctx context.Contex
 			return nil
 		}
 
+		// If the built-in default ResourceSlice class has been administratively disabled on the provider,
+		// deny slices of the default (or empty) class instead of accepting them.
+		if !r.sliceStatusOptions.DefaultResourceSliceClassEnabled {
+			klog.V(4).Infof("ResourceSlice %q denied: the built-in default ResourceSlice class is administratively disabled",
+				client.ObjectKeyFromObject(resourceSlice))
+			denyResourcesWithReason(resourceSlice, r.eventRecorder,
+				"DefaultResourceSliceClassDisabled",
+				"the default ResourceSlice class has been administratively disabled on the provider")
+			return nil
+		}
+
 		// Default class: accept requested resources and set the default values for the resources not specified.
 		findOrDefault := func(resource corev1.ResourceName, val resource.Quantity) resource.Quantity {
 			v, ok := resourceSlice.Spec.Resources[resource]
@@ -419,21 +430,25 @@ func acceptResources(resourceSlice *authv1beta1.ResourceSlice, er record.EventRe
 }
 
 func denyResources(resourceSlice *authv1beta1.ResourceSlice, er record.EventRecorder) {
+	denyResourcesWithReason(resourceSlice, er, "ResourceSliceResourcesDenied", "ResourceSlice resources denied")
+}
+
+func denyResourcesWithReason(resourceSlice *authv1beta1.ResourceSlice, er record.EventRecorder, reason, message string) {
 	switch authentication.EnsureCondition(
 		resourceSlice,
 		authv1beta1.ResourceSliceConditionTypeResources,
 		authv1beta1.ResourceSliceConditionDenied,
-		"ResourceSliceResourcesDenied",
-		"ResourceSlice resources denied",
+		reason,
+		message,
 	) {
 	case controllerutil.OperationResultNone:
 		klog.V(4).Infof("ResourceSlice resources %q already denied", resourceSlice.Name)
 	case controllerutil.OperationResultUpdated:
 		klog.Infof("ResourceSlice resources %q denied", resourceSlice.Name)
-		er.Event(resourceSlice, corev1.EventTypeNormal, "ResourceSliceResourcesDenied", "ResourceSlice resources updated")
+		er.Event(resourceSlice, corev1.EventTypeNormal, reason, "ResourceSlice resources updated")
 	case controllerutil.OperationResultCreated:
 		klog.Infof("ResourceSlice resources %q denied", resourceSlice.Name)
-		er.Event(resourceSlice, corev1.EventTypeNormal, "ResourceSliceResourcesDenied", "ResourceSlice resources denied")
+		er.Event(resourceSlice, corev1.EventTypeNormal, reason, "ResourceSlice resources denied")
 	default:
 		return
 	}

--- a/pkg/liqo-controller-manager/authentication/remoteresourceslice-controller/slicestatus.go
+++ b/pkg/liqo-controller-manager/authentication/remoteresourceslice-controller/slicestatus.go
@@ -34,6 +34,9 @@ type SliceStatusOptions struct {
 	LoadBalancerClasses       argutils.ClassNameList
 	ClusterLabels             map[string]string
 	DefaultResourceQuantity   corev1.ResourceList
+	// DefaultResourceSliceClassEnabled enables the built-in default ResourceSlice class.
+	// When false, ResourceSlices of the default (or empty) class are denied instead of accepted.
+	DefaultResourceSliceClassEnabled bool
 }
 
 func getIngressClasses(opts *SliceStatusOptions) []liqov1beta1.IngressType {

--- a/pkg/liqo-controller-manager/flags.go
+++ b/pkg/liqo-controller-manager/flags.go
@@ -89,6 +89,9 @@ func InitFlags(flagset *pflag.FlagSet, opts *Options) {
 	flagset.BoolVar(&opts.TrustedCA, "trusted-ca", false, "Whether the Kubernetes APIServer certificate is issue by a trusted CA")
 	flagset.BoolVar(&opts.TLSCompatibilityMode, "tls-compatibility-mode", false,
 		"Enable TLS compatibility mode for client certificates and keys (use RSA instead of Ed25519)")
+	flagset.BoolVar(&opts.DefaultResourceSliceClassEnabled, "default-resource-slice-class-enabled", true,
+		"Enable the built-in default ResourceSlice class. When disabled, the provider denies ResourceSlices "+
+			"that use the \"default\" class, so consumers must use an explicit provider-approved class")
 	flagset.StringVar(&opts.AWSConfig.AwsAccessKeyID, "aws-access-key-id", "", "AWS IAM AccessKeyID for the Liqo User")
 	flagset.StringVar(&opts.AWSConfig.AwsSecretAccessKey, "aws-secret-access-key", "", "AWS IAM SecretAccessKey for the Liqo User")
 	flagset.StringVar(&opts.AWSConfig.AwsRegion, "aws-region", "", "AWS region where the local cluster is running")

--- a/pkg/liqo-controller-manager/options.go
+++ b/pkg/liqo-controller-manager/options.go
@@ -58,17 +58,18 @@ type Options struct {
 	RouteConfigurationRulePriority int
 
 	// Authentication module
-	APIServerAddressOverride string
-	CAOverride               string
-	TrustedCA                bool
-	TLSCompatibilityMode     bool
-	AWSConfig                *identitymanager.LocalAwsConfig
-	ClusterLabels            args.StringMap
-	IngressClasses           args.ClassNameList
-	LoadBalancerClasses      args.ClassNameList
-	DefaultNodeResources     args.ResourceMap
-	GlobalLabels             args.StringMap
-	GlobalAnnotations        args.StringMap
+	APIServerAddressOverride         string
+	CAOverride                       string
+	TrustedCA                        bool
+	TLSCompatibilityMode             bool
+	DefaultResourceSliceClassEnabled bool
+	AWSConfig                        *identitymanager.LocalAwsConfig
+	ClusterLabels                    args.StringMap
+	IngressClasses                   args.ClassNameList
+	LoadBalancerClasses              args.ClassNameList
+	DefaultNodeResources             args.ResourceMap
+	GlobalLabels                     args.StringMap
+	GlobalAnnotations                args.StringMap
 
 	// Offloading module
 	EnableStorage               bool


### PR DESCRIPTION
# Description

Today the built-in `ResourceSlice` class controller on the provider accepts **every** request of the `default` class (and of the empty class, which Liqo treats as `default`). As a result a provider cannot enforce its own allocation policy: even with a custom `ResourceSlice` class controller, a consumer can bypass it by simply requesting `class: default` or omitting the class.

This PR adds a **provider-side switch to disable the built-in `default` class**:

- New Helm value **`authentication.defaultResourceSliceClassEnabled`** (default `true`), wired to a new controller-manager flag **`--default-resource-slice-class-enabled`**.
- When set to `false`, the `RemoteResourceSliceReconciler` **denies** `ResourceSlice`s of the `default` and empty (`""`) class, setting the `Resources` condition to `Denied` with a clear message (`the default ResourceSlice class has been administratively disabled on the provider`) instead of leaving the consumer to time out. It reuses the existing deny path, so there is no new status surface.
- **Custom classes are unaffected** and continue to be handled by their own controllers. No change to `Quota` creation or runtime enforcement.
- **Opt-in and fully backward-compatible** — the default preserves today's behavior.

This is the first, minimal step of the direction agreed in #3306 (make the default class disable-able); the `ResourceSliceClass` registry and per-tenant `Accept`/`Deny` policy are intended as follow-ups.

Part of #3306

cc @everpeace @claudiolor @frisso 

# How Has This Been Tested?

Tested end-to-end on **two k3s clusters (consumer + provider) running Liqo v1.2.0**, with the provider running the controller-manager image built from this branch. Verified via **both** the controller-manager flag and the Helm value (`helm upgrade … --set authentication.defaultResourceSliceClassEnabled=false`).

- [x] **Default enabled (baseline):** `default` and empty-class `ResourceSlice`s are `Accepted` — behavior unchanged.
- [x] **Disabled:** a `default`-class slice transitions to `Resources=Denied` with the clear message.
- [x] **Empty class:** a slice with `class: ""` is also `Denied` (cannot bypass by omitting the class).
- [x] **Custom class:** a slice with a custom class is left untouched (no accept/deny by the built-in controller).
- [x] **Re-enable:** toggling back re-accepts the default class (backward-compatible round-trip).
