### PR TITLE
feat: support dynamic RouteConfiguration expansion for multi-tunnel gateways

### DIFF
--- a/cmd/fabric/main.go
+++ b/cmd/fabric/main.go
@@ -216,6 +216,8 @@ func run(cmd *cobra.Command, _ []string) error {
 		mgr.GetClient(),
 		mgr.GetScheme(),
 		mgr.GetEventRecorder("route-binding-controller"),
+		"",
+		nil,
 	)
 
 	if err := rcr.SetupWithManager(cmd.Context(), mgr, routeTargetRef,

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -39,6 +39,7 @@ import (
 	"github.com/liqotech/liqo/pkg/gateway/concurrent"
 	"github.com/liqotech/liqo/pkg/gateway/connection"
 	"github.com/liqotech/liqo/pkg/gateway/connection/conncheck"
+	"github.com/liqotech/liqo/pkg/gateway/tunnel"
 	"github.com/liqotech/liqo/pkg/liqo-controller-manager/networking/external-network/remapping"
 	"github.com/liqotech/liqo/pkg/route"
 	argsutils "github.com/liqotech/liqo/pkg/utils/args"
@@ -106,6 +107,11 @@ func run(cmd *cobra.Command, _ []string) error {
 		if err := kernelversion.CheckKernelVersion(&connoptions.GwOptions.MinimumKernelVersion); err != nil {
 			return fmt.Errorf("kernel version check failed: %w, disable this check with --%s", err, gateway.FlagNameDisableKernelVersionCheck)
 		}
+	}
+
+	// Check if the number of interfaces is valid (must be at least 1).
+	if connoptions.GwOptions.NumInterfaces < 1 {
+		return fmt.Errorf("invalid number of interfaces (%d): must be at least 1", connoptions.GwOptions.NumInterfaces)
 	}
 
 	// Enable ip_forwarding.
@@ -193,6 +199,13 @@ func run(cmd *cobra.Command, _ []string) error {
 		}
 	}
 
+	tunnelName := tunnel.TunnelInterfaceName
+
+	interfaceNames := make([]string, connoptions.GwOptions.NumInterfaces)
+	for i := range connoptions.GwOptions.NumInterfaces {
+		interfaceNames[i] = tunnel.GetTunnelName(i)
+	}
+
 	rcr, err := route.NewRouteConfigurationReconcilerWithoutFinalizer(
 		mgr.GetClient(),
 		mgr.GetScheme(),
@@ -203,6 +216,8 @@ func run(cmd *cobra.Command, _ []string) error {
 			gateway.ForgeRouteInternalTargetLabels(),
 			gateway.ForgeRouteInternalTargetLabelsByNode(connoptions.GwOptions.NodeName),
 		},
+		tunnelName,
+		interfaceNames,
 	)
 	if err != nil {
 		return fmt.Errorf("unable to create routeconfiguration reconciler: %w", err)

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -116,6 +116,11 @@ func run(cmd *cobra.Command, _ []string) error {
 		}
 	}
 
+	// Check if the number of interfaces is valid (must be at least 1).
+	if connoptions.GwOptions.NumInterfaces < 1 {
+		return fmt.Errorf("invalid number of interfaces (%d): must be at least 1", connoptions.GwOptions.NumInterfaces)
+	}
+
 	// Enable ip_forwarding.
 	if err = kernel.EnableIPForwarding(); err != nil {
 		return err
@@ -215,11 +220,19 @@ func run(cmd *cobra.Command, _ []string) error {
 		Name:       connoptions.GwOptions.PodName,
 		Namespace:  connoptions.GwOptions.Namespace,
 	}
+	tunnelName := tunnel.TunnelInterfaceName
+
+	interfaceNames := make([]string, connoptions.GwOptions.NumInterfaces)
+	for i := range connoptions.GwOptions.NumInterfaces {
+		interfaceNames[i] = tunnel.GetTunnelName(i)
+	}
 
 	rcr := route.NewRouteConfigurationBindingReconciler(
 		mgr.GetClient(),
 		mgr.GetScheme(),
 		mgr.GetEventRecorder("route-binding-controller"),
+		tunnelName,
+		interfaceNames,
 	)
 
 	if err := rcr.SetupWithManager(cmd.Context(), mgr, routeTargetRef,

--- a/deployments/liqo/templates/liqo-wireguard-gateway-client-template.yaml
+++ b/deployments/liqo/templates/liqo-wireguard-gateway-client-template.yaml
@@ -95,6 +95,7 @@ spec:
                 - --enable-nft-monitor={{ .Values.networking.gatewayTemplates.nftablesMonitor }}
                 - --enable-route-monitor={{ .Values.networking.gatewayTemplates.routeMonitor }}
                 - --enable-multipath-hash-policy={{ printf "{{ if gt (len .Spec.Endpoint.Ports) 1 }}true{{ else }}false{{ end }}" }}
+                - --num-interfaces={{ "{{ if .Spec.Endpoint.Ports }}{{ len .Spec.Endpoint.Ports }}{{ else }}1{{ end }}" }}
                 volumeMounts:
                 - name: ipc
                   mountPath: /ipc

--- a/deployments/liqo/templates/liqo-wireguard-gateway-client-template.yaml
+++ b/deployments/liqo/templates/liqo-wireguard-gateway-client-template.yaml
@@ -100,6 +100,7 @@ spec:
                 - --enable-nft-monitor={{ .Values.networking.gatewayTemplates.nftablesMonitor }}
                 - --enable-route-monitor={{ .Values.networking.gatewayTemplates.routeMonitor }}
                 - --enable-multipath-hash-policy={{ printf "{{ if gt (len .Spec.Endpoint.Ports) 1 }}true{{ else }}false{{ end }}" }}
+                - --num-interfaces={{ "{{ if .Spec.Endpoint.Ports }}{{ len .Spec.Endpoint.Ports }}{{ else }}1{{ end }}" }}
                 {{- if .Values.networking.gatewayTemplates.container.gateway.extraArgs }}
                 {{- toYaml .Values.networking.gatewayTemplates.container.gateway.extraArgs | nindent 16 }}
                 {{- end }}

--- a/deployments/liqo/templates/liqo-wireguard-gateway-server-template.yaml
+++ b/deployments/liqo/templates/liqo-wireguard-gateway-server-template.yaml
@@ -115,6 +115,7 @@ spec:
                 - --enable-nft-monitor={{ .Values.networking.gatewayTemplates.nftablesMonitor }}
                 - --enable-route-monitor={{ .Values.networking.gatewayTemplates.routeMonitor }}
                 - --enable-multipath-hash-policy={{ printf "{{ if gt (len .Spec.Endpoint.Ports) 1 }}true{{ else }}false{{ end }}" }}
+                - --num-interfaces={{ "{{ if .Spec.Endpoint.Ports }}{{ len .Spec.Endpoint.Ports }}{{ else }}1{{ end }}" }}
                 volumeMounts:
                 - name: ipc
                   mountPath: /ipc

--- a/deployments/liqo/templates/liqo-wireguard-gateway-server-template.yaml
+++ b/deployments/liqo/templates/liqo-wireguard-gateway-server-template.yaml
@@ -120,6 +120,7 @@ spec:
                 - --enable-nft-monitor={{ .Values.networking.gatewayTemplates.nftablesMonitor }}
                 - --enable-route-monitor={{ .Values.networking.gatewayTemplates.routeMonitor }}
                 - --enable-multipath-hash-policy={{ printf "{{ if gt (len .Spec.Endpoint.Ports) 1 }}true{{ else }}false{{ end }}" }}
+                - --num-interfaces={{ "{{ if .Spec.Endpoint.Ports }}{{ len .Spec.Endpoint.Ports }}{{ else }}1{{ end }}" }}
                 {{- if .Values.networking.gatewayTemplates.container.gateway.extraArgs }}
                 {{- toYaml .Values.networking.gatewayTemplates.container.gateway.extraArgs | nindent 16 }}
                 {{- end }}

--- a/pkg/gateway/flags.go
+++ b/pkg/gateway/flags.go
@@ -86,6 +86,8 @@ const (
 	// gateway pod's network namespace; (2) this is meaningful only if the gateway uses multiple
 	// parallel tunnels to exchange date with its remote endpoint.
 	FlagNameEnableMultipathHashPolicy FlagName = "enable-multipath-hash-policy"
+	// FlagNameNumInterfaces is the number of WireGuard interfaces available to the gateway.
+	FlagNameNumInterfaces FlagName = "num-interfaces"
 )
 
 // RequiredFlags contains the list of the mandatory flags.
@@ -136,6 +138,7 @@ func InitFlags(flagset *pflag.FlagSet, opts *Options) {
 	flagset.Var(&opts.MinimumKernelVersion, FlagNameMinimumKernelVersion.String(), "Minimum kernel version required by Liqo")
 	flagset.BoolVar(&opts.EnableMultipathHashPolicy, FlagNameEnableMultipathHashPolicy.String(), false,
 		"Set fib_multipath_hash_policy=1 to use 5-tuple hashing for multipath routing")
+	flagset.IntVar(&opts.NumInterfaces, FlagNameNumInterfaces.String(), 1, "Number of WireGuard interfaces")
 }
 
 // MarkFlagsRequired marks the flags as required.

--- a/pkg/gateway/flags.go
+++ b/pkg/gateway/flags.go
@@ -89,6 +89,8 @@ const (
 	// gateway pod's network namespace; (2) this is meaningful only if the gateway uses multiple
 	// parallel tunnels to exchange date with its remote endpoint.
 	FlagNameEnableMultipathHashPolicy FlagName = "enable-multipath-hash-policy"
+	// FlagNameNumInterfaces is the number of WireGuard interfaces available to the gateway.
+	FlagNameNumInterfaces FlagName = "num-interfaces"
 )
 
 // RequiredFlags contains the list of the mandatory flags.
@@ -140,6 +142,7 @@ func InitFlags(flagset *pflag.FlagSet, opts *Options) {
 	flagset.Var(&opts.MinimumKernelVersion, FlagNameMinimumKernelVersion.String(), "Minimum kernel version required by Liqo")
 	flagset.BoolVar(&opts.EnableMultipathHashPolicy, FlagNameEnableMultipathHashPolicy.String(), false,
 		"Set fib_multipath_hash_policy=1 to use 5-tuple hashing for multipath routing")
+	flagset.IntVar(&opts.NumInterfaces, FlagNameNumInterfaces.String(), 1, "Number of WireGuard interfaces")
 }
 
 // MarkFlagsRequired marks the flags as required.

--- a/pkg/gateway/options.go
+++ b/pkg/gateway/options.go
@@ -52,6 +52,7 @@ type Options struct {
 	DisableKernelVersionCheck bool
 	MinimumKernelVersion      kernelversion.KernelVersion
 	EnableMultipathHashPolicy bool
+	NumInterfaces             int
 }
 
 // NewOptions returns a new Options struct.

--- a/pkg/gateway/options.go
+++ b/pkg/gateway/options.go
@@ -53,6 +53,7 @@ type Options struct {
 	DisableKernelVersionCheck bool
 	MinimumKernelVersion      kernelversion.KernelVersion
 	EnableMultipathHashPolicy bool
+	NumInterfaces             int
 }
 
 // NewOptions returns a new Options struct.

--- a/pkg/liqo-controller-manager/networking/internal-network/route/internalnode_k8s.go
+++ b/pkg/liqo-controller-manager/networking/internal-network/route/internalnode_k8s.go
@@ -301,13 +301,13 @@ func forgeRouteConfigurationExtCIDRRules(internalnode *networkingv1beta1.Interna
 			dst := &podCIDRs[j]
 			rules = append(rules, networkingv1beta1.Rule{
 				Dst:    dst,
-				Iif:    ptr.To(tunnel.TunnelInterfaceName),
+				Iif:    ptr.To(fmt.Sprintf("%s*", tunnel.TunnelInterfaceName)),
 				Routes: forgeRouteConfigurationExtCIDRRoutes(internalnode, dst),
 			})
 		}
 	}
 	rules = append(rules, networkingv1beta1.Rule{
-		Iif:    ptr.To(tunnel.TunnelInterfaceName),
+		Iif:    ptr.To(fmt.Sprintf("%s*", tunnel.TunnelInterfaceName)),
 		Routes: forgeRouteConfigurationExtCIDRRoutesIP(internalnode, ips),
 	})
 	return rules

--- a/pkg/liqo-controller-manager/networking/internal-network/route/pod_k8s.go
+++ b/pkg/liqo-controller-manager/networking/internal-network/route/pod_k8s.go
@@ -123,7 +123,7 @@ func forgeRoutePodUpdateFunction(internalnode *networkingv1beta1.InternalNode, r
 
 		if routecfg.Spec.Table.Rules == nil || len(routecfg.Spec.Table.Rules) < 2 {
 			routecfg.Spec.Table.Rules = append(routecfg.Spec.Table.Rules, networkingv1beta1.Rule{})
-			routecfg.Spec.Table.Rules[1].Iif = ptr.To(tunnel.TunnelInterfaceName)
+			routecfg.Spec.Table.Rules[1].Iif = ptr.To(fmt.Sprintf("%s*", tunnel.TunnelInterfaceName))
 		}
 
 		if existingroute, exists := routeContainsPod(pod, &routecfg.Spec.Table.Rules[1]); exists {

--- a/pkg/route/routeconfiguration_controller.go
+++ b/pkg/route/routeconfiguration_controller.go
@@ -28,6 +28,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -53,31 +54,41 @@ type RouteConfigurationReconciler struct {
 	LabelsSets []labels.Set
 	// EnableFinalizer is used to enable the finalizer on the reconciled resources.
 	EnableFinalizer bool
+	// TunnelName is the base name used to build the placeholder ("<TunnelName>*")
+	// that marks rules to be expanded per tunnel interface.
+	TunnelName string
+	// TunnelInterfaceNames are the concrete tunnel interface names used to expand
+	// placeholder rules.
+	TunnelInterfaceNames []string
 }
 
 // newRouteConfigurationReconciler returns a new RouteConfigurationReconciler.
 func newRouteConfigurationReconciler(cl client.Client, s *runtime.Scheme, podname string,
-	er record.EventRecorder, labelsSets []labels.Set, enableFinalizer bool) (*RouteConfigurationReconciler, error) {
+	er record.EventRecorder, labelsSets []labels.Set, enableFinalizer bool,
+	tunnelName string, tunnelInterfaceNames []string) (*RouteConfigurationReconciler, error) {
 	return &RouteConfigurationReconciler{
-		PodName:         podname,
-		Client:          cl,
-		Scheme:          s,
-		EventsRecorder:  er,
-		LabelsSets:      labelsSets,
-		EnableFinalizer: enableFinalizer,
+		PodName:              podname,
+		Client:               cl,
+		Scheme:               s,
+		EventsRecorder:       er,
+		LabelsSets:           labelsSets,
+		EnableFinalizer:      enableFinalizer,
+		TunnelName:           tunnelName,
+		TunnelInterfaceNames: tunnelInterfaceNames,
 	}, nil
 }
 
 // NewRouteConfigurationReconcilerWithFinalizer initializes a reconciler that uses finalizers on routeconfigurations.
 func NewRouteConfigurationReconcilerWithFinalizer(cl client.Client, s *runtime.Scheme, podname string,
 	er record.EventRecorder, labelsSets []labels.Set) (*RouteConfigurationReconciler, error) {
-	return newRouteConfigurationReconciler(cl, s, podname, er, labelsSets, true)
+	return newRouteConfigurationReconciler(cl, s, podname, er, labelsSets, true, "", nil)
 }
 
 // NewRouteConfigurationReconcilerWithoutFinalizer initializes a reconciler that doesn't use finalizers on routeconfigurations.
 func NewRouteConfigurationReconcilerWithoutFinalizer(cl client.Client, s *runtime.Scheme, podname string,
-	er record.EventRecorder, labelsSets []labels.Set) (*RouteConfigurationReconciler, error) {
-	return newRouteConfigurationReconciler(cl, s, podname, er, labelsSets, false)
+	er record.EventRecorder, labelsSets []labels.Set,
+	tunnelName string, tunnelInterfaceNames []string) (*RouteConfigurationReconciler, error) {
+	return newRouteConfigurationReconciler(cl, s, podname, er, labelsSets, false, tunnelName, tunnelInterfaceNames)
 }
 
 // cluster-role
@@ -110,6 +121,8 @@ func (r *RouteConfigurationReconciler) Reconcile(ctx context.Context, req ctrl.R
 		return ctrl.Result{}, fmt.Errorf("getting the table ID: %w", err)
 	}
 
+	expandedRules := expandRules(routeconfiguration.Spec.Table.Rules, r.TunnelName, r.TunnelInterfaceNames)
+
 	// Manage Finalizers and routeconfiguration deletion.
 	deleting := !routeconfiguration.ObjectMeta.DeletionTimestamp.IsZero()
 	containsFinalizer := ctrlutil.ContainsFinalizer(routeconfiguration, routeconfigurationControllerFinalizer)
@@ -122,11 +135,11 @@ func (r *RouteConfigurationReconciler) Reconcile(ctx context.Context, req ctrl.R
 		return ctrl.Result{}, nil
 
 	case deleting && containsFinalizer && r.EnableFinalizer:
-		for i := range routeconfiguration.Spec.Table.Rules {
-			if err = EnsureRuleAbsence(&routeconfiguration.Spec.Table.Rules[i], tableID); err != nil {
+		for i := range expandedRules {
+			if err = EnsureRuleAbsence(&expandedRules[i], tableID); err != nil {
 				return ctrl.Result{}, fmt.Errorf("ensuring rule absence: %w", err)
 			}
-			if err = EnsureRoutesAbsence(routeconfiguration.Spec.Table.Rules[i].Routes, tableID); err != nil {
+			if err = EnsureRoutesAbsence(expandedRules[i].Routes, tableID); err != nil {
 				return ctrl.Result{}, fmt.Errorf("ensuring routes absence: %w", err)
 			}
 		}
@@ -147,15 +160,15 @@ func (r *RouteConfigurationReconciler) Reconcile(ctx context.Context, req ctrl.R
 		return ctrl.Result{}, nil
 	}
 
-	if err = CleanRules(routeconfiguration.Spec.Table.Rules, tableID); err != nil {
+	if err = CleanRules(expandedRules, tableID); err != nil {
 		return ctrl.Result{}, fmt.Errorf("cleaning rules: %w", err)
 	}
 
 	allRoutes := []networkingv1beta1.Route{}
-	for i := range routeconfiguration.Spec.Table.Rules {
+	for i := range expandedRules {
 		// Append all the routes in the same table in a single array.
 		// This is necessary because we can't list the route rules filtering per rule.
-		allRoutes = append(allRoutes, routeconfiguration.Spec.Table.Rules[i].Routes...)
+		allRoutes = append(allRoutes, expandedRules[i].Routes...)
 	}
 	if err = CleanRoutes(allRoutes, tableID); err != nil {
 		return ctrl.Result{}, fmt.Errorf("cleaning routes: %w", err)
@@ -167,11 +180,11 @@ func (r *RouteConfigurationReconciler) Reconcile(ctx context.Context, req ctrl.R
 		return ctrl.Result{}, fmt.Errorf("ensuring table presence: %w", err)
 	}
 
-	for i := range routeconfiguration.Spec.Table.Rules {
-		if err = EnsureRulePresence(&routeconfiguration.Spec.Table.Rules[i], tableID); err != nil {
+	for _, rule := range expandedRules {
+		if err = EnsureRulePresence(&rule, tableID); err != nil {
 			return ctrl.Result{}, fmt.Errorf("ensuring rule presence: %w", err)
 		}
-		if err := EnsureRoutesPresence(routeconfiguration.Spec.Table.Rules[i].Routes, tableID); err != nil {
+		if err := EnsureRoutesPresence(rule.Routes, tableID); err != nil {
 			if errors.As(err, &netlink.LinkNotFoundError{}) {
 				klog.V(3).Infof("Link not found for routeconfiguration %s, requeuing: %v", req.String(), err)
 				return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
@@ -255,4 +268,29 @@ func (r *RouteConfigurationReconciler) UpdateStatus(ctx context.Context, er reco
 		err = errors.Join(err, clerr)
 	}
 	return err
+}
+
+// expandRules expands the existing rules by creating a specialized rule for each active
+// network interface that matches the provided tunnel name prefix (acting as a placeholder).
+func expandRules(rules []networkingv1beta1.Rule, tunnelName string, tunnelInterfaceNames []string) []networkingv1beta1.Rule {
+	if tunnelName == "" && len(tunnelInterfaceNames) == 0 {
+		return rules
+	}
+	expandedRules := []networkingv1beta1.Rule{}
+	placeholder := tunnelName + "*"
+
+	for i := range rules {
+		rule := rules[i]
+
+		if rule.Iif != nil && *rule.Iif == placeholder {
+			for _, iface := range tunnelInterfaceNames {
+				newRule := rule
+				newRule.Iif = ptr.To(iface)
+				expandedRules = append(expandedRules, newRule)
+			}
+		} else {
+			expandedRules = append(expandedRules, rule)
+		}
+	}
+	return expandedRules
 }

--- a/pkg/route/routeconfigurationbinding_controller.go
+++ b/pkg/route/routeconfigurationbinding_controller.go
@@ -29,6 +29,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/events"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -48,15 +49,23 @@ type RouteConfigurationBindingReconciler struct {
 	client.Client
 	Scheme         *runtime.Scheme
 	EventsRecorder events.EventRecorder
+	// TunnelName is the base name used to build the placeholder ("<TunnelName>*")
+	// that marks rules to be expanded per tunnel interface.
+	TunnelName string
+	// TunnelInterfaceNames are the concrete tunnel interface names used to expand
+	// placeholder rules.
+	TunnelInterfaceNames []string
 }
 
 // NewRouteConfigurationBindingReconciler returns a new RouteConfigurationBindingReconciler.
 func NewRouteConfigurationBindingReconciler(cl client.Client, s *runtime.Scheme,
-	er events.EventRecorder) *RouteConfigurationBindingReconciler {
+	er events.EventRecorder, tunnelName string, tunnelInterfaceNames []string) *RouteConfigurationBindingReconciler {
 	return &RouteConfigurationBindingReconciler{
-		Client:         cl,
-		Scheme:         s,
-		EventsRecorder: er,
+		Client:               cl,
+		Scheme:               s,
+		EventsRecorder:       er,
+		TunnelName:           tunnelName,
+		TunnelInterfaceNames: tunnelInterfaceNames,
 	}
 }
 
@@ -143,13 +152,15 @@ func (r *RouteConfigurationBindingReconciler) Reconcile(ctx context.Context, req
 		return ctrl.Result{}, fmt.Errorf("getting the table ID: %w", err)
 	}
 
+	expandedRules := expandRules(routecfg.Spec.Table.Rules, r.TunnelName, r.TunnelInterfaceNames)
+
 	klog.V(4).Infof("Applying routeconfigurationbinding %s (routecfg %s)", req.String(), routecfg.Name)
 
 	existingRules, err := GetRulesByTableID(tableID)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("listing existing rules: %w", err)
 	}
-	if err = CleanRules(routecfg.Spec.Table.Rules, existingRules); err != nil {
+	if err = CleanRules(expandedRules, existingRules); err != nil {
 		return ctrl.Result{}, fmt.Errorf("cleaning rules: %w", err)
 	}
 
@@ -159,8 +170,8 @@ func (r *RouteConfigurationBindingReconciler) Reconcile(ctx context.Context, req
 	}
 
 	allRoutes := []networkingv1beta1.Route{}
-	for i := range routecfg.Spec.Table.Rules {
-		allRoutes = append(allRoutes, routecfg.Spec.Table.Rules[i].Routes...)
+	for i := range expandedRules {
+		allRoutes = append(allRoutes, expandedRules[i].Routes...)
 	}
 	if err = CleanRoutes(allRoutes, existingRoutes); err != nil {
 		return ctrl.Result{}, fmt.Errorf("cleaning routes: %w", err)
@@ -175,11 +186,11 @@ func (r *RouteConfigurationBindingReconciler) Reconcile(ctx context.Context, req
 	// NOT in the desired spec, while Ensure*Presence only looks up entries that ARE in the desired
 	// spec, so the two never operate on the same rows and the stale snapshot cannot cause a wrong
 	// exists/not-exists result. Re-fetching here would just be a redundant netlink list.
-	for i := range routecfg.Spec.Table.Rules {
-		if err = EnsureRulePresence(&routecfg.Spec.Table.Rules[i], tableID, existingRules); err != nil {
+	for _, rule := range expandedRules {
+		if err = EnsureRulePresence(&rule, tableID, existingRules); err != nil {
 			return ctrl.Result{}, fmt.Errorf("ensuring rule presence: %w", err)
 		}
-		if err := EnsureRoutesPresence(routecfg.Spec.Table.Rules[i].Routes, tableID, existingRoutes); err != nil {
+		if err := EnsureRoutesPresence(rule.Routes, tableID, existingRoutes); err != nil {
 			if errors.Is(err, ErrNetworkUnreachable) {
 				klog.Warningf("Network is unreachable for routeconfigurationbinding %s, requeuing: %v", req.String(), err)
 				return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
@@ -330,4 +341,29 @@ func cleanupBinding(ctx context.Context, cl client.Client, binding *networkingv1
 	}
 	klog.Infof("Shutdown cleanup: removed finalizer from RouteConfigurationBinding %s/%s",
 		binding.Namespace, binding.Name)
+}
+
+// expandRules expands the existing rules by creating a specialized rule for each active
+// network interface that matches the provided tunnel name prefix (acting as a placeholder).
+func expandRules(rules []networkingv1beta1.Rule, tunnelName string, tunnelInterfaceNames []string) []networkingv1beta1.Rule {
+	if tunnelName == "" && len(tunnelInterfaceNames) == 0 {
+		return rules
+	}
+	expandedRules := []networkingv1beta1.Rule{}
+	placeholder := tunnelName + "*"
+
+	for i := range rules {
+		rule := rules[i]
+
+		if rule.Iif != nil && *rule.Iif == placeholder {
+			for _, iface := range tunnelInterfaceNames {
+				newRule := rule
+				newRule.Iif = ptr.To(iface)
+				expandedRules = append(expandedRules, newRule)
+			}
+		} else {
+			expandedRules = append(expandedRules, rule)
+		}
+	}
+	return expandedRules
 }


### PR DESCRIPTION
Part of the multi-tunnel WireGuard implementation (8th PR related to #3225).

When managing return traffic from WireGuard gateway interfaces to cluster pods, routing rules are defined in RouteConfiguration resources (e.g., <local-cluster-id>-<node-name>-gw-node and <node>-extcidr). These resources are created during the initial Liqo installation, before peering occurs, and are shared across all gateways.

Previously, these resources used a hardcoded incoming interface (`iif: liqo-tunnel`).

In a multi-tunnel setup:
- Each gateway instance may be configured with a different number of WireGuard interfaces.
- Statically expanding the rules in the shared RouteConfiguration resources is impractical, as it would bloat the resources and require continuous synchronization based on the maximum number of interfaces across all active gateways.

To address this, this PR introduces a dynamic placeholder mechanism (`liqo-tunnel*`) in the RouteConfiguration resources. Each gateway's RouteConfigurationBinding controller expands the placeholder locally according to its configured number of WireGuard interfaces.

### Changes
- Added the `--num-interfaces` flag (default: `1`) to the gateway container. The value is populated in both gateway client and server templates based on the number of ports.
- Added validation during gateway startup to ensure `--num-interfaces >= 1`.
- Updated `internalnode_k8s.go` and `pod_k8s.go` to generate RouteConfiguration resources using `iif: liqo-tunnel*` instead of the static `iif: liqo-tunnel`.
- Extended `RouteConfigurationBindingReconciler` to store both the tunnel interface prefix and the list of concrete tunnel interface names for the local gateway instance (e.g., `liqo-tunnel0`, `liqo-tunnel1`).
- Introduced `expandRules()` in `RouteConfigurationBindingReconciler.Reconcile()` to expand `iif: liqo-tunnel*` placeholder rules into one rule per local WireGuard interface before applying kernel routing rules and routes.
