### PR TITLE
[Networking] expose WireGuard packet counters and host-wide UDP/softnet backlog metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ docs/_build
 
 # claude
 .claude
+
+# Kimchi
+.kimchi

--- a/cmd/fabric/main.go
+++ b/cmd/fabric/main.go
@@ -232,6 +232,10 @@ func run(cmd *cobra.Command, _ []string) error {
 	if err := metrics.Registry.Register(fabric.NewGeneveTrafficCollector(mgr.GetClient(), options.NodeName)); err != nil {
 		return fmt.Errorf("unable to register geneve traffic collector: %w", err)
 	}
+	// Register the host network metrics collector (reads /proc/net statistics once per node).
+	if err := metrics.Registry.Register(fabric.NewHostNetworkCollector(options.NodeName)); err != nil {
+		return fmt.Errorf("unable to register host network collector: %w", err)
+	}
 
 	runnableGeneveCleanup, err := fabric.NewRunnableGeneveCleanup(mgr.GetClient(), options.GeneveCleanupInterval)
 	if err != nil {

--- a/docs/_downloads/grafana/liqonetwork.json
+++ b/docs/_downloads/grafana/liqonetwork.json
@@ -100,7 +100,7 @@
               },
               "fieldConfig": {
                 "defaults": {
-                  "unit": "µs",
+                  "unit": "\u00b5s",
                   "thresholds": {
                     "mode": "absolute",
                     "steps": [
@@ -963,7 +963,7 @@
               },
               "fieldConfig": {
                 "defaults": {
-                  "unit": "µs",
+                  "unit": "\u00b5s",
                   "thresholds": {
                     "mode": "absolute",
                     "steps": [
@@ -1085,7 +1085,7 @@
               },
               "fieldConfig": {
                 "defaults": {
-                  "unit": "µs",
+                  "unit": "\u00b5s",
                   "thresholds": {
                     "mode": "absolute",
                     "steps": [
@@ -1207,7 +1207,7 @@
               },
               "fieldConfig": {
                 "defaults": {
-                  "unit": "µs",
+                  "unit": "\u00b5s",
                   "thresholds": {
                     "mode": "absolute",
                     "steps": [
@@ -1337,7 +1337,7 @@
                   "color": "rgba(255,0,255,0.7)"
                 },
                 "filterValues": {
-                  "le": 1e-9
+                  "le": 1e-09
                 },
                 "legend": {
                   "show": true
@@ -1353,7 +1353,7 @@
                 "yAxis": {
                   "axisPlacement": "left",
                   "reverse": false,
-                  "unit": "µs"
+                  "unit": "\u00b5s"
                 }
               },
               "fieldConfig": {
@@ -1440,7 +1440,7 @@
               },
               "fieldConfig": {
                 "defaults": {
-                  "unit": "µs",
+                  "unit": "\u00b5s",
                   "thresholds": {
                     "mode": "absolute",
                     "steps": [
@@ -1529,7 +1529,7 @@
               },
               "fieldConfig": {
                 "defaults": {
-                  "unit": "µs",
+                  "unit": "\u00b5s",
                   "thresholds": {
                     "mode": "absolute",
                     "steps": [
@@ -1651,7 +1651,7 @@
               },
               "fieldConfig": {
                 "defaults": {
-                  "unit": "µs",
+                  "unit": "\u00b5s",
                   "thresholds": {
                     "mode": "absolute",
                     "steps": [
@@ -1773,7 +1773,7 @@
               },
               "fieldConfig": {
                 "defaults": {
-                  "unit": "µs",
+                  "unit": "\u00b5s",
                   "thresholds": {
                     "mode": "absolute",
                     "steps": [
@@ -1903,7 +1903,7 @@
                   "color": "rgba(255,0,255,0.7)"
                 },
                 "filterValues": {
-                  "le": 1e-9
+                  "le": 1e-09
                 },
                 "legend": {
                   "show": true
@@ -1919,7 +1919,7 @@
                 "yAxis": {
                   "axisPlacement": "left",
                   "reverse": false,
-                  "unit": "µs"
+                  "unit": "\u00b5s"
                 }
               },
               "fieldConfig": {
@@ -2008,7 +2008,7 @@
               },
               "fieldConfig": {
                 "defaults": {
-                  "unit": "µs",
+                  "unit": "\u00b5s",
                   "thresholds": {
                     "mode": "absolute",
                     "steps": [
@@ -2976,7 +2976,7 @@
               },
               "fieldConfig": {
                 "defaults": {
-                  "unit": "µs",
+                  "unit": "\u00b5s",
                   "thresholds": {
                     "mode": "absolute",
                     "steps": [
@@ -3009,6 +3009,1612 @@
                     "insertNulls": false,
                     "lineInterpolation": "linear",
                     "lineWidth": 2,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-wg-pps": {
+        "kind": "Panel",
+        "spec": {
+          "id": 60,
+          "title": "WireGuard packet rate",
+          "description": "Received and transmitted packets per second on the WireGuard interface for peer $clusterid. High pps with a small average packet size means the CPU is spending most of its time handling interrupts, not moving bytes.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "${datasource}"
+                      },
+                      "spec": {
+                        "disableTextWrap": false,
+                        "editorMode": "code",
+                        "expr": "sum by (cluster_id) (rate(liqo_wireguard_interface_rx_packets_total{cluster_id=\"$clusterid\"}[$__rate_interval]))",
+                        "fullMetaSearch": false,
+                        "includeNullMetadata": true,
+                        "legendFormat": "RX pps",
+                        "range": true,
+                        "useBackend": false
+                      }
+                    },
+                    "refId": "RX",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "${datasource}"
+                      },
+                      "spec": {
+                        "disableTextWrap": false,
+                        "editorMode": "code",
+                        "expr": "sum by (cluster_id) (rate(liqo_wireguard_interface_tx_packets_total{cluster_id=\"$clusterid\"}[$__rate_interval]))",
+                        "fullMetaSearch": false,
+                        "includeNullMetadata": true,
+                        "legendFormat": "TX pps",
+                        "range": true,
+                        "useBackend": false
+                      }
+                    },
+                    "refId": "TX",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "13.1.0",
+            "spec": {
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "enableFacetedFilter": false,
+                  "overflow": "ellipsis",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "pps",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-wg-avg-size": {
+        "kind": "Panel",
+        "spec": {
+          "id": 61,
+          "title": "Average packet size",
+          "description": "Average packet size = bytes / packets for peer $clusterid. Values well below the path MTU (for example under 500 bytes) while latency is high indicate a packets-per-second problem rather than a bandwidth problem.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "${datasource}"
+                      },
+                      "spec": {
+                        "disableTextWrap": false,
+                        "editorMode": "code",
+                        "expr": "sum by (cluster_id) (rate(liqo_peer_receive_bytes_total{cluster_id=\"$clusterid\"}[$__rate_interval])) / sum by (cluster_id) (rate(liqo_wireguard_interface_rx_packets_total{cluster_id=\"$clusterid\"}[$__rate_interval]))",
+                        "fullMetaSearch": false,
+                        "includeNullMetadata": true,
+                        "legendFormat": "RX avg size",
+                        "range": true,
+                        "useBackend": false
+                      }
+                    },
+                    "refId": "RX",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "${datasource}"
+                      },
+                      "spec": {
+                        "disableTextWrap": false,
+                        "editorMode": "code",
+                        "expr": "sum by (cluster_id) (rate(liqo_peer_transmit_bytes_total{cluster_id=\"$clusterid\"}[$__rate_interval])) / sum by (cluster_id) (rate(liqo_wireguard_interface_tx_packets_total{cluster_id=\"$clusterid\"}[$__rate_interval]))",
+                        "fullMetaSearch": false,
+                        "includeNullMetadata": true,
+                        "legendFormat": "TX avg size",
+                        "range": true,
+                        "useBackend": false
+                      }
+                    },
+                    "refId": "TX",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "13.1.0",
+            "spec": {
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "enableFacetedFilter": false,
+                  "overflow": "ellipsis",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "bytes",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-wg-drops": {
+        "kind": "Panel",
+        "spec": {
+          "id": 62,
+          "title": "Interface drops",
+          "description": "Packets dropped on ingress/egress of the WireGuard interface for peer $clusterid. Non-zero values mean the interface queues could not accept traffic.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "${datasource}"
+                      },
+                      "spec": {
+                        "disableTextWrap": false,
+                        "editorMode": "code",
+                        "expr": "sum by (cluster_id) (rate(liqo_wireguard_interface_rx_dropped_total{cluster_id=\"$clusterid\"}[$__rate_interval]))",
+                        "fullMetaSearch": false,
+                        "includeNullMetadata": true,
+                        "legendFormat": "RX drops",
+                        "range": true,
+                        "useBackend": false
+                      }
+                    },
+                    "refId": "RX",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "${datasource}"
+                      },
+                      "spec": {
+                        "disableTextWrap": false,
+                        "editorMode": "code",
+                        "expr": "sum by (cluster_id) (rate(liqo_wireguard_interface_tx_dropped_total{cluster_id=\"$clusterid\"}[$__rate_interval]))",
+                        "fullMetaSearch": false,
+                        "includeNullMetadata": true,
+                        "legendFormat": "TX drops",
+                        "range": true,
+                        "useBackend": false
+                      }
+                    },
+                    "refId": "TX",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "13.1.0",
+            "spec": {
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "enableFacetedFilter": false,
+                  "overflow": "ellipsis",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "pps",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-wg-errors": {
+        "kind": "Panel",
+        "spec": {
+          "id": 63,
+          "title": "Interface errors",
+          "description": "Receive and transmit errors on the WireGuard interface for peer $clusterid. Look here for framing, CRC, or length problems.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "${datasource}"
+                      },
+                      "spec": {
+                        "disableTextWrap": false,
+                        "editorMode": "code",
+                        "expr": "sum by (cluster_id) (rate(liqo_wireguard_interface_rx_errors_total{cluster_id=\"$clusterid\"}[$__rate_interval]))",
+                        "fullMetaSearch": false,
+                        "includeNullMetadata": true,
+                        "legendFormat": "RX errors",
+                        "range": true,
+                        "useBackend": false
+                      }
+                    },
+                    "refId": "RX",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "${datasource}"
+                      },
+                      "spec": {
+                        "disableTextWrap": false,
+                        "editorMode": "code",
+                        "expr": "sum by (cluster_id) (rate(liqo_wireguard_interface_tx_errors_total{cluster_id=\"$clusterid\"}[$__rate_interval]))",
+                        "fullMetaSearch": false,
+                        "includeNullMetadata": true,
+                        "legendFormat": "TX errors",
+                        "range": true,
+                        "useBackend": false
+                      }
+                    },
+                    "refId": "TX",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "13.1.0",
+            "spec": {
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "enableFacetedFilter": false,
+                  "overflow": "ellipsis",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "pps",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-wg-fifo": {
+        "kind": "Panel",
+        "spec": {
+          "id": 64,
+          "title": "Interface FIFO errors",
+          "description": "RX/TX FIFO (ring-buffer) errors on the WireGuard interface for peer $clusterid. These indicate the driver ring buffer overflowed, which is another sign that the receive/transmit path cannot keep up.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "${datasource}"
+                      },
+                      "spec": {
+                        "disableTextWrap": false,
+                        "editorMode": "code",
+                        "expr": "sum by (cluster_id) (rate(liqo_wireguard_interface_rx_fifo_errors_total{cluster_id=\"$clusterid\"}[$__rate_interval]))",
+                        "fullMetaSearch": false,
+                        "includeNullMetadata": true,
+                        "legendFormat": "RX FIFO errors",
+                        "range": true,
+                        "useBackend": false
+                      }
+                    },
+                    "refId": "RX",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "${datasource}"
+                      },
+                      "spec": {
+                        "disableTextWrap": false,
+                        "editorMode": "code",
+                        "expr": "sum by (cluster_id) (rate(liqo_wireguard_interface_tx_fifo_errors_total{cluster_id=\"$clusterid\"}[$__rate_interval]))",
+                        "fullMetaSearch": false,
+                        "includeNullMetadata": true,
+                        "legendFormat": "TX FIFO errors",
+                        "range": true,
+                        "useBackend": false
+                      }
+                    },
+                    "refId": "TX",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "13.1.0",
+            "spec": {
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "enableFacetedFilter": false,
+                  "overflow": "ellipsis",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "pps",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-host-squeeze": {
+        "kind": "Panel",
+        "spec": {
+          "id": 66,
+          "title": "Softnet time squeeze",
+          "description": "Number of times per CPU the NET_RX softirq exhausted its budget with work remaining. Increasing values while latency grows confirm the softirq worker cannot keep up.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "${datasource}"
+                      },
+                      "spec": {
+                        "disableTextWrap": false,
+                        "editorMode": "code",
+                        "expr": "sum by (node, cpu) (rate(liqo_fabric_host_softnet_time_squeeze_total[$__rate_interval]))",
+                        "fullMetaSearch": false,
+                        "includeNullMetadata": true,
+                        "legendFormat": "{{node}} CPU {{cpu}}",
+                        "range": true,
+                        "useBackend": false
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "13.1.0",
+            "spec": {
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "enableFacetedFilter": false,
+                  "overflow": "ellipsis",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "cps",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-host-backlog": {
+        "kind": "Panel",
+        "spec": {
+          "id": 67,
+          "title": "Softnet backlog length",
+          "description": "Current number of packets waiting in the per-CPU netdev backlog. If this number grows and stays high, packets are queueing in the kernel, which directly increases latency.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "${datasource}"
+                      },
+                      "spec": {
+                        "disableTextWrap": false,
+                        "editorMode": "code",
+                        "expr": "sum by (node, cpu) (liqo_fabric_host_softnet_backlog_length)",
+                        "fullMetaSearch": false,
+                        "includeNullMetadata": true,
+                        "legendFormat": "{{node}} CPU {{cpu}}",
+                        "range": true,
+                        "useBackend": false
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "13.1.0",
+            "spec": {
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "enableFacetedFilter": false,
+                  "overflow": "ellipsis",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-host-dropped": {
+        "kind": "Panel",
+        "spec": {
+          "id": 68,
+          "title": "Softnet dropped packets",
+          "description": "Packets dropped because the per-CPU netdev backlog was full. Non-zero values mean the backlog overflowed and packets were lost.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "${datasource}"
+                      },
+                      "spec": {
+                        "disableTextWrap": false,
+                        "editorMode": "code",
+                        "expr": "sum by (node, cpu) (rate(liqo_fabric_host_softnet_dropped_packets_total[$__rate_interval]))",
+                        "fullMetaSearch": false,
+                        "includeNullMetadata": true,
+                        "legendFormat": "{{node}} CPU {{cpu}}",
+                        "range": true,
+                        "useBackend": false
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "13.1.0",
+            "spec": {
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "enableFacetedFilter": false,
+                  "overflow": "ellipsis",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "pps",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-host-processed": {
+        "kind": "Panel",
+        "spec": {
+          "id": 69,
+          "title": "Softnet processed packets",
+          "description": "Total packets the NET_RX softirq processed per CPU. Use this as the baseline pps the kernel interrupt handler is dealing with.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "${datasource}"
+                      },
+                      "spec": {
+                        "disableTextWrap": false,
+                        "editorMode": "code",
+                        "expr": "sum by (node, cpu) (rate(liqo_fabric_host_softnet_processed_packets_total[$__rate_interval]))",
+                        "fullMetaSearch": false,
+                        "includeNullMetadata": true,
+                        "legendFormat": "{{node}} CPU {{cpu}}",
+                        "range": true,
+                        "useBackend": false
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "13.1.0",
+            "spec": {
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "enableFacetedFilter": false,
+                  "overflow": "ellipsis",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "pps",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-wg-udp": {
+        "kind": "Panel",
+        "spec": {
+          "id": 70,
+          "title": "UDP buffer errors",
+          "description": "UDP-level drops from /proc/net/snmp, scoped to the gateway pod network namespace for peer $clusterid. RcvbufErrors means the WireGuard UDP socket receive buffer was full; SndbufErrors means a send buffer was full. These are the most direct proof of UDP socket buffer saturation.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "${datasource}"
+                      },
+                      "spec": {
+                        "disableTextWrap": false,
+                        "editorMode": "code",
+                        "expr": "sum by (cluster_id) (rate(liqo_wireguard_udp_rcvbuf_errors_total{cluster_id=\"$clusterid\"}[$__rate_interval]))",
+                        "fullMetaSearch": false,
+                        "includeNullMetadata": true,
+                        "legendFormat": "RcvbufErrors",
+                        "range": true,
+                        "useBackend": false
+                      }
+                    },
+                    "refId": "RcvbufErrors",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "${datasource}"
+                      },
+                      "spec": {
+                        "disableTextWrap": false,
+                        "editorMode": "code",
+                        "expr": "sum by (cluster_id) (rate(liqo_wireguard_udp_sndbuf_errors_total{cluster_id=\"$clusterid\"}[$__rate_interval]))",
+                        "fullMetaSearch": false,
+                        "includeNullMetadata": true,
+                        "legendFormat": "SndbufErrors",
+                        "range": true,
+                        "useBackend": false
+                      }
+                    },
+                    "refId": "SndbufErrors",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "${datasource}"
+                      },
+                      "spec": {
+                        "disableTextWrap": false,
+                        "editorMode": "code",
+                        "expr": "sum by (cluster_id) (rate(liqo_wireguard_udp_in_errors_total{cluster_id=\"$clusterid\"}[$__rate_interval]))",
+                        "fullMetaSearch": false,
+                        "includeNullMetadata": true,
+                        "legendFormat": "InErrors",
+                        "range": true,
+                        "useBackend": false
+                      }
+                    },
+                    "refId": "InErrors",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "${datasource}"
+                      },
+                      "spec": {
+                        "disableTextWrap": false,
+                        "editorMode": "code",
+                        "expr": "sum by (cluster_id) (rate(liqo_wireguard_udp_no_ports_total{cluster_id=\"$clusterid\"}[$__rate_interval]))",
+                        "fullMetaSearch": false,
+                        "includeNullMetadata": true,
+                        "legendFormat": "NoPorts",
+                        "range": true,
+                        "useBackend": false
+                      }
+                    },
+                    "refId": "NoPorts",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "13.1.0",
+            "spec": {
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "enableFacetedFilter": false,
+                  "overflow": "ellipsis",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "pps",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-wg-udp-queues": {
+        "kind": "Panel",
+        "spec": {
+          "id": 71,
+          "title": "UDP socket queue bytes and buffer limits",
+          "description": "Current bytes queued in the WireGuard UDP socket send/receive queues and the configured maximum UDP buffer sizes (rmem_max / wmem_max) for peer $clusterid. Use this panel to see buffer pressure in real time together with its ceiling.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "${datasource}"
+                      },
+                      "spec": {
+                        "disableTextWrap": false,
+                        "editorMode": "code",
+                        "expr": "sum by (cluster_id) (liqo_wireguard_udp_rx_queue_bytes{cluster_id=\"$clusterid\"})",
+                        "fullMetaSearch": false,
+                        "includeNullMetadata": true,
+                        "legendFormat": "RX queue",
+                        "range": true,
+                        "useBackend": false
+                      }
+                    },
+                    "refId": "RX",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "${datasource}"
+                      },
+                      "spec": {
+                        "disableTextWrap": false,
+                        "editorMode": "code",
+                        "expr": "sum by (cluster_id) (liqo_wireguard_udp_tx_queue_bytes{cluster_id=\"$clusterid\"})",
+                        "fullMetaSearch": false,
+                        "includeNullMetadata": true,
+                        "legendFormat": "TX queue",
+                        "range": true,
+                        "useBackend": false
+                      }
+                    },
+                    "refId": "TX",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "${datasource}"
+                      },
+                      "spec": {
+                        "disableTextWrap": false,
+                        "editorMode": "code",
+                        "expr": "sum by (cluster_id) (liqo_wireguard_udp_rmem_max_bytes{cluster_id=\"$clusterid\"})",
+                        "fullMetaSearch": false,
+                        "includeNullMetadata": true,
+                        "legendFormat": "rmem_max",
+                        "range": true,
+                        "useBackend": false
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "${datasource}"
+                      },
+                      "spec": {
+                        "disableTextWrap": false,
+                        "editorMode": "code",
+                        "expr": "sum by (cluster_id) (liqo_wireguard_udp_wmem_max_bytes{cluster_id=\"$clusterid\"})",
+                        "fullMetaSearch": false,
+                        "includeNullMetadata": true,
+                        "legendFormat": "wmem_max",
+                        "range": true,
+                        "useBackend": false
+                      }
+                    },
+                    "refId": "B",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "13.1.0",
+            "spec": {
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "enableFacetedFilter": false,
+                  "overflow": "ellipsis",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "bytes",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
@@ -3291,6 +4897,97 @@
                                     "name": "panel-44"
                                   }
                                 }
+                              },
+                              {
+                                "kind": "GridLayoutItem",
+                                "spec": {
+                                  "x": 0,
+                                  "y": 24,
+                                  "width": 12,
+                                  "height": 6,
+                                  "element": {
+                                    "kind": "ElementReference",
+                                    "name": "panel-wg-pps"
+                                  }
+                                }
+                              },
+                              {
+                                "kind": "GridLayoutItem",
+                                "spec": {
+                                  "x": 12,
+                                  "y": 24,
+                                  "width": 12,
+                                  "height": 6,
+                                  "element": {
+                                    "kind": "ElementReference",
+                                    "name": "panel-wg-avg-size"
+                                  }
+                                }
+                              },
+                              {
+                                "kind": "GridLayoutItem",
+                                "spec": {
+                                  "x": 0,
+                                  "y": 30,
+                                  "width": 8,
+                                  "height": 6,
+                                  "element": {
+                                    "kind": "ElementReference",
+                                    "name": "panel-wg-drops"
+                                  }
+                                }
+                              },
+                              {
+                                "kind": "GridLayoutItem",
+                                "spec": {
+                                  "x": 8,
+                                  "y": 30,
+                                  "width": 8,
+                                  "height": 6,
+                                  "element": {
+                                    "kind": "ElementReference",
+                                    "name": "panel-wg-errors"
+                                  }
+                                }
+                              },
+                              {
+                                "kind": "GridLayoutItem",
+                                "spec": {
+                                  "x": 16,
+                                  "y": 30,
+                                  "width": 8,
+                                  "height": 6,
+                                  "element": {
+                                    "kind": "ElementReference",
+                                    "name": "panel-wg-fifo"
+                                  }
+                                }
+                              },
+                              {
+                                "kind": "GridLayoutItem",
+                                "spec": {
+                                  "x": 0,
+                                  "y": 36,
+                                  "width": 24,
+                                  "height": 6,
+                                  "element": {
+                                    "kind": "ElementReference",
+                                    "name": "panel-wg-udp"
+                                  }
+                                }
+                              },
+                              {
+                                "kind": "GridLayoutItem",
+                                "spec": {
+                                  "x": 0,
+                                  "y": 42,
+                                  "width": 24,
+                                  "height": 6,
+                                  "element": {
+                                    "kind": "ElementReference",
+                                    "name": "panel-wg-udp-queues"
+                                  }
+                                }
                               }
                             ]
                           }
@@ -3424,6 +5121,72 @@
                               }
                             ]
                           }
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "title": "Host-wide receive path (fabric)",
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 12,
+                        "height": 7,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-host-squeeze"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 12,
+                        "y": 0,
+                        "width": 12,
+                        "height": 7,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-host-backlog"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 0,
+                        "y": 7,
+                        "width": 12,
+                        "height": 7,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-host-dropped"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 12,
+                        "y": 7,
+                        "width": 12,
+                        "height": 7,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-host-processed"
                         }
                       }
                     }

--- a/pkg/fabric/metrics.go
+++ b/pkg/fabric/metrics.go
@@ -17,6 +17,7 @@ package fabric
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/apimachinery/pkg/types"
@@ -127,4 +128,100 @@ func observeGeneveLatency(internalfabric *networkingv1beta1.InternalFabric, gt *
 			tunnel.GeneveMetricsLabels[2]: gt.Namespace,
 			tunnel.GeneveMetricsLabels[3]: internalfabric.Labels[consts.RemoteClusterID],
 		})
+}
+
+const hostNetNodeLabel = "node"
+
+var (
+	// Softnet (NET_RX softirq) statistics from /proc/net/softnet_stat (labels: node, cpu).
+	// These are global to the host kernel, not limited to a single tunnel or socket.
+
+	// MetricsHostSoftnetProcessedPackets counts the packets processed by the
+	// NET_RX softirq per CPU.
+	MetricsHostSoftnetProcessedPackets = prometheus.NewDesc(
+		"liqo_fabric_host_softnet_processed_packets_total",
+		"Total number of packets processed by the NET_RX softirq, per CPU (host-wide statistic).",
+		[]string{hostNetNodeLabel, "cpu"},
+		nil,
+	)
+	// MetricsHostSoftnetDroppedPackets counts the packets dropped because the
+	// per-CPU netdev backlog was full.
+	MetricsHostSoftnetDroppedPackets = prometheus.NewDesc(
+		"liqo_fabric_host_softnet_dropped_packets_total",
+		"Total number of packets dropped due to a full per-CPU netdev backlog (host-wide statistic).",
+		[]string{hostNetNodeLabel, "cpu"},
+		nil,
+	)
+	// MetricsHostSoftnetTimeSqueeze counts the times the NET_RX softirq
+	// exhausted its budget with work remaining.
+	MetricsHostSoftnetTimeSqueeze = prometheus.NewDesc(
+		"liqo_fabric_host_softnet_time_squeeze_total",
+		"Total number of times the NET_RX softirq exhausted its time/length budget, per CPU (host-wide statistic).",
+		[]string{hostNetNodeLabel, "cpu"},
+		nil,
+	)
+	// MetricsHostSoftnetBacklogLen reports the current length of the netdev
+	// backlog queue per CPU.
+	MetricsHostSoftnetBacklogLen = prometheus.NewDesc(
+		"liqo_fabric_host_softnet_backlog_length",
+		"Current length of the per-CPU netdev backlog queue (host-wide statistic).",
+		[]string{hostNetNodeLabel, "cpu"},
+		nil,
+	)
+)
+
+var _ prometheus.Collector = &HostNetworkCollector{}
+
+// HostNetworkCollector exports host-wide Linux network statistics that are
+// useful for debugging tunnel latency but must be collected only once per node.
+// Collecting them from the gateway would duplicate the same host counters when
+// multiple gateways run on the same node, so they live here in the fabric
+// (which runs once per node).
+type HostNetworkCollector struct {
+	nodeName string
+}
+
+// NewHostNetworkCollector creates a new HostNetworkCollector.
+func NewHostNetworkCollector(nodeName string) *HostNetworkCollector {
+	return &HostNetworkCollector{nodeName: nodeName}
+}
+
+// Describe implements prometheus.Collector.
+func (c *HostNetworkCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- MetricsHostSoftnetProcessedPackets
+	ch <- MetricsHostSoftnetDroppedPackets
+	ch <- MetricsHostSoftnetTimeSqueeze
+	ch <- MetricsHostSoftnetBacklogLen
+}
+
+// Collect implements prometheus.Collector.
+func (c *HostNetworkCollector) Collect(ch chan<- prometheus.Metric) {
+	c.collectSoftnetStats(ch)
+}
+
+// collectSoftnetStats collects per-CPU softnet (NET_RX softirq) statistics from
+// /proc/net/softnet_stat. These are host-wide statistics: growing time_squeeze
+// or dropped counters indicate that the softirq receive path cannot keep up
+// with the packet rate, which typically manifests as increasing latency under
+// load.
+func (c *HostNetworkCollector) collectSoftnetStats(ch chan<- prometheus.Metric) {
+	stats, err := readSoftnetStats()
+	if err != nil {
+		err = fmt.Errorf("error collecting softnet statistics: %w", err)
+		ch <- prometheus.NewInvalidMetric(MetricsHostSoftnetProcessedPackets, err)
+		ch <- prometheus.NewInvalidMetric(MetricsHostSoftnetDroppedPackets, err)
+		ch <- prometheus.NewInvalidMetric(MetricsHostSoftnetTimeSqueeze, err)
+		ch <- prometheus.NewInvalidMetric(MetricsHostSoftnetBacklogLen, err)
+		return
+	}
+
+	for i := range stats {
+		labels := []string{c.nodeName, strconv.Itoa(i)}
+		ch <- prometheus.MustNewConstMetric(MetricsHostSoftnetProcessedPackets, prometheus.CounterValue, float64(stats[i].processed), labels...)
+		ch <- prometheus.MustNewConstMetric(MetricsHostSoftnetDroppedPackets, prometheus.CounterValue, float64(stats[i].dropped), labels...)
+		ch <- prometheus.MustNewConstMetric(MetricsHostSoftnetTimeSqueeze, prometheus.CounterValue, float64(stats[i].timeSqueeze), labels...)
+		if stats[i].hasBacklog {
+			ch <- prometheus.MustNewConstMetric(MetricsHostSoftnetBacklogLen, prometheus.GaugeValue, float64(stats[i].backlogLen), labels...)
+		}
+	}
 }

--- a/pkg/fabric/procnet.go
+++ b/pkg/fabric/procnet.go
@@ -1,0 +1,87 @@
+// Copyright 2019-2026 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fabric
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+const (
+	// procNetSoftnetPath is the path of the file exposing per-CPU softnet (NET_RX softirq) statistics.
+	procNetSoftnetPath = "/proc/net/softnet_stat"
+)
+
+// softnetStat holds the counters parsed from a line of /proc/net/softnet_stat.
+// Columns (hex, in order): processed, dropped, time_squeeze, 0, 0, 0, 0,
+// cpu_collision, received_rps, flow_limit_count, backlog_len.
+type softnetStat struct {
+	processed   uint64 // packets processed by the NET_RX softirq on this CPU.
+	dropped     uint64 // packets dropped because the per-CPU netdev backlog was full.
+	timeSqueeze uint64 // times the softirq exhausted its budget/timeslice with work remaining.
+	backlogLen  uint64 // current netdev backlog queue length (present only on recent kernels).
+	hasBacklog  bool   // whether the kernel reports the backlog_len column.
+}
+
+// parseNetSoftnet parses /proc/net/softnet_stat content, returning one
+// softnetStat entry per CPU (file line order corresponds to CPU index).
+func parseNetSoftnet(content string) ([]softnetStat, error) {
+	var stats []softnetStat
+	for _, line := range strings.Split(content, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 3 {
+			return nil, fmt.Errorf("malformed softnet_stat line %q: got %d fields, expected at least 3", line, len(fields))
+		}
+		values := make([]uint64, len(fields))
+		for i, f := range fields {
+			v, err := strconv.ParseUint(f, 16, 64)
+			if err != nil {
+				return nil, fmt.Errorf("parsing softnet_stat line %q: %w", line, err)
+			}
+			values[i] = v
+		}
+		stat := softnetStat{
+			processed:   values[0],
+			dropped:     values[1],
+			timeSqueeze: values[2],
+		}
+		// The backlog_len column (11th, index 10) was added in kernel 2.6.41;
+		// tolerate older kernels reporting fewer columns.
+		if len(values) > 10 {
+			stat.backlogLen = values[10]
+			stat.hasBacklog = true
+		}
+		stats = append(stats, stat)
+	}
+	if len(stats) == 0 {
+		return nil, fmt.Errorf("no softnet_stat entries found")
+	}
+	return stats, nil
+}
+
+// readSoftnetStats reads and parses /proc/net/softnet_stat.
+func readSoftnetStats() ([]softnetStat, error) {
+	data, err := os.ReadFile(procNetSoftnetPath)
+	if err != nil {
+		return nil, fmt.Errorf("reading %q: %w", procNetSoftnetPath, err)
+	}
+	return parseNetSoftnet(string(data))
+}

--- a/pkg/fabric/procnet_test.go
+++ b/pkg/fabric/procnet_test.go
@@ -1,0 +1,59 @@
+// Copyright 2019-2026 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fabric
+
+import (
+	"testing"
+)
+
+// 3 CPUs; first has 11 columns (with backlog_len), second full, third minimal (8 columns).
+const validSoftnet = `00007b1f 00000000 00000002 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000006
+00001234 00000005 00000000 00000000 00000000 00000000 00000000 00000001 00000000 00000000 00000000
+00000042 00000000 00000001 00000000 00000000 00000000 00000000 00000000
+`
+
+func TestParseNetSoftnet(t *testing.T) {
+	stats, err := parseNetSoftnet(validSoftnet)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(stats) != 3 {
+		t.Fatalf("expected 3 CPUs, got %d", len(stats))
+	}
+	if stats[0].processed != 0x7b1f || stats[0].dropped != 0 || stats[0].timeSqueeze != 2 {
+		t.Fatalf("unexpected cpu0 values: %+v", stats[0])
+	}
+	if !stats[0].hasBacklog || stats[0].backlogLen != 6 {
+		t.Fatalf("unexpected cpu0 backlog: %+v", stats[0])
+	}
+	if stats[1].dropped != 5 {
+		t.Fatalf("unexpected cpu1 dropped: %+v", stats[1])
+	}
+	if stats[2].hasBacklog {
+		t.Fatalf("cpu2 should not report backlog length: %+v", stats[2])
+	}
+}
+
+func TestParseNetSoftnetMalformed(t *testing.T) {
+	if _, err := parseNetSoftnet("00000001 00000000\n"); err == nil {
+		t.Fatal("expected error for short line")
+	}
+	if _, err := parseNetSoftnet("zz 0 0\n"); err == nil {
+		t.Fatal("expected error for non-hex content")
+	}
+	if _, err := parseNetSoftnet("\n\n"); err == nil {
+		t.Fatal("expected error for empty content")
+	}
+}

--- a/pkg/gateway/tunnel/wireguard/metrics.go
+++ b/pkg/gateway/tunnel/wireguard/metrics.go
@@ -18,7 +18,9 @@ import (
 	"fmt"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/vishvananda/netlink"
 	"golang.zx2c4.com/wireguard/wgctrl"
+	"k8s.io/klog/v2"
 
 	"github.com/liqotech/liqo/pkg/gateway/tunnel"
 )
@@ -36,9 +38,169 @@ var (
 		[]string{tunnel.MetricsLabels[0], implLabel},
 		nil,
 	)
+
+	// Interface-level statistics (labels: driver, cluster_id).
+
+	// MetricsInterfaceRxPackets is the metric that counts the packets received on the wireguard interface.
+	MetricsInterfaceRxPackets = prometheus.NewDesc(
+		"liqo_wireguard_interface_rx_packets_total",
+		"Total number of packets received on the Wireguard interface.",
+		tunnel.MetricsLabels,
+		nil,
+	)
+	// MetricsInterfaceTxPackets is the metric that counts the packets transmitted on the wireguard interface.
+	MetricsInterfaceTxPackets = prometheus.NewDesc(
+		"liqo_wireguard_interface_tx_packets_total",
+		"Total number of packets transmitted on the Wireguard interface.",
+		tunnel.MetricsLabels,
+		nil,
+	)
+	// MetricsInterfaceRxDropped is the metric that counts the packets dropped on ingress on the wireguard interface.
+	MetricsInterfaceRxDropped = prometheus.NewDesc(
+		"liqo_wireguard_interface_rx_dropped_total",
+		"Total number of received packets dropped on the Wireguard interface (e.g. no space in queues).",
+		tunnel.MetricsLabels,
+		nil,
+	)
+	// MetricsInterfaceTxDropped is the metric that counts the packets dropped on egress on the wireguard interface.
+	MetricsInterfaceTxDropped = prometheus.NewDesc(
+		"liqo_wireguard_interface_tx_dropped_total",
+		"Total number of transmitted packets dropped on the Wireguard interface (e.g. no space in queues).",
+		tunnel.MetricsLabels,
+		nil,
+	)
+	// MetricsInterfaceRxErrors is the metric that counts the receive errors on the wireguard interface.
+	MetricsInterfaceRxErrors = prometheus.NewDesc(
+		"liqo_wireguard_interface_rx_errors_total",
+		"Total number of receive errors on the Wireguard interface.",
+		tunnel.MetricsLabels,
+		nil,
+	)
+	// MetricsInterfaceTxErrors is the metric that counts the transmit errors on the wireguard interface.
+	MetricsInterfaceTxErrors = prometheus.NewDesc(
+		"liqo_wireguard_interface_tx_errors_total",
+		"Total number of transmit errors on the Wireguard interface.",
+		tunnel.MetricsLabels,
+		nil,
+	)
+	// MetricsInterfaceRxFIFODropped is the metric that counts the RX FIFO buffer errors on the wireguard interface.
+	MetricsInterfaceRxFIFODropped = prometheus.NewDesc(
+		"liqo_wireguard_interface_rx_fifo_errors_total",
+		"Total number of RX FIFO buffer errors on the Wireguard interface.",
+		tunnel.MetricsLabels,
+		nil,
+	)
+	// MetricsInterfaceTxFIFODropped is the metric that counts the TX FIFO buffer errors on the wireguard interface.
+	MetricsInterfaceTxFIFODropped = prometheus.NewDesc(
+		"liqo_wireguard_interface_tx_fifo_errors_total",
+		"Total number of TX FIFO buffer errors on the Wireguard interface.",
+		tunnel.MetricsLabels,
+		nil,
+	)
+
+	// UDP socket statistics from /proc/net/snmp (labels: driver, cluster_id).
+	// These counters are scoped to the gateway pod's network namespace, so they
+	// describe the UDP stack used by the WireGuard kernel socket.
+
+	// MetricsUDPRcvbufErrors counts datagrams dropped because the UDP socket
+	// receive buffer was full (i.e. WireGuard could not drain packets fast enough).
+	MetricsUDPRcvbufErrors = prometheus.NewDesc(
+		"liqo_wireguard_udp_rcvbuf_errors_total",
+		"Total number of UDP datagrams dropped due to a full socket receive buffer (RcvbufErrors).",
+		tunnel.MetricsLabels,
+		nil,
+	)
+	// MetricsUDPSndbufErrors counts datagrams dropped because the UDP socket send buffer was full.
+	MetricsUDPSndbufErrors = prometheus.NewDesc(
+		"liqo_wireguard_udp_sndbuf_errors_total",
+		"Total number of UDP datagrams dropped due to a full socket send buffer (SndbufErrors).",
+		tunnel.MetricsLabels,
+		nil,
+	)
+	// MetricsUDPInErrors counts UDP datagrams dropped for other reasons (e.g. memory pressure).
+	MetricsUDPInErrors = prometheus.NewDesc(
+		"liqo_wireguard_udp_in_errors_total",
+		"Total number of UDP datagrams dropped for reasons other than a full buffer (InErrors).",
+		tunnel.MetricsLabels,
+		nil,
+	)
+	// MetricsUDPNoPorts counts UDP datagrams received for a closed port.
+	MetricsUDPNoPorts = prometheus.NewDesc(
+		"liqo_wireguard_udp_no_ports_total",
+		"Total number of UDP datagrams received for a closed port (NoPorts).",
+		tunnel.MetricsLabels,
+		nil,
+	)
+
+	// UDP socket queue and limit gauges (labels: driver, cluster_id).
+
+	// MetricsUDPRxQueueBytes reports the current size of the WireGuard UDP socket receive queue.
+	MetricsUDPRxQueueBytes = prometheus.NewDesc(
+		"liqo_wireguard_udp_rx_queue_bytes",
+		"Current number of bytes queued in the WireGuard UDP socket receive queue.",
+		tunnel.MetricsLabels,
+		nil,
+	)
+	// MetricsUDPTxQueueBytes reports the current size of the WireGuard UDP socket send queue.
+	MetricsUDPTxQueueBytes = prometheus.NewDesc(
+		"liqo_wireguard_udp_tx_queue_bytes",
+		"Current number of bytes queued in the WireGuard UDP socket send queue.",
+		tunnel.MetricsLabels,
+		nil,
+	)
+	// MetricsUDPRmemMaxBytes reports the kernel maximum UDP socket receive buffer size.
+	MetricsUDPRmemMaxBytes = prometheus.NewDesc(
+		"liqo_wireguard_udp_rmem_max_bytes",
+		"Maximum UDP socket receive buffer size configured for the gateway namespace (rmem_max).",
+		tunnel.MetricsLabels,
+		nil,
+	)
+	// MetricsUDPWmemMaxBytes reports the kernel maximum UDP socket send buffer size.
+	MetricsUDPWmemMaxBytes = prometheus.NewDesc(
+		"liqo_wireguard_udp_wmem_max_bytes",
+		"Maximum UDP socket send buffer size configured for the gateway namespace (wmem_max).",
+		tunnel.MetricsLabels,
+		nil,
+	)
 )
 
 var _ prometheus.Collector = &PrometheusCollector{}
+
+// emitInvalidInterfaceMetrics reports an invalid metric for every interface-level
+// descriptor, used when rtnetlink statistics cannot be retrieved.
+func emitInvalidInterfaceMetrics(ch chan<- prometheus.Metric, err error) {
+	ch <- prometheus.NewInvalidMetric(MetricsInterfaceRxPackets, err)
+	ch <- prometheus.NewInvalidMetric(MetricsInterfaceTxPackets, err)
+	ch <- prometheus.NewInvalidMetric(MetricsInterfaceRxDropped, err)
+	ch <- prometheus.NewInvalidMetric(MetricsInterfaceTxDropped, err)
+	ch <- prometheus.NewInvalidMetric(MetricsInterfaceRxErrors, err)
+	ch <- prometheus.NewInvalidMetric(MetricsInterfaceTxErrors, err)
+	ch <- prometheus.NewInvalidMetric(MetricsInterfaceRxFIFODropped, err)
+	ch <- prometheus.NewInvalidMetric(MetricsInterfaceTxFIFODropped, err)
+}
+
+// emitInvalidUDPMetrics reports an invalid metric for every UDP /proc/net/snmp
+// descriptor, used when the UDP summary cannot be read.
+func emitInvalidUDPMetrics(ch chan<- prometheus.Metric, err error) {
+	ch <- prometheus.NewInvalidMetric(MetricsUDPRcvbufErrors, err)
+	ch <- prometheus.NewInvalidMetric(MetricsUDPSndbufErrors, err)
+	ch <- prometheus.NewInvalidMetric(MetricsUDPInErrors, err)
+	ch <- prometheus.NewInvalidMetric(MetricsUDPNoPorts, err)
+}
+
+// emitInvalidUDPQueueMetrics reports an invalid metric for the UDP socket queue
+// gauges, used when INET_DIAG cannot retrieve the queue sizes.
+func emitInvalidUDPQueueMetrics(ch chan<- prometheus.Metric, err error) {
+	ch <- prometheus.NewInvalidMetric(MetricsUDPRxQueueBytes, err)
+	ch <- prometheus.NewInvalidMetric(MetricsUDPTxQueueBytes, err)
+}
+
+// emitInvalidSocketBufferLimitMetrics reports an invalid metric for the socket
+// buffer limit gauges, used when /proc/sys/net/core values cannot be read.
+func emitInvalidSocketBufferLimitMetrics(ch chan<- prometheus.Metric, err error) {
+	ch <- prometheus.NewInvalidMetric(MetricsUDPRmemMaxBytes, err)
+	ch <- prometheus.NewInvalidMetric(MetricsUDPWmemMaxBytes, err)
+}
 
 // PrometheusCollector is a prometheus.Collector that collects Wireguard metrics.
 type PrometheusCollector struct {
@@ -70,13 +232,39 @@ func (pc *PrometheusCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- tunnel.MetricsPeerReceivedBytes
 	ch <- tunnel.MetricsPeerTransmittedBytes
 	ch <- MetricsWgUserImpl
+
+	ch <- MetricsInterfaceRxPackets
+	ch <- MetricsInterfaceTxPackets
+	ch <- MetricsInterfaceRxDropped
+	ch <- MetricsInterfaceTxDropped
+	ch <- MetricsInterfaceRxErrors
+	ch <- MetricsInterfaceTxErrors
+	ch <- MetricsInterfaceRxFIFODropped
+	ch <- MetricsInterfaceTxFIFODropped
+
+	ch <- MetricsUDPRcvbufErrors
+	ch <- MetricsUDPSndbufErrors
+	ch <- MetricsUDPInErrors
+	ch <- MetricsUDPNoPorts
+
+	ch <- MetricsUDPRxQueueBytes
+	ch <- MetricsUDPTxQueueBytes
+	ch <- MetricsUDPRmemMaxBytes
+	ch <- MetricsUDPWmemMaxBytes
 }
 
 // Collect implements prometheus.Collector.
 func (pc *PrometheusCollector) Collect(ch chan<- prometheus.Metric) {
 	device, err := pc.clientwg.Device(tunnel.TunnelInterfaceName)
 	if err != nil {
-		ch <- prometheus.NewInvalidMetric(MetricsWgUserImpl, fmt.Errorf("error collecting wireguard metrics: %w", err))
+		err = fmt.Errorf("error collecting wireguard metrics: %w", err)
+		ch <- prometheus.NewInvalidMetric(MetricsWgUserImpl, err)
+		ch <- prometheus.NewInvalidMetric(tunnel.MetricsPeerReceivedBytes, err)
+		ch <- prometheus.NewInvalidMetric(tunnel.MetricsPeerTransmittedBytes, err)
+		emitInvalidInterfaceMetrics(ch, err)
+		emitInvalidUDPMetrics(ch, err)
+		emitInvalidUDPQueueMetrics(ch, err)
+		emitInvalidSocketBufferLimitMetrics(ch, err)
 		return
 	}
 
@@ -91,6 +279,10 @@ func (pc *PrometheusCollector) Collect(ch chan<- prometheus.Metric) {
 		err := fmt.Errorf("error collecting wireguard metrics: gateway must have exactly 1 peer, it has %d", len(device.Peers))
 		ch <- prometheus.NewInvalidMetric(tunnel.MetricsPeerReceivedBytes, err)
 		ch <- prometheus.NewInvalidMetric(tunnel.MetricsPeerTransmittedBytes, err)
+		emitInvalidInterfaceMetrics(ch, err)
+		emitInvalidUDPMetrics(ch, err)
+		emitInvalidUDPQueueMetrics(ch, err)
+		emitInvalidSocketBufferLimitMetrics(ch, err)
 		return
 	}
 
@@ -111,4 +303,87 @@ func (pc *PrometheusCollector) Collect(ch chan<- prometheus.Metric) {
 		float64(peer.TransmitBytes),
 		labels...,
 	)
+
+	pc.collectInterfaceStats(ch, labels)
+	pc.collectUDPStats(ch, labels)
+	pc.collectUDPQueueStats(ch, labels, device.ListenPort)
+	pc.collectSocketBufferLimits(ch, labels)
+}
+
+// collectUDPStats collects UDP protocol statistics from /proc/net/snmp,
+// scoped to the gateway pod's network namespace. RcvbufErrors/SndbufErrors
+// growth indicates that the WireGuard UDP socket buffer is saturating.
+func (pc *PrometheusCollector) collectUDPStats(ch chan<- prometheus.Metric, labels []string) {
+	summary, err := readUDPSummary()
+	if err != nil {
+		err = fmt.Errorf("error collecting UDP statistics: %w", err)
+		emitInvalidUDPMetrics(ch, err)
+		return
+	}
+
+	ch <- prometheus.MustNewConstMetric(MetricsUDPRcvbufErrors, prometheus.CounterValue, float64(summary.rcvbuf), labels...)
+	ch <- prometheus.MustNewConstMetric(MetricsUDPSndbufErrors, prometheus.CounterValue, float64(summary.sndbuf), labels...)
+	ch <- prometheus.MustNewConstMetric(MetricsUDPInErrors, prometheus.CounterValue, float64(summary.inErrors), labels...)
+	ch <- prometheus.MustNewConstMetric(MetricsUDPNoPorts, prometheus.CounterValue, float64(summary.noPorts), labels...)
+}
+
+// collectUDPQueueStats collects the current send/receive queue sizes of the
+// WireGuard UDP socket via the kernel's INET_DIAG netlink interface. The
+// listen port reported by the wireguard device is used to locate the correct
+// socket row. When the lookup fails (e.g. userspace wireguard without a
+// kernel-bound socket, missing CAP_NET_ADMIN, or a transient unbound state),
+// the metrics are reported as invalid so the scrape failure is visible in
+// Prometheus instead of being masked as zero queue bytes.
+func (pc *PrometheusCollector) collectUDPQueueStats(ch chan<- prometheus.Metric, labels []string, listenPort int) {
+	queues, err := readUDPQueueStats(listenPort)
+	if err != nil {
+		err = fmt.Errorf("UDP queue statistics unavailable for WireGuard device on port %d: %w", listenPort, err)
+		klog.Warningf("%v", err)
+		emitInvalidUDPQueueMetrics(ch, err)
+		return
+	}
+
+	ch <- prometheus.MustNewConstMetric(MetricsUDPRxQueueBytes, prometheus.GaugeValue, float64(queues.rxBytes), labels...)
+	ch <- prometheus.MustNewConstMetric(MetricsUDPTxQueueBytes, prometheus.GaugeValue, float64(queues.txBytes), labels...)
+}
+
+// collectSocketBufferLimits exposes the kernel-configured maximum UDP socket
+// buffer sizes for the gateway namespace.
+func (pc *PrometheusCollector) collectSocketBufferLimits(ch chan<- prometheus.Metric, labels []string) {
+	limits, err := readSocketBufferLimits()
+	if err != nil {
+		err = fmt.Errorf("error collecting socket buffer limits: %w", err)
+		emitInvalidSocketBufferLimitMetrics(ch, err)
+		return
+	}
+
+	ch <- prometheus.MustNewConstMetric(MetricsUDPRmemMaxBytes, prometheus.GaugeValue, float64(limits.rmemMax), labels...)
+	ch <- prometheus.MustNewConstMetric(MetricsUDPWmemMaxBytes, prometheus.GaugeValue, float64(limits.wmemMax), labels...)
+}
+
+// collectInterfaceStats collects packet-level statistics of the wireguard interface
+// (rx/tx packets, drops, errors) via rtnetlink, reporting 64-bit counters.
+func (pc *PrometheusCollector) collectInterfaceStats(ch chan<- prometheus.Metric, labels []string) {
+	link, err := netlink.LinkByName(tunnel.TunnelInterfaceName)
+	if err != nil {
+		err = fmt.Errorf("error getting wireguard interface %q stats: %w", tunnel.TunnelInterfaceName, err)
+		emitInvalidInterfaceMetrics(ch, err)
+		return
+	}
+
+	stats := link.Attrs().Statistics
+	if stats == nil {
+		err = fmt.Errorf("no statistics available for wireguard interface %q", tunnel.TunnelInterfaceName)
+		emitInvalidInterfaceMetrics(ch, err)
+		return
+	}
+
+	ch <- prometheus.MustNewConstMetric(MetricsInterfaceRxPackets, prometheus.CounterValue, float64(stats.RxPackets), labels...)
+	ch <- prometheus.MustNewConstMetric(MetricsInterfaceTxPackets, prometheus.CounterValue, float64(stats.TxPackets), labels...)
+	ch <- prometheus.MustNewConstMetric(MetricsInterfaceRxDropped, prometheus.CounterValue, float64(stats.RxDropped), labels...)
+	ch <- prometheus.MustNewConstMetric(MetricsInterfaceTxDropped, prometheus.CounterValue, float64(stats.TxDropped), labels...)
+	ch <- prometheus.MustNewConstMetric(MetricsInterfaceRxErrors, prometheus.CounterValue, float64(stats.RxErrors), labels...)
+	ch <- prometheus.MustNewConstMetric(MetricsInterfaceTxErrors, prometheus.CounterValue, float64(stats.TxErrors), labels...)
+	ch <- prometheus.MustNewConstMetric(MetricsInterfaceRxFIFODropped, prometheus.CounterValue, float64(stats.RxFifoErrors), labels...)
+	ch <- prometheus.MustNewConstMetric(MetricsInterfaceTxFIFODropped, prometheus.CounterValue, float64(stats.TxFifoErrors), labels...)
 }

--- a/pkg/gateway/tunnel/wireguard/procnet.go
+++ b/pkg/gateway/tunnel/wireguard/procnet.go
@@ -1,0 +1,148 @@
+// Copyright 2019-2026 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wireguard
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+const (
+	// procNetSnmpPath is the path of the file exposing per-protocol (namespaced) network statistics.
+	procNetSnmpPath = "/proc/net/snmp"
+	// procSysRmemMax is the path to the maximum UDP socket receive buffer size.
+	procSysRmemMax = "/proc/sys/net/core/rmem_max"
+	// procSysWmemMax is the path to the maximum UDP socket send buffer size.
+	procSysWmemMax = "/proc/sys/net/core/wmem_max"
+
+	// snmpUDPPrefix is the protocol prefix in /proc/net/snmp.
+	snmpUDPPrefix = "Udp:"
+
+	// Field names of interest in the Udp: section of /proc/net/snmp.
+	udpFieldRcvbufErrors = "RcvbufErrors"
+	udpFieldSndbufErrors = "SndbufErrors"
+	udpFieldInErrors     = "InErrors"
+	udpFieldNoPorts      = "NoPorts"
+)
+
+// udpSummary holds the Udp: counters parsed from /proc/net/snmp.
+// These counters are scoped to the network namespace of the process that
+// reads the file; in the gateway pod they describe the UDP stack that the
+// WireGuard kernel socket uses.
+type udpSummary struct {
+	rcvbuf   uint64 // RcvbufErrors: datagrams dropped due to a full socket receive buffer.
+	sndbuf   uint64 // SndbufErrors: datagrams dropped due to a full socket send buffer.
+	inErrors uint64 // InErrors: datagrams dropped for other reasons (e.g. no memory).
+	noPorts  uint64 // NoPorts: datagrams received for closed ports.
+}
+
+// parseNetSnmp parses /proc/net/snmp content and returns the Udp: counters.
+// The file contains, for each protocol, a header line listing field names
+// immediately followed by a values line with the counters, e.g.:
+//
+//	Udp: InDatagrams NoPorts InErrors OutDatagrams RcvbufErrors SndbufErrors ...
+//	Udp: 1234 5 6 1234 0 0 ...
+func parseNetSnmp(content string) (*udpSummary, error) {
+	var headers []string
+	for _, line := range strings.Split(content, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, snmpUDPPrefix) {
+			continue
+		}
+		fields := strings.Fields(strings.TrimPrefix(line, snmpUDPPrefix))
+		if len(fields) == 0 {
+			return nil, fmt.Errorf("malformed %q line: no fields", snmpUDPPrefix)
+		}
+		if headers == nil {
+			// Header line.
+			headers = fields
+			continue
+		}
+		// Values line.
+		if len(fields) != len(headers) {
+			return nil, fmt.Errorf("malformed %q values line: got %d values, expected %d",
+				snmpUDPPrefix, len(fields), len(headers))
+		}
+		values := make([]uint64, len(fields))
+		for i, f := range fields {
+			v, err := strconv.ParseUint(f, 10, 64)
+			if err != nil {
+				return nil, fmt.Errorf("parsing %q values line: %w", snmpUDPPrefix, err)
+			}
+			values[i] = v
+		}
+		m := map[string]uint64{}
+		for i := range headers {
+			m[headers[i]] = values[i]
+		}
+		// Validate that all fields of interest are present.
+		for _, name := range []string{udpFieldRcvbufErrors, udpFieldSndbufErrors, udpFieldInErrors, udpFieldNoPorts} {
+			if _, ok := m[name]; !ok {
+				return nil, fmt.Errorf("field %q not found in %q section", name, snmpUDPPrefix)
+			}
+		}
+		return &udpSummary{
+			rcvbuf:   m[udpFieldRcvbufErrors],
+			sndbuf:   m[udpFieldSndbufErrors],
+			inErrors: m[udpFieldInErrors],
+			noPorts:  m[udpFieldNoPorts],
+		}, nil
+	}
+	return nil, fmt.Errorf("%q section not found", snmpUDPPrefix)
+}
+
+// readUDPSummary reads and parses the Udp: section of /proc/net/snmp.
+func readUDPSummary() (*udpSummary, error) {
+	data, err := os.ReadFile(procNetSnmpPath)
+	if err != nil {
+		return nil, fmt.Errorf("reading %q: %w", procNetSnmpPath, err)
+	}
+	return parseNetSnmp(string(data))
+}
+
+// socketBufferLimits holds the kernel-configured maximum UDP socket buffer
+// sizes visible to the current network namespace.
+type socketBufferLimits struct {
+	rmemMax uint64
+	wmemMax uint64
+}
+
+// readSocketBufferLimits reads /proc/sys/net/core/{r,w}mem_max.
+func readSocketBufferLimits() (*socketBufferLimits, error) {
+	rmem, err := readUintFile(procSysRmemMax)
+	if err != nil {
+		return nil, fmt.Errorf("reading rmem_max: %w", err)
+	}
+	wmem, err := readUintFile(procSysWmemMax)
+	if err != nil {
+		return nil, fmt.Errorf("reading wmem_max: %w", err)
+	}
+	return &socketBufferLimits{rmemMax: rmem, wmemMax: wmem}, nil
+}
+
+// readUintFile reads a file containing a single unsigned integer.
+func readUintFile(path string) (uint64, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0, fmt.Errorf("reading %q: %w", path, err)
+	}
+	v, err := strconv.ParseUint(strings.TrimSpace(string(data)), 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("parsing %q: %w", path, err)
+	}
+	return v, nil
+}

--- a/pkg/gateway/tunnel/wireguard/procnet_linux.go
+++ b/pkg/gateway/tunnel/wireguard/procnet_linux.go
@@ -1,0 +1,88 @@
+// Copyright 2019-2026 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+
+package wireguard
+
+import (
+	"fmt"
+
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
+)
+
+// udpQueueStats holds the current send/receive queue lengths (in bytes) for
+// the WireGuard UDP socket(s), expressed as the sum across all matching sockets.
+type udpQueueStats struct {
+	txBytes uint64
+	rxBytes uint64
+}
+
+// readUDPQueueStats returns the current tx/rx queue byte counters of the
+// WireGuard UDP socket(s) bound to localPort, using the INET_DIAG netlink
+// interface (kernel ≥ 2.6.32). It works for both server (where the listen
+// port is set explicitly) and client (where the kernel auto-binds an
+// ephemeral port and reflects it in the device's netlink attributes) modes.
+//
+// When localPort <= 0 — for example with userspace WireGuard, which does not
+// bind a kernel UDP socket — this function returns an error. The metrics
+// collector handles that by reporting invalid metrics, so the failure is
+// visible in Prometheus rather than being masked as zero queue bytes.
+func readUDPQueueStats(localPort int) (*udpQueueStats, error) {
+	if localPort <= 0 || localPort > 65535 {
+		return nil, fmt.Errorf("invalid local port %d", localPort)
+	}
+
+	// WireGuard tunnels in Liqo use IPv4 endpoints. Enumerate UDP sockets for
+	// AF_INET only; if v6 support is ever added to the wireguard tunnels here,
+	// a parallel call for unix.AF_INET6 and a sum would be straightforward.
+	socks, err := netlink.SocketDiagUDP(unix.AF_INET)
+	if err != nil {
+		return nil, fmt.Errorf("listing UDP sockets via INET_DIAG: %w", err)
+	}
+
+	stats, found := filterUDPQueueStatsByPort(socks, localPort)
+	if !found {
+		return nil, fmt.Errorf("no UDP socket found for port %d", localPort)
+	}
+	return stats, nil
+}
+
+// filterUDPQueueStatsByPort sums the tx/rx queue bytes of all UDP sockets
+// matching the given local source port. Multiple rows can match the same
+// port when several endpoints share it (e.g. IPv4-mapped or duplicate binds);
+// in that case we sum, matching the previous /proc/net/udp semantics.
+//
+// Exposed at package scope so it can be unit-tested with synthetic socket
+// rows without needing CAP_NET_ADMIN.
+func filterUDPQueueStatsByPort(socks []*netlink.Socket, localPort int) (*udpQueueStats, bool) {
+	var stats udpQueueStats
+	var found bool
+	for _, s := range socks {
+		if s == nil {
+			continue
+		}
+		if int(s.ID.SourcePort) != localPort {
+			continue
+		}
+		stats.txBytes += uint64(s.WQueue)
+		stats.rxBytes += uint64(s.RQueue)
+		found = true
+	}
+	if !found {
+		return nil, false
+	}
+	return &stats, true
+}

--- a/pkg/gateway/tunnel/wireguard/procnet_linux_test.go
+++ b/pkg/gateway/tunnel/wireguard/procnet_linux_test.go
@@ -1,0 +1,70 @@
+// Copyright 2019-2026 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+
+package wireguard
+
+import (
+	"testing"
+
+	"github.com/vishvananda/netlink"
+)
+
+func TestFilterUDPQueueStatsByPort_Match(t *testing.T) {
+	socks := []*netlink.Socket{
+		{ID: netlink.SocketID{SourcePort: 1234}, WQueue: 10, RQueue: 20},
+		{ID: netlink.SocketID{SourcePort: 8080}, WQueue: 100, RQueue: 200},
+		{ID: netlink.SocketID{SourcePort: 8080}, WQueue: 1, RQueue: 2},
+	}
+	got, ok := filterUDPQueueStatsByPort(socks, 8080)
+	if !ok {
+		t.Fatal("expected match for port 8080")
+	}
+	// Multiple sockets on the same port must be summed.
+	if got.txBytes != 101 || got.rxBytes != 202 {
+		t.Fatalf("unexpected queue bytes: tx=%d rx=%d", got.txBytes, got.rxBytes)
+	}
+}
+
+func TestFilterUDPQueueStatsByPort_NoMatch(t *testing.T) {
+	socks := []*netlink.Socket{
+		{ID: netlink.SocketID{SourcePort: 1234}, WQueue: 10, RQueue: 20},
+	}
+	if _, ok := filterUDPQueueStatsByPort(socks, 9999); ok {
+		t.Fatal("expected no match for port 9999")
+	}
+}
+
+func TestFilterUDPQueueStatsByPort_EmptyAndNil(t *testing.T) {
+	if _, ok := filterUDPQueueStatsByPort(nil, 8080); ok {
+		t.Fatal("expected no match for empty input")
+	}
+	socks := []*netlink.Socket{nil, {ID: netlink.SocketID{SourcePort: 1234}}}
+	if _, ok := filterUDPQueueStatsByPort(socks, 1234); ok {
+		t.Fatal("nil entries must not match")
+	}
+}
+
+func TestReadUDPQueueStats_InvalidPort(t *testing.T) {
+	if _, err := readUDPQueueStats(0); err == nil {
+		t.Fatal("expected error for port 0")
+	}
+	if _, err := readUDPQueueStats(70000); err == nil {
+		t.Fatal("expected error for port > 65535")
+	}
+	if _, err := readUDPQueueStats(-1); err == nil {
+		t.Fatal("expected error for negative port")
+	}
+}

--- a/pkg/gateway/tunnel/wireguard/procnet_other.go
+++ b/pkg/gateway/tunnel/wireguard/procnet_other.go
@@ -1,0 +1,35 @@
+// Copyright 2019-2026 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !linux
+
+package wireguard
+
+import "fmt"
+
+// udpQueueStats is defined on Linux; this stub matches the type so the
+// non-Linux build can keep the metrics package compiling.
+type udpQueueStats struct {
+	txBytes uint64
+	rxBytes uint64
+}
+
+// readUDPQueueStats is unavailable on non-Linux platforms because the
+// vishvananda/netlink INET_DIAG helpers used here are Linux-only. The
+// metrics collector treats this as an unrecoverable error and falls back
+// to emitting 0 with a logged warning, which is the correct behavior for
+// a non-Linux host (the gateway runs on Linux in production).
+func readUDPQueueStats(_ int) (*udpQueueStats, error) {
+	return nil, fmt.Errorf("UDP queue statistics are only supported on Linux")
+}

--- a/pkg/gateway/tunnel/wireguard/procnet_test.go
+++ b/pkg/gateway/tunnel/wireguard/procnet_test.go
@@ -1,0 +1,59 @@
+// Copyright 2019-2026 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wireguard
+
+import (
+	"testing"
+)
+
+const validSnmp = `Ip: Forwarding DefaultTTL InReceives InHdrErrors InAddrErrors ForwDatagrams InUnknownProtos InDiscards InDelivers OutRequests OutDiscards OutNoRoutes ReasmTimeout ReasmReqds ReasmOKs ReasmFails FragOKs FragFails FragCreates
+Ip: 1 64 100000 0 0 0 0 0 90000 95000 0 0 0 0 0 0 0 0 0
+Tcp: RtoAlgorithm RtoMin RtoMax MaxConn ActiveOpens PassiveOpens AttemptFails EstabResets CurrEstab InSegs OutSegs RetransSegs InErrs OutRsts InCsumErrors
+Tcp: 1 200 120000 -1 100 50 2 1 5 50000 48000 10 0 3 0
+Udp: InDatagrams NoPorts InErrors OutDatagrams RcvbufErrors SndbufErrors InCsumErrors IgnoredMulti MemErrors
+Udp: 2000 4 7 2100 42 5 1 0 0
+UdpLite: InDatagrams NoPorts InErrors OutDatagrams RcvbufErrors SndbufErrors InCsumErrors IgnoredMulti MemErrors
+UdpLite: 0 0 0 0 0 0 0 0 0
+`
+
+func TestParseNetSnmp(t *testing.T) {
+	s, err := parseNetSnmp(validSnmp)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if s.rcvbuf != 42 || s.sndbuf != 5 || s.inErrors != 7 || s.noPorts != 4 {
+		t.Fatalf("unexpected values: %+v", s)
+	}
+}
+
+func TestParseNetSnmpMissingSection(t *testing.T) {
+	if _, err := parseNetSnmp("Ip: A\nIp: 1\n"); err == nil {
+		t.Fatal("expected error for missing Udp: section")
+	}
+}
+
+func TestParseNetSnmpMissingField(t *testing.T) {
+	content := "Udp: InDatagrams OutDatagrams\nUdp: 1 2\n"
+	if _, err := parseNetSnmp(content); err == nil {
+		t.Fatal("expected error for missing fields of interest")
+	}
+}
+
+func TestParseNetSnmpMismatch(t *testing.T) {
+	content := "Udp: InDatagrams NoPorts\nUdp: 1 2 3\n"
+	if _, err := parseNetSnmp(content); err == nil {
+		t.Fatal("expected error for mismatched header/values lengths")
+	}
+}


### PR DESCRIPTION
# PR: Expose WireGuard packet and Linux buffer/queue metrics

## Summary

Extend Liqo networking metrics to expose:

1. **Per-WireGuard-interface packet counters and UDP socket buffer counters**
   from the gateway collector.
2. **Host-wide softnet/backlog statistics** from the fabric collector.

The Grafana dashboard shows the UDP socket queue bytes and the UDP socket
buffer limits in a single graph, so buffer pressure and its ceiling are visible
at a glance.

These metrics make it possible to investigate latency growth under sustained
traffic, especially when bandwidth is low but the CPU is spending a lot of time
in `softirq`.

The host-wide `softnet_stat` statistics live in the fabric (which runs once per
node) to avoid emitting the same host counter multiple times when several
gateways run on the same node. UDP socket buffer counters stay on the gateway
because the WireGuard UDP socket lives in the gateway pod's network namespace.

## What changed

### New source files

- `pkg/gateway/tunnel/wireguard/procnet.go`
  - Stdlib-only parser for `/proc/net/snmp` (UDP counters).
- `pkg/gateway/tunnel/wireguard/procnet_test.go`
  - Unit tests for the UDP parser.
- `pkg/fabric/procnet.go`
  - Stdlib-only parser for `/proc/net/softnet_stat` (per-CPU softirq/backlog
    counters).
- `pkg/fabric/procnet_test.go`
  - Unit tests for the softnet parser.

### Modified files

- `pkg/fabric/metrics.go`
  - Added the `HostNetworkCollector` that emits the host-wide softnet/backlog
    metrics once per node.
- `pkg/gateway/tunnel/wireguard/metrics.go`
  - Added per-interface packet counters (rx/tx packets, drops, errors, FIFO
    errors) via 64-bit rtnetlink statistics from `vishvananda/netlink`.
  - Added UDP socket buffer counters from `/proc/net/snmp`.
- `cmd/fabric/main.go`
  - Registered the new `HostNetworkCollector`.
- `docs/_downloads/grafana/liqonetwork.json`
  - Merged the UDP socket queue bytes and UDP socket buffer limits panels into
    a single graph, with all four series (RX queue, TX queue, rmem_max,
    wmem_max) on one panel.

### New metrics

#### WireGuard interface packet counters

| Metric | Description |
|--------|-------------|
| `liqo_wireguard_interface_rx_packets_total` | Packets received on the WireGuard interface |
| `liqo_wireguard_interface_tx_packets_total` | Packets transmitted on the WireGuard interface |
| `liqo_wireguard_interface_rx_dropped_total` | Ingress drops on the interface |
| `liqo_wireguard_interface_tx_dropped_total` | Egress drops on the interface |
| `liqo_wireguard_interface_rx_errors_total` | Receive errors |
| `liqo_wireguard_interface_tx_errors_total` | Transmit errors |
| `liqo_wireguard_interface_rx_fifo_errors_total` | RX FIFO/ring-buffer errors |
| `liqo_wireguard_interface_tx_fifo_errors_total` | TX FIFO/ring-buffer errors |

Labels: `driver`, `cluster_id`.

#### UDP socket buffer counters (gateway, per-peer)

| Metric | Description |
|--------|-------------|
| `liqo_wireguard_udp_rcvbuf_errors_total` | UDP datagrams dropped due to a full receive buffer |
| `liqo_wireguard_udp_sndbuf_errors_total` | UDP datagrams dropped due to a full send buffer |
| `liqo_wireguard_udp_in_errors_total` | UDP datagrams dropped for other reasons |
| `liqo_wireguard_udp_no_ports_total` | UDP datagrams received on closed ports |

Labels: `driver`, `cluster_id`.

#### UDP socket queue and limit gauges (gateway, per-peer)

| Metric | Type | Description |
|--------|------|-------------|
| `liqo_wireguard_udp_rx_queue_bytes` | Gauge | Bytes currently queued in the WireGuard UDP socket receive queue |
| `liqo_wireguard_udp_tx_queue_bytes` | Gauge | Bytes currently queued in the WireGuard UDP socket send queue |
| `liqo_wireguard_udp_rmem_max_bytes` | Gauge | Maximum UDP receive buffer size configured for the gateway namespace (`rmem_max`) |
| `liqo_wireguard_udp_wmem_max_bytes` | Gauge | Maximum UDP send buffer size configured for the gateway namespace (`wmem_max`) |

Labels: `driver`, `cluster_id`.

#### Softnet / softirq counters (fabric, host-wide)

| Metric | Description |
|--------|-------------|
| `liqo_fabric_host_softnet_processed_packets_total` | Packets processed by the NET_RX softirq per CPU |
| `liqo_fabric_host_softnet_dropped_packets_total` | Packets dropped because the per-CPU netdev backlog was full |
| `liqo_fabric_host_softnet_time_squeeze_total` | Times the softirq exhausted its budget with work left |
| `liqo_fabric_host_softnet_backlog_length` | Current per-CPU netdev backlog queue length (gauge) |

Labels: `node`, `cpu`.

## What problem each metric helps debug

### WireGuard interface packet counters

These metrics answer: **is the tunnel moving many small packets or a few big
ones?** They come from the netdev statistics of the WireGuard interface, so
they are per-interface and safe to collect from every gateway.

- **When latency grows but throughput stays low**, compute the average packet
  size: `rate(bytes) / rate(packets)`. If the result is small (e.g. under
  500 bytes), the CPU is stressed by **packets-per-second**, not by
  bandwidth. This is the classic “softirq high, system low” signature.
- **Drops / errors / FIFO errors** on the WireGuard interface point to the
  interface's own transmit/receive queues (or ring buffers) being too small
  or too busy. Non-zero FIFO errors especially suggest the driver queue is
  overflowing.

### UDP socket buffer counters (gateway)

These metrics answer: **are UDP datagrams being dropped because the WireGuard
UDP socket buffer is full?**

- `liqo_wireguard_udp_rcvbuf_errors_total` increasing while latency grows
  means the WireGuard kernel socket cannot drain packets fast enough and Linux
  is dropping them. The fix is usually to raise `net.core.rmem_max` /
  `net.core.rmem_default` for the gateway pod, or to reduce the packet rate.
- `liqo_wireguard_udp_sndbuf_errors_total` increasing points to the same
  problem on the transmit side.
- `liqo_wireguard_udp_no_ports_total` is normally flat; if it rises, traffic
  is arriving on a UDP port with no listener, which hints at a configuration
  or port mismatch.
- `liqo_wireguard_udp_rx_queue_bytes` / `tx_queue_bytes` show the **current**
  number of bytes sitting in the UDP socket queues. Unlike the error counters,
  these are gauges, so they rise and fall with the actual buffer pressure.
  Spikes close to `liqo_wireguard_udp_rmem_max_bytes` or
  `wmem_max_bytes` mean the socket is running out of headroom and
  `RcvbufErrors`/`SndbufErrors` are likely to follow.
  If the INET_DIAG lookup fails (e.g. userspace WireGuard, missing
  `CAP_NET_ADMIN`, or an unbound socket), these metrics are reported as
  invalid instead of being silently emitted as zero, so scrape failures are
  visible in Prometheus.
- `liqo_wireguard_udp_rmem_max_bytes` / `wmem_max_bytes` expose the ceiling
  for the buffer. They are static per namespace, but they let you compute a
  utilization ratio (queue / limit) without logging into the pod.

Because the gateway pod has its own network namespace, these counters describe
the exact UDP stack that the WireGuard socket uses.

### Softnet / softirq counters (fabric)

These metrics answer: **is the per-CPU network receive path the bottleneck?**
They come from `/proc/net/softnet_stat`, which is host-global. Collecting
them from the fabric avoids duplication when multiple gateways coexist on the
same node.

- `liqo_fabric_host_softnet_time_squeeze_total` increasing is the **smoking
  gun**: the NET_RX softirq worker ran out of its budget/time slice with work
  still pending. Packets are then deferred to the netdev backlog, which
  directly increases latency.
- `liqo_fabric_host_softnet_backlog_length` growing and staying high shows
  the backlog queue filling up. This is the “buffer growing under the hood”
  hypothesis: packets wait in the backlog, so latency rises even without
  drops.
- `liqo_fabric_host_softnet_dropped_packets_total` increasing means the
  backlog queue overflowed and packets were dropped.
- `liqo_fabric_host_softnet_processed_packets_total` gives the baseline pps
  the softirq is handling, which helps correlate CPU load with tunnel
  traffic.

## How to validate the hypothesis with these metrics

Look for these patterns while latency is growing:

1. High packet rate with small average packet size:
   ```promql
   rate(liqo_wireguard_interface_rx_packets_total[1m])
   rate(liqo_peer_receive_bytes_total[1m]) / rate(liqo_wireguard_interface_rx_packets_total[1m])
   ```
2. Softirq backlog saturation:
   ```promql
   rate(liqo_fabric_host_softnet_time_squeeze_total[1m])
   liqo_fabric_host_softnet_backlog_length
   ```
3. UDP socket buffer saturation:
   ```promql
   rate(liqo_wireguard_udp_rcvbuf_errors_total{cluster_id="$clusterid"}[5m])
   liqo_wireguard_udp_rx_queue_bytes{cluster_id="$clusterid"}
   liqo_wireguard_udp_rmem_max_bytes{cluster_id="$clusterid"}
   ```

If `time_squeeze` and `backlog_length` rise together with latency, the
bottleneck is the per-packet NET_RX softirq path.

## Testing

- `go test ./pkg/fabric/` — unit tests for `/proc` parsers.
- `go build ./pkg/gateway/tunnel/wireguard/... ./pkg/fabric/... ./cmd/fabric/...`
  — Linux cross-compile passes.
- `gofmt` — clean.

## Notes

- `softnet_stat` counters are host-global, not per-namespace. They are emitted
  by the fabric (once per node) to avoid duplication when multiple gateways
  share a node.
- UDP `/proc/net/snmp` counters are namespaced to the gateway pod's network
  namespace, so they reflect the UDP stack used by the WireGuard socket.
- No new Go dependencies were added; `/proc` parsing uses the standard library.
- This PR applies the new metrics on top of the current `master` version of
  `metrics.go`, which no longer contains the latency/connection code that was
  present in the older branch. Restoring latency metrics is out of scope here.

## Related documentation

- `.kimchi/docs/wireguard-buffer-metrics-plan.md`
- `.kimchi/docs/wireguard-latency-and-metrics-explained.md`
