### PR TITLE
feat: extend template rendering to support multiple Service ports

### DIFF
--- a/deployments/liqo/templates/liqo-wireguard-gateway-server-template.yaml
+++ b/deployments/liqo/templates/liqo-wireguard-gateway-server-template.yaml
@@ -33,11 +33,9 @@ spec:
             {{- include "liqo.selectorTemplate" (merge (dict "isService" true) $templateConfig) | nindent 12 }}
           type: "{{"{{ .Spec.Endpoint.ServiceType }}"}}"
           ?loadBalancerIP: "{{"{{ .Spec.Endpoint.LoadBalancerIP }}"}}"
-          ports:
-          - port: "{{"{{ .Spec.Endpoint.Port }}"}}"
-            protocol: UDP
-            targetPort: "{{"{{ .Spec.Endpoint.Port }}"}}"
-            ?nodePort: "{{"{{ .Spec.Endpoint.NodePort }}"}}"
+          +ports:
+            Ports: "{{ "{{ if .Spec.Endpoint.Ports }}{{ .Spec.Endpoint.Ports }}{{ else }}[{{ .Spec.Endpoint.Port }}]{{ end }}" }}"
+            nodePorts: "{{ "{{ if .Spec.Endpoint.NodePorts }}{{ .Spec.Endpoint.NodePorts }}{{ else if .Spec.Endpoint.NodePort }}[{{ .Spec.Endpoint.NodePort }}]{{ end }}" }}"
           {{- if .Values.networking.gatewayTemplates.server.service.allocateLoadBalancerNodePorts }}
           allocateLoadBalancerNodePorts: {{ .Values.networking.gatewayTemplates.server.service.allocateLoadBalancerNodePorts }}
           {{- end }}

--- a/pkg/liqo-controller-manager/networking/external-network/utils/template.go
+++ b/pkg/liqo-controller-manager/networking/external-network/utils/template.go
@@ -70,6 +70,7 @@ func RenderTemplate(obj, data interface{}, forceString bool) (interface{}, error
 
 	// if the object is a map, render the template for each value
 	if reflect.TypeOf(obj).Kind() == reflect.Map {
+
 		for k, v := range obj.(map[string]interface{}) {
 			useKey, useValue, options := preProcessOptional(k, v, obj)
 
@@ -82,7 +83,9 @@ func RenderTemplate(obj, data interface{}, forceString bool) (interface{}, error
 				obj.(map[string]interface{})[useKey] = res
 			}
 		}
-
+		if err := expandPorts(obj.(map[string]interface{})); err != nil {
+			return obj, err
+		}
 		return obj, nil
 	}
 
@@ -180,4 +183,77 @@ func WatchByGVKs(ctrlBuilder *builder.TypedBuilder[reconcile.Request], gvks []sc
 		obj.SetGroupVersionKind(gvk)
 		ctrlBuilder = ctrlBuilder.Watches(obj, handler.EnqueueRequestsFromMapFunc(mapFunc))
 	}
+}
+
+// expandPorts expands the templates replacing the custom syntax "+ports"
+// into a standard Kubernetes "ports" slice.
+func expandPorts(obj map[string]interface{}) error {
+	val, ok := obj["+ports"]
+	if !ok {
+		return nil
+	}
+
+	instructions, ok := val.(map[string]interface{})
+	if !ok {
+		return fmt.Errorf("+ports must be a map")
+	}
+
+	portsStr, ok := instructions["Ports"].(string)
+	if !ok {
+		return fmt.Errorf("+ports found but missing 'Ports' field")
+	}
+
+	nodePortsStr, hasNodePorts := instructions["nodePorts"].(string)
+
+	if _, hasRegularPorts := obj["ports"]; hasRegularPorts {
+		fmt.Println("WARNING: both 'ports' and '+ports' found, '+ports' takes precedence")
+		delete(obj, "ports")
+	}
+
+	s := strings.Trim(portsStr, "[]")
+	parts := strings.Fields(s)
+
+	var nodePortsParts []string
+	if hasNodePorts {
+		ns := strings.Trim(nodePortsStr, "[]")
+		nodePortsParts = strings.Fields(ns)
+	}
+
+	namePrefix, hasPrefix := instructions["namePrefix"].(string)
+	if !hasPrefix {
+		namePrefix = "liqo-tunnel"
+	}
+
+	expanded := []interface{}{}
+
+	for i, p := range parts {
+		port, err := strconv.Atoi(p)
+		if err != nil {
+			return fmt.Errorf("invalid port value %s: %w", p, err)
+		}
+
+		element := map[string]interface{}{
+			"port":       int64(port),
+			"targetPort": int64(port),
+			"protocol":   "UDP",
+		}
+
+		if len(parts) > 1 {
+			element["name"] = fmt.Sprintf("%s-%d", namePrefix, i)
+		}
+
+		if hasNodePorts && i < len(nodePortsParts) {
+			nodePort, err := strconv.Atoi(nodePortsParts[i])
+			if err != nil {
+				return fmt.Errorf("invalid nodePort value %s: %w", nodePortsParts[i], err)
+			}
+			element["nodePort"] = int64(nodePort)
+		}
+
+		expanded = append(expanded, element)
+	}
+
+	delete(obj, "+ports")
+	obj["ports"] = expanded
+	return nil
 }


### PR DESCRIPTION
## Context and Motivation

Part of the multi-tunnel WireGuard implementation (6th PR related to #3225).

The Service exposing the WireGuard server interfaces must dynamically map the multiple listening ports defined in the `GatewayServer` resource.

Generating the Service manifest directly in `server_controller.go` was discarded as an anti-pattern, as it would duplicate the resource definition outside the templates, increasing the risk of drift and making the resource structure harder to maintain. At the same time, the current template rendering mechanism could not easily support a dynamic list of Service ports directly in the YAML.

## Solution

To preserve the template-driven approach while supporting dynamic port expansion, this PR extends the `RenderTemplate` function with support for a custom `+ports` block.

Specifically:

- Introduces the `+ports` template directive to represent a dynamic list of Service ports, including optional `nodePort` values.
- Extends `RenderTemplate` to invoke a new helper, `expandPorts`, which processes the `+ports` directive at render time and expands it into a fully compliant Kubernetes Service ports array.
- Automatically assigns unique names to each generated port when multiple ports are exposed, as required by Kubernetes. Port names are generated using a configurable `namePrefix`, which defaults to `liqo-tunnel-<index>`.
- Replaces the temporary `+ports` directive with the generated ports array before the rendered object is returned.

