### PR TITLE
feat(authentication): allow the provider to resolve the ResourceSlice class when unspecified

### DIFF
--- a/apis/authentication/v1beta1/resourceslice_types.go
+++ b/apis/authentication/v1beta1/resourceslice_types.go
@@ -45,6 +45,9 @@ const (
 )
 
 // ResourceSliceSpec defines the desired state of ResourceSlice.
+// +kubebuilder:validation:XValidation:rule="has(self.class) == has(oldSelf.class) && (!has(self.class) || self.class == oldSelf.class)",message="Class is immutable"
+//
+//nolint:lll // ignore long lines given by Kubebuilder marker annotations
 type ResourceSliceSpec struct {
 	// ConsumerClusterID is the id of the consumer cluster.
 	ConsumerClusterID *liqov1beta1.ClusterID `json:"consumerClusterID,omitempty"`
@@ -52,10 +55,13 @@ type ResourceSliceSpec struct {
 	ProviderClusterID *liqov1beta1.ClusterID `json:"providerClusterID,omitempty"`
 	// Resources contains the slice of resources requested.
 	Resources corev1.ResourceList `json:"resources,omitempty"`
-	// Class contains the class of the ResourceSlice.
+	// Class contains the class of the ResourceSlice. It is immutable once the ResourceSlice is created.
 	Class ResourceSliceClass `json:"class,omitempty"`
 	// CSR is the Certificate Signing Request of the consumer cluster.
 	CSR []byte `json:"csr,omitempty"`
+
+	// NOTE: the immutability rule for Class is enforced at the spec level, and not on the field itself,
+	// as validation rules defined on optional fields are not evaluated when the field is unset.
 }
 
 // ResourceSliceConditionType represents different types of conditions that a ResourceSlice could assume.
@@ -99,6 +105,11 @@ type ResourceSliceCondition struct {
 type ResourceSliceStatus struct {
 	// Conditions contains the conditions of the ResourceSlice.
 	Conditions []ResourceSliceCondition `json:"conditions,omitempty"`
+	// Class contains the class resolved by the provider cluster, when the consumer did not request
+	// an explicit one. It is set at most once, when the resources of the ResourceSlice are first
+	// handled, so that configuring or changing the default on the provider only affects the
+	// ResourceSlices created afterwards.
+	Class ResourceSliceClass `json:"class,omitempty"`
 	// Resources contains the slice of resources accepted.
 	Resources corev1.ResourceList `json:"resources,omitempty"`
 	// AuthParams contains the authentication parameters for the resources given by the provider cluster.
@@ -129,6 +140,17 @@ type ResourceSlice struct {
 
 	Spec   ResourceSliceSpec   `json:"spec,omitempty"`
 	Status ResourceSliceStatus `json:"status,omitempty"`
+}
+
+// EffectiveClass returns the class the ResourceSlice is handled with: the one resolved by the
+// provider cluster, if any, or the one requested by the consumer otherwise.
+// ResourceSlice class controllers must rely on this method, and not on the spec alone, to select
+// the ResourceSlices they are responsible for.
+func (rs *ResourceSlice) EffectiveClass() ResourceSliceClass {
+	if rs.Status.Class != ResourceSliceClassUnknown {
+		return rs.Status.Class
+	}
+	return rs.Spec.Class
 }
 
 // +kubebuilder:object:root=true

--- a/cmd/liqo-controller-manager/modules/authentication.go
+++ b/cmd/liqo-controller-manager/modules/authentication.go
@@ -22,6 +22,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
+	authv1beta1 "github.com/liqotech/liqo/apis/authentication/v1beta1"
 	liqov1beta1 "github.com/liqotech/liqo/apis/core/v1beta1"
 	identitymanager "github.com/liqotech/liqo/pkg/identityManager"
 	liqocontrollermanager "github.com/liqotech/liqo/pkg/liqo-controller-manager"
@@ -71,6 +72,7 @@ func NewAuthOption(identityProvider identitymanager.IdentityProvider, namespaceM
 			ClusterLabels:                    opts.ClusterLabels.StringMap,
 			DefaultResourceQuantity:          opts.DefaultNodeResources.ToResourceList(),
 			DefaultResourceSliceClassEnabled: opts.DefaultResourceSliceClassEnabled,
+			DefaultResourceSliceClass:        authv1beta1.ResourceSliceClass(opts.DefaultResourceSliceClass),
 		},
 	}
 }

--- a/cmd/liqoctl/cmd/peer.go
+++ b/cmd/liqoctl/cmd/peer.go
@@ -121,7 +121,8 @@ func newPeerCommand(ctx context.Context, f *factory.Factory) *cobra.Command {
 
 	// Authentication flags
 	cmd.Flags().BoolVar(&options.CreateResourceSlice, "create-resource-slice", true, "Create a ResourceSlice for the peering")
-	cmd.Flags().StringVar(&options.ResourceSliceClass, "resource-slice-class", "default", "The class of the ResourceSlice")
+	cmd.Flags().StringVar(&options.ResourceSliceClass, "resource-slice-class", "", "The class of the ResourceSlice. "+
+		"When left empty, the class configured on the provider cluster is used")
 	cmd.Flags().BoolVar(&options.InBand, "in-band", false, "Use in-band authentication. Use it only if required and if you know what you are doing")
 	cmd.Flags().StringVar(&options.ProxyURL, "proxy-url", "", "The URL of the proxy to use for the communication with the remote cluster")
 

--- a/deployments/liqo/README.md
+++ b/deployments/liqo/README.md
@@ -10,6 +10,7 @@
 | authentication.awsConfig.region | string | `""` | AWS region where the clsuter is runnnig. |
 | authentication.awsConfig.secretAccessKey | string | `""` | SecretAccessKey for the Liqo user. |
 | authentication.awsConfig.useExistingSecret | bool | `false` | Use an existing secret to configure the AWS credentials. |
+| authentication.defaultResourceSliceClass | string | `""` | The ResourceSlice class assigned by the provider to the ResourceSlices that do not request an explicit one. The resolved class is recorded once, hence changing this value only affects the ResourceSlices created afterwards. Leave empty to keep handling them with the built-in default class. |
 | authentication.defaultResourceSliceClassEnabled | bool | `true` | Enable the built-in default ResourceSlice class. When set to false, the provider denies ResourceSlices that use the "default" class, so consumers must use an explicit, provider-approved ResourceSlice class. |
 | authentication.enabled | bool | `true` | Enable/Disable the authentication module. |
 | authentication.tlsCompatibilityMode | bool | `false` | Enable TLS compatibility mode for client certificates and keys. If set to true, Liqo will use widely supported algorithm (RSA) instead of Ed25519 (default) for generating private keys and CSRs. Enable this option to ensure compatibility with systems that do not yet support Ed25519 as signature algorithm. |

--- a/deployments/liqo/charts/liqo-crds/crds/authentication.liqo.io_resourceslices.yaml
+++ b/deployments/liqo/charts/liqo-crds/crds/authentication.liqo.io_resourceslices.yaml
@@ -55,7 +55,8 @@ spec:
             description: ResourceSliceSpec defines the desired state of ResourceSlice.
             properties:
               class:
-                description: Class contains the class of the ResourceSlice.
+                description: Class contains the class of the ResourceSlice. It is
+                  immutable once the ResourceSlice is created.
                 type: string
               consumerClusterID:
                 description: ConsumerClusterID is the id of the consumer cluster.
@@ -80,6 +81,10 @@ spec:
                 description: Resources contains the slice of resources requested.
                 type: object
             type: object
+            x-kubernetes-validations:
+            - message: Class is immutable
+              rule: has(self.class) == has(oldSelf.class) && (!has(self.class) ||
+                self.class == oldSelf.class)
           status:
             description: ResourceSliceStatus defines the observed state of ResourceSlice.
             properties:
@@ -119,6 +124,13 @@ spec:
                     format: byte
                     type: string
                 type: object
+              class:
+                description: |-
+                  Class contains the class resolved by the provider cluster, when the consumer did not request
+                  an explicit one. It is set at most once, when the resources of the ResourceSlice are first
+                  handled, so that configuring or changing the default on the provider only affects the
+                  ResourceSlices created afterwards.
+                type: string
               conditions:
                 description: Conditions contains the conditions of the ResourceSlice.
                 items:

--- a/deployments/liqo/templates/liqo-controller-manager-deployment.yaml
+++ b/deployments/liqo/templates/liqo-controller-manager-deployment.yaml
@@ -54,6 +54,9 @@ spec:
           - --authentication-enabled={{ .Values.authentication.enabled }}
           - --tls-compatibility-mode={{ .Values.authentication.tlsCompatibilityMode }}
           - --default-resource-slice-class-enabled={{ .Values.authentication.defaultResourceSliceClassEnabled }}
+          {{- if .Values.authentication.defaultResourceSliceClass }}
+          - --default-resource-slice-class={{ .Values.authentication.defaultResourceSliceClass }}
+          {{- end }}
           - --offloading-enabled={{ .Values.offloading.enabled }}
           - --default-limits-enforcement={{ .Values.controllerManager.config.defaultLimitsEnforcement }}
           {{- $d := dict "commandName" "--default-node-resources" "dictionary" .Values.offloading.defaultNodeResources -}}

--- a/deployments/liqo/values.yaml
+++ b/deployments/liqo/values.yaml
@@ -259,6 +259,10 @@ authentication:
   # ResourceSlices that use the "default" class, so consumers must
   # use an explicit, provider-approved ResourceSlice class.
   defaultResourceSliceClassEnabled: true
+  # -- The ResourceSlice class assigned by the provider to the ResourceSlices that do not request an
+  # explicit one. The resolved class is recorded once, hence changing this value only affects the
+  # ResourceSlices created afterwards. Leave empty to keep handling them with the built-in default class.
+  defaultResourceSliceClass: ""
   # AWS-specific configuration for the local cluster and the Liqo user.
   # This user should be able (1) to create new IAM users, (2) to create new programmatic access
   # credentials, and (3) to describe EKS clusters.

--- a/docs/advanced/peering/offloading-in-depth.md
+++ b/docs/advanced/peering/offloading-in-depth.md
@@ -153,6 +153,9 @@ Once a custom class is defined in the `ResourceSlice` spec, the custom ResourceS
 The custom controller might deny the request, fully accept it, or partially accept it by providing only a portion of the requested resources.
 The `VirtualNode` in the consumer cluster and the `Quota` in the provider cluster will be created based on the resources granted by the custom controller.
 
+If the class is left unspecified, the provider cluster may assign one of its own, configured through the `authentication.defaultResourceSliceClass` Helm value, and record it in `status.class` (see [Choosing the class on the provider](/usage/resource-reservation.md#choosing-the-class-on-the-provider)).
+The class a `ResourceSlice` is handled with is therefore the one in `status.class` when set, and the one in `spec.class` otherwise: a custom controller must select the `ResourceSlice`s it is responsible for through this pair, as implemented by the `EffectiveClass()` method of the `ResourceSlice` type.
+
 ### Delete ResourceSlice
 
 You can revert the process by deleting the `ResourceSlice` in the consumer cluster.

--- a/docs/usage/liqoctl/liqoctl_create.md
+++ b/docs/usage/liqoctl/liqoctl_create.md
@@ -508,7 +508,7 @@ liqoctl create resourceslice [flags]
 ### Options
 `--class` _string_:
 
->The class of the ResourceSlice **(default "default")**
+>The class of the ResourceSlice. When left empty, the class configured on the provider cluster is used
 
 `--cpu` _string_:
 

--- a/docs/usage/liqoctl/liqoctl_peer.md
+++ b/docs/usage/liqoctl/liqoctl_peer.md
@@ -153,7 +153,7 @@ liqoctl peer [flags]
 
 `--resource-slice-class` _string_:
 
->The class of the ResourceSlice **(default "default")**
+>The class of the ResourceSlice. When left empty, the class configured on the provider cluster is used
 
 `--skip-validation`
 

--- a/docs/usage/resource-reservation.md
+++ b/docs/usage/resource-reservation.md
@@ -251,6 +251,27 @@ authentication:
 
 When the default class is disabled, any `ResourceSlice` that uses the `default` class is denied: its `Resources` condition is set to `Denied` with an explanatory message, instead of leaving the consumer waiting until timeout. Consumers must then request an explicit class handled by a custom controller. The default value is `true`, which preserves the previous behavior.
 
+(ResourceReservationDefaultClass)=
+
+### Choosing the class on the provider
+
+Requiring an explicit class means that every consumer has to know the class names used by the provider. To avoid that, the **provider** can declare which class to use for the `ResourceSlice`s that do not request one:
+
+```{code-block} yaml
+:caption: "values.yaml (provider)"
+authentication:
+  defaultResourceSliceClass: "my-class"
+```
+
+When a consumer creates a `ResourceSlice` without specifying a class, the provider assigns the configured one and records it in `status.class`. The consumer's `spec.class` is left untouched, so the request keeps reflecting what was asked for, while the provider decides how it is served.
+
+The class is resolved **once**, when the `ResourceSlice` is first reconciled. Changing `defaultResourceSliceClass` later therefore affects only the `ResourceSlice`s created afterwards, and never reshuffles the existing ones. Consistently, `spec.class` is immutable: attempting to change it on an existing `ResourceSlice` is rejected.
+
+```{admonition} Writing a class controller
+:class: note
+The class actually in use is the one in `status.class` when set, and `spec.class` otherwise. Custom class controllers must select the `ResourceSlice`s they are responsible for through this pair, and not through `spec.class` alone, otherwise they will not see the requests remapped by the provider. The `EffectiveClass()` method on the `ResourceSlice` type implements this.
+```
+
 (ResourceReservationSuspendReclaim)=
 
 ## Suspend and reclaim a reservation

--- a/pkg/liqo-controller-manager/authentication/forge/forge_suite_test.go
+++ b/pkg/liqo-controller-manager/authentication/forge/forge_suite_test.go
@@ -1,0 +1,35 @@
+// Copyright 2019-2026 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package forge_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/klog/v2"
+
+	testutil "github.com/liqotech/liqo/pkg/utils/testutil"
+)
+
+var _ = BeforeSuite(func() {
+	testutil.LogsToGinkgoWriter()
+})
+
+func TestForge(t *testing.T) {
+	RegisterFailHandler(Fail)
+	klog.InitFlags(nil)
+	RunSpecs(t, "Authentication Forge Suite")
+}

--- a/pkg/liqo-controller-manager/authentication/forge/resourceslice.go
+++ b/pkg/liqo-controller-manager/authentication/forge/resourceslice.go
@@ -67,8 +67,15 @@ func MutateResourceSlice(resourceSlice *authv1beta1.ResourceSlice, remoteCluster
 		return err
 	}
 
+	// Preserve the class already set on the ResourceSlice when no explicit one is requested: the class
+	// is immutable, hence resetting it to the empty value would make the update be rejected.
+	class := opts.Class
+	if class == authv1beta1.ResourceSliceClassUnknown {
+		class = resourceSlice.Spec.Class
+	}
+
 	resourceSlice.Spec = authv1beta1.ResourceSliceSpec{
-		Class:             opts.Class,
+		Class:             class,
 		ProviderClusterID: ptr.To(remoteClusterID),
 		Resources:         rl,
 	}

--- a/pkg/liqo-controller-manager/authentication/forge/resourceslice_test.go
+++ b/pkg/liqo-controller-manager/authentication/forge/resourceslice_test.go
@@ -1,0 +1,78 @@
+// Copyright 2019-2026 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package forge_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	authv1beta1 "github.com/liqotech/liqo/apis/authentication/v1beta1"
+	liqov1beta1 "github.com/liqotech/liqo/apis/core/v1beta1"
+	"github.com/liqotech/liqo/pkg/liqo-controller-manager/authentication/forge"
+)
+
+var _ = Describe("The MutateResourceSlice function", func() {
+	const (
+		remoteClusterID = liqov1beta1.ClusterID("cool-firefly")
+		existingClass   = authv1beta1.ResourceSliceClass("custom-class")
+		requestedClass  = authv1beta1.ResourceSliceClass("other-class")
+	)
+
+	var (
+		resourceSlice *authv1beta1.ResourceSlice
+		opts          *forge.ResourceSliceOptions
+		err           error
+	)
+
+	JustBeforeEach(func() {
+		err = forge.MutateResourceSlice(resourceSlice, remoteClusterID, opts, true)
+	})
+
+	When("no class is requested, and the ResourceSlice already has one", func() {
+		BeforeEach(func() {
+			resourceSlice = &authv1beta1.ResourceSlice{Spec: authv1beta1.ResourceSliceSpec{Class: existingClass}}
+			opts = &forge.ResourceSliceOptions{Class: authv1beta1.ResourceSliceClassUnknown}
+		})
+
+		It("should preserve the existing class, as it is immutable", func() {
+			Expect(err).ToNot(HaveOccurred())
+			Expect(resourceSlice.Spec.Class).To(BeEquivalentTo(existingClass))
+		})
+	})
+
+	When("a class is requested", func() {
+		BeforeEach(func() {
+			resourceSlice = &authv1beta1.ResourceSlice{Spec: authv1beta1.ResourceSliceSpec{Class: existingClass}}
+			opts = &forge.ResourceSliceOptions{Class: requestedClass}
+		})
+
+		It("should set the requested class, letting the API server reject the change", func() {
+			Expect(err).ToNot(HaveOccurred())
+			Expect(resourceSlice.Spec.Class).To(BeEquivalentTo(requestedClass))
+		})
+	})
+
+	When("no class is requested, and the ResourceSlice does not have one", func() {
+		BeforeEach(func() {
+			resourceSlice = &authv1beta1.ResourceSlice{}
+			opts = &forge.ResourceSliceOptions{Class: authv1beta1.ResourceSliceClassUnknown}
+		})
+
+		It("should leave the class empty, for the provider to resolve it", func() {
+			Expect(err).ToNot(HaveOccurred())
+			Expect(resourceSlice.Spec.Class).To(BeEquivalentTo(authv1beta1.ResourceSliceClassUnknown))
+		})
+	})
+})

--- a/pkg/liqo-controller-manager/authentication/remoteresourceslice-controller/classresolution_test.go
+++ b/pkg/liqo-controller-manager/authentication/remoteresourceslice-controller/classresolution_test.go
@@ -1,0 +1,171 @@
+// Copyright 2019-2026 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package remoteresourceslicecontroller
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/client-go/tools/record"
+
+	authv1beta1 "github.com/liqotech/liqo/apis/authentication/v1beta1"
+)
+
+var _ = Describe("ResourceSlice class resolution", func() {
+	const (
+		providerClass = authv1beta1.ResourceSliceClass("provider-class")
+		customClass   = authv1beta1.ResourceSliceClass("custom-class")
+	)
+
+	var (
+		reconciler    *RemoteResourceSliceReconciler
+		resourceSlice *authv1beta1.ResourceSlice
+	)
+
+	// newReconciler returns a reconciler configured with the given provider-side default class.
+	newReconciler := func(defaultClass authv1beta1.ResourceSliceClass) *RemoteResourceSliceReconciler {
+		return &RemoteResourceSliceReconciler{
+			eventRecorder: record.NewFakeRecorder(10),
+			sliceStatusOptions: &SliceStatusOptions{
+				DefaultResourceSliceClass: defaultClass,
+			},
+			reconciledClasses: []authv1beta1.ResourceSliceClass{
+				authv1beta1.ResourceSliceClassDefault,
+				authv1beta1.ResourceSliceClassUnknown,
+			},
+		}
+	}
+
+	newResourceSlice := func(spec, status authv1beta1.ResourceSliceClass) *authv1beta1.ResourceSlice {
+		return &authv1beta1.ResourceSlice{
+			Spec:   authv1beta1.ResourceSliceSpec{Class: spec},
+			Status: authv1beta1.ResourceSliceStatus{Class: status},
+		}
+	}
+
+	// handled marks the resources of the ResourceSlice as already processed by a class controller.
+	handled := func(rs *authv1beta1.ResourceSlice) *authv1beta1.ResourceSlice {
+		rs.Status.Conditions = append(rs.Status.Conditions, authv1beta1.ResourceSliceCondition{
+			Type:   authv1beta1.ResourceSliceConditionTypeResources,
+			Status: authv1beta1.ResourceSliceConditionAccepted,
+		})
+		return rs
+	}
+
+	Describe("The resolveClass function", func() {
+		JustBeforeEach(func() { reconciler.resolveClass(resourceSlice) })
+
+		When("no default class is configured on the provider", func() {
+			BeforeEach(func() {
+				reconciler = newReconciler(authv1beta1.ResourceSliceClassUnknown)
+				resourceSlice = newResourceSlice(authv1beta1.ResourceSliceClassUnknown, authv1beta1.ResourceSliceClassUnknown)
+			})
+
+			It("should leave the class unresolved, preserving the previous behavior", func() {
+				Expect(resourceSlice.Status.Class).To(BeEquivalentTo(authv1beta1.ResourceSliceClassUnknown))
+				Expect(resourceSlice.EffectiveClass()).To(BeEquivalentTo(authv1beta1.ResourceSliceClassUnknown))
+			})
+		})
+
+		When("a default class is configured, and the consumer did not request any", func() {
+			BeforeEach(func() {
+				reconciler = newReconciler(providerClass)
+				resourceSlice = newResourceSlice(authv1beta1.ResourceSliceClassUnknown, authv1beta1.ResourceSliceClassUnknown)
+			})
+
+			It("should record the configured class in the status, leaving the spec untouched", func() {
+				Expect(resourceSlice.Status.Class).To(BeEquivalentTo(providerClass))
+				Expect(resourceSlice.Spec.Class).To(BeEquivalentTo(authv1beta1.ResourceSliceClassUnknown))
+				Expect(resourceSlice.EffectiveClass()).To(BeEquivalentTo(providerClass))
+			})
+		})
+
+		When("the class has already been resolved", func() {
+			BeforeEach(func() {
+				reconciler = newReconciler(providerClass)
+				resourceSlice = newResourceSlice(authv1beta1.ResourceSliceClassUnknown, customClass)
+			})
+
+			It("should never reconsider it, so that changing the default only affects new ResourceSlices", func() {
+				Expect(resourceSlice.Status.Class).To(BeEquivalentTo(customClass))
+			})
+		})
+
+		When("the consumer requested an explicit class", func() {
+			BeforeEach(func() {
+				reconciler = newReconciler(providerClass)
+				resourceSlice = newResourceSlice(customClass, authv1beta1.ResourceSliceClassUnknown)
+			})
+
+			It("should honor it, without resolving anything", func() {
+				Expect(resourceSlice.Status.Class).To(BeEquivalentTo(authv1beta1.ResourceSliceClassUnknown))
+				Expect(resourceSlice.EffectiveClass()).To(BeEquivalentTo(customClass))
+			})
+		})
+
+		When("the resources have already been handled, before any default was configured", func() {
+			BeforeEach(func() {
+				reconciler = newReconciler(providerClass)
+				resourceSlice = handled(newResourceSlice(authv1beta1.ResourceSliceClassUnknown, authv1beta1.ResourceSliceClassUnknown))
+			})
+
+			It("should leave it to the controller already responsible for it", func() {
+				Expect(resourceSlice.Status.Class).To(BeEquivalentTo(authv1beta1.ResourceSliceClassUnknown))
+				Expect(isInResourceClasses(resourceSlice, reconciler.reconciledClasses...)).To(BeTrue())
+			})
+		})
+	})
+
+	Describe("The isInResourceClasses function", func() {
+		var claimed bool
+
+		JustBeforeEach(func() {
+			reconciler.resolveClass(resourceSlice)
+			claimed = isInResourceClasses(resourceSlice, reconciler.reconciledClasses...)
+		})
+
+		When("the empty class is remapped to a custom one", func() {
+			BeforeEach(func() {
+				reconciler = newReconciler(providerClass)
+				resourceSlice = newResourceSlice(authv1beta1.ResourceSliceClassUnknown, authv1beta1.ResourceSliceClassUnknown)
+			})
+
+			It("should leave the ResourceSlice to the controller of the resolved class", func() {
+				Expect(claimed).To(BeFalse())
+			})
+		})
+
+		When("no default class is configured", func() {
+			BeforeEach(func() {
+				reconciler = newReconciler(authv1beta1.ResourceSliceClassUnknown)
+				resourceSlice = newResourceSlice(authv1beta1.ResourceSliceClassUnknown, authv1beta1.ResourceSliceClassUnknown)
+			})
+
+			It("should keep handling the empty class with the built-in one", func() {
+				Expect(claimed).To(BeTrue())
+			})
+		})
+
+		When("the empty class is remapped to the built-in default one", func() {
+			BeforeEach(func() {
+				reconciler = newReconciler(authv1beta1.ResourceSliceClassDefault)
+				resourceSlice = newResourceSlice(authv1beta1.ResourceSliceClassUnknown, authv1beta1.ResourceSliceClassUnknown)
+			})
+
+			It("should keep handling it with the built-in one", func() {
+				Expect(claimed).To(BeTrue())
+			})
+		})
+	})
+})

--- a/pkg/liqo-controller-manager/authentication/remoteresourceslice-controller/remoteresourceslice_controller.go
+++ b/pkg/liqo-controller-manager/authentication/remoteresourceslice-controller/remoteresourceslice_controller.go
@@ -17,6 +17,7 @@ package remoteresourceslicecontroller
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -242,9 +243,39 @@ func (r *RemoteResourceSliceReconciler) handleAuthenticationStatus(ctx context.C
 	return requeueIn, nil
 }
 
+// resolveClass records the class the provider assigns to a ResourceSlice that did not request an explicit
+// one. It is recorded in the status, which is owned by the provider, so that the spec keeps reflecting what
+// the consumer asked for. The class is resolved at most once, and never for the ResourceSlices whose
+// resources have already been handled, so that configuring or changing the default on the provider leaves
+// the existing ResourceSlices untouched, and only affects the ones created later on.
+func (r *RemoteResourceSliceReconciler) resolveClass(resourceSlice *authv1beta1.ResourceSlice) {
+	resourcesCondition := authentication.GetCondition(resourceSlice, authv1beta1.ResourceSliceConditionTypeResources)
+
+	switch {
+	case r.sliceStatusOptions.DefaultResourceSliceClass == authv1beta1.ResourceSliceClassUnknown:
+		// No default configured: the ResourceSlice keeps being handled by the built-in default class.
+	case resourceSlice.Status.Class != authv1beta1.ResourceSliceClassUnknown:
+		// The class has already been resolved, and it is never reconsidered.
+	case resourceSlice.Spec.Class != authv1beta1.ResourceSliceClassUnknown:
+		// The consumer requested an explicit class, which is honored as it is.
+	case resourcesCondition != nil && resourcesCondition.Status != "":
+		// The resources have already been handled, hence the ResourceSlice predates the configuration of
+		// the default class: reassigning it now would change the controller responsible for it.
+	default:
+		resourceSlice.Status.Class = r.sliceStatusOptions.DefaultResourceSliceClass
+		klog.Infof("ResourceSlice %q class resolved to %q",
+			client.ObjectKeyFromObject(resourceSlice), resourceSlice.Status.Class)
+		r.eventRecorder.Event(resourceSlice, corev1.EventTypeNormal, "ResourceSliceClassResolved",
+			fmt.Sprintf("ResourceSlice class resolved to %q", resourceSlice.Status.Class))
+	}
+}
+
 func (r *RemoteResourceSliceReconciler) handleResourcesStatus(ctx context.Context,
 	resourceSlice *authv1beta1.ResourceSlice, tenant *authv1beta1.Tenant) error {
 	var err error
+
+	// Fill in the class requested by the consumer, if empty, with the one configured on the provider.
+	r.resolveClass(resourceSlice)
 
 	switch tenant.Spec.TenantCondition {
 	case authv1beta1.TenantConditionActive:
@@ -455,12 +486,7 @@ func denyResourcesWithReason(resourceSlice *authv1beta1.ResourceSlice, er record
 }
 
 func isInResourceClasses(resourceSlice *authv1beta1.ResourceSlice, classes ...authv1beta1.ResourceSliceClass) bool {
-	for _, class := range classes {
-		if resourceSlice.Spec.Class == class {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(classes, resourceSlice.EffectiveClass())
 }
 
 // validateRSNamespace makes sure that the ResourceSlice has been created in the tenant namespace dedicated to the consumer cluster.

--- a/pkg/liqo-controller-manager/authentication/remoteresourceslice-controller/remoteresourceslice_suite_test.go
+++ b/pkg/liqo-controller-manager/authentication/remoteresourceslice-controller/remoteresourceslice_suite_test.go
@@ -1,0 +1,35 @@
+// Copyright 2019-2026 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package remoteresourceslicecontroller
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/klog/v2"
+
+	testutil "github.com/liqotech/liqo/pkg/utils/testutil"
+)
+
+var _ = BeforeSuite(func() {
+	testutil.LogsToGinkgoWriter()
+})
+
+func TestRemoteResourceSliceController(t *testing.T) {
+	RegisterFailHandler(Fail)
+	klog.InitFlags(nil)
+	RunSpecs(t, "RemoteResourceSlice Controller Suite")
+}

--- a/pkg/liqo-controller-manager/authentication/remoteresourceslice-controller/slicestatus.go
+++ b/pkg/liqo-controller-manager/authentication/remoteresourceslice-controller/slicestatus.go
@@ -22,6 +22,7 @@ import (
 	storagev1 "k8s.io/api/storage/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	authv1beta1 "github.com/liqotech/liqo/apis/authentication/v1beta1"
 	liqov1beta1 "github.com/liqotech/liqo/apis/core/v1beta1"
 	argutils "github.com/liqotech/liqo/pkg/utils/args"
 )
@@ -37,6 +38,9 @@ type SliceStatusOptions struct {
 	// DefaultResourceSliceClassEnabled enables the built-in default ResourceSlice class.
 	// When false, ResourceSlices of the default (or empty) class are denied instead of accepted.
 	DefaultResourceSliceClassEnabled bool
+	// DefaultResourceSliceClass is the class assigned to the ResourceSlices that do not request an
+	// explicit one. When empty, they keep being handled by the built-in default class.
+	DefaultResourceSliceClass authv1beta1.ResourceSliceClass
 }
 
 func getIngressClasses(opts *SliceStatusOptions) []liqov1beta1.IngressType {

--- a/pkg/liqo-controller-manager/flags.go
+++ b/pkg/liqo-controller-manager/flags.go
@@ -92,6 +92,10 @@ func InitFlags(flagset *pflag.FlagSet, opts *Options) {
 	flagset.BoolVar(&opts.DefaultResourceSliceClassEnabled, "default-resource-slice-class-enabled", true,
 		"Enable the built-in default ResourceSlice class. When disabled, the provider denies ResourceSlices "+
 			"that use the \"default\" class, so consumers must use an explicit provider-approved class")
+	flagset.StringVar(&opts.DefaultResourceSliceClass, "default-resource-slice-class", "",
+		"The ResourceSlice class the provider assigns to the ResourceSlices that do not request an explicit one. "+
+			"The resolved class is recorded once, hence changing this value only affects the ResourceSlices created afterwards. "+
+			"Leave empty to keep handling them with the built-in default class")
 	flagset.StringVar(&opts.AWSConfig.AwsAccessKeyID, "aws-access-key-id", "", "AWS IAM AccessKeyID for the Liqo User")
 	flagset.StringVar(&opts.AWSConfig.AwsSecretAccessKey, "aws-secret-access-key", "", "AWS IAM SecretAccessKey for the Liqo User")
 	flagset.StringVar(&opts.AWSConfig.AwsRegion, "aws-region", "", "AWS region where the local cluster is running")

--- a/pkg/liqo-controller-manager/options.go
+++ b/pkg/liqo-controller-manager/options.go
@@ -63,6 +63,7 @@ type Options struct {
 	TrustedCA                        bool
 	TLSCompatibilityMode             bool
 	DefaultResourceSliceClassEnabled bool
+	DefaultResourceSliceClass        string
 	AWSConfig                        *identitymanager.LocalAwsConfig
 	ClusterLabels                    args.StringMap
 	IngressClasses                   args.ClassNameList

--- a/pkg/liqoctl/rest/resourceslice/create.go
+++ b/pkg/liqoctl/rest/resourceslice/create.go
@@ -78,7 +78,8 @@ func (o *Options) Create(ctx context.Context, options *rest.CreateOptions) *cobr
 		"Output the resulting ResourceSlice resource, instead of applying it. Supported formats: json, yaml")
 
 	cmd.Flags().Var(&o.RemoteClusterID, "remote-cluster-id", "The cluster ID of the remote cluster")
-	cmd.Flags().StringVar(&o.Class, "class", "default", "The class of the ResourceSlice")
+	cmd.Flags().StringVar(&o.Class, "class", "", "The class of the ResourceSlice. "+
+		"When left empty, the class configured on the provider cluster is used")
 	cmd.Flags().StringVar(&o.CPU, "cpu", "", "The amount of CPU requested in the resource slice")
 	cmd.Flags().StringVar(&o.Memory, "memory", "", "The amount of memory requested in the resource slice")
 	cmd.Flags().StringVar(&o.Pods, "pods", "", "The amount of pods requested in the resource slice")


### PR DESCRIPTION
# Description

Today the class of a `ResourceSlice` is entirely up to the consumer, and a consumer that does not care about class names has no option other than the built-in default one. This means a provider that wants its own allocation policy has to ask every consumer to spell out a class name it defines.

This PR lets the provider declare which class to use when the consumer does not request one, as suggested by @claudiolor while reviewing #3319:

- New Helm value **`authentication.defaultResourceSliceClass`** (default empty, hence no behavior change), wired to a new controller-manager flag `--default-resource-slice-class`.
- The provider now reports the class every `ResourceSlice` is handled with in the new **`status.class`** field: the class requested by the consumer, or, when none is requested, the configured default (the built-in `default` class if nothing is configured). The consumer's `spec.class` is left untouched, so the spec keeps describing what the consumer asked for while the provider decides how it is served. As discussed on #3319, keeping the resolution out of the spec also avoids fighting the crd-replicator, which owns the spec in the consumer → provider direction.
- Class controllers, including the built-in one, select the `ResourceSlice`s they are responsible for through `status.class` alone.
- The class is resolved **once**. Configuring or changing the default therefore only affects the `ResourceSlice`s created afterwards, which is the "future-only" semantics agreed with @everpeace and @frisso.
- **`spec.class` is now immutable**, as requested by @claudiolor: changing the class of an existing `ResourceSlice` is rejected rather than silently ignored.
- **liqoctl** no longer defaults `--class` / `--resource-slice-class` to `"default"`, so that the provider-side resolution is actually reachable. It also preserves a class already set on a `ResourceSlice` when none is requested, so that re-running `liqoctl create resourceslice` to adjust the resources keeps working under the new immutability rule.

Composes with `defaultResourceSliceClassEnabled` from #3319: a `ResourceSlice` resolved to a custom class is no longer a default-class request, so it is routed to that class' controller instead of being denied. This gives consumers a working path even while the lenient default class is disabled.

Docs updated in `usage/resource-reservation.md` (a new *Choosing the class on the provider* section) and in `advanced/peering/offloading-in-depth.md` (the selection contract for custom class controllers, and what happens to a request for a class no controller handles).

Note this changes the `ResourceSlice` CRD: it adds the optional `status.class` field, and a validation rule that makes `spec.class` immutable, so updates that previously succeeded on that field are now rejected.

Follow-up to #3319. Part of #3306.

cc @claudiolor @frisso @everpeace

## Two notes for reviewers

**The immutability rule is intentionally defined on the spec, not on the `class` field.** `Class` is optional, and CRD validation rules on an optional field are not evaluated when the field is unset, so a field-level `self == oldSelf` would still allow setting a class on a `ResourceSlice` that had none. The spec-level rule covers that case too, and it is verified by one of the tests below.

**`ResourceSlice`s that predate this change keep the built-in default class.** A `ResourceSlice` created before this version has no `status.class`. If the provider is upgraded and `defaultResourceSliceClass` is configured in the same step, resolving such a slice to the new default would silently move an already-accepted slice away from the controller that accepted it. So when the `Resources` condition is already set, an empty class resolves to the built-in `default`. This scenario was caught while testing an earlier revision on real clusters, and it is covered by a unit test.

# How Has This Been Tested?

Unit tests were added for the resolution rules (`classresolution_test.go`) and for the liqoctl class preservation (`forge/resourceslice_test.go`).

End to end on **two k3s clusters** (consumer + provider) running this branch, with the provider configured through the Helm value.

- [x] **Not configured:** an empty class is still accepted by the built-in controller, and reported as `default` in `status.class`.
- [x] **Enabling the default:** `ResourceSlice`s that already existed keep their class.
- [x] **Remap:** a new `ResourceSlice` with no class gets `status.class` set to the configured class, and is left to that class' controller.
- [x] **Future-only:** after changing the configured default, existing `ResourceSlice`s keep their class and only the new ones get the new value, verified across three successive values.
- [x] **Explicit class:** a class requested by the consumer is reported as is in `status.class`, and never overridden.
- [x] **Pre-existing slices:** a `ResourceSlice` whose resources were handled before any class was resolved resolves to `default`, even when a custom default is configured.
- [x] **Immutability:** changing, unsetting, and adding `spec.class` on an existing `ResourceSlice` are all rejected.
- [x] **liqoctl re-run:** re-running `liqoctl create resourceslice` without `--class` preserves the class and updates the resources.
- [x] **Status propagation:** the resolved class is visible on the consumer, replicated with no change to the crd-replicator.
- [x] **Composition with #3319:** with the default class disabled, `ResourceSlice`s resolved to `default` are still denied, while those resolved to a custom class are routed to their class controller.