### PR TITLE
fix: genevetunnel conncheck ping remote ip

### DIFF
--- a/pkg/fabric/genevetunnel_controller.go
+++ b/pkg/fabric/genevetunnel_controller.go
@@ -225,7 +225,7 @@ func (r *GeneveTunnelReconciler) ensureSender(cc *conncheck.ConnChecker, key typ
 	}
 
 	observer := onTransition(observeGeneveLatency(internalfabric, gt), r.enqueueTransition(key))
-	if err := cc.AddSender(context.Background(), gt.Name, internalnode.Spec.Interface.Node.IP.String(), observer); err != nil {
+	if err := cc.AddSender(context.Background(), gt.Name, internalfabric.Spec.Interface.Gateway.IP.String(), observer); err != nil {
 		var dupErr *conncheck.DuplicateError
 		if !errors.As(err, &dupErr) {
 			return fmt.Errorf("unable to add conncheck sender: %w", err)


### PR DESCRIPTION
# Description

The fabric-side conncheck sender now pings internalfabric.Spec.Interface.Gateway.IP (the gateway's geneve IP), instead of internalnode.Spec.Interface.Node.IP. Previously, the sender was pinging itself, which would always show  `Connected` even if the geneve tunnel was broken.    
