### PR TITLE
fix: fetch rules/routes once during routeconfiguration reconcile

### DIFF
--- a/pkg/route/route.go
+++ b/pkg/route/route.go
@@ -30,13 +30,13 @@ import (
 var ErrNetworkUnreachable = errors.New("network unreachable")
 
 // EnsureRoutesPresence ensures the presence of the given routes.
-func EnsureRoutesPresence(routes []networkingv1beta1.Route, tableID uint32) error {
+func EnsureRoutesPresence(routes []networkingv1beta1.Route, tableID uint32, existing []netlink.Route) error {
 	for i := range routes {
 		route, err := forgeNetlinkRoute(&routes[i], tableID)
 		if err != nil {
 			return err
 		}
-		existingroute, exists, err := ExistsRoute(&routes[i], tableID)
+		existingroute, exists, err := FindRouteInList(&routes[i], existing)
 		if err != nil {
 			return err
 		}
@@ -62,12 +62,12 @@ func EnsureRoutesPresence(routes []networkingv1beta1.Route, tableID uint32) erro
 }
 
 // EnsureRoutesAbsence ensures the absence of the given routes.
-func EnsureRoutesAbsence(routes []networkingv1beta1.Route, tableID uint32) error {
+func EnsureRoutesAbsence(routes []networkingv1beta1.Route, existing []netlink.Route) error {
 	for i := range routes {
 		if routes[i].Dst == nil {
 			continue
 		}
-		existingRoute, exists, err := ExistsRoute(&routes[i], tableID)
+		existingRoute, exists, err := FindRouteInList(&routes[i], existing)
 		if err != nil {
 			return fmt.Errorf("checking route existence: %w", err)
 		}
@@ -80,30 +80,40 @@ func EnsureRoutesAbsence(routes []networkingv1beta1.Route, tableID uint32) error
 	return nil
 }
 
-// ExistsRoute checks if the given route is already present in the route list.
-func ExistsRoute(route *networkingv1beta1.Route, tableID uint32) (*netlink.Route, bool, error) {
+// FindRouteInList searches for a route matching the given spec within the provided list of existing routes.
+// It returns the matching netlink.Route and true if found, or an error if more than one route matches.
+func FindRouteInList(route *networkingv1beta1.Route, existing []netlink.Route) (*netlink.Route, bool, error) {
+	if route.Dst == nil {
+		return nil, false, nil
+	}
 	_, dst, err := net.ParseCIDR(route.Dst.String())
 	if err != nil {
 		return nil, false, err
 	}
+	var found *netlink.Route
+	for i := range existing {
+		if existing[i].Dst == nil {
+			continue
+		}
+		if existing[i].Dst.String() != dst.String() {
+			continue
+		}
+		if found != nil {
+			return nil, false, fmt.Errorf("multiple routes found with same destination %s", dst.String())
+		}
+		found = &existing[i]
+	}
+	if found == nil {
+		return nil, false, nil
+	}
+	return found, true, nil
+}
 
-	existingRoutes, err := netlink.RouteListFiltered(netlink.FAMILY_ALL, &netlink.Route{
-		Dst:   dst,
+// GetRoutesByTableID returns all the routes associated with the given table ID.
+func GetRoutesByTableID(tableID uint32) ([]netlink.Route, error) {
+	return netlink.RouteListFiltered(netlink.FAMILY_ALL, &netlink.Route{
 		Table: int(tableID),
-	}, netlink.RT_FILTER_DST|netlink.RT_FILTER_TABLE)
-	if err != nil {
-		return nil, false, err
-	}
-
-	if len(existingRoutes) > 1 {
-		return nil, false, fmt.Errorf("%v routes found with same destination", len(existingRoutes))
-	}
-
-	if len(existingRoutes) == 1 {
-		return &existingRoutes[0], true, nil
-	}
-
-	return nil, false, nil
+	}, netlink.RT_FILTER_TABLE)
 }
 
 // IsEqualRoute checks if the two routes are equal.
@@ -127,14 +137,10 @@ func IsEqualRoute(route1, route2 *netlink.Route) bool {
 }
 
 // CleanRoutes cleans the routes that are not contained in the given route list.
-func CleanRoutes(routes []networkingv1beta1.Route, tableID uint32) error {
-	existingrules, err := netlink.RouteListFiltered(netlink.FAMILY_ALL, &netlink.Route{Table: int(tableID)}, netlink.RT_FILTER_TABLE)
-	if err != nil {
-		return err
-	}
-	for i := range existingrules {
-		if !IsContainedRoute(&existingrules[i], routes) {
-			if err := netlink.RouteDel(&existingrules[i]); err != nil {
+func CleanRoutes(routes []networkingv1beta1.Route, existing []netlink.Route) error {
+	for i := range existing {
+		if !IsContainedRoute(&existing[i], routes) {
+			if err := netlink.RouteDel(&existing[i]); err != nil {
 				return err
 			}
 		}

--- a/pkg/route/routeconfiguration_controller.go
+++ b/pkg/route/routeconfiguration_controller.go
@@ -122,11 +122,20 @@ func (r *RouteConfigurationReconciler) Reconcile(ctx context.Context, req ctrl.R
 		return ctrl.Result{}, nil
 
 	case deleting && containsFinalizer && r.EnableFinalizer:
+		existingRules, err := GetRulesByTableID(tableID)
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("listing existing rules: %w", err)
+		}
+		existingRoutes, err := GetRoutesByTableID(tableID)
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("listing existing routes: %w", err)
+		}
+
 		for i := range routeconfiguration.Spec.Table.Rules {
-			if err = EnsureRuleAbsence(&routeconfiguration.Spec.Table.Rules[i], tableID); err != nil {
+			if err = EnsureRuleAbsence(&routeconfiguration.Spec.Table.Rules[i], existingRules); err != nil {
 				return ctrl.Result{}, fmt.Errorf("ensuring rule absence: %w", err)
 			}
-			if err = EnsureRoutesAbsence(routeconfiguration.Spec.Table.Rules[i].Routes, tableID); err != nil {
+			if err = EnsureRoutesAbsence(routeconfiguration.Spec.Table.Rules[i].Routes, existingRoutes); err != nil {
 				return ctrl.Result{}, fmt.Errorf("ensuring routes absence: %w", err)
 			}
 		}
@@ -147,8 +156,17 @@ func (r *RouteConfigurationReconciler) Reconcile(ctx context.Context, req ctrl.R
 		return ctrl.Result{}, nil
 	}
 
-	if err = CleanRules(routeconfiguration.Spec.Table.Rules, tableID); err != nil {
+	existingRules, err := GetRulesByTableID(tableID)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("listing existing rules: %w", err)
+	}
+	if err = CleanRules(routeconfiguration.Spec.Table.Rules, existingRules); err != nil {
 		return ctrl.Result{}, fmt.Errorf("cleaning rules: %w", err)
+	}
+
+	existingRoutes, err := GetRoutesByTableID(tableID)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("listing existing routes: %w", err)
 	}
 
 	allRoutes := []networkingv1beta1.Route{}
@@ -157,7 +175,7 @@ func (r *RouteConfigurationReconciler) Reconcile(ctx context.Context, req ctrl.R
 		// This is necessary because we can't list the route rules filtering per rule.
 		allRoutes = append(allRoutes, routeconfiguration.Spec.Table.Rules[i].Routes...)
 	}
-	if err = CleanRoutes(allRoutes, tableID); err != nil {
+	if err = CleanRoutes(allRoutes, existingRoutes); err != nil {
 		return ctrl.Result{}, fmt.Errorf("cleaning routes: %w", err)
 	}
 
@@ -167,11 +185,16 @@ func (r *RouteConfigurationReconciler) Reconcile(ctx context.Context, req ctrl.R
 		return ctrl.Result{}, fmt.Errorf("ensuring table presence: %w", err)
 	}
 
+	// existingRules/existingRoutes were snapshotted before CleanRules/CleanRoutes ran, so they no
+	// longer reflect kernel state. Reusing them here is still correct: Clean only deletes entries
+	// NOT in the desired spec, while Ensure*Presence only looks up entries that ARE in the desired
+	// spec, so the two never operate on the same rows and the stale snapshot cannot cause a wrong
+	// exists/not-exists result. Re-fetching here would just be a redundant netlink list.
 	for i := range routeconfiguration.Spec.Table.Rules {
-		if err = EnsureRulePresence(&routeconfiguration.Spec.Table.Rules[i], tableID); err != nil {
+		if err = EnsureRulePresence(&routeconfiguration.Spec.Table.Rules[i], tableID, existingRules); err != nil {
 			return ctrl.Result{}, fmt.Errorf("ensuring rule presence: %w", err)
 		}
-		if err := EnsureRoutesPresence(routeconfiguration.Spec.Table.Rules[i].Routes, tableID); err != nil {
+		if err := EnsureRoutesPresence(routeconfiguration.Spec.Table.Rules[i].Routes, tableID, existingRoutes); err != nil {
 			if errors.As(err, &netlink.LinkNotFoundError{}) {
 				klog.V(3).Infof("Link not found for routeconfiguration %s, requeuing: %v", req.String(), err)
 				return ctrl.Result{RequeueAfter: 1 * time.Second}, nil

--- a/pkg/route/rule.go
+++ b/pkg/route/rule.go
@@ -25,13 +25,8 @@ import (
 )
 
 // EnsureRulePresence ensures the presence of the given rule.
-func EnsureRulePresence(rule *networkingv1beta1.Rule, tableID uint32) error {
-	rules, err := GetRulesByTableID(tableID)
-	if err != nil {
-		return err
-	}
-
-	_, exists, err := ExistsRule(rule, rules)
+func EnsureRulePresence(rule *networkingv1beta1.Rule, tableID uint32, existing []netlink.Rule) error {
+	_, exists, err := ExistsRule(rule, existing)
 	if err != nil {
 		return err
 	}
@@ -43,13 +38,8 @@ func EnsureRulePresence(rule *networkingv1beta1.Rule, tableID uint32) error {
 }
 
 // EnsureRuleAbsence ensures the absence of the given rule.
-func EnsureRuleAbsence(rule *networkingv1beta1.Rule, tableID uint32) error {
-	rules, err := GetRulesByTableID(tableID)
-	if err != nil {
-		return err
-	}
-
-	existingrule, exists, err := ExistsRule(rule, rules)
+func EnsureRuleAbsence(rule *networkingv1beta1.Rule, existing []netlink.Rule) error {
+	existingrule, exists, err := ExistsRule(rule, existing)
 	if err != nil {
 		return err
 	}
@@ -180,14 +170,10 @@ func RuleIsEqual(rule *networkingv1beta1.Rule, netlinkRule *netlink.Rule) bool {
 }
 
 // CleanRules deletes all the rules which are not contained anymore in the given rules list.
-func CleanRules(rules []networkingv1beta1.Rule, tableID uint32) error {
-	existingrules, err := GetRulesByTableID(tableID)
-	if err != nil {
-		return err
-	}
-	for i := range existingrules {
-		if !IsContainedRule(&existingrules[i], rules) {
-			if err := netlink.RuleDel(&existingrules[i]); err != nil {
+func CleanRules(rules []networkingv1beta1.Rule, existing []netlink.Rule) error {
+	for i := range existing {
+		if !IsContainedRule(&existing[i], rules) {
+			if err := netlink.RuleDel(&existing[i]); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
## Description

`RouteConfigurationReconciler.Reconcile` previously called `netlink.RuleListFiltered`/`netlink.RouteListFiltered` separately inside `CleanRules`/`CleanRoutes` and again inside `EnsureRulePresence`/`EnsureRoutesPresence` (once per rule), issuing redundant netlink list calls on every reconcile.

This change fetches the existing rules and routes for the table once per reconcile (`GetRulesByTableID`/`GetRoutesByTableID`) and passes the snapshot down to `CleanRules`, `CleanRoutes`, `EnsureRuleAbsence`, `EnsureRoutesAbsence`, `EnsureRulePresence`, and `EnsureRoutesPresence`, replacing their internal netlink lookups with in-memory search (`FindRouteInList` / existing `ExistsRule` against the passed-in list).

Using a snapshot taken before `CleanRules`/`CleanRoutes` run is still correct for the later `EnsureRulePresence`/`EnsureRoutesPresence` calls: `Clean*` only deletes entries *not* in the desired spec, while `Ensure*Presence` only looks up entries that *are* in the desired spec, so the two never operate on the same rows.

## How Has This Been Tested?

- [x] Existing unit tests in `pkg/route` pass with the updated signatures.