### PR TITLE
[VK] Add type=virtual-kubelet label to Liqo virtual nodes

### DIFF
--- a/pkg/virtualKubelet/liqoNodeProvider/setup.go
+++ b/pkg/virtualKubelet/liqoNodeProvider/setup.go
@@ -39,6 +39,8 @@ const (
 	labelNodeExcludeBalancersAlpha = "alpha.service-controller.kubernetes.io/exclude-balancer"
 	roleLabelKey                   = "kubernetes.io/role"
 	roleLabelValue                 = "agent"
+	typeLabelKey                   = "type"
+	virtualKubeletType             = "virtual-kubelet"
 )
 
 // InitConfig is the config passed to initialize the LiqoNodeProvider.
@@ -101,7 +103,10 @@ func node(cfg *InitConfig) *corev1.Node {
 		corev1.LabelOSStable:   strings.ToLower(linuxos),
 		corev1.LabelArchStable: architecture,
 
-		liqoconst.TypeLabel:       liqoconst.TypeNode,
+		liqoconst.TypeLabel: liqoconst.TypeNode,
+		// Standard label for virtual-kubelet nodes. This is especially useful for
+		// the K8s node autoscaler. When this label is present, the autoscaler skips provider ID parsing.
+		typeLabelKey:              virtualKubeletType,
 		liqoconst.RemoteClusterID: string(cfg.RemoteClusterID),
 
 		corev1.LabelNodeExcludeBalancers: strconv.FormatBool(true),


### PR DESCRIPTION
# Description

The K8s autoscaler relies on the type=virtual-kubelet label to skip the validation of the provider ID. When this label is not present, a Liqo virtual node might block nodes upscaling.
This commit fixes this issue by always adding that label by default.

