### PR TITLE
fix: consolidate gw-ext rules

### DIFF
--- a/apis/networking/v1beta1/firewall/filterrule_types.go
+++ b/apis/networking/v1beta1/firewall/filterrule_types.go
@@ -39,6 +39,11 @@ const (
 	// ActionNotrack is the action to be applied to the rule.
 	// ActionNotrack disables connection tracking for the matched packet.
 	ActionNotrack FilterAction = "notrack"
+	// ActionSetMetaMark is the action to be applied to the rule.
+	// It is used to set the packet meta mark (fwmark) directly to the value specified in Value.
+	// Unlike ActionCtMark + ActionSetMetaMarkFromCtMark, this sets the mark per-packet
+	// (not per-connection) and is available immediately for route lookup when used in prerouting.
+	ActionSetMetaMark FilterAction = "setmetamark"
 )
 
 // FilterRule is a rule to be applied to a filter chain.
@@ -53,7 +58,7 @@ type FilterRule struct {
 	// They can be multiple and they are applied with an AND operator.
 	Match []Match `json:"match"`
 	// Action is the action to be applied to the rule.
-	// +kubebuilder:validation:Enum=ctmark;metamarkfromctmark;tcpmssclamp;accept;drop;reject;notrack
+	// +kubebuilder:validation:Enum=ctmark;metamarkfromctmark;tcpmssclamp;accept;drop;reject;notrack;setmetamark
 	Action FilterAction `json:"action"`
 	// Value is the value to be used for the action.
 	Value *string `json:"value,omitempty"`

--- a/apis/networking/v1beta1/firewall/match_types.go
+++ b/apis/networking/v1beta1/firewall/match_types.go
@@ -82,6 +82,11 @@ type MatchDev struct {
 	// Position is the source device of the packet.
 	// +kubebuilder:validation:Enum=in;out
 	Position MatchDevPosition `json:"position"`
+	// Wildcard enables prefix matching on the device name.
+	// When true, the match compares only the prefix bytes of Value against the interface name,
+	// allowing a single rule to match all interfaces sharing a common prefix (e.g. "liqo.").
+	// +kubebuilder:default=false
+	Wildcard bool `json:"wildcard,omitempty"`
 }
 
 // MatchProto is a protocol to be matched.

--- a/deployments/liqo/charts/liqo-crds/crds/networking.liqo.io_firewallconfigurations.yaml
+++ b/deployments/liqo/charts/liqo-crds/crds/networking.liqo.io_firewallconfigurations.yaml
@@ -108,6 +108,7 @@ spec:
                                     - drop
                                     - reject
                                     - notrack
+                                    - setmetamark
                                     type: string
                                   counter:
                                     default: true
@@ -137,6 +138,13 @@ spec:
                                               description: Value is the name of the
                                                 device to be matched.
                                               type: string
+                                            wildcard:
+                                              default: false
+                                              description: |-
+                                                Wildcard enables prefix matching on the device name.
+                                                When true, the match compares only the prefix bytes of Value against the interface name,
+                                                allowing a single rule to match all interfaces sharing a common prefix (e.g. "liqo.").
+                                              type: boolean
                                           required:
                                           - position
                                           - value
@@ -247,6 +255,13 @@ spec:
                                               description: Value is the name of the
                                                 device to be matched.
                                               type: string
+                                            wildcard:
+                                              default: false
+                                              description: |-
+                                                Wildcard enables prefix matching on the device name.
+                                                When true, the match compares only the prefix bytes of Value against the interface name,
+                                                allowing a single rule to match all interfaces sharing a common prefix (e.g. "liqo.").
+                                              type: boolean
                                           required:
                                           - position
                                           - value

--- a/pkg/firewall/utils/filterule.go
+++ b/pkg/firewall/utils/filterule.go
@@ -16,6 +16,7 @@ package utils
 
 import (
 	"fmt"
+	"math"
 	"strconv"
 
 	"github.com/google/nftables"
@@ -126,6 +127,9 @@ func applyCtMarkAction(value *string, rule *nftables.Rule) error {
 	valueInt, err := strconv.Atoi(*value)
 	if err != nil {
 		return fmt.Errorf("cannot convert value to int: %w", err)
+	}
+	if valueInt < 0 || valueInt > math.MaxUint32 {
+		return fmt.Errorf("value %d is out of range for a uint32 mark", valueInt)
 	}
 	rule.Exprs = append(rule.Exprs,
 		&expr.Immediate{
@@ -252,6 +256,9 @@ func applySetMetaMarkAction(value *string, rule *nftables.Rule) error {
 	valueInt, err := strconv.Atoi(*value)
 	if err != nil {
 		return fmt.Errorf("cannot convert value to int: %w", err)
+	}
+	if valueInt < 0 || valueInt > math.MaxUint32 {
+		return fmt.Errorf("value %d is out of range for a uint32 mark", valueInt)
 	}
 	rule.Exprs = append(rule.Exprs,
 		&expr.Immediate{

--- a/pkg/firewall/utils/filterule.go
+++ b/pkg/firewall/utils/filterule.go
@@ -112,6 +112,10 @@ func forgeFilterRule(fr *firewallv1beta1.FilterRule, chain *nftables.Chain) (*nf
 		applyRejectAction(rule)
 	case firewallv1beta1.ActionNotrack:
 		applyNotrackAction(rule)
+	case firewallv1beta1.ActionSetMetaMark:
+		if err := applySetMetaMarkAction(fr.Value, rule); err != nil {
+			return nil, fmt.Errorf("cannot apply setmetamark action: %w", err)
+		}
 	default:
 	}
 
@@ -242,6 +246,25 @@ func applyRejectAction(rule *nftables.Rule) {
 
 func applyNotrackAction(rule *nftables.Rule) {
 	rule.Exprs = append(rule.Exprs, &expr.Notrack{})
+}
+
+func applySetMetaMarkAction(value *string, rule *nftables.Rule) error {
+	valueInt, err := strconv.Atoi(*value)
+	if err != nil {
+		return fmt.Errorf("cannot convert value to int: %w", err)
+	}
+	rule.Exprs = append(rule.Exprs,
+		&expr.Immediate{
+			Register: 1,
+			Data:     binaryutil.NativeEndian.PutUint32(uint32(valueInt)),
+		},
+		&expr.Meta{
+			Key:            expr.MetaKeyMARK,
+			SourceRegister: true,
+			Register:       1,
+		},
+	)
+	return nil
 }
 
 func applyCounter(rule *nftables.Rule) {

--- a/pkg/firewall/utils/match.go
+++ b/pkg/firewall/utils/match.go
@@ -219,6 +219,16 @@ func applyMatchDev(m *firewallv1beta1.Match, rule *nftables.Rule, op expr.CmpOp)
 		return err
 	}
 
+	var data []byte
+	if m.Dev.Wildcard {
+		// Prefix match: compare only the prefix bytes without null-padding to 16 bytes.
+		// nftables performs a byte-by-byte comparison, so a short data slice matches any
+		// interface name that starts with the given prefix.
+		data = []byte(m.Dev.Value)
+	} else {
+		data = ifname(m.Dev.Value)
+	}
+
 	rule.Exprs = append(rule.Exprs,
 		&expr.Meta{
 			Register: 1,
@@ -227,7 +237,7 @@ func applyMatchDev(m *firewallv1beta1.Match, rule *nftables.Rule, op expr.CmpOp)
 		&expr.Cmp{
 			Op:       op,
 			Register: 1,
-			Data:     ifname(m.Dev.Value),
+			Data:     data,
 		},
 	)
 

--- a/pkg/gateway/label.go
+++ b/pkg/gateway/label.go
@@ -64,6 +64,15 @@ func ForgeRouteExternalTargetLabels(remoteID string) map[string]string {
 	}
 }
 
+// ForgeFirewallExternalTargetLabels returns the labels used by the firewallconfiguration controller
+// to reconcile only resources related to a single gateway and external-network.
+func ForgeFirewallExternalTargetLabels(remoteID string) map[string]string {
+	return map[string]string{
+		firewall.FirewallCategoryTargetKey: FirewallCategoryGwTargetValue,
+		firewall.FirewallUniqueTargetKey:   remoteID,
+	}
+}
+
 // ForgeRouteInternalTargetLabels returns the labels used by the routeconfiguration controller
 // to reconcile only resources related to internal-network.
 func ForgeRouteInternalTargetLabels() map[string]string {

--- a/pkg/liqo-controller-manager/networking/external-network/route/configuration_controller.go
+++ b/pkg/liqo-controller-manager/networking/external-network/route/configuration_controller.go
@@ -56,7 +56,7 @@ func NewConfigurationReconciler(cl client.Client, s *runtime.Scheme,
 // cluster-role
 // +kubebuilder:rbac:groups=networking.liqo.io,resources=configurations,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=networking.liqo.io,resources=routeconfigurations,verbs=get;list;watch;update;patch;create;delete
-// +kubebuilder:rbac:groups=networking.liqo.io,resources=internalnodes,verbs=get;list;watch
+// +kubebuilder:rbac:groups=networking.liqo.io,resources=firewallconfigurations,verbs=get;list;watch;update;patch;create;delete
 // +kubebuilder:rbac:groups=networking.liqo.io,resources=gatewayservers,verbs=get;list;watch
 // +kubebuilder:rbac:groups=networking.liqo.io,resources=gatewayclients,verbs=get;list;watch
 
@@ -92,26 +92,7 @@ func (r *ConfigurationReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			&networkingv1beta1.GatewayClient{},
 			handler.EnqueueRequestsFromMapFunc(r.configurationEnqueuerByRemoteID()),
 		).
-		Watches(
-			&networkingv1beta1.InternalNode{},
-			handler.EnqueueRequestsFromMapFunc(r.configurationEnqueuerForAllConfigurations()),
-		).
 		Complete(r)
-}
-
-func (r *ConfigurationReconciler) configurationEnqueuerForAllConfigurations() handler.MapFunc {
-	return func(ctx context.Context, _ client.Object) []reconcile.Request {
-		var cfgList networkingv1beta1.ConfigurationList
-		if err := r.List(ctx, &cfgList); err != nil {
-			klog.Errorf("unable to list configurations: %s", err)
-			return nil
-		}
-		requests := make([]reconcile.Request, 0, len(cfgList.Items))
-		for i := range cfgList.Items {
-			requests = append(requests, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(&cfgList.Items[i])})
-		}
-		return requests
-	}
 }
 
 func (r *ConfigurationReconciler) configurationEnqueuerByRemoteID() handler.MapFunc {

--- a/pkg/liqo-controller-manager/networking/external-network/route/k8s.go
+++ b/pkg/liqo-controller-manager/networking/external-network/route/k8s.go
@@ -20,7 +20,6 @@ import (
 	"slices"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -28,6 +27,7 @@ import (
 
 	liqov1beta1 "github.com/liqotech/liqo/apis/core/v1beta1"
 	networkingv1beta1 "github.com/liqotech/liqo/apis/networking/v1beta1"
+	"github.com/liqotech/liqo/apis/networking/v1beta1/firewall"
 	"github.com/liqotech/liqo/pkg/consts"
 	"github.com/liqotech/liqo/pkg/gateway"
 	"github.com/liqotech/liqo/pkg/gateway/tunnel"
@@ -35,8 +35,31 @@ import (
 	"github.com/liqotech/liqo/pkg/utils/resource"
 )
 
+const (
+	// gwExtMark is the fwmark value used to tag traffic arriving on Geneve interfaces (liqo.*).
+	// It allows the gw-ext RouteConfiguration to match on FwMark + Dst instead of Iif + Dst,
+	// collapsing N*R rules to R rules while still preventing routing loops (packets arriving
+	// on the WireGuard interface liqo-tunnel are not marked and do not match).
+	// The mark is set per-packet in the prerouting chain (not via conntrack) so it is available
+	// for route lookup and does not leak to return traffic.
+	//
+	// The value 0xFF00 is chosen to avoid collision with the internal-network mark allocator
+	// (pkg/liqo-controller-manager/networking/internal-network/route/mark.go), which assigns
+	// sequential marks starting from 1, one per node. A high value ensures no overlap even in
+	// very large clusters.
+	gwExtMark = 0xFF00
+
+	// gwExtGenevePrefix is the prefix shared by all Geneve interfaces created by Liqo.
+	gwExtGenevePrefix = "liqo."
+)
+
 // GenerateRouteConfigurationName generates the name of the RouteConfiguration object.
 func GenerateRouteConfigurationName(cfg *networkingv1beta1.Configuration) string {
+	return fmt.Sprintf("%s-gw-ext", cfg.Name)
+}
+
+// GenerateFirewallConfigurationName generates the name of the FirewallConfiguration object.
+func GenerateFirewallConfigurationName(cfg *networkingv1beta1.Configuration) string {
 	return fmt.Sprintf("%s-gw-ext", cfg.Name)
 }
 
@@ -52,7 +75,8 @@ func GetRemoteClusterID(cfg *networkingv1beta1.Configuration) (liqov1beta1.Clust
 	return liqov1beta1.ClusterID(remoteID), nil
 }
 
-// enforceRouteConfigurationPresence creates or updates a RouteConfiguration object.
+// enforceRouteConfigurationPresence creates or updates a RouteConfiguration object and its
+// associated FirewallConfiguration.
 func enforceRouteConfigurationPresence(ctx context.Context, cl client.Client, scheme *runtime.Scheme,
 	cfg *networkingv1beta1.Configuration) error {
 	remoteClusterID, err := GetRemoteClusterID(cfg)
@@ -74,28 +98,93 @@ func enforceRouteConfigurationPresence(ctx context.Context, cl client.Client, sc
 		return err
 	}
 
+	// Ensure the FirewallConfiguration that marks traffic arriving on Geneve interfaces.
+	fwcfg := &networkingv1beta1.FirewallConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      GenerateFirewallConfigurationName(cfg),
+			Namespace: cfg.Namespace,
+		},
+	}
+	if _, err = resource.CreateOrUpdate(ctx, cl, fwcfg,
+		forgeMutateFirewallConfiguration(cfg, fwcfg, scheme, remoteClusterID)); err != nil {
+		return fmt.Errorf("ensuring firewall configuration %q: %w", fwcfg.Name, err)
+	}
+
 	routecfg := &networkingv1beta1.RouteConfiguration{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      GenerateRouteConfigurationName(cfg),
 			Namespace: cfg.Namespace,
 		},
 	}
-
-	internalNodes, err := getters.ListInternalNodesByLabels(ctx, cl, labels.Everything())
-	if err != nil {
-		return err
-	}
-
 	_, err = resource.CreateOrUpdate(ctx, cl, routecfg,
-		forgeMutateRouteConfiguration(cfg, routecfg, scheme, remoteClusterID, remoteInterfaceIP, internalNodes))
+		forgeMutateRouteConfiguration(cfg, routecfg, scheme, remoteClusterID, remoteInterfaceIP))
 	return err
+}
+
+// forgeMutateFirewallConfiguration mutates a FirewallConfiguration object that marks traffic
+// arriving on any Geneve interface (liqo.*) with a constant fwmark. The mark is set directly
+// on the packet (not via conntrack) in the prerouting chain at mangle priority, so it is
+// available for ip rule route lookup. This is per-packet, not per-connection, preventing
+// return traffic on liqo-tunnel from being marked.
+func forgeMutateFirewallConfiguration(cfg *networkingv1beta1.Configuration,
+	fwcfg *networkingv1beta1.FirewallConfiguration, scheme *runtime.Scheme,
+	remoteClusterID liqov1beta1.ClusterID) func() error {
+	return func() error {
+		if err := controllerutil.SetOwnerReference(cfg, fwcfg, scheme); err != nil {
+			return err
+		}
+
+		fwcfg.ObjectMeta.Labels = gateway.ForgeFirewallExternalTargetLabels(string(remoteClusterID))
+
+		markValue := fmt.Sprintf("%d", gwExtMark)
+
+		fwcfg.Spec = networkingv1beta1.FirewallConfigurationSpec{
+			Table: firewall.Table{
+				Name:   ptr.To(cfg.Name),
+				Family: ptr.To(firewall.TableFamilyIPv4),
+				Chains: []firewall.Chain{
+					{
+						// Prerouting chain at mangle priority: set the packet fwmark directly for any
+						// packet arriving on a liqo.* interface. Runs before route lookup so ip rule
+						// can match on FwMark. The WireGuard interface (liqo-tunnel) uses a dash, not
+						// a dot, so it does not match the "liqo." prefix.
+						Name:     ptr.To("gw-ext-mark"),
+						Type:     firewall.ChainTypeFilter,
+						Policy:   ptr.To(firewall.ChainPolicyAccept),
+						Hook:     ptr.To(firewall.ChainHookPrerouting),
+						Priority: &firewall.ChainPriorityMangle,
+						Rules: firewall.RulesSet{
+							FilterRules: []firewall.FilterRule{
+								{
+									Name: ptr.To("gw-ext-mark"),
+									Match: []firewall.Match{
+										{
+											Op: firewall.MatchOperationEq,
+											Dev: &firewall.MatchDev{
+												Value:    gwExtGenevePrefix,
+												Position: firewall.MatchDevPositionIn,
+												Wildcard: true,
+											},
+										},
+									},
+									Action: firewall.ActionSetMetaMark,
+									Value:  ptr.To(markValue),
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		return nil
+	}
 }
 
 // forgeMutateRouteConfiguration mutates a RouteConfiguration object.
 func forgeMutateRouteConfiguration(cfg *networkingv1beta1.Configuration,
 	routecfg *networkingv1beta1.RouteConfiguration, scheme *runtime.Scheme,
 	remoteClusterID liqov1beta1.ClusterID,
-	remoteInterfaceIP string, internalNodes *networkingv1beta1.InternalNodeList) func() error {
+	remoteInterfaceIP string) func() error {
 	return func() error {
 		var err error
 
@@ -112,21 +201,19 @@ func forgeMutateRouteConfiguration(cfg *networkingv1beta1.Configuration,
 		}
 
 		remoteCIDRs := slices.Concat(cfg.Spec.Remote.CIDR.Pod, cfg.Spec.Remote.CIDR.External)
-		for i := range internalNodes.Items {
-			iif := &internalNodes.Items[i].Spec.Interface.Gateway.Name
-			for j := range remoteCIDRs {
-				dst := &remoteCIDRs[j]
-				routecfg.Spec.Table.Rules = append(routecfg.Spec.Table.Rules, networkingv1beta1.Rule{
-					Iif: iif,
-					Dst: dst,
-					Routes: []networkingv1beta1.Route{
-						{
-							Dst: dst,
-							Gw:  ptr.To(networkingv1beta1.IP(remoteInterfaceIP)),
-						},
+		mark := gwExtMark
+		for j := range remoteCIDRs {
+			dst := &remoteCIDRs[j]
+			routecfg.Spec.Table.Rules = append(routecfg.Spec.Table.Rules, networkingv1beta1.Rule{
+				FwMark: &mark,
+				Dst:    dst,
+				Routes: []networkingv1beta1.Route{
+					{
+						Dst: dst,
+						Gw:  ptr.To(networkingv1beta1.IP(remoteInterfaceIP)),
 					},
-				})
-			}
+				},
+			})
 		}
 		return nil
 	}

--- a/pkg/liqo-controller-manager/networking/external-network/route/k8s.go
+++ b/pkg/liqo-controller-manager/networking/external-network/route/k8s.go
@@ -134,7 +134,7 @@ func forgeMutateFirewallConfiguration(cfg *networkingv1beta1.Configuration,
 			return err
 		}
 
-		fwcfg.ObjectMeta.Labels = gateway.ForgeFirewallExternalTargetLabels(string(remoteClusterID))
+		fwcfg.Labels = gateway.ForgeFirewallExternalTargetLabels(string(remoteClusterID))
 
 		markValue := fmt.Sprintf("%d", gwExtMark)
 


### PR DESCRIPTION
The external-network route controller previously generated N×R ip rule entries in the gw-ext RouteConfiguration — one per Geneve interface × remote CIDR. Each rule matched on Iif=<geneve-interface> + Dst=<remote-CIDR> and routed to the same WireGuard gateway IP. With 60 nodes and 2 remote CIDRs, this produced ~120 netlink policy routing rules that the kernel scanned linearly per packet.

 This change replaces the Iif filter with a FwMark-based approach: a new FirewallConfiguration marks traffic arriving on any liqo.* Geneve interface with a constant fwmark (0xFF00), and the RouteConfiguration rules match on FwMark + Dst instead of Iif + Dst. This collapses the rule count to R (one per remote CIDR), independent of node count.

 ### Background

 The Iif filter served two purposes:
 1. Routing loop prevention — packets arriving on the WireGuard tunnel (liqo-tunnel) destined for a remote CIDR (e.g. overlapping external CIDR) would not match, since Iif=liqo-tunnel ≠ liqo.<geneve>. Removing Iif without a replacement causes return traffic to bounce back through the tunnel.
 2. Per-node rule multiplication — each Geneve interface needed its own set of rules, even though the routing action (gateway IP) was identical for all of them.

 The fwmark approach preserves loop prevention while eliminating per-node rule duplication.

 ### How it works

 New FirewallConfiguration (1 chain, 1 rule):
 - A prerouting chain at mangle priority (-150) matches iifname "liqo." (wildcard prefix) and sets the packet's fwmark to 0xFF00 via a new setmetamark action.
 - This runs before route lookup, so the mark is available for ip rule evaluation.
 - The WireGuard interface is named liqo-tunnel (dash), while Geneve interfaces use liqo. (dot) — the wildcard "liqo." matches Geneve interfaces but not the tunnel, so tunnel-originated traffic is never marked.
 - The mark is set per-packet (not via conntrack), so the first packet of a connection is marked correctly, and return traffic on the tunnel doesn't inherit the mark.

 RouteConfiguration (R rules instead of N×R):
 - Rules now match on FwMark=0xFF00 + Dst=<remote-CIDR> → route to Gw=169.254.18.x (WireGuard).
 - Only R rules exist — one per remote CIDR, independent of node count.