### PR TITLE
feat: add watch for network config in shadowendpointslice controller

### DIFF
--- a/pkg/liqo-controller-manager/networking/utils/configuration.go
+++ b/pkg/liqo-controller-manager/networking/utils/configuration.go
@@ -15,6 +15,8 @@
 package utils
 
 import (
+	"slices"
+
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -45,4 +47,19 @@ func AreConfigurationNetworkCIDRsConfiguredPredicate() predicate.Predicate {
 		}
 		return AreConfigurationNetworkCIDRsConfigured(cfg)
 	})
+}
+
+// AreConfigurationNetworkCIDRsEqual reports whether the two Network Configuration objects have equal network CIDRs.
+func AreConfigurationNetworkCIDRsEqual(cfg1, cfg2 *networkingv1beta1.Configuration) bool {
+	if !AreConfigurationNetworkCIDRsConfigured(cfg1) || !AreConfigurationNetworkCIDRsConfigured(cfg2) {
+		return false
+	}
+	if !slices.Equal(cfg1.Status.Remote.CIDR.External, cfg2.Status.Remote.CIDR.External) {
+		return false
+	}
+	if !slices.Equal(cfg1.Status.Remote.CIDR.Pod, cfg2.Status.Remote.CIDR.Pod) {
+		return false
+	}
+
+	return true
 }

--- a/pkg/liqo-controller-manager/offloading/shadowendpointslice-controller/shadowendpointslice_controller.go
+++ b/pkg/liqo-controller-manager/offloading/shadowendpointslice-controller/shadowendpointslice_controller.go
@@ -38,12 +38,15 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	liqov1beta1 "github.com/liqotech/liqo/apis/core/v1beta1"
+	networkingv1beta1 "github.com/liqotech/liqo/apis/networking/v1beta1"
 	offloadingv1beta1 "github.com/liqotech/liqo/apis/offloading/v1beta1"
 	"github.com/liqotech/liqo/pkg/consts"
+	networkingutils "github.com/liqotech/liqo/pkg/liqo-controller-manager/networking/utils"
 	"github.com/liqotech/liqo/pkg/utils"
 	clientutils "github.com/liqotech/liqo/pkg/utils/clients"
 	"github.com/liqotech/liqo/pkg/utils/directconnection"
 	foreigncluster "github.com/liqotech/liqo/pkg/utils/foreigncluster"
+	"github.com/liqotech/liqo/pkg/utils/indexer"
 	"github.com/liqotech/liqo/pkg/utils/resource"
 	"github.com/liqotech/liqo/pkg/virtualKubelet/forge"
 )
@@ -209,6 +212,56 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	}
 }
 
+func (r *Reconciler) getNetworkConfigEventHandler(ctx context.Context) handler.EventHandler {
+	return &handler.Funcs{
+		CreateFunc: func(_ context.Context, ce event.TypedCreateEvent[client.Object], trli workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+			newNetworkConfig, ok := ce.Object.(*networkingv1beta1.Configuration)
+			if !ok {
+				klog.Errorf("object %v is not a Configuration", ce.Object)
+				return
+			}
+
+			shadowList := r.getShadowEndpointSlicesFromNetworkConfig(ctx, newNetworkConfig)
+			if shadowList == nil {
+				return
+			}
+
+			for i := range shadowList.Items {
+				shadow := &shadowList.Items[i]
+				trli.Add(reconcile.Request{
+					NamespacedName: types.NamespacedName{
+						Name:      shadow.Name,
+						Namespace: shadow.Namespace,
+					},
+				})
+			}
+		},
+
+		UpdateFunc: func(_ context.Context, ue event.TypedUpdateEvent[client.Object], trli workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+			newNetworkConfig, ok := ue.ObjectNew.(*networkingv1beta1.Configuration)
+			if !ok {
+				klog.Errorf("object %v is not a Configuration", ue.ObjectNew)
+				return
+			}
+
+			shadowList := r.getShadowEndpointSlicesFromNetworkConfig(ctx, newNetworkConfig)
+			if shadowList == nil {
+				return
+			}
+
+			for i := range shadowList.Items {
+				shadow := &shadowList.Items[i]
+				trli.Add(reconcile.Request{
+					NamespacedName: types.NamespacedName{
+						Name:      shadow.Name,
+						Namespace: shadow.Namespace,
+					},
+				})
+			}
+		},
+	}
+}
+
 // getForeignClusterEventHandler returns an event handler that reacts on ForeignClusters updates.
 // In particular, it reacts on changes on the NetworkStatus condition.
 func (r *Reconciler) getForeignClusterEventHandler(ctx context.Context) handler.EventHandler {
@@ -246,7 +299,32 @@ func (r *Reconciler) getForeignClusterEventHandler(ctx context.Context) handler.
 	}
 }
 
