### PR TITLE
feat: propagate multi-port status to WgGatewayServer and GatewayServer

### DIFF
--- a/pkg/liqo-controller-manager/networking/external-network/utils/getters.go
+++ b/pkg/liqo-controller-manager/networking/external-network/utils/getters.go
@@ -37,6 +37,15 @@ func ParseEndpoint(endpoint map[string]interface{}) *networkingv1beta1.EndpointS
 	if value, ok := endpoint["port"]; ok {
 		res.Port = int32(value.(int64))
 	}
+	if value, ok := endpoint["ports"]; ok {
+		if list, ok := value.([]interface{}); ok {
+			for _, v := range list {
+				if port, ok := v.(int64); ok {
+					res.Ports = append(res.Ports, int32(port))
+				}
+			}
+		}
+	}
 	if value, ok := endpoint["protocol"]; ok {
 		tmp := corev1.Protocol(value.(string))
 		res.Protocol = &tmp

--- a/pkg/liqo-controller-manager/networking/external-network/utils/getters.go
+++ b/pkg/liqo-controller-manager/networking/external-network/utils/getters.go
@@ -41,7 +41,7 @@ func ParseEndpoint(endpoint map[string]interface{}) *networkingv1beta1.EndpointS
 		if list, ok := value.([]interface{}); ok {
 			for _, v := range list {
 				if port, ok := v.(int64); ok {
-					res.Ports = append(res.Ports, int32(port))
+					res.Ports = append(res.Ports, int32(port)) //nolint:gosec // value comes from a validated k8s Service port
 				}
 			}
 		}

--- a/pkg/liqo-controller-manager/networking/external-network/wireguard/wggatewayserver_controller.go
+++ b/pkg/liqo-controller-manager/networking/external-network/wireguard/wggatewayserver_controller.go
@@ -362,14 +362,25 @@ func (r *WgGatewayServerReconciler) forgeEndpointStatusClusterIP(service *corev1
 		return nil, err
 	}
 
-	port := service.Spec.Ports[0].Port
 	protocol := &service.Spec.Ports[0].Protocol
 	addresses := service.Spec.ClusterIPs
 
+	if len(service.Spec.Ports) == 1 {
+		return &networkingv1beta1.EndpointStatus{
+			Protocol:  protocol,
+			Port:      service.Spec.Ports[0].Port,
+			Addresses: addresses,
+		}, nil
+	}
+	ports := make([]int32, 0, len(service.Spec.Ports))
+	for i := 0; i < len(service.Spec.Ports); i++ {
+		ports = append(ports, service.Spec.Ports[i].Port)
+	}
+
 	return &networkingv1beta1.EndpointStatus{
 		Protocol:  protocol,
-		Port:      port,
 		Addresses: addresses,
+		Ports:     ports,
 	}, nil
 }
 
@@ -381,7 +392,6 @@ func (r *WgGatewayServerReconciler) forgeEndpointStatusNodePort(ctx context.Cont
 		return nil, err
 	}
 
-	port := service.Spec.Ports[0].NodePort
 	protocol := &service.Spec.Ports[0].Protocol
 
 	pod, err := listActiveGatewayPod(ctx, r.Client, dep.Namespace)
@@ -404,10 +414,23 @@ func (r *WgGatewayServerReconciler) forgeEndpointStatusNodePort(ctx context.Cont
 		}
 	}
 
+	if len(service.Spec.Ports) == 1 {
+		return &networkingv1beta1.EndpointStatus{
+			Protocol:  protocol,
+			Port:      service.Spec.Ports[0].NodePort,
+			Addresses: addresses,
+		}, nil
+	}
+
+	ports := make([]int32, 0, len(service.Spec.Ports))
+	for i := 0; i < len(service.Spec.Ports); i++ {
+		ports = append(ports, service.Spec.Ports[i].NodePort)
+	}
+
 	return &networkingv1beta1.EndpointStatus{
 		Protocol:  protocol,
-		Port:      port,
 		Addresses: addresses,
+		Ports:     ports,
 	}, nil
 }
 
@@ -418,15 +441,26 @@ func (r *WgGatewayServerReconciler) forgeEndpointStatusLoadBalancer(service *cor
 		return nil, err
 	}
 
-	port := service.Spec.Ports[0].Port
 	protocol := &service.Spec.Ports[0].Protocol
-
 	addresses := getters.CollectLoadBalancerAddresses(service.Status.LoadBalancer.Ingress)
+
+	if len(service.Spec.Ports) == 1 {
+		return &networkingv1beta1.EndpointStatus{
+			Protocol:  protocol,
+			Port:      service.Spec.Ports[0].Port,
+			Addresses: addresses,
+		}, nil
+	}
+
+	ports := make([]int32, 0, len(service.Spec.Ports))
+	for i := 0; i < len(service.Spec.Ports); i++ {
+		ports = append(ports, service.Spec.Ports[i].Port)
+	}
 
 	return &networkingv1beta1.EndpointStatus{
 		Protocol:  protocol,
-		Port:      port,
 		Addresses: addresses,
+		Ports:     ports,
 	}, nil
 }
 


### PR DESCRIPTION
## Context & Motivation

Part of the multi-tunnel WireGuard implementation (7th PR related to #3225).

The controller (`wggatewayserver_controller.go`) must publish all exposed server ports in the status of the `WgGatewayServer` and `GatewayServer` resources.

While `EndpointStatus` has already been extended to support multiple ports, the status-forging logic was still reporting only a single port. This PR updates the controller to collect all the ports exposed by the underlying Kubernetes Service and propagate them through the CRD status.

## Solution

- Updated `forgeEndpointStatusClusterIP`, `forgeEndpointStatusNodePort`, and `forgeEndpointStatusLoadBalancer` in `wggatewayserver_controller.go`.
  - If the Service exposes a single port, the existing single-port behavior is preserved to maintain full backward compatibility.
  - If the Service exposes multiple ports, all exposed ports (or `NodePort`s for `NodePort` Services) are collected and populated in the `EndpointStatus.Ports` field.
- Extended `ParseEndpoint` in `getters.go` (controller-manager) to parse the `ports` field, ensuring that multi-port endpoint information is correctly deserialized and propagated when copying the status between `WgGatewayServer` and `GatewayServer`.
