### PR TITLE
[Networking] ping in internalnode source-detector to check if the CNI is ready

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/virtual-kubelet/virtual-kubelet v1.11.0
 	github.com/vishvananda/netlink v1.3.0
 	golang.org/x/mod v0.29.0
+	golang.org/x/net v0.47.0
 	golang.org/x/sync v0.18.0
 	golang.org/x/sys v0.38.0
 	golang.zx2c4.com/wireguard v0.0.0-20220904105730-b51010ba13f0
@@ -258,7 +259,6 @@ require (
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/crypto v0.45.0 // indirect
-	golang.org/x/net v0.47.0 // indirect
 	golang.org/x/oauth2 v0.30.0 // indirect
 	golang.org/x/term v0.37.0 // indirect
 	golang.org/x/text v0.31.0 // indirect

--- a/pkg/fabric/source-detector/gateway_controller.go
+++ b/pkg/fabric/source-detector/gateway_controller.go
@@ -17,6 +17,7 @@ package sourcedetector
 import (
 	"context"
 	"fmt"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -87,6 +88,15 @@ func (r *GatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 
 	klog.V(4).Infof("Reconciling gateway pod %s", req.String())
+
+	// Verify that the gateway pod is actually reachable via ICMP before
+	// trusting the route selected by the kernel. This avoids recording a
+	// transient/wrong source IP when the CNI has not finished setting up
+	// the node routes yet.
+	if err := PingIP(pod.Status.PodIP, PingTimeout); err != nil {
+		klog.V(4).Infof("Gateway pod %s is not reachable yet: %v. Checking later", req.String(), err)
+		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+	}
 
 	src, err := GetSrcIPFromDstIP(pod.Status.PodIP)
 	if err != nil {

--- a/pkg/fabric/source-detector/ping.go
+++ b/pkg/fabric/source-detector/ping.go
@@ -1,0 +1,125 @@
+// Copyright 2019-2026 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sourcedetector
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"time"
+
+	"golang.org/x/net/icmp"
+	"golang.org/x/net/ipv4"
+	"golang.org/x/net/ipv6"
+)
+
+const (
+	// PingTimeout is the default timeout used when checking IP reachability.
+	PingTimeout = 5 * time.Second
+	// PingPayload is the payload sent with every ICMP echo request.
+	PingPayload = "liqo-source-detector"
+)
+
+// PingIP checks whether the provided IP is reachable by sending a single
+// ICMP echo request and waiting for an echo reply.
+// It works for both IPv4 and IPv6 destinations.
+func PingIP(ip string, timeout time.Duration) error {
+	dst := net.ParseIP(ip)
+	if dst == nil {
+		return fmt.Errorf("unable to parse IP %q", ip)
+	}
+
+	isV4 := dst.To4() != nil
+
+	var network string
+	var requestType, replyType icmp.Type
+	var proto int
+
+	if isV4 {
+		network = "ip4:icmp"
+		requestType = ipv4.ICMPTypeEcho
+		replyType = ipv4.ICMPTypeEchoReply
+		proto = ipv4.ICMPTypeEcho.Protocol()
+	} else {
+		network = "ip6:ipv6-icmp"
+		requestType = ipv6.ICMPTypeEchoRequest
+		replyType = ipv6.ICMPTypeEchoReply
+		proto = ipv6.ICMPTypeEchoRequest.Protocol()
+	}
+
+	conn, err := icmp.ListenPacket(network, "")
+	if err != nil {
+		return fmt.Errorf("unable to open ICMP socket: %w", err)
+	}
+	defer conn.Close()
+
+	if err := conn.SetDeadline(time.Now().Add(timeout)); err != nil {
+		return fmt.Errorf("unable to set ICMP deadline: %w", err)
+	}
+
+	id := os.Getpid() & 0xffff
+	seq := 1
+
+	msg := &icmp.Message{
+		Type: requestType,
+		Code: 0,
+		Body: &icmp.Echo{
+			ID:   id,
+			Seq:  seq,
+			Data: []byte(PingPayload),
+		},
+	}
+
+	data, err := msg.Marshal(nil)
+	if err != nil {
+		return fmt.Errorf("unable to marshal ICMP echo request: %w", err)
+	}
+
+	if _, err := conn.WriteTo(data, &net.IPAddr{IP: dst}); err != nil {
+		return fmt.Errorf("unable to send ICMP echo request to %q: %w", ip, err)
+	}
+
+	reply := make([]byte, 1500)
+	for {
+		n, peer, err := conn.ReadFrom(reply)
+		if err != nil {
+			return fmt.Errorf("ICMP ping to %q timed out or failed: %w", ip, err)
+		}
+
+		rm, err := icmp.ParseMessage(proto, reply[:n])
+		if err != nil {
+			continue
+		}
+
+		if rm.Type != replyType {
+			continue
+		}
+
+		echo, ok := rm.Body.(*icmp.Echo)
+		if !ok {
+			continue
+		}
+
+		if echo.ID != id || echo.Seq != seq {
+			continue
+		}
+
+		if peerIP, ok := peer.(*net.IPAddr); !ok || !peerIP.IP.Equal(dst) {
+			continue
+		}
+
+		return nil
+	}
+}

--- a/pkg/fabric/source-detector/ping_test.go
+++ b/pkg/fabric/source-detector/ping_test.go
@@ -1,0 +1,26 @@
+// Copyright 2019-2026 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sourcedetector
+
+import (
+	"testing"
+	"time"
+)
+
+func TestPingIPInvalidAddress(t *testing.T) {
+	if err := PingIP("not-an-ip", time.Second); err == nil {
+		t.Errorf("PingIP(%q) should return an error for invalid IPs", "not-an-ip")
+	}
+}


### PR DESCRIPTION
## Problem

When a new node is spun up, the CNI may not have finished programming the host routes yet. The `source-detector` controller runs with `hostNetwork: true` and computes the source IP used to reach a gateway pod via `netlink.RouteGet`. During the CNI setup window `RouteGet` can return a transient or wrong route, and the controller currently writes that result directly into `InternalNode.Status.NodeIP.Local/Remote`. Once written, downstream consumers treat the value as authoritative.

## Solution

Add an ICMP reachability check before trusting the route. The controller now sends a single ICMP echo request to the gateway pod IP and waits for an echo reply. If the pod is not reachable, the reconciliation is requeued after 5 seconds instead of recording a wrong source IP.

This approach is CNI-agnostic: it does not rely on CNI-specific files, annotations, or behaviours. It only requires that the destination is reachable through the routes installed by the CNI, which is true for any correctly configured CNI.

## Changes

- Added `pkg/fabric/source-detector/ping.go` with a `PingIP` helper supporting IPv4 and IPv6.
- Updated `pkg/fabric/source-detector/gateway_controller.go` to call `PingIP` before `GetSrcIPFromDstIP`.
- Added a basic unit test for invalid IP handling in `pkg/fabric/source-detector/ping_test.go`.
- Promoted `golang.org/x/net` to a direct dependency in `go.mod`.

## Verification

```bash
GOOS=linux go build ./pkg/fabric/source-detector/...
GOOS=linux go vet ./pkg/fabric/source-detector/...
GOOS=linux go test -c ./pkg/fabric/source-detector/...
```

## Notes / Limitations

- The fabric DaemonSet is `hostNetwork: true`, `privileged: true`, and has `NET_RAW`, so raw ICMP sockets are available.
- If ICMP is firewalled between nodes, the controller will keep requeueing. In such environments this check should be combined with additional route/interface readiness validation.

Special thanks to @Gabbe64 for finding this bug