-func (r *Reconciler) endpointsShouldBeUpdated(newObj, oldObj client.Object) bool {
+func (r *Reconciler) validateNetworkConfigOnCreate(newObj client.Object) bool {
+	newNetworkConfig, ok := newObj.(*networkingv1beta1.Configuration)
+	if !ok {
+		klog.Errorf("object %v is not a Configuration", newObj)
+		return false
+	}
+
+	return networkingutils.AreConfigurationNetworkCIDRsConfigured(newNetworkConfig)
+}
+
+func (r *Reconciler) validateNetworkConfigOnUpdate(newObj, oldObj client.Object) bool {
+	oldNetworkConfig, ok := oldObj.(*networkingv1beta1.Configuration)
+	if !ok {
+		klog.Errorf("object %v is not a Configuration", oldObj)
+		return false
+	}
+	newNetworkConfig, ok := newObj.(*networkingv1beta1.Configuration)
+	if !ok {
+		klog.Errorf("object %v is not a Configuration", newObj)
+		return false
+	}
+
+	return !networkingutils.AreConfigurationNetworkCIDRsEqual(oldNetworkConfig, newNetworkConfig)
+}
+
+func (r *Reconciler) validateForeignClusterOnUpdate(newObj, oldObj client.Object) bool {
 	oldForeignCluster, ok := oldObj.(*liqov1beta1.ForeignCluster)
 	if !ok {
 		klog.Errorf("object %v is not a ForeignCluster", oldObj)
@@ -275,17 +353,51 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, wor
 	fcPredicates := predicate.Funcs{
 		DeleteFunc:  func(_ event.DeleteEvent) bool { return false },
 		CreateFunc:  func(_ event.CreateEvent) bool { return false },
-		UpdateFunc:  func(e event.UpdateEvent) bool { return r.endpointsShouldBeUpdated(e.ObjectNew, e.ObjectOld) },
+		UpdateFunc:  func(e event.UpdateEvent) bool { return r.validateForeignClusterOnUpdate(e.ObjectNew, e.ObjectOld) },
 		GenericFunc: func(_ event.GenericEvent) bool { return false },
+	}
+
+	ncPredicates := predicate.Funcs{
+		DeleteFunc:  func(_ event.DeleteEvent) bool { return false },
+		CreateFunc:  func(e event.CreateEvent) bool { return r.validateNetworkConfigOnCreate(e.Object) },
+		UpdateFunc:  func(e event.UpdateEvent) bool { return r.validateNetworkConfigOnUpdate(e.ObjectNew, e.ObjectOld) },
+		GenericFunc: func(_ event.GenericEvent) bool { return false },
+	}
+
+	if err := mgr.GetFieldIndexer().IndexField(ctx, &offloadingv1beta1.ShadowEndpointSlice{},
+		indexer.FieldDirectConnectionClusterIDs, indexer.ExtractDirectConnectionClusterIDs); err != nil {
+		return fmt.Errorf("unable to setup field indexer for direct-connection cluster IDs: %w", err)
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).Named(consts.CtrlShadowEndpointSlice).
 		For(&offloadingv1beta1.ShadowEndpointSlice{}).
 		Owns(&discoveryv1.EndpointSlice{}).
+		Watches(&networkingv1beta1.Configuration{},
+			r.getNetworkConfigEventHandler(ctx), builder.WithPredicates(ncPredicates)).
 		Watches(&liqov1beta1.ForeignCluster{},
 			r.getForeignClusterEventHandler(ctx), builder.WithPredicates(fcPredicates)).
 		WithOptions(controller.Options{MaxConcurrentReconciles: workers}).
 		Complete(r)
+}
+
+func (r *Reconciler) getShadowEndpointSlicesFromNetworkConfig(
+	ctx context.Context,
+	networkConfig *networkingv1beta1.Configuration,
+) *offloadingv1beta1.ShadowEndpointSliceList {
+	clusterID := networkConfig.Labels[consts.RemoteClusterID]
+	if clusterID == "" {
+		klog.Errorf("network configuration %q has no label %q", klog.KObj(networkConfig), consts.RemoteClusterID)
+		return nil
+	}
+
+	// List all shadowendpointslices with direct-connections-data including clusterID
+	var shadowList offloadingv1beta1.ShadowEndpointSliceList
+	if err := r.List(ctx, &shadowList, client.MatchingFields{indexer.FieldDirectConnectionClusterIDs: clusterID}); err != nil {
+		klog.Errorf("Unable to list shadowendpointslices related to network configuration %q: %v", klog.KObj(networkConfig), err)
+		return nil
+	}
+
+	return &shadowList
 }
 
 // removeDirectConnectionAnnotation returns a copy of annotations without direct-connection data.

--- a/pkg/liqo-controller-manager/offloading/shadowendpointslice-controller/shadowendpointslice_controller_test.go
+++ b/pkg/liqo-controller-manager/offloading/shadowendpointslice-controller/shadowendpointslice_controller_test.go
@@ -235,6 +235,37 @@ var _ = Describe("ShadowEndpointSlice Controller", func() {
 		klog.Flush()
 	})
 
+	When("network configuration changes and shadowendpointslices exist", func() {
+		BeforeEach(func() {
+			testShadowEps = newShadowEps(true)
+			testFc = newFc(true, true)
+			// start with non-remapped config
+			testConf = newConfiguration(false)
+			fakeClient = fake.NewClientBuilder().WithScheme(scheme.Scheme).
+				WithObjects(testShadowEps.DeepCopy(), testFc, testConf).Build()
+		})
+
+		It("should use updated network config for endpoint remapping", func() {
+			// first reconcile with non-remapped config — addresses unchanged
+			eps := discoveryv1.EndpointSlice{}
+			Expect(fakeClient.Get(ctx, req.NamespacedName, &eps)).To(Succeed())
+			Expect(eps.Endpoints[0].Addresses).To(Equal([]string{"10.10.0.1"}))
+
+			// update config to remapped CIDRs and reconcile again
+			remappedConf := networkingv1beta1.Configuration{}
+			Expect(fakeClient.Get(ctx, client.ObjectKey{Name: testConf.Name, Namespace: shadowEpsNamespace}, &remappedConf)).To(Succeed())
+			remappedConf.Status.Remote = newConfiguration(true).Status.Remote
+			Expect(fakeClient.Update(ctx, &remappedConf)).To(Succeed())
+
+			r := &Reconciler{Client: fakeClient, Scheme: scheme.Scheme}
+			_, err := r.Reconcile(ctx, req)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(fakeClient.Get(ctx, req.NamespacedName, &eps)).To(Succeed())
+			Expect(eps.Endpoints[0].Addresses[0]).To(HavePrefix("10.30."))
+		})
+	})
+
 	When("shadowendpointslice is not found", func() {
 		BeforeEach(func() {
 			fakeClient = fake.NewClientBuilder().WithScheme(scheme.Scheme).Build()
@@ -629,6 +660,219 @@ var _ = Describe("ShadowEndpointSlice Controller", func() {
 				Expect(eps.Endpoints[0].Addresses).To(Equal([]string{"10.40.0.1"}))
 				Expect(eps.Endpoints[1].Addresses).To(Equal([]string{"10.30.0.1"}))
 			})
+		})
+	})
+})
+
+var _ = Describe("ShadowEndpointSlice Predicates", func() {
+	const (
+		shadowEpsNamespace string = "default"
+		testFcID           string = "test-fc-id"
+	)
+
+	var (
+		r      *Reconciler
+		ctx    context.Context
+		buffer *bytes.Buffer
+
+		newFc = func(networkReady, apiServerReady bool) *liqov1beta1.ForeignCluster {
+			networkStatus := liqov1beta1.ConditionStatusEstablished
+			if !networkReady {
+				networkStatus = liqov1beta1.ConditionStatusError
+			}
+
+			apiServerStatus := liqov1beta1.ConditionStatusEstablished
+			if !apiServerReady {
+				apiServerStatus = liqov1beta1.ConditionStatusError
+			}
+
+			return &liqov1beta1.ForeignCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: testFcID,
+					Labels: map[string]string{
+						consts.RemoteClusterID: testFcID,
+					},
+				},
+				Spec: liqov1beta1.ForeignClusterSpec{
+					ClusterID: liqov1beta1.ClusterID(testFcID),
+				},
+				Status: liqov1beta1.ForeignClusterStatus{
+					Modules: liqov1beta1.Modules{
+						Networking: liqov1beta1.Module{
+							Enabled: true,
+							Conditions: []liqov1beta1.Condition{{
+								Type:   liqov1beta1.NetworkConnectionStatusCondition,
+								Status: networkStatus,
+							}},
+						},
+					},
+					Conditions: []liqov1beta1.Condition{{
+						Type:   liqov1beta1.APIServerStatusCondition,
+						Status: apiServerStatus,
+					}},
+				},
+			}
+		}
+
+		newConfiguration = func(remapped bool) *networkingv1beta1.Configuration {
+			var remappedPodCIDRs, remappedExternalCIDRs []string
+			if remapped {
+				remappedPodCIDRs = []string{"10.30.0.0/16", "10.50.0.0/16"}
+				remappedExternalCIDRs = []string{"10.40.0.0/16", "10.60.0.0/16"}
+			} else {
+				remappedPodCIDRs = []string{"10.10.0.0/16", "10.11.0.0/16"}
+				remappedExternalCIDRs = []string{"10.20.0.0/16", "10.21.0.0/16"}
+			}
+
+			return &networkingv1beta1.Configuration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test",
+					Namespace:  "default",
+					Generation: 1,
+					Labels: map[string]string{
+						consts.RemoteClusterID: testFcID,
+					},
+				},
+				Spec: networkingv1beta1.ConfigurationSpec{
+					Remote: networkingv1beta1.ClusterConfig{
+						CIDR: networkingv1beta1.ClusterConfigCIDR{
+							Pod:      cidrutils.FromStrings([]string{"10.10.0.0/16", "10.11.0.0/16"}),
+							External: cidrutils.FromStrings([]string{"10.20.0.0/16", "10.21.0.0/16"}),
+						},
+					},
+				},
+				Status: networkingv1beta1.ConfigurationStatus{
+					Conditions: []metav1.Condition{{
+						Type:               networkingv1beta1.ConfigurationConditionNetworkCIDRsConfigured,
+						Status:             metav1.ConditionTrue,
+						Reason:             "NetworkCIDRsConfigured",
+						Message:            "All network CIDRs are configured",
+						ObservedGeneration: 1,
+						LastTransitionTime: metav1.Now(),
+					}},
+					Remote: &networkingv1beta1.ClusterConfig{
+						CIDR: networkingv1beta1.ClusterConfigCIDR{
+							Pod:      cidrutils.FromStrings(remappedPodCIDRs),
+							External: cidrutils.FromStrings(remappedExternalCIDRs),
+						},
+					},
+				},
+			}
+		}
+	)
+
+	BeforeEach(func() {
+		ctx = context.TODO()
+		buffer = &bytes.Buffer{}
+		klog.SetOutput(buffer)
+		r = &Reconciler{Scheme: scheme.Scheme}
+	})
+
+	When("validateNetworkConfigOnCreate predicate", func() {
+		It("should return true when CIDRs are configured", func() {
+			nc := newConfiguration(false)
+			Expect(r.validateNetworkConfigOnCreate(nc)).To(BeTrue())
+		})
+
+		It("should return false when CIDRs are not configured", func() {
+			nc := &networkingv1beta1.Configuration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-nc",
+					Namespace: shadowEpsNamespace,
+				},
+				Status: networkingv1beta1.ConfigurationStatus{
+					Conditions: []metav1.Condition{{
+						Type:   networkingv1beta1.ConfigurationConditionNetworkCIDRsConfigured,
+						Status: metav1.ConditionFalse,
+					}},
+				},
+			}
+			Expect(r.validateNetworkConfigOnCreate(nc)).To(BeFalse())
+		})
+
+		It("should return false when object is not a valid Configuration", func() {
+			fc := newFc(true, true)
+			Expect(r.validateNetworkConfigOnCreate(fc)).To(BeFalse())
+		})
+	})
+
+	When("validateNetworkConfigOnUpdate predicate", func() {
+		It("should return true when pod CIDRs changed", func() {
+			oldNC := newConfiguration(false)
+			newNC := newConfiguration(true) // different remapped CIDRs
+			Expect(r.validateNetworkConfigOnUpdate(newNC, oldNC)).To(BeTrue())
+		})
+
+		It("should return false when CIDRs are unchanged", func() {
+			oldNC := newConfiguration(false)
+			newNC := newConfiguration(false) // identical CIDRs
+			Expect(r.validateNetworkConfigOnUpdate(newNC, oldNC)).To(BeFalse())
+		})
+
+		It("should return false when old object is not a valid Configuration", func() {
+			fc := newFc(true, true)
+			newNC := newConfiguration(false)
+			Expect(r.validateNetworkConfigOnUpdate(newNC, fc)).To(BeFalse())
+		})
+
+		It("should return false when new object is not a valid Configuration", func() {
+			oldNC := newConfiguration(false)
+			fc := newFc(true, true)
+			Expect(r.validateNetworkConfigOnUpdate(fc, oldNC)).To(BeFalse())
+		})
+	})
+
+	When("validateForeignClusterOnUpdate predicate", func() {
+		It("should return true when network status changes from not ready to ready", func() {
+			oldFc := newFc(false, true)
+			newFc := newFc(true, true)
+			Expect(r.validateForeignClusterOnUpdate(newFc, oldFc)).To(BeTrue())
+		})
+
+		It("should return true when network status changes from ready to not ready", func() {
+			oldFc := newFc(true, true)
+			newFc := newFc(false, true)
+			Expect(r.validateForeignClusterOnUpdate(newFc, oldFc)).To(BeTrue())
+		})
+
+		It("should return true when API server status changes", func() {
+			oldFc := newFc(true, true)
+			newFc := newFc(true, false)
+			Expect(r.validateForeignClusterOnUpdate(newFc, oldFc)).To(BeTrue())
+		})
+
+		It("should return false when neither network nor API server status changed", func() {
+			oldFc := newFc(true, true)
+			newFc := newFc(true, true)
+			Expect(r.validateForeignClusterOnUpdate(newFc, oldFc)).To(BeFalse())
+		})
+
+		It("should return false when old object is not a ForeignCluster", func() {
+			nc := newConfiguration(false)
+			newFc := newFc(true, true)
+			Expect(r.validateForeignClusterOnUpdate(newFc, nc)).To(BeFalse())
+		})
+
+		It("should return false when new object is not a ForeignCluster", func() {
+			oldFc := newFc(true, true)
+			nc := newConfiguration(false)
+			Expect(r.validateForeignClusterOnUpdate(nc, oldFc)).To(BeFalse())
+		})
+	})
+
+	When("network configuration has no RemoteClusterID label", func() {
+		It("getShadowEndpointSlicesFromNetworkConfig should return nil and log error", func() {
+			testConf := &networkingv1beta1.Configuration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: shadowEpsNamespace,
+				},
+			}
+
+			result := r.getShadowEndpointSlicesFromNetworkConfig(ctx, testConf)
+			Expect(result).To(BeNil())
+			klog.Flush()
+			Expect(buffer.String()).To(ContainSubstring("has no label"))
 		})
 	})
 })

