### PR TITLE
feat: add force uninstall

### DIFF
--- a/cmd/uninstaller/main.go
+++ b/cmd/uninstaller/main.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 	"syscall"
 
+	"github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/dynamic"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -52,8 +53,9 @@ func init() {
 }
 
 // cluster-role
-// +kubebuilder:rbac:groups=offloading.liqo.io,resources=namespaceoffloadings,verbs=get;list;watch
+// +kubebuilder:rbac:groups=offloading.liqo.io,resources=namespaceoffloadings,verbs=get;list;watch;delete
 // +kubebuilder:rbac:groups=core,resources=nodes,verbs=get;list;watch
+// +kubebuilder:rbac:groups=core,resources=namespaces,verbs=get;list;watch;delete
 // +kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=core.liqo.io,resources=foreignclusters,verbs=get;list;watch;patch;update;delete;deletecollection;
@@ -66,6 +68,9 @@ func init() {
 
 func main() {
 	log.SetLogger(klog.NewKlogr())
+
+	force := pflag.Bool("force", false, "Force uninstall by marking all ForeignClusters as permanently unreachable and deleting leftover resources")
+	pflag.Parse()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	sig := make(chan os.Signal, 1)
@@ -101,10 +106,21 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Run pre-uninstall checks
-	if err := utils.PreUninstall(ctx, cl); err != nil {
-		klog.Errorf("Pre-uninstall checks failed: %v", err)
-		os.Exit(1)
+	// Run pre-uninstall checks, unless force uninstall is requested.
+	if !*force {
+		if err := utils.PreUninstall(ctx, cl); err != nil {
+			klog.Errorf("Pre-uninstall checks failed: %v", err)
+			os.Exit(1)
+		}
+	}
+
+	// When force uninstalling, mark all ForeignClusters as permanently unreachable so that Liqo
+	// controllers treat remote resources as dead and release finalizers.
+	if *force {
+		if err := uninstaller.MarkForeignClustersPermanentlyUnreachable(ctx, cl); err != nil {
+			klog.Errorf("Unable to mark ForeignClusters as permanently unreachable: %s", err)
+			os.Exit(1)
+		}
 	}
 
 	// Annotate the controller-manager deployment to signal the uninstall process.
@@ -113,9 +129,27 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err := uninstaller.DeleteAllForeignClusters(ctx, dynClient); err != nil {
-		klog.Errorf("Unable to delete foreign clusters: %s", err)
-		os.Exit(1)
+	// When force uninstalling, delete leftover resources that could otherwise block uninstall.
+	if *force {
+		if err := uninstaller.DeleteNamespaceOffloadings(ctx, dynClient); err != nil {
+			klog.Errorf("Unable to delete NamespaceOffloadings: %s", err)
+			os.Exit(1)
+		}
+
+		if err := uninstaller.DeleteVirtualNodes(ctx, dynClient); err != nil {
+			klog.Errorf("Unable to delete VirtualNodes: %s", err)
+			os.Exit(1)
+		}
+
+		if err := uninstaller.DeleteResourceSlices(ctx, dynClient); err != nil {
+			klog.Errorf("Unable to delete ResourceSlices: %s", err)
+			os.Exit(1)
+		}
+
+		if err := uninstaller.DeleteTenantNamespaces(ctx, dynClient); err != nil {
+			klog.Errorf("Unable to delete tenant namespaces: %s", err)
+			os.Exit(1)
+		}
 	}
 
 	if err := uninstaller.DeleteInternalNodes(ctx, dynClient); err != nil {
@@ -133,9 +167,21 @@ func main() {
 		os.Exit(1)
 	}
 
+	phase := uninstaller.PhaseCleanup
+	if *force {
+		phase = uninstaller.PhaseForcedUninstall
+	}
+
 	// Wait for resources to be effectively deleted, to allow releasing possible finalizers.
-	if err := uninstaller.WaitForResources(dynClient, uninstaller.PhaseCleanup); err != nil {
+	if err := uninstaller.WaitForResources(dynClient, phase); err != nil {
 		klog.Errorf("Unable to wait deletion of objects: %s", err)
+		os.Exit(1)
+	}
+
+	// Delete all ForeignClusters, to prevent the controller-manager from re-creating them.
+	// No need to wait as the ForeignCluster has no finalizers, since everything has already been deleted, we can just proceed.
+	if err := uninstaller.DeleteAllForeignClusters(ctx, dynClient); err != nil {
+		klog.Errorf("Unable to delete foreign clusters: %s", err)
 		os.Exit(1)
 	}
 }

--- a/deployments/liqo/README.md
+++ b/deployments/liqo/README.md
@@ -208,6 +208,7 @@
 | telemetry.pod.extraArgs | list | `[]` | Extra arguments for the telemetry pod. |
 | telemetry.pod.labels | object | `{}` | Labels for the telemetry pod. |
 | telemetry.pod.resources | object | `{"limits":{},"requests":{}}` | Resource requests and limits (https://kubernetes.io/docs/user-guide/compute-resources/) for the telemetry pod. |
+| uninstaller.forceUninstall | bool | `false` | Force the uninstall of Liqo, even if there are still active peerings or offloaded namespaces. When enabled, the pre-delete job marks all ForeignClusters as permanently unreachable and deletes leftover resources before proceeding with the standard uninstall cleanup. Force uninstall is a destructive operation, which might even cause data loss. |
 | uninstaller.image.name | string | `"ghcr.io/liqotech/uninstaller"` | Image repository for the uninstaller pod. |
 | uninstaller.image.version | string | `""` | Custom version for the uninstaller image. If not specified, the global tag is used. |
 | uninstaller.pod.annotations | object | `{}` | Annotations for the uninstaller pod. |

--- a/deployments/liqo/files/liqo-pre-delete-ClusterRole.yaml
+++ b/deployments/liqo/files/liqo-pre-delete-ClusterRole.yaml
@@ -9,6 +9,15 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - namespaces
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - nodes
   verbs:
   - get
@@ -76,6 +85,7 @@ rules:
   resources:
   - namespaceoffloadings
   verbs:
+  - delete
   - get
   - list
   - watch

--- a/deployments/liqo/templates/pre-delete-job.yaml
+++ b/deployments/liqo/templates/pre-delete-job.yaml
@@ -33,13 +33,16 @@ spec:
         securityContext:
           {{- include "liqo.containerSecurityContext" . | nindent 10 }}
         command: ["/usr/bin/uninstaller"]
-        {{- if or .Values.uninstaller.pod.extraArgs .Values.common.extraArgs }}
+        {{- if or .Values.uninstaller.pod.extraArgs .Values.common.extraArgs .Values.uninstaller.forceUninstall }}
         args:
           {{- if .Values.common.extraArgs }}
           {{- toYaml .Values.common.extraArgs | nindent 10 }}
           {{- end }}
           {{- if .Values.uninstaller.pod.extraArgs }}
           {{- toYaml .Values.uninstaller.pod.extraArgs | nindent 10 }}
+          {{- end }}
+          {{- if .Values.uninstaller.forceUninstall }}
+          - --force
           {{- end }}
         {{- end }}
         env:

--- a/deployments/liqo/values.yaml
+++ b/deployments/liqo/values.yaml
@@ -734,6 +734,11 @@ virtualKubelet:
       labels: {}
 
 uninstaller:
+  # -- Force the uninstall of Liqo, even if there are still active peerings or offloaded namespaces.
+  # When enabled, the pre-delete job marks all ForeignClusters as permanently unreachable and deletes
+  # leftover resources before proceeding with the standard uninstall cleanup.
+  # Force uninstall is a destructive operation, which might even cause data loss.
+  forceUninstall: false
   pod:
     # -- Annotations for the uninstaller pod.
     annotations: {}

--- a/docs/installation/install.md
+++ b/docs/installation/install.md
@@ -613,6 +613,27 @@ Those fields and labels have the following meaning:
   * **argocd.argoproj.io/compare-options: IgnoreExtraneous**: allows ArgoCD to ignore resources created by Liqo controllers when the sync status is determined.
   * **argocd.argoproj.io/sync-options: Prune=false**: prevents ArgoCD from deleting the resources managed by the Liqo controllers.
 
+### Force uninstall
+
+By default, the Liqo pre-delete uninstaller job performs a set of safety checks to ensure that no active peerings or leftover resources would be orphaned during uninstallation. If these checks detect active peerings, the uninstall process blocks to prevent data loss.
+
+In situations where the cluster is no longer reachable, the peerings are known to be permanently down, or the standard uninstall process is stuck due to resources that cannot be cleaned up automatically, you can opt in to a force uninstall by setting the Helm value:
+
+```yaml
+uninstaller:
+  forceUninstall: true
+```
+
+When `uninstaller.forceUninstall` is enabled, the uninstaller job:
+
+* Annotates all `ForeignCluster` resources as permanently unreachable, so that Liqo controllers stop waiting for remote clusters.
+* Force-deletes the resources that normally block uninstallation: `NamespaceOffloadings`, `ResourceSlices`, `VirtualNodes`, and the tenant namespaces labeled `liqo.io/tenant-namespace: "true"`.
+* Proceeds with the standard uninstall sequence.
+
+```{warning}
+Force uninstall is a destructive operation, which might even cause data loss. Use it only when the standard uninstall process fails and the remaining Liqo peerings and offloaded namespaces are no longer needed.
+```
+
 ## CNIs
 
 ### Cilium

--- a/pkg/consts/annotations.go
+++ b/pkg/consts/annotations.go
@@ -53,4 +53,8 @@ const (
 	// ForeignClusterPermanentlyUnreachableAnnotationKey is the annotation used to signal that the foreign cluster is not reachable and it will
 	// never come up.
 	ForeignClusterPermanentlyUnreachableAnnotationKey = "liqo.io/foreign-cluster-permanently-unreachable"
+
+	// ForeignClusterPermanentlyUnreachableAnnotationValue is the value of the annotation used to signal that the foreign cluster is not
+	// reachable and it will never come up.
+	ForeignClusterPermanentlyUnreachableAnnotationValue = "true"
 )

--- a/pkg/liqoctl/force/unpeer/handler.go
+++ b/pkg/liqoctl/force/unpeer/handler.go
@@ -70,7 +70,7 @@ func (o *Options) RunForceUnpeer(ctx context.Context) error {
 
 	fc.SetAnnotations(
 		mapsutil.Merge(fc.Annotations, map[string]string{
-			consts.ForeignClusterPermanentlyUnreachableAnnotationKey: "true",
+			consts.ForeignClusterPermanentlyUnreachableAnnotationKey: consts.ForeignClusterPermanentlyUnreachableAnnotationValue,
 		}),
 	)
 

--- a/pkg/uninstaller/const.go
+++ b/pkg/uninstaller/const.go
@@ -21,7 +21,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
-	liqov1beta1 "github.com/liqotech/liqo/apis/core/v1beta1"
 	ipamv1alpha1 "github.com/liqotech/liqo/apis/ipam/v1alpha1"
 	networkingv1beta1 "github.com/liqotech/liqo/apis/networking/v1beta1"
 	offloadingv1beta1 "github.com/liqotech/liqo/apis/offloading/v1beta1"
@@ -55,6 +54,8 @@ const (
 	PhaseUnpeering phase = iota
 	// PhaseCleanup -> the final cleanup after unpeering is being performed.
 	PhaseCleanup
+	// PhaseForcedUninstall -> the uninstall is being forced, and all the resource are being deleted.
+	PhaseForcedUninstall
 )
 
 var (
@@ -67,11 +68,6 @@ var (
 				},
 			},
 			phase: PhaseUnpeering,
-		},
-		{
-			gvr:           liqov1beta1.ForeignClusterGroupVersionResource,
-			labelSelector: metav1.LabelSelector{},
-			phase:         PhaseCleanup,
 		},
 		{
 			gvr:           offloadingv1beta1.NamespaceOffloadingGroupVersionResource,

--- a/pkg/uninstaller/deletion.go
+++ b/pkg/uninstaller/deletion.go
@@ -16,27 +16,99 @@ package uninstaller
 
 import (
 	"context"
+	"fmt"
 
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 
+	authv1beta1 "github.com/liqotech/liqo/apis/authentication/v1beta1"
 	liqov1beta1 "github.com/liqotech/liqo/apis/core/v1beta1"
 	ipamv1alpha1 "github.com/liqotech/liqo/apis/ipam/v1alpha1"
 	networkingv1beta1 "github.com/liqotech/liqo/apis/networking/v1beta1"
+	offloadingv1beta1 "github.com/liqotech/liqo/apis/offloading/v1beta1"
+	"github.com/liqotech/liqo/pkg/consts"
 )
 
 // DeleteAllForeignClusters deletes all ForeignCluster resources.
 func DeleteAllForeignClusters(ctx context.Context, client dynamic.Interface) error {
-	r1 := client.Resource(liqov1beta1.ForeignClusterGroupVersionResource)
-	err := r1.DeleteCollection(ctx,
-		metav1.DeleteOptions{TypeMeta: metav1.TypeMeta{}}, metav1.ListOptions{TypeMeta: metav1.TypeMeta{}})
-	return err
+	err := deleteAllResources(ctx, client, liqov1beta1.ForeignClusterGroupVersionResource)
+	if err != nil {
+		return fmt.Errorf("deleting ForeignCluster resources: %w", err)
+	}
+
+	return nil
 }
 
 // DeleteInternalNodes deletes all InternalNode resources.
 func DeleteInternalNodes(ctx context.Context, client dynamic.Interface) error {
-	r1 := client.Resource(networkingv1beta1.InternalNodeGroupVersionResource)
-	unstructured, err := r1.List(ctx, metav1.ListOptions{})
+	err := deleteAllResources(ctx, client, networkingv1beta1.InternalNodeGroupVersionResource)
+	if err != nil {
+		return fmt.Errorf("deleting InternalNode resources: %w", err)
+	}
+
+	return nil
+}
+
+// DeleteNetworks deletes the Networks installed.
+func DeleteNetworks(ctx context.Context, client dynamic.Interface) error {
+	err := deleteAllResources(ctx, client, ipamv1alpha1.NetworkGroupVersionResource)
+	if err != nil {
+		return fmt.Errorf("deleting Network resources: %w", err)
+	}
+
+	return nil
+}
+
+// DeleteIPs deletes the IPs installed.
+func DeleteIPs(ctx context.Context, client dynamic.Interface) error {
+	err := deleteAllResources(ctx, client, ipamv1alpha1.IPGroupVersionResource)
+	if err != nil {
+		return fmt.Errorf("deleting IP resources: %w", err)
+	}
+
+	return nil
+}
+
+// DeleteNamespaceOffloadings deletes all NamespaceOffloading resources.
+func DeleteNamespaceOffloadings(ctx context.Context, client dynamic.Interface) error {
+	err := deleteAllResources(ctx, client, offloadingv1beta1.NamespaceOffloadingGroupVersionResource)
+	if err != nil {
+		return fmt.Errorf("deleting NamespaceOffloading resources: %w", err)
+	}
+
+	return nil
+}
+
+// DeleteVirtualNodes deletes all VirtualNode resources.
+func DeleteVirtualNodes(ctx context.Context, client dynamic.Interface) error {
+	err := deleteAllResources(ctx, client, offloadingv1beta1.VirtualNodeGroupVersionResource)
+	if err != nil {
+		return fmt.Errorf("deleting VirtualNode resources: %w", err)
+	}
+
+	return nil
+}
+
+// DeleteResourceSlices deletes all ResourceSlice resources.
+func DeleteResourceSlices(ctx context.Context, client dynamic.Interface) error {
+	err := deleteAllResources(ctx, client, authv1beta1.ResourceSliceGroupVersionResource)
+	if err != nil {
+		return fmt.Errorf("deleting ResourceSlice resources: %w", err)
+	}
+
+	return nil
+}
+
+// DeleteTenantNamespaces deletes all namespaces labeled as Liqo tenant namespaces.
+func DeleteTenantNamespaces(ctx context.Context, client dynamic.Interface) error {
+	r1 := client.Resource(corev1.SchemeGroupVersion.WithResource("namespaces"))
+	selector := metav1.FormatLabelSelector(&metav1.LabelSelector{
+		MatchLabels: map[string]string{consts.TenantNamespaceLabel: "true"},
+	})
+	unstructured, err := r1.List(ctx, metav1.ListOptions{LabelSelector: selector})
 	if err != nil {
 		return err
 	}
@@ -50,34 +122,17 @@ func DeleteInternalNodes(ctx context.Context, client dynamic.Interface) error {
 	return nil
 }
 
-// DeleteNetworks deletes the Networks installed.
-func DeleteNetworks(ctx context.Context, client dynamic.Interface) error {
-	r1 := client.Resource(ipamv1alpha1.NetworkGroupVersionResource)
-	unstructured, err := r1.List(ctx, metav1.ListOptions{})
+func deleteAllResources(ctx context.Context, client dynamic.Interface, gvr schema.GroupVersionResource) error {
+	res := client.Resource(gvr)
+	unstructured, err := res.List(ctx, metav1.ListOptions{})
 	if err != nil {
-		return err
+		return fmt.Errorf("getting %v resources: %w", gvr, err)
 	}
 
 	for _, item := range unstructured.Items {
-		if err := r1.Namespace(item.GetNamespace()).Delete(ctx, item.GetName(), metav1.DeleteOptions{}); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-// DeleteIPs deletes the IPs installed.
-func DeleteIPs(ctx context.Context, client dynamic.Interface) error {
-	r1 := client.Resource(ipamv1alpha1.IPGroupVersionResource)
-	unstructured, err := r1.List(ctx, metav1.ListOptions{})
-	if err != nil {
-		return err
-	}
-
-	for _, item := range unstructured.Items {
-		if err := r1.Namespace(item.GetNamespace()).Delete(ctx, item.GetName(), metav1.DeleteOptions{}); err != nil {
-			return err
+		err := res.Namespace(item.GetNamespace()).Delete(ctx, item.GetName(), metav1.DeleteOptions{})
+		if err != nil && !k8serrors.IsNotFound(err) {
+			return fmt.Errorf("deleting %v resource %v: %w", gvr, item.GetName(), err)
 		}
 	}
 

--- a/pkg/uninstaller/deletion_test.go
+++ b/pkg/uninstaller/deletion_test.go
@@ -1,0 +1,159 @@
+// Copyright 2019-2026 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package uninstaller_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic/fake"
+
+	authv1beta1 "github.com/liqotech/liqo/apis/authentication/v1beta1"
+	liqov1beta1 "github.com/liqotech/liqo/apis/core/v1beta1"
+	offloadingv1beta1 "github.com/liqotech/liqo/apis/offloading/v1beta1"
+	"github.com/liqotech/liqo/pkg/consts"
+	"github.com/liqotech/liqo/pkg/uninstaller"
+)
+
+var _ = Describe("Force-deletion helpers", func() {
+	var (
+		ctx    context.Context
+		client *fake.FakeDynamicClient
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		scheme := runtime.NewScheme()
+		_ = offloadingv1beta1.AddToScheme(scheme)
+		_ = authv1beta1.AddToScheme(scheme)
+		_ = corev1.AddToScheme(scheme)
+		_ = liqov1beta1.AddToScheme(scheme)
+		client = fake.NewSimpleDynamicClient(scheme)
+	})
+
+	newUnstructured := func(gvr schema.GroupVersionResource, namespace, name string, labels map[string]string) *unstructured.Unstructured {
+		obj := &unstructured.Unstructured{}
+		obj.SetGroupVersionKind(schema.GroupVersionKind{
+			Group:   gvr.Group,
+			Version: gvr.Version,
+			Kind:    "Dummy",
+		})
+		obj.SetNamespace(namespace)
+		obj.SetName(name)
+		if len(labels) > 0 {
+			obj.SetLabels(labels)
+		}
+		return obj
+	}
+
+	Context("NamespaceOffloadings", func() {
+		It("should delete existing NamespaceOffloadings", func() {
+			obj := newUnstructured(offloadingv1beta1.NamespaceOffloadingGroupVersionResource, "test-ns", "offloading", nil)
+			_, err := client.Resource(offloadingv1beta1.NamespaceOffloadingGroupVersionResource).Namespace("test-ns").Create(ctx, obj, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(uninstaller.DeleteNamespaceOffloadings(ctx, client)).To(Succeed())
+
+			_, err = client.Resource(offloadingv1beta1.NamespaceOffloadingGroupVersionResource).
+				Namespace("test-ns").
+				Get(ctx, "offloading", metav1.GetOptions{})
+			Expect(k8serrors.IsNotFound(err)).To(BeTrue(), "NamespaceOffloading should be deleted")
+		})
+	})
+
+	Context("VirtualNodes", func() {
+		It("should delete existing VirtualNodes", func() {
+			obj := newUnstructured(offloadingv1beta1.VirtualNodeGroupVersionResource, "liqo", "vn", nil)
+			_, err := client.Resource(offloadingv1beta1.VirtualNodeGroupVersionResource).Namespace("liqo").Create(ctx, obj, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(uninstaller.DeleteVirtualNodes(ctx, client)).To(Succeed())
+
+			_, err = client.Resource(offloadingv1beta1.VirtualNodeGroupVersionResource).Namespace("liqo").Get(ctx, "vn", metav1.GetOptions{})
+			Expect(k8serrors.IsNotFound(err)).To(BeTrue(), "VirtualNode should be deleted")
+		})
+	})
+
+	Context("ResourceSlices", func() {
+		It("should delete existing ResourceSlices", func() {
+			obj := newUnstructured(authv1beta1.ResourceSliceGroupVersionResource, "liqo", "rs", nil)
+			_, err := client.Resource(authv1beta1.ResourceSliceGroupVersionResource).Namespace("liqo").Create(ctx, obj, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(uninstaller.DeleteResourceSlices(ctx, client)).To(Succeed())
+
+			_, err = client.Resource(authv1beta1.ResourceSliceGroupVersionResource).Namespace("liqo").Get(ctx, "rs", metav1.GetOptions{})
+			Expect(k8serrors.IsNotFound(err)).To(BeTrue(), "ResourceSlice should be deleted")
+		})
+	})
+
+	Context("ForeignClusters", func() {
+		It("should delete existing ForeignClusters", func() {
+			obj := newUnstructured(liqov1beta1.ForeignClusterGroupVersionResource, "", "fc", nil)
+			_, err := client.Resource(liqov1beta1.ForeignClusterGroupVersionResource).Create(ctx, obj, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(uninstaller.DeleteAllForeignClusters(ctx, client)).To(Succeed())
+
+			_, err = client.Resource(liqov1beta1.ForeignClusterGroupVersionResource).Get(ctx, "fc", metav1.GetOptions{})
+			Expect(k8serrors.IsNotFound(err)).To(BeTrue(), "ForeignCluster should be deleted")
+		})
+	})
+
+	Context("Tenant namespaces", func() {
+		It("should delete tenant namespaces and preserve regular namespaces", func() {
+			tenantNs := &corev1.Namespace{
+				TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Namespace"},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "liqo-tenant-foo",
+					Labels: map[string]string{consts.TenantNamespaceLabel: "true"},
+				},
+			}
+			regularNs := &corev1.Namespace{
+				TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Namespace"},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "regular",
+					Labels: map[string]string{"app": "foo"},
+				},
+			}
+
+			unstrTenant, err := runtime.DefaultUnstructuredConverter.ToUnstructured(tenantNs)
+			Expect(err).ToNot(HaveOccurred())
+			unstrRegular, err := runtime.DefaultUnstructuredConverter.ToUnstructured(regularNs)
+			Expect(err).ToNot(HaveOccurred())
+
+			nsGVR := corev1.SchemeGroupVersion.WithResource("namespaces")
+			_, err = client.Resource(nsGVR).Create(ctx, &unstructured.Unstructured{Object: unstrTenant}, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			_, err = client.Resource(nsGVR).Create(ctx, &unstructured.Unstructured{Object: unstrRegular}, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(uninstaller.DeleteTenantNamespaces(ctx, client)).To(Succeed())
+
+			_, err = client.Resource(nsGVR).Get(ctx, "liqo-tenant-foo", metav1.GetOptions{})
+			Expect(k8serrors.IsNotFound(err)).To(BeTrue(), "Tenant namespace should be deleted")
+
+			_, err = client.Resource(nsGVR).Get(ctx, "regular", metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+})

--- a/pkg/uninstaller/helpers.go
+++ b/pkg/uninstaller/helpers.go
@@ -25,11 +25,13 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	liqov1beta1 "github.com/liqotech/liqo/apis/core/v1beta1"
 	"github.com/liqotech/liqo/pkg/consts"
 	fcutils "github.com/liqotech/liqo/pkg/utils/foreigncluster"
 	"github.com/liqotech/liqo/pkg/utils/getters"
+	mapsutil "github.com/liqotech/liqo/pkg/utils/maps"
 )
 
 // AnnotateControllerManagerDeployment annotates the controller-manager deployment with the uninstaller label.
@@ -54,6 +56,33 @@ func AnnotateControllerManagerDeployment(ctx context.Context, client dynamic.Int
 		)
 		return err
 	})
+}
+
+// MarkForeignClustersPermanentlyUnreachable annotates all ForeignCluster resources with the
+// permanently-unreachable annotation, so that Liqo controllers treat them as dead and release finalizers.
+func MarkForeignClustersPermanentlyUnreachable(ctx context.Context, cl ctrlclient.Client) error {
+	var foreignClusters liqov1beta1.ForeignClusterList
+	if err := cl.List(ctx, &foreignClusters); err != nil {
+		return err
+	}
+
+	for i := range foreignClusters.Items {
+		fc := &foreignClusters.Items[i]
+		patch := ctrlclient.MergeFrom(fc.DeepCopy())
+
+		if fc.Annotations == nil {
+			fc.Annotations = map[string]string{}
+		}
+		fc.SetAnnotations(mapsutil.Merge(fc.Annotations, map[string]string{
+			consts.ForeignClusterPermanentlyUnreachableAnnotationKey: consts.ForeignClusterPermanentlyUnreachableAnnotationValue,
+		}))
+
+		if err := cl.Patch(ctx, fc, patch); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // getForeignList retrieve the list of available ForeignCluster and return it as a ForeignClusterList object.

--- a/pkg/uninstaller/helpers_test.go
+++ b/pkg/uninstaller/helpers_test.go
@@ -1,0 +1,70 @@
+// Copyright 2019-2026 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package uninstaller_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	liqov1beta1 "github.com/liqotech/liqo/apis/core/v1beta1"
+	"github.com/liqotech/liqo/pkg/consts"
+	"github.com/liqotech/liqo/pkg/uninstaller"
+)
+
+var _ = Describe("ForeignCluster annotation helper", func() {
+	var (
+		ctx context.Context
+		cl  client.Client
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		scheme := runtime.NewScheme()
+		Expect(liqov1beta1.AddToScheme(scheme)).To(Succeed())
+		cl = fake.NewClientBuilder().WithScheme(scheme).Build()
+	})
+
+	It("should annotate all ForeignClusters as permanently unreachable", func() {
+		fc1 := &liqov1beta1.ForeignCluster{
+			ObjectMeta: metav1.ObjectMeta{Name: "cluster-1"},
+		}
+		fc2 := &liqov1beta1.ForeignCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "cluster-2",
+				Annotations: map[string]string{"other": "value"},
+			},
+		}
+		Expect(cl.Create(ctx, fc1)).To(Succeed())
+		Expect(cl.Create(ctx, fc2)).To(Succeed())
+
+		Expect(uninstaller.MarkForeignClustersPermanentlyUnreachable(ctx, cl)).To(Succeed())
+
+		var clusters liqov1beta1.ForeignClusterList
+		Expect(cl.List(ctx, &clusters)).To(Succeed())
+		Expect(clusters.Items).To(HaveLen(2))
+
+		for _, fc := range clusters.Items {
+			value, ok := fc.GetAnnotations()[consts.ForeignClusterPermanentlyUnreachableAnnotationKey]
+			Expect(ok).To(BeTrue(), "ForeignCluster %q should have the permanently-unreachable annotation", fc.Name)
+			Expect(value).To(Equal("true"))
+		}
+	})
+})

--- a/pkg/uninstaller/uninstaller_suite_test.go
+++ b/pkg/uninstaller/uninstaller_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright 2019-2026 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package uninstaller
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestUninstaller(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Uninstaller Suite")
+}

--- a/pkg/uninstaller/wait.go
+++ b/pkg/uninstaller/wait.go
@@ -35,7 +35,7 @@ func WaitForResources(client dynamic.Interface, phase phase) error {
 	deletionResult := make(chan *resultType, len(toCheck))
 	conditionResult := make(chan *resultType, ConditionsToCheck)
 	for i := range toCheck {
-		if toCheck[i].phase == phase {
+		if phase == PhaseForcedUninstall || toCheck[i].phase == phase {
 			wg.Add(1)
 			go WaitForEffectiveDeletion(client, &toCheck[i], deletionResult, &wg, CheckDeletion)
 		}


### PR DESCRIPTION
# Description

This pull request introduces a "force uninstall" feature to the Liqo uninstaller, allowing users to forcibly remove all Liqo resources even if there are active peerings or leftover namespaces that would normally block a standard uninstall. This is intended for use in situations where the standard uninstall is stuck.

These changes make the Liqo uninstall process more robust in failure scenarios but introduce the risk of data loss when the force option is used. Use the force uninstall feature only when the standard uninstall process cannot succeed and you are certain that remaining resources are no longer needed.
