### PR TITLE
fix(e2e): bump Calico version and fix Flannel installation parameters

### DIFF
--- a/pkg/consts/internalnetwork.go
+++ b/pkg/consts/internalnetwork.go
@@ -21,6 +21,9 @@ const (
 	DefaultGenevePort uint16 = 6091
 	// DefaultGeneveCleanupInterval is the default interval used to cleanup the geneve tunnels.
 	DefaultGeneveCleanupInterval = time.Minute * 30
+	// DefaultSourceIPRefreshInterval is the default interval used to check that the source IPs used
+	// by a node to reach the gateways are still the ones stored in the InternalNode resource.
+	DefaultSourceIPRefreshInterval = time.Second * 30
 	// DefaultRouteTable is the name of the default table used for routes.
 	DefaultRouteTable = "liqo"
 	// InternalFabricName is the label used to identify the internal fabric name.

--- a/pkg/fabric/flags.go
+++ b/pkg/fabric/flags.go
@@ -58,6 +58,9 @@ const (
 	FlagNameGenevePort FlagName = "geneve-port"
 	// FlagNameGeneveCleanupInterval is the flag to set the Geneve cleanup interval.
 	FlagNameGeneveCleanupInterval FlagName = "geneve-cleanup-interval"
+	// FlagNameSourceIPRefreshInterval is the flag to set the interval between two checks of the
+	// source IPs used to reach the gateways.
+	FlagNameSourceIPRefreshInterval FlagName = "source-ip-refresh-interval"
 )
 
 // RequiredFlags contains the list of the mandatory flags.
@@ -85,6 +88,8 @@ func InitFlags(flagset *pflag.FlagSet, opts *Options) {
 	flagset.Uint16Var(&opts.GenevePort, FlagNameGenevePort.String(), consts.DefaultGenevePort, "Geneve port")
 	flagset.DurationVar(&opts.GeneveCleanupInterval, FlagNameGeneveCleanupInterval.String(),
 		consts.DefaultGeneveCleanupInterval, "Geneve cleanup interval")
+	flagset.DurationVar(&opts.SourceIPRefreshInterval, FlagNameSourceIPRefreshInterval.String(),
+		consts.DefaultSourceIPRefreshInterval, "Interval between two checks of the source IPs used to reach the gateways")
 }
 
 // MarkFlagsRequired marks the flags as required.

--- a/pkg/fabric/options.go
+++ b/pkg/fabric/options.go
@@ -39,6 +39,10 @@ type Options struct {
 	DisableARP            bool
 	GenevePort            uint16
 	GeneveCleanupInterval time.Duration
+
+	// SourceIPRefreshInterval is the interval between two checks of the source IPs used by the node
+	// to reach the gateways.
+	SourceIPRefreshInterval time.Duration
 }
 
 // NewOptions returns a new Options struct.

--- a/pkg/fabric/source-detector/gateway_controller.go
+++ b/pkg/fabric/source-detector/gateway_controller.go
@@ -93,15 +93,42 @@ func (r *GatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return ctrl.Result{}, err
 	}
 
-	if pod.Spec.NodeName == r.Options.NodeName {
-		internalnode.Status.NodeIP.Local = ptr.To(networkingv1beta1.IP(src))
-		klog.Infof("Enforced internal node local IP %s", src)
-	} else {
-		internalnode.Status.NodeIP.Remote = ptr.To(networkingv1beta1.IP(src))
-		klog.Infof("Enforced internal node remote IP %s", src)
+	// The source IP is sampled from the routing table of the node, which is not necessarily complete
+	// when the sample is taken: a CNI programs the routes towards the other nodes asynchronously, and
+	// a node joining a cluster whose peerings are already established reconciles the gateway pods as
+	// soon as it sees them. Until the route towards the gateway exists, the lookup falls back to the
+	// default route and returns an address the node stops using as soon as the CNI converges, leaving
+	// the gateway with a geneve tunnel whose remote never matches the packets it receives.
+	// Reconcile periodically, so that a sample taken too early is corrected instead of being kept
+	// for the whole life of the node.
+	local := pod.Spec.NodeName == r.Options.NodeName
+	current := internalnode.Status.NodeIP.Remote
+	if local {
+		current = internalnode.Status.NodeIP.Local
 	}
 
-	return ctrl.Result{}, r.Client.Status().Update(ctx, internalnode)
+	if current != nil && current.String() == src {
+		return ctrl.Result{RequeueAfter: r.Options.SourceIPRefreshInterval}, nil
+	}
+
+	previous := "none"
+	if current != nil {
+		previous = current.String()
+	}
+
+	if local {
+		internalnode.Status.NodeIP.Local = ptr.To(networkingv1beta1.IP(src))
+		klog.Infof("Enforced internal node local IP %s (previous: %s)", src, previous)
+	} else {
+		internalnode.Status.NodeIP.Remote = ptr.To(networkingv1beta1.IP(src))
+		klog.Infof("Enforced internal node remote IP %s (previous: %s)", src, previous)
+	}
+
+	if err := r.Client.Status().Update(ctx, internalnode); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{RequeueAfter: r.Options.SourceIPRefreshInterval}, nil
 }
 
 // SetupWithManager register the GatewayReconciler to the manager.

--- a/pkg/liqoctl/test/network/check/endpointslices.go
+++ b/pkg/liqoctl/test/network/check/endpointslices.go
@@ -17,22 +17,178 @@ package check
 import (
 	"context"
 	"fmt"
+	"slices"
+	"strings"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/liqotech/liqo/pkg/liqoctl/test/network/client"
 	"github.com/liqotech/liqo/pkg/liqoctl/test/network/setup"
+	utilspod "github.com/liqotech/liqo/pkg/utils/pod"
+)
+
+const (
+	// targetsStabilityTimeout is the maximum time waited for the endpoints to settle.
+	targetsStabilityTimeout = 60 * time.Second
+	// targetsStabilityInterval is the delay between two consecutive readings of the endpoints.
+	targetsStabilityInterval = 3 * time.Second
 )
 
 // Targets ia a map where the key is the name of the provider/consumer
 // and the values are the endpoints from their point of view.
 type Targets map[string][]string
 
-// ForgePodTargets creates a map of targets for the pod-to-pod tests.
+// Equal returns whether the two sets contain the same addresses for the same clusters.
+func (t Targets) Equal(other Targets) bool {
+	if len(t) != len(other) {
+		return false
+	}
+	for name := range t {
+		o, ok := other[name]
+		if !ok || len(t[name]) != len(o) {
+			return false
+		}
+		current, previous := slices.Clone(t[name]), slices.Clone(o)
+		slices.Sort(current)
+		slices.Sort(previous)
+		if !slices.Equal(current, previous) {
+			return false
+		}
+	}
+	return true
+}
+
+// ForgePodTargets returns the addresses to probe in the pod-to-pod tests, once they are stable and
+// backed by running pods.
+//
+// The endpoints are read repeatedly, and are accepted only once two consecutive readings agree and
+// are consistent with the pods (see ValidateTargets). An EndpointSlice read while the pods are being
+// replaced exposes the address of a pod which is already gone: the checks would then probe a dead
+// address until they time out, reporting a connectivity failure which is not one.
 func ForgePodTargets(ctx context.Context, cl *client.Client, totalReplicas int32) (Targets, error) {
+	var previous Targets
+	var lastErr error
+
+	timeout, cancel := context.WithTimeout(ctx, targetsStabilityTimeout)
+	defer cancel()
+
+	if err := wait.PollUntilContextCancel(timeout, targetsStabilityInterval, true,
+		func(ctx context.Context) (done bool, err error) {
+			current, ferr := forgePodTargets(ctx, cl, totalReplicas)
+			if ferr != nil {
+				previous, lastErr = nil, ferr
+				return false, nil
+			}
+
+			if verr := ValidateTargets(ctx, cl, current); verr != nil {
+				previous, lastErr = nil, verr
+				return false, nil
+			}
+
+			if previous != nil && previous.Equal(current) {
+				return true, nil
+			}
+
+			previous, lastErr = current, fmt.Errorf("the endpoints are still changing")
+			return false, nil
+		}); err != nil {
+		return nil, fmt.Errorf("the endpoints did not settle within %s: %w", targetsStabilityTimeout, lastErr)
+	}
+
+	return previous, nil
+}
+
+// ValidateTargets checks the addresses to probe against the pods of the cluster they belong to.
+//
+// The consumer has a pod for every backend: the local ones, and the offloaded ones, whose status
+// carries the address remapped by the virtual kubelet. A provider, instead, only hosts part of them:
+// the remaining addresses are reflected from the other clusters and have no pod to be resolved
+// against. The check is therefore expressed as "every running and ready pod of a cluster must appear
+// among its targets": an address left behind by a pod which has been replaced makes the pod that
+// replaced it missing from the list, and is detected.
+func ValidateTargets(ctx context.Context, cl *client.Client, targets Targets) error {
+	if err := validateClusterTargets(ctx, cl.Consumer, cl.ConsumerName, targets[cl.ConsumerName]); err != nil {
+		return err
+	}
+
+	for name := range cl.Providers {
+		if err := validateClusterTargets(ctx, cl.Providers[name], name, targets[name]); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func validateClusterTargets(ctx context.Context, cl ctrlclient.Client, name string, targets []string) error {
+	pods := corev1.PodList{}
+	if err := cl.List(ctx, &pods,
+		ctrlclient.InNamespace(setup.NamespaceName),
+		ctrlclient.MatchingLabels{setup.PodLabelApp: setup.DeploymentName},
+	); err != nil {
+		return fmt.Errorf("failed to list the pods of cluster %q: %w", name, err)
+	}
+
+	targetSet := make(map[string]any, len(targets))
+	for i := range targets {
+		targetSet[targets[i]] = nil
+	}
+
+	var missing []string
+	for i := range pods.Items {
+		pod := &pods.Items[i]
+		if pod.Status.PodIP == "" {
+			continue
+		}
+
+		_, isTarget := targetSet[pod.Status.PodIP]
+		ready, reason := utilspod.IsPodReady(pod)
+		terminating := pod.DeletionTimestamp != nil
+
+		switch {
+		case isTarget && terminating:
+			return fmt.Errorf("target %s of cluster %q is backed by pod %s, which is terminating",
+				pod.Status.PodIP, name, pod.Name)
+		case isTarget && !ready:
+			return fmt.Errorf("target %s of cluster %q is backed by pod %s, which is not ready: %s",
+				pod.Status.PodIP, name, pod.Name, reason)
+		case !isTarget && ready && !terminating:
+			missing = append(missing, fmt.Sprintf("%s (%s)", pod.Name, pod.Status.PodIP))
+		}
+	}
+
+	if len(missing) > 0 {
+		return fmt.Errorf("cluster %q: pods %s are running and ready, but their addresses are not among the endpoints %v",
+			name, strings.Join(missing, ", "), targets)
+	}
+
+	return nil
+}
+
+// RefreshConsumerTargets re-reads the addresses to probe from the consumer.
+func RefreshConsumerTargets(ctx context.Context, cl *client.Client, totalReplicas int32) ([]string, error) {
+	target := Targets{}
+	if err := ForgePodTargetForConsumer(ctx, cl, totalReplicas, target); err != nil {
+		return nil, err
+	}
+	return target[cl.ConsumerName], nil
+}
+
+// RefreshProviderTargets re-reads the addresses to probe from the given provider.
+func RefreshProviderTargets(ctx context.Context, cl *client.Client, name string, totalReplicas int32) ([]string, error) {
+	target := Targets{}
+	if err := ForgePodTargetForProvider(ctx, cl, name, totalReplicas, target); err != nil {
+		return nil, err
+	}
+	return target[name], nil
+}
+
+// forgePodTargets creates a map of targets for the pod-to-pod tests.
+func forgePodTargets(ctx context.Context, cl *client.Client, totalReplicas int32) (Targets, error) {
 	var target Targets = make(map[string][]string)
 
 	if err := ForgePodTargetForConsumer(ctx, cl, totalReplicas, target); err != nil {

--- a/pkg/liqoctl/test/network/check/exec.go
+++ b/pkg/liqoctl/test/network/check/exec.go
@@ -37,9 +37,24 @@ const MaxRetries = 10
 type ExecFunc func(ctx context.Context, pod *corev1.Pod, clset *kubernetes.Clientset,
 	cfg *rest.Config, quiet bool, endpoint string, logger *pterm.Logger) (ok bool, err error)
 
+// TargetsRefresher re-reads the addresses to probe of a cluster.
+type TargetsRefresher func(ctx context.Context) ([]string, error)
+
 // RunCheckToTargets runs the checks to the targets.
 func RunCheckToTargets(ctx context.Context, cl ctrlclient.Client, cfg *rest.Config, opts *flags.Options,
 	owner string, targets []string, hostnetwork bool, execFunc ExecFunc) (successCount, errorCount int32, err error) {
+	return RunCheckToTargetsWithRefresh(ctx, cl, cfg, opts, owner, targets, hostnetwork, execFunc, nil)
+}
+
+// RunCheckToTargetsWithRefresh runs the checks to the targets, re-reading them between two attempts
+// through the given refresher, when provided.
+//
+// Retrying the same address is pointless when it is the one of a pod which has been replaced in the
+// meantime: all the attempts fail, and the check reports a connectivity failure which is not one.
+// The refresher lets the check follow the endpoints of the moment instead.
+func RunCheckToTargetsWithRefresh(ctx context.Context, cl ctrlclient.Client, cfg *rest.Config, opts *flags.Options,
+	owner string, targets []string, hostnetwork bool, execFunc ExecFunc,
+	refresh TargetsRefresher) (successCount, errorCount int32, err error) {
 	logger := opts.Topts.LocalFactory.Printer.Logger
 	pods, err := listPods(ctx, cl, owner, hostnetwork)
 	if err != nil {
@@ -52,12 +67,19 @@ func RunCheckToTargets(ctx context.Context, cl ctrlclient.Client, cfg *rest.Conf
 	}
 	for i := range pods.Items {
 		for j := range targets {
+			target, attempt := targets[j], 0
 			ok, err := podutils.TryFor(ctx, MaxRetries, func() (bool, error) {
-				return execFunc(ctx, &pods.Items[i], clset, cfg, !opts.Topts.Verbose, targets[j], logger)
+				if attempt > 0 && refresh != nil {
+					if updated := refreshTarget(ctx, refresh, target, j, logger); updated != "" {
+						target = updated
+					}
+				}
+				attempt++
+				return execFunc(ctx, &pods.Items[i], clset, cfg, !opts.Topts.Verbose, target, logger)
 			})
 			if !ok || err != nil {
 				logger.Error(fmt.Sprintf("Curl command failed after %d retries", MaxRetries), logger.Args(
-					"pod", pods.Items[i].Name, "target", targets[j], "error", err,
+					"pod", pods.Items[i].Name, "target", target, "error", err,
 				))
 			}
 			successCount, errorCount, err = testutils.ManageResults(opts.Topts.FailFast, err, ok, successCount, errorCount)
@@ -67,6 +89,33 @@ func RunCheckToTargets(ctx context.Context, cl ctrlclient.Client, cfg *rest.Conf
 		}
 	}
 	return successCount, errorCount, nil
+}
+
+// refreshTarget returns the address to probe in place of the current one, when the latter is not an
+// endpoint anymore. It returns an empty string when the address is still valid, and when the
+// endpoints cannot be read: in both cases the caller keeps probing the address it already has.
+func refreshTarget(ctx context.Context, refresh TargetsRefresher, target string, index int, logger *pterm.Logger) string {
+	current, err := refresh(ctx)
+	if err != nil {
+		logger.Warn("Unable to refresh the targets", logger.Args("error", err))
+		return ""
+	}
+
+	for i := range current {
+		if current[i] == target {
+			// The address is still an endpoint: the failure is not caused by a stale target.
+			return ""
+		}
+	}
+
+	if index >= len(current) {
+		return ""
+	}
+
+	logger.Warn("The target is not an endpoint anymore, probing the current one", logger.Args(
+		"old", target, "new", current[index],
+	))
+	return current[index]
 }
 
 // ExecCurl executes a curl command.

--- a/pkg/liqoctl/test/network/check/node.go
+++ b/pkg/liqoctl/test/network/check/node.go
@@ -32,8 +32,9 @@ func RunChecksNodeToPod(ctx context.Context, cl *client.Client, cfg client.Confi
 		return 0, 0, fmt.Errorf("failed to forge targets: %w", err)
 	}
 
-	successCount, errorCount, err = RunCheckToTargets(ctx, cl.Consumer, cfg[cl.ConsumerName],
-		opts, cl.ConsumerName, targets[cl.ConsumerName], true, ExecCurl)
+	successCount, errorCount, err = RunCheckToTargetsWithRefresh(ctx, cl.Consumer, cfg[cl.ConsumerName],
+		opts, cl.ConsumerName, targets[cl.ConsumerName], true, ExecCurl,
+		func(ctx context.Context) ([]string, error) { return RefreshConsumerTargets(ctx, cl, totreplicas) })
 	if err != nil {
 		return 0, 0, fmt.Errorf("consumer failed to run checks: %w", err)
 	}
@@ -41,8 +42,9 @@ func RunChecksNodeToPod(ctx context.Context, cl *client.Client, cfg client.Confi
 	errorCountTot += errorCount
 
 	for k := range cl.Providers {
-		successCount, errorCount, err := RunCheckToTargets(ctx, cl.Providers[k],
-			cfg[k], opts, k, targets[k], true, ExecCurl)
+		successCount, errorCount, err := RunCheckToTargetsWithRefresh(ctx, cl.Providers[k],
+			cfg[k], opts, k, targets[k], true, ExecCurl,
+			func(ctx context.Context) ([]string, error) { return RefreshProviderTargets(ctx, cl, k, totreplicas) })
 		if err != nil {
 			return 0, 0, fmt.Errorf("provider %q failed to run checks: %w", k, err)
 		}

--- a/pkg/liqoctl/test/network/check/pod.go
+++ b/pkg/liqoctl/test/network/check/pod.go
@@ -32,8 +32,9 @@ func RunChecksPodToPod(ctx context.Context, cl *client.Client, cfg client.Config
 		return 0, 0, fmt.Errorf("failed to forge targets: %w", err)
 	}
 
-	successCount, errorCount, err = RunCheckToTargets(ctx, cl.Consumer, cfg[cl.ConsumerName],
-		opts, cl.ConsumerName, targets[cl.ConsumerName], false, ExecCurl)
+	successCount, errorCount, err = RunCheckToTargetsWithRefresh(ctx, cl.Consumer, cfg[cl.ConsumerName],
+		opts, cl.ConsumerName, targets[cl.ConsumerName], false, ExecCurl,
+		func(ctx context.Context) ([]string, error) { return RefreshConsumerTargets(ctx, cl, totreplicas) })
 	successCountTot += successCount
 	errorCountTot += errorCount
 	if err != nil {
@@ -41,8 +42,9 @@ func RunChecksPodToPod(ctx context.Context, cl *client.Client, cfg client.Config
 	}
 
 	for k := range cl.Providers {
-		successCount, errorCount, err := RunCheckToTargets(ctx, cl.Providers[k], cfg[k],
-			opts, k, targets[k], false, ExecCurl)
+		successCount, errorCount, err := RunCheckToTargetsWithRefresh(ctx, cl.Providers[k], cfg[k],
+			opts, k, targets[k], false, ExecCurl,
+			func(ctx context.Context) ([]string, error) { return RefreshProviderTargets(ctx, cl, k, totreplicas) })
 		successCountTot += successCount
 		errorCountTot += errorCount
 		if err != nil {

--- a/test/e2e/cruise/network/network_test.go
+++ b/test/e2e/cruise/network/network_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -51,6 +52,12 @@ const (
 	testName = "NETWORK"
 	// StressMax is the maximum number of stress iterations.
 	stressMax = 3
+
+	// fabricPodLabelKey and fabricPodLabelValue select the fabric pods, one per node.
+	fabricPodLabelKey   = "app.kubernetes.io/name"
+	fabricPodLabelValue = "fabric"
+	// geneveContainerName is the container of the gateway pod owning the geneve interfaces.
+	geneveContainerName = "geneve"
 )
 
 func TestE2E(t *testing.T) {
@@ -133,11 +140,10 @@ var _ = Describe("Liqo E2E", func() {
 				}, timeout, interval).Should(Succeed())
 
 				// Restart the gateway pods.
+				restartTime := time.Now()
 				for i := range testContext.Clusters {
 					RestartPods(testContext.Clusters[i].ControllerClient)
 				}
-
-				time.Sleep(time.Second * 60)
 
 				// Check if there is only one active gateway pod per remote cluster.
 				for i := range testContext.Clusters {
@@ -147,10 +153,29 @@ var _ = Describe("Liqo E2E", func() {
 					}, timeout, interval).Should(Succeed())
 				}
 
+				// Wait for the connections to be re-established after the restart, instead of assuming
+				// a duration for it: a fixed wait hides how long the failover actually takes, and the
+				// checks below would otherwise be free to observe the state preceding the restart.
+				for i := range testContext.Clusters {
+					Eventually(func() error {
+						return checkConnectionsReady(testContext.Clusters[i].ControllerClient, restartTime)
+					}, timeout, interval).Should(Succeed())
+				}
+
 				// Check that the internal fabric caught up with the new gateway pods.
 				for i := range testContext.Clusters {
 					Eventually(func() error {
 						return checkInternalFabricConverged(testContext.Clusters[i].ControllerClient)
+					}, timeout, interval).Should(Succeed())
+				}
+
+				// Check that what the internal fabric caught up with is also what the datapath needs.
+				for i := range testContext.Clusters {
+					Eventually(func() error {
+						return checkSourceIPsMatchRoutes(&testContext.Clusters[i], testContext.Namespace)
+					}, timeout, interval).Should(Succeed())
+					Eventually(func() error {
+						return checkGeneveTunnelsProgrammed(&testContext.Clusters[i])
 					}, timeout, interval).Should(Succeed())
 				}
 
@@ -191,6 +216,16 @@ var _ = Describe("Liqo E2E", func() {
 					for j := range testContext.Clusters {
 						Eventually(func() error {
 							return checkInternalFabricConverged(testContext.Clusters[j].ControllerClient)
+						}, timeout, interval).Should(Succeed())
+					}
+
+					// Check that what the internal fabric caught up with is also what the datapath needs.
+					for j := range testContext.Clusters {
+						Eventually(func() error {
+							return checkSourceIPsMatchRoutes(&testContext.Clusters[j], testContext.Namespace)
+						}, timeout, interval).Should(Succeed())
+						Eventually(func() error {
+							return checkGeneveTunnelsProgrammed(&testContext.Clusters[j])
 						}, timeout, interval).Should(Succeed())
 					}
 
@@ -406,20 +441,14 @@ func checkConnectionsReady(cl client.Client, restartTime time.Time) error {
 // and remote pods from flannel.1) a stale value makes the gateway drop every packet coming from
 // that node, so probe the datapath only once both resources match the current placement.
 func checkInternalFabricConverged(cl client.Client) error {
-	activeGatewayPods := &corev1.PodList{}
-	if err := cl.List(ctx, activeGatewayPods, &client.ListOptions{
-		LabelSelector: labels.SelectorFromSet(gateway.ForgeActiveGatewayPodLabels()),
-	}); err != nil {
-		return fmt.Errorf("unable to list active gateway pods: %w", err)
+	activeGatewayPods, err := listActiveGatewayPods(cl)
+	if err != nil {
+		return err
 	}
 
 	activeGatewayIPs := make(map[string]any)
 	for i := range activeGatewayPods.Items {
-		pod := &activeGatewayPods.Items[i]
-		if pod.Status.PodIP == "" {
-			return fmt.Errorf("active gateway pod %s/%s has no IP yet", pod.Namespace, pod.Name)
-		}
-		activeGatewayIPs[pod.Status.PodIP] = struct{}{}
+		activeGatewayIPs[activeGatewayPods.Items[i].Status.PodIP] = struct{}{}
 	}
 
 	internalFabricList := &networkingv1beta1.InternalFabricList{}
@@ -457,6 +486,189 @@ func checkInternalFabricConverged(cl client.Client) error {
 	}
 
 	return nil
+}
+
+// checkSourceIPsMatchRoutes checks that the source IPs recorded in the InternalNodes are the ones
+// the nodes actually use to reach the active gateway pods.
+//
+// checkInternalFabricConverged only requires those fields to be set, and a value sampled while the
+// CNI was still programming the routes of a node is set as well: a node which joins a cluster whose
+// peerings are already established samples the source towards the gateways as soon as it sees them,
+// and when the route is not there yet the lookup falls back to the default route and records an
+// address the node stops using seconds later. The gateway then builds a geneve tunnel whose remote
+// never matches the packets that node sends, and the datapath fails as a plain curl timeout, minutes
+// later and with nothing pointing at the cause. Comparing what was recorded with what the node
+// really uses reports the mismatch itself.
+func checkSourceIPsMatchRoutes(cluster *tester.ClusterContext, liqoNamespace string) error {
+	activeGatewayPods, err := listActiveGatewayPods(cluster.ControllerClient)
+	if err != nil {
+		return err
+	}
+
+	internalNodeList := &networkingv1beta1.InternalNodeList{}
+	if err := cluster.ControllerClient.List(ctx, internalNodeList); err != nil {
+		return fmt.Errorf("unable to list internalnodes: %w", err)
+	}
+
+	fabricPods := &corev1.PodList{}
+	if err := cluster.ControllerClient.List(ctx, fabricPods, client.InNamespace(liqoNamespace),
+		client.MatchingLabels{fabricPodLabelKey: fabricPodLabelValue}); err != nil {
+		return fmt.Errorf("unable to list the fabric pods: %w", err)
+	}
+
+	for i := range internalNodeList.Items {
+		internalNode := &internalNodeList.Items[i]
+		fabric := fabricPodOnNode(fabricPods, internalNode.Name)
+		if fabric == nil {
+			return fmt.Errorf("no fabric pod found on node %s", internalNode.Name)
+		}
+
+		for j := range activeGatewayPods.Items {
+			pod := &activeGatewayPods.Items[j]
+
+			recorded, kind := internalNode.Status.NodeIP.Remote, "remote"
+			if pod.Spec.NodeName == internalNode.Name {
+				recorded, kind = internalNode.Status.NodeIP.Local, "local"
+			}
+			if recorded == nil {
+				return fmt.Errorf("internalnode %s has no %s source IP yet for the active gateway pod %s/%s",
+					internalNode.Name, kind, pod.Namespace, pod.Name)
+			}
+
+			actual, err := sourceIPTowards(cluster, fabric, liqoNamespace, pod.Status.PodIP)
+			if err != nil {
+				return err
+			}
+
+			if actual != recorded.String() {
+				return fmt.Errorf(
+					"internalnode %s records %s source IP %s to reach the gateway pod %s/%s (%s), but node %s sources from %s",
+					internalNode.Name, kind, recorded, pod.Namespace, pod.Name, pod.Status.PodIP, internalNode.Name, actual)
+			}
+		}
+	}
+
+	return nil
+}
+
+// checkGeneveTunnelsProgrammed checks that every active gateway pod has a geneve interface towards
+// every node of its cluster.
+//
+// The gateway skips the nodes whose source IP is not set yet, and a gateway which becomes active
+// needs the field that the node it runs on, and the node the previous gateway ran on, have never had
+// populated: until the fabric fills them the peering has no internal fabric at all, and every check
+// crossing it fails. Asserting the interfaces are there makes the datapath probes start once the
+// gateway is really able to carry them.
+func checkGeneveTunnelsProgrammed(cluster *tester.ClusterContext) error {
+	activeGatewayPods, err := listActiveGatewayPods(cluster.ControllerClient)
+	if err != nil {
+		return err
+	}
+
+	internalNodeList := &networkingv1beta1.InternalNodeList{}
+	if err := cluster.ControllerClient.List(ctx, internalNodeList); err != nil {
+		return fmt.Errorf("unable to list internalnodes: %w", err)
+	}
+
+	for j := range activeGatewayPods.Items {
+		pod := &activeGatewayPods.Items[j]
+
+		stdout, stderr, err := util.ExecCmdInContainer(ctx, cluster.Config, cluster.NativeClient,
+			pod.Name, pod.Namespace, geneveContainerName, "ip -d link show type geneve")
+		if err != nil {
+			return fmt.Errorf("unable to list the geneve interfaces of gateway pod %s/%s: %w (%s)",
+				pod.Namespace, pod.Name, err, stderr)
+		}
+		programmed := parseGeneveRemotes(stdout)
+
+		for i := range internalNodeList.Items {
+			internalNode := &internalNodeList.Items[i]
+
+			expected := internalNode.Status.NodeIP.Remote
+			if pod.Spec.NodeName == internalNode.Name {
+				expected = internalNode.Status.NodeIP.Local
+			}
+			if expected == nil {
+				return fmt.Errorf("internalnode %s has no source IP yet for the active gateway pod %s/%s",
+					internalNode.Name, pod.Namespace, pod.Name)
+			}
+
+			if !slices.Contains(programmed, expected.String()) {
+				return fmt.Errorf("gateway pod %s/%s has no geneve interface towards %s (node %s), but only %v",
+					pod.Namespace, pod.Name, expected, internalNode.Name, programmed)
+			}
+		}
+	}
+
+	return nil
+}
+
+// listActiveGatewayPods returns the gateway pods which are currently active, once they all have an
+// address: the checks above compare that address with what the other resources point to.
+func listActiveGatewayPods(cl client.Client) (*corev1.PodList, error) {
+	activeGatewayPods := &corev1.PodList{}
+	if err := cl.List(ctx, activeGatewayPods, &client.ListOptions{
+		LabelSelector: labels.SelectorFromSet(gateway.ForgeActiveGatewayPodLabels()),
+	}); err != nil {
+		return nil, fmt.Errorf("unable to list active gateway pods: %w", err)
+	}
+
+	for i := range activeGatewayPods.Items {
+		pod := &activeGatewayPods.Items[i]
+		if pod.Status.PodIP == "" {
+			return nil, fmt.Errorf("active gateway pod %s/%s has no IP yet", pod.Namespace, pod.Name)
+		}
+	}
+
+	return activeGatewayPods, nil
+}
+
+// fabricPodOnNode returns the fabric pod running on the given node, nil when there is none.
+func fabricPodOnNode(pods *corev1.PodList, node string) *corev1.Pod {
+	for i := range pods.Items {
+		if pods.Items[i].Spec.NodeName == node {
+			return &pods.Items[i]
+		}
+	}
+	return nil
+}
+
+// sourceIPTowards returns the address the node of the given fabric pod uses to reach dst. The fabric
+// runs in the host network, so its routing table is the one of the node. Its image carries no
+// iproute2, only the ip applet of busybox: the plain "route get" both provide is enough here, as the
+// source address is read out of the fields of the answer.
+func sourceIPTowards(cluster *tester.ClusterContext, fabric *corev1.Pod, liqoNamespace, dst string) (string, error) {
+	stdout, stderr, err := util.ExecCmd(ctx, cluster.Config, cluster.NativeClient,
+		fabric.Name, liqoNamespace, fmt.Sprintf("ip route get %s", dst))
+	if err != nil {
+		return "", fmt.Errorf("unable to get the route to %s from node %s: %w (%s)",
+			dst, fabric.Spec.NodeName, err, stderr)
+	}
+
+	fields := strings.Fields(stdout)
+	for i := 0; i < len(fields)-1; i++ {
+		if fields[i] == "src" {
+			return fields[i+1], nil
+		}
+	}
+
+	return "", fmt.Errorf("no source address in the route to %s from node %s: %q", dst, fabric.Spec.NodeName, stdout)
+}
+
+// parseGeneveRemotes returns the remote addresses of the interfaces listed by
+// "ip -d link show type geneve", which carry them on their geneve detail line.
+func parseGeneveRemotes(out string) []string {
+	remotes := []string{}
+	for _, line := range strings.Split(out, "\n") {
+		fields := strings.Fields(line)
+		for i := 0; i < len(fields)-1; i++ {
+			if fields[i] == "remote" {
+				remotes = append(remotes, fields[i+1])
+				break
+			}
+		}
+	}
+	return remotes
 }
 
 // checkUniqueActiveGatewayPod checks if there is only one active gateway pod.

--- a/test/e2e/cruise/network/network_test.go
+++ b/test/e2e/cruise/network/network_test.go
@@ -147,6 +147,13 @@ var _ = Describe("Liqo E2E", func() {
 					}, timeout, interval).Should(Succeed())
 				}
 
+				// Check that the internal fabric caught up with the new gateway pods.
+				for i := range testContext.Clusters {
+					Eventually(func() error {
+						return checkInternalFabricConverged(testContext.Clusters[i].ControllerClient)
+					}, timeout, interval).Should(Succeed())
+				}
+
 				// Run the tests again.
 				Eventually(func() error {
 					return runLiqoctlNetworkTests(defaultArgs)
@@ -176,6 +183,14 @@ var _ = Describe("Liqo E2E", func() {
 					for j := range testContext.Clusters {
 						Eventually(func() error {
 							return checkConnectionsReady(testContext.Clusters[j].ControllerClient, restartTime)
+						}, timeout, interval).Should(Succeed())
+					}
+
+					// Connections only cover the inter-gateway tunnel: wait for the internal
+					// fabric to catch up with the new gateway pods before probing the datapath.
+					for j := range testContext.Clusters {
+						Eventually(func() error {
+							return checkInternalFabricConverged(testContext.Clusters[j].ControllerClient)
 						}, timeout, interval).Should(Succeed())
 					}
 
@@ -369,6 +384,78 @@ func checkConnectionsReady(cl client.Client, restartTime time.Time) error {
 				conn.Namespace, conn.Name, conn.Status.Latency.Timestamp, restartTime)
 		}
 	}
+	return nil
+}
+
+// checkInternalFabricConverged checks that the internal fabric has been reconfigured for the
+// gateway pods that are currently active.
+//
+// Connections only tell that the inter-gateway tunnel is up: they are probed over the tunnel
+// interface and never traverse the geneve tunnels connecting the nodes to the gateways. After a
+// gateway pod is replaced, the geneve tunnels are reprogrammed from two resources, and until both
+// caught up the node-to-gateway datapath may still point to the previous pod:
+//
+//   - InternalFabric.Spec.GatewayIP, the address the nodes use as the remote end of their geneve
+//     tunnel, which must be the IP of the active gateway pod;
+//   - InternalNode.Status.NodeIP, the address the gateway uses as the remote end of its own geneve
+//     tunnel towards each node. Local is the source a node uses to reach a gateway pod scheduled on
+//     itself, Remote the one it uses to reach a gateway pod on another node: which of the two is
+//     needed depends on where the active gateway pod is currently scheduled.
+//
+// With CNIs where the two sources differ (e.g. Flannel, where a node reaches local pods from cni0
+// and remote pods from flannel.1) a stale value makes the gateway drop every packet coming from
+// that node, so probe the datapath only once both resources match the current placement.
+func checkInternalFabricConverged(cl client.Client) error {
+	activeGatewayPods := &corev1.PodList{}
+	if err := cl.List(ctx, activeGatewayPods, &client.ListOptions{
+		LabelSelector: labels.SelectorFromSet(gateway.ForgeActiveGatewayPodLabels()),
+	}); err != nil {
+		return fmt.Errorf("unable to list active gateway pods: %w", err)
+	}
+
+	activeGatewayIPs := make(map[string]any)
+	for i := range activeGatewayPods.Items {
+		pod := &activeGatewayPods.Items[i]
+		if pod.Status.PodIP == "" {
+			return fmt.Errorf("active gateway pod %s/%s has no IP yet", pod.Namespace, pod.Name)
+		}
+		activeGatewayIPs[pod.Status.PodIP] = struct{}{}
+	}
+
+	internalFabricList := &networkingv1beta1.InternalFabricList{}
+	if err := cl.List(ctx, internalFabricList); err != nil {
+		return fmt.Errorf("unable to list internalfabrics: %w", err)
+	}
+
+	for i := range internalFabricList.Items {
+		internalFabric := &internalFabricList.Items[i]
+		if _, ok := activeGatewayIPs[internalFabric.Spec.GatewayIP.String()]; !ok {
+			return fmt.Errorf("internalfabric %s/%s still points to %s, which is not an active gateway pod",
+				internalFabric.Namespace, internalFabric.Name, internalFabric.Spec.GatewayIP)
+		}
+	}
+
+	internalNodeList := &networkingv1beta1.InternalNodeList{}
+	if err := cl.List(ctx, internalNodeList); err != nil {
+		return fmt.Errorf("unable to list internalnodes: %w", err)
+	}
+
+	for i := range internalNodeList.Items {
+		internalNode := &internalNodeList.Items[i]
+		for j := range activeGatewayPods.Items {
+			pod := &activeGatewayPods.Items[j]
+			if pod.Spec.NodeName == internalNode.Name {
+				if internalNode.Status.NodeIP.Local == nil {
+					return fmt.Errorf("internalnode %s hosts the active gateway pod %s/%s but has no local source IP yet",
+						internalNode.Name, pod.Namespace, pod.Name)
+				}
+			} else if internalNode.Status.NodeIP.Remote == nil {
+				return fmt.Errorf("internalnode %s has no remote source IP yet to reach the active gateway pod %s/%s",
+					internalNode.Name, pod.Namespace, pod.Name)
+			}
+		}
+	}
+
 	return nil
 }
 

--- a/test/e2e/pipeline/infra/cni.sh
+++ b/test/e2e/pipeline/infra/cni.sh
@@ -16,7 +16,10 @@ DOCKER_PROXY="${DOCKER_PROXY:-docker.io}"
 
 function install_calico() {
   local kubeconfig=$1
-  "${KUBECTL}" create -f https://raw.githubusercontent.com/projectcalico/calico/v3.26.1/manifests/tigera-operator.yaml --kubeconfig "$kubeconfig"
+  local calico_version="v3.32.1"
+
+  "${KUBECTL}" create -f "https://raw.githubusercontent.com/projectcalico/calico/${calico_version}/manifests/operator-crds.yaml" --kubeconfig "$kubeconfig"
+  "${KUBECTL}" create -f "https://raw.githubusercontent.com/projectcalico/calico/${calico_version}/manifests/tigera-operator.yaml" --kubeconfig "$kubeconfig"
 
   # Wait for the Installation CRD to be available
   if ! waitandretry 5s 12 "${KUBECTL} get crd installations.operator.tigera.io --kubeconfig $kubeconfig"; then
@@ -127,7 +130,7 @@ function install_flannel() {
   "${KUBECTL}" create ns kube-flannel --kubeconfig "$kubeconfig"
   "${KUBECTL}" label --overwrite ns kube-flannel pod-security.kubernetes.io/enforce=privileged --kubeconfig "$kubeconfig"
   "${HELM}" repo add flannel https://flannel-io.github.io/flannel/
-  "${HELM}" install flannel --set podCidr="${POD_CIDR}" --namespace kube-flannel flannel/flannel --kubeconfig "$kubeconfig"
+  "${HELM}" install flannel --set podCidr="${POD_CIDR}",flannel.mtu=1400,flannel.backendPort=8473 --namespace kube-flannel flannel/flannel --kubeconfig "$kubeconfig"
 }
 
 function wait_flannel() {

--- a/test/e2e/pipeline/infra/cni.sh
+++ b/test/e2e/pipeline/infra/cni.sh
@@ -140,3 +140,117 @@ function wait_flannel() {
     exit 1
   fi
 }
+
+# CNI_CHECK_NAMESPACE is the namespace hosting the pods used to check the CNI datapath.
+CNI_CHECK_NAMESPACE="liqo-cni-check"
+# CNI_CHECK_IMAGE is the image used by the pods checking the CNI datapath. It only needs a shell,
+# an HTTP server and an HTTP client, so keep it as small as possible to avoid slowing down the pull.
+CNI_CHECK_IMAGE="${CNI_CHECK_IMAGE:-${DOCKER_PROXY}/library/busybox:1.36}"
+
+# cni_probe_once issues a single HTTP request from the given pod to the given address.
+# It is a standalone function as waitandretry runs its command unquoted.
+function cni_probe_once() {
+  local kubeconfig=$1
+  local pod=$2
+  local address=$3
+
+  "${KUBECTL}" exec --kubeconfig "$kubeconfig" -n "${CNI_CHECK_NAMESPACE}" "$pod" -- \
+    wget -q -O /dev/null -T 3 "http://${address}:8080/"
+}
+
+# check_cni_datapath checks that two pods scheduled on different nodes can reach each other.
+#
+# A CNI reports its own pods as ready before the routes towards the other nodes are programmed:
+# Calico, for instance, has to allocate a block for every node and propagate it to the others.
+# Installing Liqo and peering on top of a partially configured datapath makes the network fabric
+# sample an incomplete routing table, and the resulting failures do not surface here: they show up
+# much later, as unreachable pods in the e2e network tests, and they do not recover on their own.
+function check_cni_datapath() {
+  local kubeconfig=$1
+
+  if ! "${KUBECTL}" wait --kubeconfig "$kubeconfig" --for=condition=Ready nodes --all --timeout=300s; then
+    echo "Failed to wait for the nodes to be ready"
+    exit 1
+  fi
+
+  local workers
+  read -r -a workers <<< "$("${KUBECTL}" get nodes --kubeconfig "$kubeconfig" \
+    --selector '!node-role.kubernetes.io/control-plane' -o jsonpath='{.items[*].metadata.name}')"
+
+  if [[ ${#workers[@]} -lt 2 ]]; then
+    echo "Skipping the CNI datapath check: it requires at least two worker nodes, found ${#workers[@]}"
+    return 0
+  fi
+
+  echo "Checking the CNI datapath between nodes ${workers[0]} and ${workers[1]}"
+
+  # The pods are pinned with nodeName to check the datapath between two given nodes without
+  # depending on the scheduler.
+  cat <<EOF | "${KUBECTL}" apply --kubeconfig "$kubeconfig" -f -
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ${CNI_CHECK_NAMESPACE}
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: cni-check-a
+  namespace: ${CNI_CHECK_NAMESPACE}
+spec:
+  nodeName: ${workers[0]}
+  containers:
+  - name: probe
+    image: ${CNI_CHECK_IMAGE}
+    command: ["/bin/sh", "-c"]
+    args: ["mkdir -p /www && echo ok > /www/index.html && exec httpd -f -p 8080 -h /www"]
+    readinessProbe:
+      tcpSocket:
+        port: 8080
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: cni-check-b
+  namespace: ${CNI_CHECK_NAMESPACE}
+spec:
+  nodeName: ${workers[1]}
+  containers:
+  - name: probe
+    image: ${CNI_CHECK_IMAGE}
+    command: ["/bin/sh", "-c"]
+    args: ["mkdir -p /www && echo ok > /www/index.html && exec httpd -f -p 8080 -h /www"]
+    readinessProbe:
+      tcpSocket:
+        port: 8080
+EOF
+
+  if ! "${KUBECTL}" wait --kubeconfig "$kubeconfig" -n "${CNI_CHECK_NAMESPACE}" \
+    --for=condition=Ready pod --all --timeout=300s; then
+    echo "Failed to wait for the CNI check pods to be ready"
+    exit 1
+  fi
+
+  local ip_a ip_b
+  ip_a=$("${KUBECTL}" get pod cni-check-a --kubeconfig "$kubeconfig" \
+    -n "${CNI_CHECK_NAMESPACE}" -o jsonpath='{.status.podIP}')
+  ip_b=$("${KUBECTL}" get pod cni-check-b --kubeconfig "$kubeconfig" \
+    -n "${CNI_CHECK_NAMESPACE}" -o jsonpath='{.status.podIP}')
+
+  # Check both directions, as the routes of the two nodes are programmed independently.
+  if ! waitandretry 2s 60 "cni_probe_once $kubeconfig cni-check-a $ip_b"; then
+    echo "Failed to reach ${ip_b} on ${workers[1]} from ${workers[0]}: the CNI datapath is not ready"
+    exit 1
+  fi
+  if ! waitandretry 2s 60 "cni_probe_once $kubeconfig cni-check-b $ip_a"; then
+    echo "Failed to reach ${ip_a} on ${workers[0]} from ${workers[1]}: the CNI datapath is not ready"
+    exit 1
+  fi
+
+  echo "The CNI datapath is ready"
+
+  "${KUBECTL}" delete namespace "${CNI_CHECK_NAMESPACE}" --kubeconfig "$kubeconfig" \
+    --wait=false --ignore-not-found
+}

--- a/test/e2e/pipeline/infra/kind/setup.sh
+++ b/test/e2e/pipeline/infra/kind/setup.sh
@@ -72,3 +72,16 @@ do
 	install_metrics_server "${TMPDIR}/kubeconfigs/liqo_kubeconf_${i}"
 done
 
+# The CNI of every cluster is checked in a second loop, so that it can converge while the
+# remaining clusters are created.
+for i in $(seq 1 "${CLUSTER_NUMBER}");
+do
+	if [[ ${DISABLE_KINDNET} == "true" ]]; then
+		echo "Waiting for the ${CNI} CNI of cluster ${CLUSTER_NAME}${i} to be ready..."
+		"wait_${CNI}" "${TMPDIR}/kubeconfigs/liqo_kubeconf_${i}"
+	fi
+
+	echo "Checking the CNI datapath of cluster ${CLUSTER_NAME}${i}..."
+	check_cni_datapath "${TMPDIR}/kubeconfigs/liqo_kubeconf_${i}"
+done
+

--- a/test/e2e/pipeline/infra/kubeadm/setup.sh
+++ b/test/e2e/pipeline/infra/kubeadm/setup.sh
@@ -104,4 +104,7 @@ done
 for i in $(seq 1 "${CLUSTER_NUMBER}"); do
   echo "Waiting for cluster ${CAPI_CLUSTER_NAME} CNI to be ready"
   "wait_${CNI}" "${TMPDIR}/kubeconfigs/liqo_kubeconf_${i}"
+
+  echo "Checking the CNI datapath of cluster ${CAPI_CLUSTER_NAME}"
+  check_cni_datapath "${TMPDIR}/kubeconfigs/liqo_kubeconf_${i}"
 done

--- a/test/e2e/testutils/util/exec.go
+++ b/test/e2e/testutils/util/exec.go
@@ -50,6 +50,13 @@ func ExecLiqoctl(kubeconfig string, args []string, output io.Writer) error {
 // ExecCmd executes a command inside a pod.
 func ExecCmd(ctx context.Context, config *rest.Config, client kubernetes.Interface,
 	podName, namespace, command string) (stdOut, stdErr string, retErr error) {
+	return ExecCmdInContainer(ctx, config, client, podName, namespace, "", command)
+}
+
+// ExecCmdInContainer executes a command inside the given container of a pod. An empty container
+// name selects the default one, as kubectl exec does.
+func ExecCmdInContainer(ctx context.Context, config *rest.Config, client kubernetes.Interface,
+	podName, namespace, container, command string) (stdOut, stdErr string, retErr error) {
 	cmd := []string{
 		"sh",
 		"-c",
@@ -61,11 +68,12 @@ func ExecCmd(ctx context.Context, config *rest.Config, client kubernetes.Interfa
 		Namespace(namespace).
 		SubResource("exec")
 	req.VersionedParams(&v1.PodExecOptions{
-		Stdin:   false,
-		Stdout:  true,
-		Stderr:  true,
-		TTY:     false,
-		Command: cmd,
+		Container: container,
+		Stdin:     false,
+		Stdout:    true,
+		Stderr:    true,
+		TTY:       false,
+		Command:   cmd,
 	}, scheme.ParameterCodec)
 
 	var stdout, stderr bytes.Buffer


### PR DESCRIPTION
This pull request updates the installation scripts for Calico and Flannel CNI plugins in the `test/e2e/pipeline/infra/cni.sh` file to improve compatibility and configuration. The main changes include updating Calico to a newer version and adding additional configuration options for Flannel.

**Calico installation updates:**
* Updated Calico installation to use version `v3.32.1` and now applies both `operator-crds.yaml` and `tigera-operator.yaml`.

**Flannel installation improvements:**
* Enhanced Flannel Helm installation by explicitly setting `flannel.mtu` to `1400` and `flannel.backendPort` to `8473`. The infrastructure had problems with the default MTU and ports it was updated to match the Cilium installation.