--- a/pkg/utils/directconnection/directconnection.go
+++ b/pkg/utils/directconnection/directconnection.go
@@ -17,6 +17,9 @@ package directconnection
 
 import (
 	"encoding/json"
+	"fmt"
+
+	"github.com/liqotech/liqo/pkg/consts"
 )
 
 // ClusterAddresses represents the addresses of pods deployed on remote clusters
@@ -79,4 +82,30 @@ func (c *ClusterAddresses) ToJSON() ([]byte, error) {
 // FromJSON deserializes JSON data into ClusterAddresses.
 func (c *ClusterAddresses) FromJSON(data []byte) error {
 	return json.Unmarshal(data, c)
+}
+
+// FromAnnotations extracts the [ClusterAddresses] from the given annotations map.
+// Returns an error if the annotation is not found or if the data cannot be parsed.
+func FromAnnotations(annotations map[string]string) (*ClusterAddresses, error) {
+	val, ok := annotations[consts.DirectConnectionDataAnnotationKey]
+	if !ok {
+		return nil, fmt.Errorf("%s not found in provided annotations", consts.DirectConnectionDataAnnotationKey)
+	}
+
+	var c ClusterAddresses
+	if err := c.FromJSON([]byte(val)); err != nil {
+		return nil, fmt.Errorf("failed to parse %s from json: %w", consts.DirectConnectionDataAnnotationKey, err)
+	}
+
+	return &c, nil
+}
+
+// ClusterIDs returns a slice of all cluster IDs present in the [ClusterAddresses].
+func (c *ClusterAddresses) ClusterIDs() []string {
+	clusterIDs := make([]string, 0, len(c.Clusters))
+	for id := range c.Clusters {
+		clusterIDs = append(clusterIDs, id)
+	}
+
+	return clusterIDs
 }

--- a/pkg/utils/indexer/indexer.go
+++ b/pkg/utils/indexer/indexer.go
@@ -20,11 +20,19 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	ctrlruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	offloadingv1beta1 "github.com/liqotech/liqo/apis/offloading/v1beta1"
+	"github.com/liqotech/liqo/pkg/consts"
+	"github.com/liqotech/liqo/pkg/utils/directconnection"
 )
 
 const (
 	// FieldNodeNameFromPod is the field name of the node name of a pod.
 	FieldNodeNameFromPod = "spec.nodeName"
+
+	// FieldDirectConnectionClusterIDs is the field index key used to index ShadowEndpointSlices by the
+	// clusterIDs present as keys in the direct-connections-data annotation (i.e., the clusterAddresses map).
+	FieldDirectConnectionClusterIDs = "metadata.annotations.direct-connections-data.clusterIDs"
 )
 
 // ExtractNodeName returns the node name of the given object.
