### PR TITLE
fix: log only on geneve tunnel creation

### DIFF
--- a/pkg/fabric/genevetunnel_controller.go
+++ b/pkg/fabric/genevetunnel_controller.go
@@ -162,7 +162,7 @@ func (r *GeneveTunnelReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{}, fmt.Errorf("getting internalnode %q: %w", gt.Spec.InternalNodeRef.Name, err)
 	}
 
-	if err := geneve.EnsureGeneveInterfacePresence(
+	created, err := geneve.EnsureGeneveInterfacePresence(
 		internalfabric.Spec.Interface.Node.Name,
 		internalnode.Spec.Interface.Node.IP.String(),
 		internalfabric.Spec.GatewayIP.String(),
@@ -170,11 +170,17 @@ func (r *GeneveTunnelReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		r.Options.DisableARP,
 		internalfabric.Spec.MTU,
 		r.Options.GenevePort,
-	); err != nil {
+	)
+
+	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("ensuring the geneve interface presence: %w", err)
 	}
 
-	klog.Infof("Enforced interface %s for genevetunnel %s", internalfabric.Spec.Interface.Node.Name, req.String())
+	if created {
+		klog.Infof("Created geneve interface %s for genevetunnel %s", internalfabric.Spec.Interface.Node.Name, req.String())
+	}
+
+	klog.V(4).Infof("Enforced interface %s for genevetunnel %s", internalfabric.Spec.Interface.Node.Name, req.String())
 
 	if r.Options.ConnCheckOptions.PingEnabled {
 		bindIP := r.Options.ConnCheckOptions.PingBindIP

--- a/pkg/gateway/fabric/genevetunnel_controller.go
+++ b/pkg/gateway/fabric/genevetunnel_controller.go
@@ -141,7 +141,7 @@ func (r *GeneveTunnelReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{}, nil
 	}
 
-	if err := geneve.EnsureGeneveInterfacePresence(
+	created, err := geneve.EnsureGeneveInterfacePresence(
 		internalnode.Spec.Interface.Gateway.Name,
 		internalfabric.Spec.Interface.Gateway.IP.String(),
 		remoteIP.String(),
@@ -149,11 +149,17 @@ func (r *GeneveTunnelReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		r.Options.DisableARP,
 		internalfabric.Spec.MTU,
 		r.Options.GenevePort,
-	); err != nil {
+	)
+
+	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("ensuring the geneve interface presence: %w", err)
 	}
 
-	klog.Infof("Enforced interface %s for genevetunnel %s", internalnode.Spec.Interface.Gateway.Name, req.String())
+	if created {
+		klog.Infof("Created geneve interface %s for genevetunnel %s", internalnode.Spec.Interface.Gateway.Name, req.String())
+	}
+
+	klog.V(4).Infof("Enforced interface %s for genevetunnel %s", internalnode.Spec.Interface.Gateway.Name, req.String())
 
 	if internalnode.Spec.Interface.Node.IP == "" {
 		klog.Infof("waiting for inner IP of internalnode %s to be set...", internalnode.Name)
@@ -202,7 +208,7 @@ func (r *GeneveTunnelReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	return ctrl.NewControllerManagedBy(mgr).Named(consts.CtrlInternalNodeGeneve).
 		For(&networkingv1beta1.GeneveTunnel{},
-			builder.WithPredicates(namespacePredicate)).
+			builder.WithPredicates(namespacePredicate, predicate.GenerationChangedPredicate{})).
 		Watches(&networkingv1beta1.InternalNode{},
 			handler.EnqueueRequestsFromMapFunc(r.internalNodeEnqueuer)).
 		Watches(&networkingv1beta1.InternalFabric{},

--- a/pkg/utils/network/geneve/netlink.go
+++ b/pkg/utils/network/geneve/netlink.go
@@ -24,12 +24,14 @@ import (
 )
 
 // EnsureGeneveInterfacePresence ensures that a geneve interface exists for the given internal node.
-func EnsureGeneveInterfacePresence(interfaceName, localIP, remoteIP string, id uint32, disableARP bool, mtu int, port uint16) error {
+func EnsureGeneveInterfacePresence(
+	interfaceName, localIP, remoteIP string, id uint32, disableARP bool, mtu int, port uint16,
+) (created bool, err error) {
 	remoteIPNet := net.ParseIP(remoteIP)
 	if remoteIPNet == nil {
 		remoteIPsNet, err := net.LookupIP(remoteIP)
 		if err != nil {
-			return err
+			return false, err
 		}
 		remoteIPNet = remoteIPsNet[0]
 	}
@@ -70,18 +72,19 @@ func ForgeGeneveInterface(name string, remote net.IP, id uint32, mtu int, port u
 }
 
 // CreateGeneveInterface creates a geneve interface with the given name, remote IP and ID.
-func CreateGeneveInterface(name string, local, remote net.IP, id uint32, disableARP bool, mtu int, port uint16) error {
+func CreateGeneveInterface(name string, local, remote net.IP, id uint32, disableARP bool, mtu int, port uint16) (created bool, err error) {
 	var geneveLink *netlink.Geneve
 	link, err := ExistGeneveInterface(name)
 	if err != nil {
-		return fmt.Errorf("checking geneve link existence: %w", err)
+		return created, fmt.Errorf("checking geneve link existence: %w", err)
 	}
 
 	if link == nil {
 		geneveLink = ForgeGeneveInterface(name, remote, id, mtu, port)
 		if err := netlink.LinkAdd(geneveLink); err != nil {
-			return fmt.Errorf("cannot create geneve link: %w", err)
+			return created, fmt.Errorf("cannot create geneve link: %w", err)
 		}
+		created = true
 	} else {
 		geneveLink = link.(*netlink.Geneve)
 		if !geneveLink.Remote.Equal(remote) || geneveLink.MTU != mtu || geneveLink.Dport != port || geneveLink.ID != id {
@@ -89,23 +92,24 @@ func CreateGeneveInterface(name string, local, remote net.IP, id uint32, disable
 				"(remote: %s -> %s, id: %d -> %d, mtu: %d -> %d, dport: %d -> %d), modifying it",
 				geneveLink.Remote.String(), remote.String(), geneveLink.ID, id, geneveLink.MTU, mtu, geneveLink.Dport, port)
 			if err := netlink.LinkDel(geneveLink); err != nil {
-				return fmt.Errorf("cannot delete geneve link: %w", err)
+				return created, fmt.Errorf("cannot delete geneve link: %w", err)
 			}
 			geneveLink = ForgeGeneveInterface(name, remote, id, mtu, port)
 			if err := netlink.LinkAdd(geneveLink); err != nil {
-				return fmt.Errorf("cannot modify geneve link: %w", err)
+				return created, fmt.Errorf("cannot modify geneve link: %w", err)
 			}
+			created = true
 		}
 	}
 
 	if disableARP {
 		if err := netlink.LinkSetARPOff(geneveLink); err != nil {
-			return fmt.Errorf("cannot set geneve link arp off: %w", err)
+			return created, fmt.Errorf("cannot set geneve link arp off: %w", err)
 		}
 	}
 
 	if err := netlink.LinkSetUp(geneveLink); err != nil {
-		return fmt.Errorf("cannot set geneve link up: %w", err)
+		return created, fmt.Errorf("cannot set geneve link up: %w", err)
 	}
 
 	if ExistGeneveInterfaceAddr(geneveLink, local) == nil {
@@ -115,11 +119,11 @@ func CreateGeneveInterface(name string, local, remote net.IP, id uint32, disable
 				Mask: net.IPMask{0xff, 0xff, 0xff, 0xff},
 			},
 		}); err != nil {
-			return fmt.Errorf("cannot add address to geneve link: %w", err)
+			return created, fmt.Errorf("cannot add address to geneve link: %w", err)
 		}
 	}
 
-	return nil
+	return created, nil
 }
 
 // ExistGeneveInterface checks if a geneve interface with the given name exists.


### PR DESCRIPTION
# Description

This commit fixes an issue with the fabric logs: it logged every 10 seconds because of the ping in the geneve tunnels. This commit increased the verbosity level of the log when the interface is ensured. And log with lowerver verbosity level when the interface is created.