### PR TITLE
fix: preserve MatchFields when merging node selectors

### DIFF
--- a/pkg/utils/nodeUtils.go
+++ b/pkg/utils/nodeUtils.go
@@ -91,11 +91,11 @@ func MergeNodeSelector(ns1, ns2 *corev1.NodeSelector) corev1.NodeSelector {
 	mergedNodeSelector := corev1.NodeSelector{NodeSelectorTerms: []corev1.NodeSelectorTerm{}}
 	for i := range ns1.NodeSelectorTerms {
 		for j := range ns2.NodeSelectorTerms {
-			newMatchExpression := ns1.NodeSelectorTerms[i].DeepCopy().MatchExpressions
-			newMatchExpression = append(newMatchExpression, ns2.NodeSelectorTerms[j].MatchExpressions...)
-			mergedNodeSelector.NodeSelectorTerms = append(mergedNodeSelector.NodeSelectorTerms, corev1.NodeSelectorTerm{
-				MatchExpressions: newMatchExpression,
-			})
+			term := ns1.NodeSelectorTerms[i].DeepCopy()
+			other := ns2.NodeSelectorTerms[j].DeepCopy()
+			term.MatchExpressions = append(term.MatchExpressions, other.MatchExpressions...)
+			term.MatchFields = append(term.MatchFields, other.MatchFields...)
+			mergedNodeSelector.NodeSelectorTerms = append(mergedNodeSelector.NodeSelectorTerms, *term)
 		}
 	}
 	return mergedNodeSelector

--- a/pkg/utils/nodeutils_test.go
+++ b/pkg/utils/nodeutils_test.go
@@ -135,6 +135,27 @@ var _ = Describe("NodeUtils", func() {
 				},
 			}),
 
+			Entry("preserve daemonset target node match field", mergeNodeSelectorTestcase{
+				nodeSelector1: &v1.NodeSelector{NodeSelectorTerms: []v1.NodeSelectorTerm{{
+					MatchFields: []v1.NodeSelectorRequirement{{
+						Key:      "metadata.name",
+						Operator: v1.NodeSelectorOpIn,
+						Values:   []string{"test-node"},
+					}},
+				}}},
+				nodeSelector2: &v1.NodeSelector{NodeSelectorTerms: []v1.NodeSelectorTerm{{
+					MatchExpressions: []v1.NodeSelectorRequirement{getExpression(1)},
+				}}},
+				expectedSelector: v1.NodeSelector{NodeSelectorTerms: []v1.NodeSelectorTerm{{
+					MatchExpressions: []v1.NodeSelectorRequirement{getExpression(1)},
+					MatchFields: []v1.NodeSelectorRequirement{{
+						Key:      "metadata.name",
+						Operator: v1.NodeSelectorOpIn,
+						Values:   []string{"test-node"},
+					}},
+				}}},
+			}),
+
 			Entry("first selector with one term and one expression, the other with multiple", mergeNodeSelectorTestcase{
 				nodeSelector1: &v1.NodeSelector{
 					NodeSelectorTerms: []v1.NodeSelectorTerm{


### PR DESCRIPTION
# Description

MergeNodeSelector only kept MatchExpressions and silently dropped the MatchFields of both input selectors, breaking the targeting of DaemonSets (or other resources) that pin to a specific node via metadata.name.

Each node selector term is now deep-copied and both MatchExpressions and MatchFields are merged, preserving the constraints of the original terms.

Adds a unit test covering the daemonset target node match field.

# How Has This Been Tested?

- [x] go build ./pkg/utils/...
- [x] go test ./pkg/utils/... (new "preserve daemonset target node match field" case)