@@ -35,6 +43,30 @@ func ExtractNodeName(rawObj client.Object) []string {
 	default:
 		return []string{}
 	}
+}
+
+// ExtractDirectConnectionClusterIDs returns all clusterIDs that appear as keys in the
+// direct-connections-data annotation of a ShadowEndpointSlice. controller-runtime uses
+// the returned slice to build a multi-value field index, so a single object can be found
+// by any of its clusterIDs via client.MatchingFields.
+func ExtractDirectConnectionClusterIDs(rawObj client.Object) []string {
+	shadow, ok := rawObj.(*offloadingv1beta1.ShadowEndpointSlice)
+	if !ok {
+		return nil
+	}
+	val, ok := shadow.Annotations[consts.DirectConnectionDataAnnotationKey]
+	if !ok {
+		return nil
+	}
+	var ca directconnection.ClusterAddresses
+	if err := ca.FromJSON([]byte(val)); err != nil {
+		return nil
+	}
+	clusterIDs := make([]string, 0, len(ca.Clusters))
+	for id := range ca.Clusters {
+		clusterIDs = append(clusterIDs, id)
+	}
+	return clusterIDs
 }
 
 // IndexField indexes the given field on the given object.

--- a/pkg/utils/indexer/indexer.go
+++ b/pkg/utils/indexer/indexer.go
@@ -22,7 +22,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	offloadingv1beta1 "github.com/liqotech/liqo/apis/offloading/v1beta1"
-	"github.com/liqotech/liqo/pkg/consts"
 	"github.com/liqotech/liqo/pkg/utils/directconnection"
 )
 
@@ -46,27 +45,21 @@ func ExtractNodeName(rawObj client.Object) []string {
 }
 
 // ExtractDirectConnectionClusterIDs returns all clusterIDs that appear as keys in the
-// direct-connections-data annotation of a ShadowEndpointSlice. controller-runtime uses
-// the returned slice to build a multi-value field index, so a single object can be found
-// by any of its clusterIDs via client.MatchingFields.
+// [direct-connections-data] annotation of a [offloadingv1beta1.ShadowEndpointSlice].
+// controller-runtime uses the returned slice to build a multi-value field index,
+// so a single object can be found by any of its clusterIDs via [client.MatchingFields].
 func ExtractDirectConnectionClusterIDs(rawObj client.Object) []string {
 	shadow, ok := rawObj.(*offloadingv1beta1.ShadowEndpointSlice)
 	if !ok {
 		return nil
 	}
-	val, ok := shadow.Annotations[consts.DirectConnectionDataAnnotationKey]
-	if !ok {
+
+	clusterAddresses, err := directconnection.FromAnnotations(shadow.Annotations)
+	if err != nil {
 		return nil
 	}
-	var ca directconnection.ClusterAddresses
-	if err := ca.FromJSON([]byte(val)); err != nil {
-		return nil
-	}
-	clusterIDs := make([]string, 0, len(ca.Clusters))
-	for id := range ca.Clusters {
-		clusterIDs = append(clusterIDs, id)
-	}
-	return clusterIDs
+
+	return clusterAddresses.ClusterIDs()
 }
 
 // IndexField indexes the given field on the given object.


### PR DESCRIPTION
# Description

This PR strengthens ShadowEndpointSlice reconciliation triggers by adding explicit handling for Network Configuration create and update events.

In direct-connection scenarios, endpoint remapping depends on Network Configuration data. If that configuration is not ready when the controller first reconciles a ShadowEndpointSlice, the controller may complete without applying the correct remapping. Before this change, the controller could miss later Configuration updates and therefore never re-trigger reconciliation for the affected ShadowEndpointSlices. The result is stale or incorrect EndpointSlice replication.

With this PR, Configuration create/update events are explicitly watched and used to enqueue the involved ShadowEndpointSlices, so the controller wakes up again as soon as a Configuration becomes available or changes. This ensures remapping is eventually applied and prevents silent drift after startup timing races or delayed network configuration.

Main changes:

* The controller now watches Configuration resources and enqueues all involved ShadowEndpointSlices when relevant events occur;
* On Configuration create, reconciliation is triggered only when network CIDRs are configured;
* On Configuration update, reconciliation is triggered only when network CIDRs actually change;
* A dedicated mapping helper retrieves impacted ShadowEndpointSlices from the RemoteClusterID and indexed direct-connection metadata, with safe handling when labels are missing.

This reduces the risk of missed events and stale EndpointSlice state after network configuration changes, improving the reliability of endpoint replication/remapping.

# How Has This Been Tested?

Added Unit tests for shadowendpointslice-controller package:
* Predicate-focused tests:
    * validateNetworkConfigOnCreate
    * validateNetworkConfigOnUpdate
    * missing RemoteClusterID handling for network config mapping
* Reconciliation behavior test:
    * verifies endpoint remapping after network configuration changes for existing ShadowEndpointSlices

Fixes #3328.